### PR TITLE
Reduce redundant CloudFront invalidation paths

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -178,7 +178,9 @@ jobs:
 
       - name: Invalidate CloudFront HTML and SEO assets
         run: |
+          # /en/* covers /en/robots.txt and /en/sitemap.xml; only invalidate
+          # root SEO files separately.
           aws cloudfront create-invalidation \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --paths "/en/*" "/robots.txt" "/en/robots.txt" "/sitemap.xml" "/en/sitemap.xml"
+            --paths "/en/*" "/robots.txt" "/sitemap.xml"
       

--- a/.github/workflows/translate_all.yml
+++ b/.github/workflows/translate_all.yml
@@ -296,7 +296,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths=("/$BRANCH/*" "/$BRANCH/sitemap.xml")
+          # The wildcard already invalidates the language sitemap, so avoid
+          # paying for a redundant explicit /$BRANCH/sitemap.xml path.
+          paths=("/$BRANCH/*")
           if [ "${{ steps.root_sitemap.outputs.changed }}" = "true" ]; then
             paths+=("/sitemap.xml")
           fi


### PR DESCRIPTION
Created by Hermes.

## Problem
CloudFront invalidations are the top wiki-account cost driver. In the last 15 days, the cloud HackTricks distribution invalidated 375 paths across 171 batches, including repeated explicit `/en/sitemap.xml` and translated `/<lang>/sitemap.xml` paths.

## Change
- Keep invalidating `/<lang>/*` and `/en/*`.
- Remove redundant explicit `/<lang>/sitemap.xml`, `/en/sitemap.xml`, and `/en/robots.txt` paths because they are already covered by the wildcard invalidation.
- Continue invalidating root `/sitemap.xml` and `/robots.txt` where needed.

## Safety
CloudFront wildcard invalidation paths cover all objects below the prefix, so this preserves cache refresh behavior while reducing billable invalidation paths.

## Validation
- Parsed modified workflow YAML with PyYAML successfully.
