### PR TITLE
Update aws-elastic-beanstalk-privesc.md

### DIFF
--- a/pentesting-cloud/aws-pentesting/aws-privilege-escalation/aws-elastic-beanstalk-privesc.md
+++ b/pentesting-cloud/aws-pentesting/aws-privilege-escalation/aws-elastic-beanstalk-privesc.md
@@ -43,7 +43,7 @@ zip 1692777270420-aws-flask-app.zip <files to zip>
 # Upload code
 aws s3 cp 1692777270420-aws-flask-app.zip s3://elasticbeanstalk-eu-west-1-947247140022/1692777270420-aws-flask-app.zip
 # Rebuild env
-aws rebuild-environment --environment-name "env-name"
+aws elasticbeanstalk rebuild-environment --environment-id "env-id"
 ```
 {% endcode %}
 


### PR DESCRIPTION
The ``--environment-name`` flag is not working on the command: ``aws rebuild-environment --environment-name "env-name"``. Instead, should be this: ``aws elasticbeanstalk rebuild-environment --environment-id "env-id"``

References: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-management-rebuild.html