### PR TITLE
fix: typos in aws basic information page

### DIFF
--- a/pentesting-cloud/aws-security/aws-basic-information/README.md
+++ b/pentesting-cloud/aws-security/aws-basic-information/README.md
@@ -236,7 +236,7 @@ A boundary is just a policy attached to a user which **indicates the maximum lev
 
 ### Session Policies
 
-A session policy is a **policy set when a role is assumed** somehow. This will by like an **IAM boundary for that session**: This means taht the session policy doesn't grant permissions but **restrict them to the ones indicated in the policy** (being the max permissions the ones the role has).
+A session policy is a **policy set when a role is assumed** somehow. This will be like an **IAM boundary for that session**: This means that the session policy doesn't grant permissions but **restrict them to the ones indicated in the policy** (being the max permissions the ones the role has).
 
 This is useful for **security meassures**: When an admin is going to assume a very privileged role he could restrict the permission to only the ones indicated in the session policy in case the session gets compromised.
 
@@ -289,7 +289,7 @@ Therefore, even if you see 2 roles with an inline policy called **`AwsSSOInlineP
 
 ### Cross Account Trusts and Roles
 
-**A user** (trusting) can create a Cross Account Role with some policies and then, **allow another user** (trusted) to **access his account** but only h**aving the access indicated in the new role policies**. To create this, just create a new Role and select Cross Account Role. Roles for Cross-Account Access offers two options. Providing access between AWS accounts that you own, and providing access between an account that you own and a third party AWS account.\
+**A user** (trusting) can create a Cross Account Role with some policies and then, **allow another user** (trusted) to **access his account** but only **having the access indicated in the new role policies**. To create this, just create a new Role and select Cross Account Role. Roles for Cross-Account Access offers two options. Providing access between AWS accounts that you own, and providing access between an account that you own and a third party AWS account.\
 It's recommended to **specify the user who is trusted and not put some generic thing** because if not, other authenticated users like federated users will be able to also abuse this trust.
 
 ### AWS Simple AD


### PR DESCRIPTION
This fixes a few typos in the AWS basic information page.