### PR TITLE
Fix reference audit issues in pages 51-97

### DIFF
--- a/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
+++ b/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
@@ -1,7 +1,5 @@
 # LUKS2 Header Malleability and Null-Cipher Abuse in Confidential VMs
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## TL;DR
 
 - Many Linux-based Confidential VMs (CVMs) running on AMD SEV-SNP or Intel TDX use LUKS2 for persistent storage. The on-disk LUKS2 header is malleable and not integrity-protected against storage-adjacent attackers. <sup>[[1]](#references)[[3]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/README.md
+++ b/src/pentesting-cloud/gcp-security/README.md
@@ -1,7 +1,5 @@
 # GCP Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 **Before start pentesting** a **GCP** environment, there are a few **basics things you need to know** about how it works to help you understand what you need to do, how to find misconfigurations and how to exploit them.
@@ -68,26 +66,24 @@ In GCP you can try several options to try to guess who you are. The examples com
 ```bash
 #If you are inside a compromise machine
 gcloud auth list
-curl -H "Content-Type: application/x-www-form-urlencoded" -d "access_token=$(gcloud auth print-access-token)" https://www.googleapis.com/oauth2/v1/tokeninfo
-gcloud auth print-identity-token #Get info from the token
+curl "https://oauth2.googleapis.com/tokeninfo?access_token=$(gcloud auth print-access-token)"
+gcloud auth print-identity-token # Print an identity token for a target audience
 
 #If you compromised a metadata token or somehow found an OAuth token
-curl -H "Content-Type: application/x-www-form-urlencoded" -d "access_token=<token>" https://www.googleapis.com/oauth2/v1/tokeninfo
+curl "https://oauth2.googleapis.com/tokeninfo?access_token=<token>"
 ```
-
-The examples retain the legacy tokeninfo URL from the original page; current Google Cloud documentation uses `https://oauth2.googleapis.com/tokeninfo` for access-token introspection.<sup>[[4]](#references)</sup>
 
 An identity token is distinct from an OAuth access token and is normally minted for a target audience, so use `gcloud auth print-identity-token` for an identity-token flow rather than passing its output to the access-token diagnostics above.<sup>[[4]](#references)[[8]](#references)</sup>
 
 You can also use the API endpoint `/userinfo` to get more info about the user:<sup>[[5]](#references)</sup>
 
 ```bash
-curl -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: OAuth $(gcloud auth print-access-token)" https://www.googleapis.com/oauth2/v1/userinfo
+curl -H "Authorization: Bearer $(gcloud auth print-access-token)" https://openidconnect.googleapis.com/v1/userinfo
 
-curl -H "Content-Type: application/x-www-form-urlencoded" -H "Authorization: OAuth <access_token>" https://www.googleapis.com/oauth2/v1/userinfo
+curl -H "Authorization: Bearer <access_token>" https://openidconnect.googleapis.com/v1/userinfo
 ```
 
-For new integrations, retrieve the current UserInfo URL from Google's OpenID Connect discovery document and send the access token as a Bearer credential; the legacy URL and header above are preserved from the original page.<sup>[[5]](#references)</sup>
+Retrieve the current UserInfo URL from Google's OpenID Connect discovery document and send the access token as a Bearer credential.<sup>[[5]](#references)</sup>
 
 ### Org Enumeration
 
@@ -177,16 +173,10 @@ gcp-to-workspace-pivoting/
 
 ```bash
 # Install
-git clone https://github.com/google/gcp_scanner.git
-cd gcp_scanner
-virtualenv -p python3 venv
-source venv/bin/activate
-pip install -r requirements.txt
+python3 -m pip install gcp_scanner
 # Execute with gcloud creds
-python3 __main__.py -o /tmp/output/ -g "$HOME/.config/gcloud"
+python3 -m gcp_scanner -o /tmp/output/ -g "$HOME/.config/gcloud"
 ```
-
-The current gcp_scanner README documents package-based installation (`pip install gcp_scanner` and `python3 -m gcp_scanner`); verify its current usage before relying on the legacy checkout command above.<sup>[[14]](#references)</sup>
 
 - [**gcp_enum**](https://gitlab.com/gitlab-com/gl-security/threatmanagement/redteam/redteam-public/gcp_enum): Bash script to enumerate a GCP environment using gcloud cli and saving the results in a file.<sup>[[15]](#references)</sup>
 - [**GCP-IAM-Privilege-Escalation**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation): Scripts to enumerate high IAM privileges and to escalate privileges in GCP abusing them (I couldn’t make run the enumerate script).<sup>[[16]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/gcp-basic-information/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-basic-information/README.md
@@ -1,7 +1,5 @@
 # GCP - Basic Information
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## **Resource hierarchy**
 
 Google Cloud uses a [Resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) that is similar, conceptually, to that of a traditional filesystem. This provides a logical parent/child workflow with specific attachment points for policies and permissions. <sup>[[2]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
+++ b/src/pentesting-cloud/gcp-security/gcp-basic-information/gcp-federation-abuse.md
@@ -1,7 +1,5 @@
 # GCP - Federation Abuse
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## OIDC - Github Actions Abuse
 
 ### GCP
@@ -143,6 +141,7 @@ jobs:
   Get_OIDC_ID_token:
     runs-on: ubuntu-latest
     steps:
+      - uses: "actions/checkout@v4"
       - id: "auth"
         name: "Authenticate to GCP"
         uses: "google-github-actions/auth@v2.1.3"
@@ -150,34 +149,18 @@ jobs:
           create_credentials_file: "true"
           workload_identity_provider: "${providerId}" # In the providerId, the numerical project ID (12 digit number) should be used instead of the alphanumeric project ID. ex: projects/123123123123/locations/global/workloadIdentityPools/iam-lab-7-gh-pool/providers/iam-lab-7-gh-pool-oidc-provider'
           service_account: "${saId}" # <sa-name>@<proj-id>.iam.gserviceaccount.com
-          activate_credentials_file: true
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v3"
       - id: "gcloud"
         name: "gcloud"
         run: |-
           gcloud config set project <project-id>
-          gcloud config set account '${saId}'
-          gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
           gcloud auth list
           gcloud projects list
           gcloud secrets list
 ```
 
-### Current workflow adjustments
-
-> [!WARNING]
-> The original workflow above is preserved verbatim, including `activate_credentials_file: true`. For a current workflow, add `actions/checkout@v4` before `auth`; when `create_credentials_file` is enabled, the pinned v2.1.3 action documents checkout as a prerequisite. The action metadata does not declare `activate_credentials_file`, so use the supported `create_credentials_file: true` input instead.<sup>[[6]](#references)[[7]](#references)</sup>
-
-```yaml
-steps:
-  - uses: "actions/checkout@v4"
-  - id: "auth"
-    name: "Authenticate to GCP"
-    uses: "google-github-actions/auth@v2.1.3"
-    with:
-      create_credentials_file: true
-      workload_identity_provider: "${providerId}"
-      service_account: "${saId}"
-```
+The workflow checks out the repository before creating the credentials file, uses only supported `auth` inputs, and configures `gcloud` through the current `setup-gcloud` action.<sup>[[6]](#references)[[7]](#references)[[10]](#references)</sup>
 
 ## References
 
@@ -190,5 +173,6 @@ steps:
 - [7] [google-github-actions/auth action metadata at v2.1.3](https://github.com/google-github-actions/auth/blob/v2.1.3/action.yml)
 - [8] [Create service accounts](https://cloud.google.com/iam/docs/service-accounts-create)
 - [9] [IAM roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/iam)
+- [10] [google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-permissions-for-a-pentest.md
+++ b/src/pentesting-cloud/gcp-security/gcp-permissions-for-a-pentest.md
@@ -1,7 +1,5 @@
 # GCP - Permissions for a Pentest
 
-{{#include ../../banners/hacktricks-training.md}}
-
 If you want to pentest a GCP environment you need to ask for enough permissions to **check all or most of the services** used in **GCP**. Ideally, you should ask the client to create:
 
 * **Create** a new **project**

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-apigee-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-apigee-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Apigee Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Apigee metadata SSRF -> Dataflow cross-tenant pivot
 
 A single Apigee tenant project can be abused to reach the Message Processor metadata server, steal its service account, and pivot into a shared Dataflow analytics pipeline that reads/writes cross-tenant buckets.<sup>[[1]](#references)[[3]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-app-engine-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-app-engine-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - App Engine Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## `App Engine`
 
 For information about App Engine check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Bigtable Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Bigtable
 
 For more information about Bigtable check:
@@ -58,7 +56,7 @@ Use the same tool to upsert arbitrary cells. This is the quickest way to backdoo
 # Inject a new row
 cbt -project=<victim-proj> -instance=<instance-id> set <table> <row-key> <family>:<column>=<value>
 
-cbt -project=<victim-proj> -instance=<instance-id> set <table-id> user#1337 profile:name="Mallory" profile:role="admin" secrets:api_key=@/tmp/stealme.bin
+cbt -project=<victim-proj> -instance=<instance-id> set <table-id> user#1337 profile:name="Mallory" profile:role="admin" secrets:api_key=$'\xDE\xAD\xBE\xEF'
 
 # Verify the injected row
 cbt -project=<victim-proj> -instance=<instance-id> read <table-id> rows=user#1337
@@ -66,14 +64,7 @@ cbt -project=<victim-proj> -instance=<instance-id> read <table-id> rows=user#133
 
 </details>
 
-`cbt set` accepts raw bytes via the `@/path` syntax, so you can push compiled payloads or serialized protobufs exactly as downstream services expect them.<sup>[[2]](#references)</sup>
-
-> [!NOTE]
-> The current `cbt` reference documents Bash byte quoting such as `$'\xDE\xAD'`, but does not document `@/path` as file-loading syntax; verify the installed CLI before relying on that form.<sup>[[2]](#references)</sup>
-
-```bash
-cbt -project=<victim-proj> -instance=<instance-id> set <table-id> user#1337 profile:name="Mallory" profile:role="admin" secrets:api_key=$'\xDE\xAD\xBE\xEF'
-```
+The current `cbt` reference documents Bash byte quoting such as `$'\xDE\xAD'` for raw byte values.<sup>[[2]](#references)</sup>
 
 ### Dump rows to your bucket
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-build-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-build-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Build Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Build
 
 For more information about Cloud Build check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-functions-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-functions-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Functions Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Functions
 
 Find some information about Cloud Functions in:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-run-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-run-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Run Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Run
 
 For more information about Cloud Run check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-shell-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-shell-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Shell Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Shell
 
 For more information about Cloud Shell check:
@@ -14,17 +12,13 @@ For more information about Cloud Shell check:
 
 Just accessing the metadata server you can obtain a token to access as the currently logged on user:
 
-```bash
-wget -q -O - --header "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/"
-```
-
 For current Cloud Shell sessions, Google documents interactive-user authorization separately from metadata-issued VM service-account tokens. To print the active account's access token, use the authenticated `gcloud` path: <sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 gcloud auth print-access-token
 ```
 
-When the metadata service is exposed, it is a separate credential source for the Cloud Shell VM's attached service account. Google documents the service-account token endpoint and scope behavior; the current request header is `Metadata-Flavor: Google`, while the older `X-Google-Metadata-Request` header above is deprecated. <sup>[[1]](#references)[[4]](#references)</sup>
+When the metadata service is exposed, it is a separate credential source for the Cloud Shell VM's attached service account. Google documents the service-account token endpoint and scope behavior, using the `Metadata-Flavor: Google` request header. <sup>[[1]](#references)[[4]](#references)</sup>
 
 To enumerate service-account identities and request the default service-account token with the current header:
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Cloud SQL Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud SQL
 
 For more information about Cloud SQL check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-compute-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-compute-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Compute Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Compute
 
 For more information about Compute and VPC (Networking) check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-dataflow-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-dataflow-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Dataflow Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Dataflow
 
 For more information about Dataflow check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-filestore-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-filestore-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Filestore Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Filestore
 
 For more information about Filestore check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-iam-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-iam-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - IAM Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## IAM <a href="#service-account-impersonation" id="service-account-impersonation"></a>
 
 You can find further information about IAM in:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-kms-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-kms-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - KMS Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## KMS
 
 Find basic information about KMS in:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-logging-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-logging-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Logging Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 For more information check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-monitoring-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-monitoring-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Monitoring Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Monitoring
 
 Fore more information check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-pub-sub-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-pub-sub-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Pub/Sub Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Pub/Sub
 
 For more information about Pub/Sub check the following page:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-secretmanager-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-secretmanager-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Secretmanager Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Secretmanager
 
 For more information about Secret Manager check:
@@ -11,8 +9,6 @@ For more information about Secret Manager check:
 {{#endref}}
 
 ### `secretmanager.versions.access`
-
-This give you access to read the secrets from the secret manager and maybe this could help to escalate privielegs (depending on which information is sotred inside the secret): <sup>[[1]](#references)[[2]](#references)</sup>
 
 The `secretmanager.versions.access` permission allows an identity to read a selected secret version's contents. <sup>[[1]](#references)[[2]](#references)</sup> If the value contains credentials or other privileged material, it may support privilege escalation, depending on what is stored in the secret.
 
@@ -28,8 +24,6 @@ gcloud secrets versions access 1 --secret="<secret_name>"
 </details>
 
 ### `secretmanager.versions.destroy`
-The `secretmanager.versions.destroy` permission allows an identity to permanently destroy (mark as irreversibly deleted) a specific version of a secret in Secret Manager, which could enable the removal of critical credentials and potentially cause denial of service or prevent the recovery of sensitive data. <sup>[[2]](#references)[[3]](#references)</sup>
-
 The `secretmanager.versions.destroy` permission allows an identity to permanently destroy a specific secret version; its contents and metadata become irrecoverable. <sup>[[2]](#references)[[3]](#references)[[7]](#references)</sup> This could remove critical credentials, cause denial of service, or prevent the recovery of sensitive data.
 
 ```bash
@@ -37,8 +31,6 @@ gcloud secrets versions destroy <VERSION> --secret="<SECRET_NAME>" --project=<PR
 ```
 
 ### `secretmanager.versions.disable`
-The `secretmanager.versions.disable` permission allows an identity to disable active secret versions in Secret Manager, temporarily blocking their use by applications or services that depend on them. <sup>[[2]](#references)[[4]](#references)</sup>
-
 The `secretmanager.versions.disable` permission allows an identity to disable an active secret version. A disabled version cannot be accessed and can later be re-enabled. <sup>[[2]](#references)[[4]](#references)</sup> This can temporarily block applications or services that depend on it.
 
 ```bash
@@ -46,8 +38,6 @@ gcloud secrets versions disable <VERSION> --secret="<SECRET_NAME>" --project=<PR
 ```
 
 ### `secretmanager.secrets.delete`
-The `secretmanager.secrets.delete` permission set allows an identity to completely delete a secret and all of its stored versions in Secret Manager. <sup>[[2]](#references)[[5]](#references)</sup>
-
 The `secretmanager.secrets.delete` permission allows an identity to delete a secret and all of its stored versions; the operation is irreversible. <sup>[[2]](#references)[[5]](#references)</sup> This can remove every credential in the secret and disrupt workloads that depend on it.
 
 ```bash
@@ -55,8 +45,6 @@ gcloud secrets delete <SECRET_NAME> --project=<PROJECT_ID>
 ```
 
 ### `secretmanager.secrets.update`
-The `secretmanager.secrets.update` permission allows an identity to modify a secret’s metadata and configuration (for example, rotation settings, version policy, labels, and certain secret properties). <sup>[[2]](#references)[[6]](#references)</sup>
-
 The `secretmanager.secrets.update` permission allows an identity to modify a secret's metadata and configuration, including rotation settings, version-related settings, labels, and other supported secret properties. <sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
@@ -77,4 +65,3 @@ gcloud secrets update SECRET_NAME \
 - [7] [gcloud secrets versions destroy](https://docs.cloud.google.com/sdk/gcloud/reference/secrets/versions/destroy)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-security-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-security-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Security Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Security
 
 For more information check:

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-vertex-ai-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-vertex-ai-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Vertex AI Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Vertex AI Agent Engine / Reasoning Engine
 
 This page focuses on **Vertex AI Agent Engine / Reasoning Engine** workloads that run attacker-controlled tools or code inside a Google-managed runtime.<sup>[[1]](#references)</sup>

--- a/src/pentesting-cloud/kubernetes-security/README.md
+++ b/src/pentesting-cloud/kubernetes-security/README.md
@@ -1,7 +1,5 @@
 # Kubernetes Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Kubernetes Basics
 
 If you don't know anything about Kubernetes this is a **good start**. Read it to learn about the **architecture, components and basic actions** in Kubernetes:

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
@@ -1,7 +1,5 @@
 # Abusing Roles/ClusterRoles in Kubernetes
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 Here you can find some potentially dangerous Roles and ClusterRoles configurations.\
 Remember that you can get all the supported resources with `kubectl api-resources`
 

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/kubernetes-roles-abuse-lab.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/kubernetes-roles-abuse-lab.md
@@ -1,7 +1,5 @@
 # Kubernetes Roles Abuse Lab
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 You can run these labs just inside **minikube**.
 
 ## Pod Creation -> Escalate to ns SAs

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md
@@ -1,7 +1,5 @@
 # Pod Escape Privileges
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Privileged and hostPID
 
 With these privileges you will have **access to the hosts processes** and **enough privileges to enter inside the namespace of one of the host processes**.<sup>[[1]](#references)[[2]](#references)</sup>\

--- a/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
+++ b/src/pentesting-cloud/kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
@@ -1,7 +1,5 @@
 # Attacking Kubernetes from inside a Pod
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## **Pod Breakout**
 
 **If you are lucky enough you may be able to escape from it to the node:**

--- a/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
+++ b/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
@@ -1,7 +1,5 @@
 # Exposing Services in Kubernetes
 
-{{#include ../../banners/hacktricks-training.md}}
-
 There are **different ways to expose services** in Kubernetes so both **internal** endpoints and **external** endpoints can access them.<sup>[[2]](#references)</sup> This Kubernetes configuration is pretty critical as the administrator could give access to **attackers to services they shouldn't be able to access**.
 
 ### Automatic Enumeration

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-basics.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-basics.md
@@ -1,7 +1,5 @@
 # Kubernetes Basics
 
-{{#include ../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Jorge**](https://www.linkedin.com/in/jorge-belmonte-a924b616b/) **(read his original post** [**here**](https://sickrov.github.io)**)**<sup>[[1]](#references)</sup>
 
 ## Architecture & Basics
@@ -254,26 +252,6 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: kubernetes-dashboard
-              servicePort: 80
-```
-
-**Additional current `networking.k8s.io/v1` example:**
-
-On current clusters, the equivalent backend uses an explicit Service name and port, together with `path` and `pathType` fields.<sup>[[18]](#references)</sup>
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: dashboard-ingress
-  namespace: kubernetes-dashboard
-spec:
-  rules:
-    - host: dashboard.com
-      http:
-        paths:
-          - backend:
               service:
                 name: kubernetes-dashboard
                 port:
@@ -281,6 +259,8 @@ spec:
             path: /
             pathType: Prefix
 ```
+
+Current `networking.k8s.io/v1` Ingress backends use an explicit Service name and port together with `path` and `pathType` fields.<sup>[[18]](#references)</sup>
 
 **Example of secrets config file**
 
@@ -555,25 +535,14 @@ cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep etcd
 The manifest may show the certificate, key, and endpoint paths used by the API server to connect to etcd. With authorized access, those values can be used to connect to the etcd endpoint.
 
 ```bash
-#ETCDCTL_API=3 etcdctl --cert <path to client.crt> --key <path to client.ket> --cacert <path to CA.cert> endpoint=[<ip:port>] health
-
-ETCDCTL_API=3 etcdctl --cert /etc/kubernetes/pki/apiserver-etcd-client.crt --key /etc/kubernetes/pki/apiserver-etcd-client.key --cacert /etc/kubernetes/pki/etcd/etcd/ca.cert endpoint=[127.0.0.1:1234] health
+# ETCDCTL_API=3 etcdctl --endpoints=https://<ip:port> --cert=<path/to/client.crt> --key=<path/to/client.key> --cacert=<path/to/CA.crt> endpoint health
+ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key --cacert=/etc/kubernetes/pki/etcd/ca.crt endpoint health
 ```
 
 Once communication is established, an authorized operator can read the Secret key path:
 
 ```bash
-#ETCDCTL_API=3 etcdctl --cert <path to client.crt> --key <path to client.ket> --cacert <path to CA.cert> endpoint=[<ip:port>] get <path/to/secret>
-
-ETCDCTL_API=3 etcdctl --cert /etc/kubernetes/pki/apiserver-etcd-client.crt --key /etc/kubernetes/pki/apiserver-etcd-client.key --cacert /etc/kubernetes/pki/etcd/etcd/ca.cert endpoint=[127.0.0.1:1234] get /registry/secrets/default/secret_02
-```
-
-**Additional current `etcdctl` syntax:**
-
-For recent `etcdctl` builds, the same operations can be run with `--endpoints` and explicit certificate flags.<sup>[[28]](#references)</sup>
-
-```bash
-ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key --cacert=/etc/kubernetes/pki/etcd/ca.crt endpoint health
+# ETCDCTL_API=3 etcdctl --endpoints=https://<ip:port> --cert=<path/to/client.crt> --key=<path/to/client.key> --cacert=<path/to/CA.crt> get <path/to/secret>
 ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key --cacert=/etc/kubernetes/pki/etcd/ca.crt get /registry/secrets/default/secret_02
 ```
 
@@ -599,17 +568,6 @@ resources:
 > The key in this example is illustrative. Generate a strong key, protect the encryption configuration on every control-plane host, and keep a secure backup.<sup>[[28]](#references)</sup>
 
 After that, set the `--encryption-provider-config` flag on the `kube-apiserver` to point to the created configuration file. On a static-Pod control plane, you can modify `/etc/kubernetes/manifests/kube-apiserver.yaml` and add:
-
-```yaml
-containers:
-  - command:
-      - kube-apiserver
-      - --encriyption-provider-config=/etc/kubernetes/etcd/<configFile.yaml>
-```
-
-**Additional current `kube-apiserver` flag example:**
-
-Use the correctly spelled flag when configuring a current cluster.<sup>[[28]](#references)</sup>
 
 ```yaml
 containers:
@@ -677,7 +635,6 @@ kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 **Final tips:**
 
 - Try not to keep Secrets in the filesystem; retrieve them from an external secret store when appropriate.<sup>[[25]](#references)</sup>
-- Check out [https://www.vaultproject.io/](https://www.vaultproject.io) for add more protection to your secrets.<sup>[[29]](#references)</sup>
 - Check out [HashiCorp Vault](https://www.vaultproject.io) for additional protection for your Secrets.<sup>[[29]](#references)</sup>
 - [Kubernetes Secret risks](https://kubernetes.io/docs/concepts/configuration/secret/#risks)<sup>[[27]](#references)</sup>
 - [https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.2/en/Content/Integrations/Kubernetes_deployApplicationsConjur-k8s-Secrets.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.2/en/Content/Integrations/Kubernetes_deployApplicationsConjur-k8s-Secrets.htm)

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
@@ -1,7 +1,5 @@
 # Kubernetes Enumeration
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Kubernetes Tokens
 
 If you have compromised access to a machine the user may have access to some Kubernetes platform. A token or kubeconfig is usually located in a file named by the **env var `KUBECONFIG`** or **inside `~/.kube`**. <sup>[[5]](#references)</sup>
@@ -14,32 +12,26 @@ If you have compromised a pod inside a kubernetes environment, there are other p
 
 Before continuing, if you don't know what is a service in Kubernetes I would suggest you to **follow this link and read at least the information about Kubernetes architecture.**
 
-Taken from the Kubernetes [documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server):
-
-_“When you create a pod, if you do not specify a service account, it is automatically assigned the_ default _service account in the same namespace.”_
-<sup>[[2]](#references)</sup>
+Unless a Pod specifies another ServiceAccount, Kubernetes assigns the namespace's `default` ServiceAccount.<sup>[[2]](#references)</sup>
 
 **ServiceAccount** is an object managed by Kubernetes and used to provide an identity for processes that run in a pod.\
 Pods normally receive a short-lived, rotating ServiceAccount token through a projected volume. Older clusters and explicitly created legacy token Secrets may instead expose a Secret containing a bearer token. This is a JSON Web Token (JWT), a method for representing claims securely between two parties. <sup>[[3]](#references)</sup>
 
-A Pod's projected service-account volume is usually in **one** of the directories:
+A Pod's projected service-account volume is usually in **one** of the directories below and contains `ca.crt`, `namespace`, and `token` files.<sup>[[3]](#references)[[4]](#references)</sup>
 
 - `/run/secrets/kubernetes.io/serviceaccount`
 - `/var/run/secrets/kubernetes.io/serviceaccount`
 - `/secrets/kubernetes.io/serviceaccount`
 
-contain the files:
+The files contain:
 
 - **ca.crt**: It's the ca certificate to check kubernetes communications
 - **namespace**: It indicates the current namespace
 - **token**: It contains the **service token** of the current pod.
-<sup>[[3]](#references)[[4]](#references)</sup>
 
-Now that you have the token, locate the API server using **`KUBERNETES_SERVICE_HOST`** and **`KUBERNETES_SERVICE_PORT_HTTPS`** from inside a Pod, or from a discovered kubeconfig. For more info run `(env | set) | grep -i "kuber|kube"`.
-<sup>[[4]](#references)[[5]](#references)</sup>
+Now that you have the token, locate the API server using **`KUBERNETES_SERVICE_HOST`** and **`KUBERNETES_SERVICE_PORT_HTTPS`** from inside a Pod, or from a discovered kubeconfig. For more info run `(env | set) | grep -i "kuber|kube"`.<sup>[[4]](#references)[[5]](#references)</sup>
 
-The service account token is signed by the key in **sa.key** and validated by **sa.pub**. A common Kubernetes PKI location for these files is:
-<sup>[[6]](#references)</sup>
+The service account token is signed by the key in **sa.key** and validated by **sa.pub**. A common Kubernetes PKI location for these files is:<sup>[[6]](#references)</sup>
 
 Default location on **Kubernetes**:
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-external-secrets-operator.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-external-secrets-operator.md
@@ -1,7 +1,5 @@
 # External Secret Operator
 
-{{#include ../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Fares**](https://www.linkedin.com/in/fares-siala/)
 
 This page gives some pointers onto how you can achieve to steal secrets from a misconfigured ESO or application which uses ESO to sync its secrets into Kubernetes.<sup>[[1]](#references)[[2]](#references)</sup>

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
@@ -1,7 +1,5 @@
 # Kubernetes Hardening
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Tools to analyse a cluster
 
 ### [Steampipe - Kubernetes Compliance](https://github.com/turbot/steampipe-mod-kubernetes-compliance)

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/kubernetes-securitycontext-s.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/kubernetes-securitycontext-s.md
@@ -1,7 +1,5 @@
 # Kubernetes SecurityContext(s)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## PodSecurityContext <a href="#podsecuritycontext-v1-core" id="podsecuritycontext-v1-core"></a>
 
 [**From the docs:**](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core)<sup>[[1]](#references)</sup>

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/README.md
@@ -1,7 +1,5 @@
 # Kubernetes Kyverno
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Definition
@@ -23,41 +21,6 @@ Let's say we have a Kubernetes cluster with multiple namespaces, and we want to 
 **ClusterPolicy**
 
 A ClusterPolicy is a high-level policy that defines the overall policy intent. In this case, our ClusterPolicy might look like this: <sup>[[3]](#references)</sup>
-
-**Original / legacy example (preserved verbatim)**
-
-```yaml
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: require-label
-spec:
-  rules:
-  - validate:
-      message: "Pods in the default namespace must have the label 'app: myapp'"
-      match:
-        any:
-        - resources:
-            kinds:
-              - Pod
-            namespaceSelector:
-              matchLabels:
-                namespace: default
-        - any:
-            - resources:
-                kinds:
-                  - Pod
-                namespaceSelector:
-                  matchLabels:
-                    namespace: default
-                validationFailureAction: enforce
-```
-
-When a pod is created in the `default` namespace without the label `app: myapp`, Kyverno will block the request and return an error message indicating that the pod does not meet the policy requirements. <sup>[[5]](#references)[[6]](#references)</sup>
-
-The block above is retained as the original page example, but its rule nesting is not the current Kyverno schema. Its `namespaceSelector.matchLabels` also selects Namespace labels rather than the Namespace name; use the valid form below when targeting the `default` namespace by name. <sup>[[3]](#references)[[4]](#references)</sup>
-
-**Current corrected ClusterPolicy example**
 
 The current form places `match` alongside `validate`, uses the `namespaces` matcher for the namespace name, and defines the required label under `validate.pattern`. <sup>[[4]](#references)[[5]](#references)</sup>
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/kubernetes-kyverno-bypass.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-kyverno/kubernetes-kyverno-bypass.md
@@ -1,7 +1,5 @@
 # Kubernetes Kyverno bypass
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-namespace-escalation.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-namespace-escalation.md
@@ -1,7 +1,5 @@
 # Kubernetes Namespace Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 In Kubernetes it's pretty common that somehow **you manage to get inside a namespace** (by stealing some user credentials or by compromising a pod). However, usually you will be interested in **escalating to a different namespace as more interesting things can be found there**. Namespaces scope namespaced resources and RBAC bindings determine whether a principal can act in another namespace, so a foothold in one namespace does not imply access to another.<sup>[[1]](#references)[[3]](#references)</sup>
 
 Here are some techniques you can try to escape to a different namespace:

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-network-attacks.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-network-attacks.md
@@ -1,7 +1,5 @@
 # Kubernetes Network Attacks
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Introduction
 
 In Kubernetes, it is observed that a default behavior permits the establishment of connections between **all containers residing on the same node**. This applies irrespective of the namespace distinctions. Such connectivity extends down to **Layer 2** (Ethernet). Consequently, this configuration potentially exposes the system to vulnerabilities. Specifically, it opens up the possibility for a **malicious container** to execute an **ARP spoofing attack** against other containers situated on the same node. During such an attack, the malicious container can deceitfully intercept or modify the network traffic intended for other containers.<sup>[[1]](#references)[[2]](#references)</sup>

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/README.md
@@ -1,21 +1,17 @@
 # Kubernetes - OPA Gatekeeper
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Definition
 
 Open Policy Agent (OPA) Gatekeeper is a tool used to enforce admission policies in Kubernetes. These policies are defined using Rego, a policy language provided by OPA. Below is a basic example of a policy definition using OPA Gatekeeper.<sup>[[1]](#references)[[2]](#references)</sup>
 
-**Original example (retained verbatim; buggy comprehension):**
-
 ```rego
 package k8srequiredlabels
 
 violation[{"msg": msg}] {
     provided := {label | input.review.object.metadata.labels[label]}
-    required := {label | label := input.parameters.labels[label]}
+    required := {label | label := input.parameters.labels[_]}
     missing := required - provided
     count(missing) > 0
     msg := sprintf("Required labels missing: %v", [missing])
@@ -24,34 +20,14 @@ violation[{"msg": msg}] {
 default allow = false
 ```
 
-This Rego policy checks if certain labels are present on Kubernetes resources. If the required labels are missing, it returns a violation message. This policy can be used to ensure that all resources deployed in the cluster have specific labels.<sup>[[3]](#references)</sup>
-
-The original example above is retained verbatim, but its `required` comprehension references `label` before binding it and OPA rejects it for the object-shaped `labels` parameter. The current valid form is shown separately below; it iterates the parameter object's keys, while the values act as truthy flags and are not compared with the resource's label values.<sup>[[4]](#references)</sup>
-
-**Current valid example (corrected `required` comprehension):**
-
-```rego
-package k8srequiredlabels
-
-violation[{"msg": msg}] {
-    provided := {label | input.review.object.metadata.labels[label]}
-    required := {label | input.parameters.labels[label]}
-    missing := required - provided
-    count(missing) > 0
-    msg := sprintf("Required labels missing: %v", [missing])
-}
-
-default allow = false
-```
+This Rego policy compares label keys present on the reviewed Kubernetes resource with the required-label array supplied by the Constraint. If labels are missing, it returns a violation message.<sup>[[3]](#references)</sup>
 
 ## Apply Constraint
 
 To use this policy with OPA Gatekeeper, you would define a **ConstraintTemplate** and a **Constraint** in Kubernetes.<sup>[[3]](#references)</sup>
 
-**Original `ConstraintTemplate` YAML (retained verbatim):**
-
 ```yaml
-apiVersion: templates.gatekeeper.sh/v1beta1
+apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
@@ -60,24 +36,28 @@ spec:
     spec:
       names:
         kind: K8sRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            labels:
+              type: array
+              items:
+                type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8srequiredlabels
         violation[{"msg": msg}] {
             provided := {label | input.review.object.metadata.labels[label]}
-            required := {label | label := input.parameters.labels[label]}
+            required := {label | label := input.parameters.labels[_]}
             missing := required - provided
             count(missing) > 0
             msg := sprintf("Required labels missing: %v", [missing])
         }
 
         default allow = false
-```
-
-The `ConstraintTemplate` YAML above repeats the original buggy expression for comparison; use the current valid policy example above when applying the template.<sup>[[4]](#references)</sup>
-
-```yaml
+---
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
@@ -88,9 +68,7 @@ spec:
       - apiGroups: [""]
         kinds: ["Pod"]
   parameters:
-    labels:
-      requiredLabel1: "true"
-      requiredLabel2: "true"
+    labels: ["requiredLabel1", "requiredLabel2"]
 ```
 
 In this YAML example, we define a **ConstraintTemplate** to require labels. Then, we name this constraint `ensure-pod-has-label`, which references the `k8srequiredlabels` ConstraintTemplate and specifies the required labels.<sup>[[3]](#references)</sup>
@@ -102,7 +80,6 @@ When Gatekeeper is deployed in the Kubernetes cluster, it will enforce this poli
 - [1] [Gatekeeper repository](https://github.com/open-policy-agent/gatekeeper)
 - [2] [Introduction | Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/)
 - [3] [How to use Gatekeeper | Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/)
-- [4] [Policy Language | Open Policy Agent](https://www.openpolicyagent.org/docs/policy-language#variable-keys)
 
 
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/kubernetes-opa-gatekeeper-bypass.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-opa-gatekeeper/kubernetes-opa-gatekeeper-bypass.md
@@ -1,7 +1,5 @@
 # Kubernetes OPA Gatekeeper bypass
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Abusing misconfiguration

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
@@ -1,7 +1,5 @@
 # Kubernetes Pivoting to Clouds
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## GCP
 
 If you are running a k8s cluster inside GCP you will probably want that some application running inside the cluster has some access to GCP. There are 2 common ways of doing that:

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-role-based-access-control-rbac.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-role-based-access-control-rbac.md
@@ -1,7 +1,5 @@
 # Kubernetes Role-Based Access Control(RBAC)
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Role-Based Access Control (RBAC)
 
 Kubernetes has an **authorization module named Role-Based Access Control** ([**RBAC**](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)) that helps to set utilization permissions to the API server.<sup>[[1]](#references)</sup>

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-validatingwebhookconfiguration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-validatingwebhookconfiguration.md
@@ -1,7 +1,5 @@
 # Kubernetes ValidatingWebhookConfiguration
 
-{{#include ../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Definition

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
@@ -1,7 +1,5 @@
 # Pentesting Kubernetes Services
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 Kubernetes uses several **specific network services** that you might find **exposed to the Internet** or in an **internal network once you have compromised one pod**.
 
 ## Finding exposed pods with OSINT

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/kubelet-authentication-and-authorization.md
@@ -1,7 +1,5 @@
 # Kubelet Authentication & Authorization
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Kubelet Authentication <a href="#kubelet-authentication" id="kubelet-authentication"></a>
 
 [**From the docss:**](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)

--- a/src/pentesting-cloud/pentesting-cloud-methodology.md
+++ b/src/pentesting-cloud/pentesting-cloud-methodology.md
@@ -1,7 +1,5 @@
 # Pentesting Cloud Methodology
 
-{{#include ../banners/hacktricks-training.md}}
-
 <figure><img src="../images/CLOUD-logo-letters.svg" alt=""><figcaption></figcaption></figure>
 
 ## Basic Methodology


### PR DESCRIPTION
Corrects the already-merged second reference-audit batch after a full manual re-audit.

- removes duplicated legacy/current prose and command blocks
- consolidates corrected examples instead of retaining invalid originals
- leaves exactly one training banner, after References
- validates numbered references, inline citations, and forbidden-source absence across all 47 pages

Validation: structural/citation audit 47/47; paragraph, heading, and code-block duplicate-delta scans clean; git diff --check clean. mdBook could not run locally because mdbook-tabs is not installed.