### PR TITLE
arte-veue

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
@@ -53,6 +53,43 @@ aws ecs describe-tasks --cluster <cluster> --tasks <tasks>
 aws ecs describe-task-definition --task-definition <TASK_NAME>:<VERSION>
 ```
 
+### On-Host Enumeration via the ECS Agent State DB (`agent.db`)
+
+When you have **shell access on an ECS container instance** , or you have **escaped a container with a host bind-mount of `/var/lib/ecs`** (a common misconfiguration when tasks run privileged or with `volumesFrom` exposing the host data dir), the ECS agent leaves `agent.db` on disk that can be read **without any AWS API call**, **without any IAM permission**, and **without triggering CloudTrail**.
+
+```
+/var/lib/ecs/data/agent.db
+```
+
+(or, when reading from a container that has the host mounted at `/host`, `/host/var/lib/ecs/data/agent.db`).
+
+```bash
+# Most useful one-liner — dumps everything readable
+strings /var/lib/ecs/data/agent.db
+
+# From inside a container with the host mounted at /host
+strings /host/var/lib/ecs/data/agent.db
+
+# Filter for the highest-value artefacts
+strings /var/lib/ecs/data/agent.db | grep -aE 'arn:aws:|AKIA|ASIA|"secret|password|TOKEN|credentials|taskRoleArn|executionRoleArn'
+
+# Save the outcome from strings for offline analysis
+strings /host/var/lib/ecs/data/agent.db >> /tmp/agent.txt
+tr -s '{}[],:"\\' '\n' < /tmp/agent.txt | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'NF && length($0)>2 && !/^[0-9.]+$/' | sort -u
+```
+
+#### What you can recover
+
+Depending on the cluster's age and workload churn, `strings` against `agent.db` typically yields:
+
+- **Task and execution IAM role ARNs** (`taskRoleArn`, `executionRoleArn`) for every task the agent has run — useful targets for [credential retrieval via the task metadata endpoint](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.html) (`169.254.170.2`).
+- **Full task definitions** — image URIs (often private ECR repos), command, entrypoint, port mappings, mount points, log configuration, and **plaintext environment variables** that frequently include database URLs, API tokens, and third-party secrets.
+- **Secrets references** — `secretOptions` and `secrets` blocks pointing at SSM Parameter Store paths and Secrets Manager ARNs (great pivot list).
+- **Container instance ARN, cluster ARN, and registration token** — confirms the cluster name and account/region context with no API call.
+- **ENI metadata** — private IPs, MAC addresses, subnet IDs, and security group IDs assigned in `awsvpc` mode (useful for lateral movement planning).
+- **Image pull credentials** — when the task definition uses `repositoryCredentials`, the referenced Secrets Manager ARN is here; on older agents private-registry auth blobs (`ECS_ENGINE_AUTH_DATA`) may also be cached.
+- **Recently-stopped task containers** — including names, IDs, exit codes and labels, sometimes long after the corresponding `aws ecs describe-tasks` call has aged them out of the API response.
+
 ### Unauthenticated Access
 
 {{#ref}}


### PR DESCRIPTION
# Summary
Adds a new subsection to AWS - ECS Enum documenting an on-host enumeration technique that is not currently covered anywhere in the HackTricks Cloud book: 
Dumping the ECS container agent's BoltDB state file at /var/lib/ecs/data/agent.db with strings command.
This is genuinely useful in real engagements because it works:
- Without any AWS API call (no CloudTrail trail, no IAM permission needed).
- Without extra tooling — strings is on every Linux box, so it works from
- As a fallback when the compromised role lacks ecs:Describe* /
- ecs:List* permissions but has host-level read access (or a container with a misconfigured /var/lib/ecs bind mount).


