### PR TITLE
ci: skip unchanged root sitemap invalidations

### DIFF
--- a/.github/workflows/translate_all.yml
+++ b/.github/workflows/translate_all.yml
@@ -275,16 +275,29 @@ jobs:
           find . -type f -name 'index.html' -print | head -n 3 | xargs -r cat
 
       - name: Refresh root sitemap index
+        id: root_sitemap
         run: |
-          LANGS=$(aws s3api list-objects-v2 --bucket hacktricks-cloud --delimiter / --query 'CommonPrefixes[].Prefix' --output text | tr '\t' '\n' | sed 's:/$::' | grep -E '^[a-z]{2}$' | sort | paste -sd, -)
+          set -euo pipefail
+          LANGS=$(aws s3api list-objects-v2 --bucket hacktricks-cloud --delimiter / --query 'CommonPrefixes[].Prefix' --output text | tr '\t' '\n' | sed 's:/$::' | grep -E '^[a-z]{2}$' | sort | paste -sd, - || true)
           if [ -z "$LANGS" ]; then
             LANGS="en"
           fi
           python3 /tmp/seo_postprocess.py index --site-url https://cloud.hacktricks.wiki --languages "$LANGS" --output ./sitemap.xml
-          aws s3 cp ./sitemap.xml s3://hacktricks-cloud/sitemap.xml --content-type application/xml --cache-control max-age=300
+          if aws s3 cp s3://hacktricks-cloud/sitemap.xml /tmp/current-root-sitemap.xml >/dev/null 2>&1 && cmp -s /tmp/current-root-sitemap.xml ./sitemap.xml; then
+            echo "Root sitemap unchanged; skipping S3 upload and CloudFront invalidation for /sitemap.xml"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            aws s3 cp ./sitemap.xml s3://hacktricks-cloud/sitemap.xml --content-type application/xml --cache-control max-age=300
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Invalidate CloudFront HTML and SEO assets
         run: |
+          set -euo pipefail
+          paths=("/$BRANCH/*" "/$BRANCH/sitemap.xml")
+          if [ "${{ steps.root_sitemap.outputs.changed }}" = "true" ]; then
+            paths+=("/sitemap.xml")
+          fi
           aws cloudfront create-invalidation \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --paths "/$BRANCH/*" "/sitemap.xml" "/$BRANCH/sitemap.xml"
+            --paths "${paths[@]}"


### PR DESCRIPTION
Created by Hermes.

## Summary
- Avoid re-uploading the root sitemap index when the generated file matches the current S3 object.
- Skip the paid CloudFront invalidation for /sitemap.xml unless that root sitemap actually changed.
- Keep per-language invalidations unchanged: /$BRANCH/* and /$BRANCH/sitemap.xml still refresh after each translation.

## Evidence
The AWS wiki cost cron found CloudFront Invalidations at $12.145 in the last 15 days. Recent invalidation samples for the cloud wiki showed /sitemap.xml repeated in every translation invalidation, even though the root sitemap index is shared across languages.

## Validation
- git diff --check
- workflow file sanity check for expected --paths array expansion
