### PR TITLE
Changed out of date curl commands for the kubelet API

### DIFF
--- a/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services.md
+++ b/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services.md
@@ -180,14 +180,17 @@ Path("/containerLogs")
 Path("/runningpods/").
 ```
 
-All of them sounds interesting.
+All of them sound interesting.
+
+You can use the [**Kubeletctl**](https://github.com/cyberark/kubeletctl) tool to interact with Kubelets and their endpoints.
+
 
 #### /pods
 
 This endpoint list pods and their containers:
 
 ```bash
-curl -ks https://worker:10250/pods
+kubeletctl pods
 ```
 
 #### /exec
@@ -195,13 +198,8 @@ curl -ks https://worker:10250/pods
 This endpoint allows to execute code inside any container very easily:
 
 ```bash
-# Tthe command is passed as an array (split by spaces) and that is a GET request.
-curl -Gks https://worker:10250/exec/{namespace}/{pod}/{container} \
-  -d 'input=1' -d 'output=1' -d 'tty=1'                             \
-  -d 'command=ls' -d 'command=/'
+kubeletctl exec [command]
 ```
-
-To automate the exploitation you can also use the script [**kubelet-anon-rce**](https://github.com/serain/kubelet-anon-rce).
 
 {% hint style="info" %}
 To avoid this attack the _**kubelet**_ service should be run with `--anonymous-auth false` and the service should be segregated at the network level.


### PR DESCRIPTION
The removed curl commands and the tool (kubelet-anon-rce) dont work anymore due to the kubelet API's using the SPDY protocol. I changed the above to use the kubeletctl tool which works now!