### PR TITLE
Fix reference audit issues in pages 1-48

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,16 +1,12 @@
 # HackTricks Cloud
 
-{{#include ./banners/hacktricks-training.md}}
-
-<sup>[[2]](#references)</sup>
-
 <figure><img src="images/cloud.gif" alt=""><figcaption></figcaption></figure>
 
-_Hacktricks logos & motion designed by_ [_@ppieranacho_](https://www.instagram.com/ppieranacho/)_._ <sup>[[1]](#references)[[3]](#references)</sup>
+_Hacktricks logos & motion designed by_ [_@ppieranacho_](https://www.instagram.com/ppieranacho/)_._ <sup>[[1]](#references)</sup>
 
 ### Run HackTricks Cloud Locally
 
-The workflow below follows Git's documented `clone`, `checkout`, and `pull` operations and the repository's published language branches and container setup. <sup>[[3]](#references)[[4]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
+The workflow below follows Git's documented `clone`, `checkout`, and `pull` operations and the repository's published language branches and container setup. <sup>[[2]](#references)[[3]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 # Download latest version of hacktricks cloud
@@ -39,56 +35,55 @@ export HT_LANG="master" # Leave master for English
 docker run -d --rm --platform linux/amd64 -p 3377:3000 --name hacktricks_cloud -v $(pwd)/hacktricks-cloud:/app ghcr.io/hacktricks-wiki/hacktricks-cloud/translator-image bash -c "mkdir -p ~/.ssh && ssh-keyscan -H github.com >> ~/.ssh/known_hosts && cd /app && git checkout $HT_LANG && git pull && MDBOOK_PREPROCESSOR__HACKTRICKS__ENV=dev mdbook serve --hostname 0.0.0.0"
 ```
 
-The container command follows Docker's documented `run` interface and uses mdBook's HTTP preview server; the repository maps the container's port 3000 to local port 3377. <sup>[[5]](#references)[[6]](#references)[[8]](#references)</sup>
+The container command follows Docker's documented `run` interface and uses mdBook's HTTP preview server; the repository maps the container's port 3000 to local port 3377. <sup>[[4]](#references)[[5]](#references)[[7]](#references)</sup>
 
-Your local copy of HackTricks Cloud will be **available at [http://localhost:3377](http://localhost:3377)** after a minute. <sup>[[3]](#references)</sup>
+Your local copy of HackTricks Cloud will be **available at [http://localhost:3377](http://localhost:3377)** after a minute. <sup>[[2]](#references)</sup>
 
-Alternatively, if you have Docker Compose, run this from the repository root: <sup>[[3]](#references)[[7]](#references)</sup>
+Alternatively, if you have Docker Compose, run this from the repository root: <sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 docker compose up
 ```
 
-The bundled `docker-compose.yml` serves your currently checked-out branch at [http://localhost:3377](http://localhost:3377) with live reload. <sup>[[3]](#references)[[7]](#references)[[8]](#references)</sup>
+The bundled `docker-compose.yml` serves your currently checked-out branch at [http://localhost:3377](http://localhost:3377) with live reload. <sup>[[2]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ### **Pentesting CI/CD Methodology**
 
-**In the HackTricks CI/CD Methodology you will find how to pentest infrastructure related to CI/CD activities.** Read the following page for an **introduction:** <sup>[[12]](#references)</sup>
+**In the HackTricks CI/CD Methodology you will find how to pentest infrastructure related to CI/CD activities.** Read the following page for an **introduction:** <sup>[[11]](#references)</sup>
 
 [pentesting-ci-cd-methodology.md](pentesting-ci-cd/pentesting-ci-cd-methodology.md)
 
 ### Pentesting Cloud Methodology
 
-**In the HackTricks Cloud Methodology you will find how to pentest cloud environments.** Read the following page for an **introduction:** <sup>[[13]](#references)</sup>
+**In the HackTricks Cloud Methodology you will find how to pentest cloud environments.** Read the following page for an **introduction:** <sup>[[12]](#references)</sup>
 
 [pentesting-cloud-methodology.md](pentesting-cloud/pentesting-cloud-methodology.md)
 
 ### License & Disclaimer
 
-**Check them in:** <sup>[[14]](#references)</sup>
+**Check them in:** <sup>[[13]](#references)</sup>
 
 [HackTricks Values & FAQ](https://app.gitbook.com/s/-L_2uGJGU7AVNRcqRvEi/welcome/hacktricks-values-and-faq)
 
 ### Github Stats
 
-![HackTricks Cloud Github Stats](https://repobeats.axiom.co/api/embed/1dfdbb0435f74afa9803cd863f01daac17cda336.svg) <sup>[[15]](#references)</sup>
+![HackTricks Cloud Github Stats](https://repobeats.axiom.co/api/embed/1dfdbb0435f74afa9803cd863f01daac17cda336.svg) <sup>[[14]](#references)</sup>
 
 ## References
 
 - [1] [Nacho Piera (@ppieranacho) on Instagram](https://www.instagram.com/ppieranacho/)
-- [2] [HackTricks Cloud training and support banner](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/src/banners/hacktricks-training.md)
-- [3] [HackTricks-wiki/hacktricks-cloud repository](https://github.com/HackTricks-wiki/hacktricks-cloud)
-- [4] [HackTricks Cloud branches](https://github.com/HackTricks-wiki/hacktricks-cloud/branches/all)
-- [5] [HackTricks Cloud docker-compose.yml](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/docker-compose.yml)
-- [6] [Docker container run reference](https://docs.docker.com/reference/cli/docker/container/run/)
-- [7] [Docker Compose up reference](https://docs.docker.com/reference/cli/docker/compose/up/)
-- [8] [mdBook serve command](https://rust-lang.github.io/mdBook/cli/serve.html)
-- [9] [Git clone documentation](https://git-scm.com/docs/git-clone)
-- [10] [Git checkout documentation](https://git-scm.com/docs/git-checkout)
-- [11] [Git pull documentation](https://git-scm.com/docs/git-pull)
-- [12] [HackTricks CI/CD Pentesting Methodology](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/src/pentesting-ci-cd/pentesting-ci-cd-methodology.md)
-- [13] [HackTricks Cloud Pentesting Methodology](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/src/pentesting-cloud/pentesting-cloud-methodology.md)
-- [14] [HackTricks Values & FAQ](https://book.hacktricks.wiki/en/welcome/hacktricks-values-and-faq.html)
-- [15] [Repobeats statistics graphic for HackTricks Cloud](https://repobeats.axiom.co/api/embed/1dfdbb0435f74afa9803cd863f01daac17cda336.svg)
+- [2] [HackTricks-wiki/hacktricks-cloud repository](https://github.com/HackTricks-wiki/hacktricks-cloud)
+- [3] [HackTricks Cloud branches](https://github.com/HackTricks-wiki/hacktricks-cloud/branches/all)
+- [4] [HackTricks Cloud docker-compose.yml](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/docker-compose.yml)
+- [5] [Docker container run reference](https://docs.docker.com/reference/cli/docker/container/run/)
+- [6] [Docker Compose up reference](https://docs.docker.com/reference/cli/docker/compose/up/)
+- [7] [mdBook serve command](https://rust-lang.github.io/mdBook/cli/serve.html)
+- [8] [Git clone documentation](https://git-scm.com/docs/git-clone)
+- [9] [Git checkout documentation](https://git-scm.com/docs/git-checkout)
+- [10] [Git pull documentation](https://git-scm.com/docs/git-pull)
+- [11] [HackTricks CI/CD Pentesting Methodology](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/src/pentesting-ci-cd/pentesting-ci-cd-methodology.md)
+- [12] [HackTricks Cloud Pentesting Methodology](https://github.com/HackTricks-wiki/hacktricks-cloud/blob/master/src/pentesting-cloud/pentesting-cloud-methodology.md)
+- [13] [HackTricks Values & FAQ](https://book.hacktricks.wiki/en/welcome/hacktricks-values-and-faq.html)
+- [14] [Repobeats statistics graphic for HackTricks Cloud](https://repobeats.axiom.co/api/embed/1dfdbb0435f74afa9803cd863f01daac17cda336.svg)
 
 {{#include ./banners/hacktricks-training.md}}

--- a/src/pentesting-ci-cd/ansible-tower-awx-automation-controller-security.md
+++ b/src/pentesting-ci-cd/ansible-tower-awx-automation-controller-security.md
@@ -1,7 +1,5 @@
 # Ansible Tower / AWX / Automation controller Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 **Ansible Tower** or it's opensource version [**AWX**](https://github.com/ansible/awx) is also known as **Ansible’s user interface, dashboard, and REST API**. <sup>[[3]](#references)</sup> With **role-based access control**, job scheduling, and graphical inventory management, you can manage your Ansible infrastructure from a modern UI. Tower’s REST API and command-line interface make it simple to integrate it into current tools and workflows.

--- a/src/pentesting-ci-cd/apache-airflow-security/README.md
+++ b/src/pentesting-ci-cd/apache-airflow-security/README.md
@@ -1,7 +1,5 @@
 # Apache Airflow Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ### Basic Information
 
 [**Apache Airflow**](https://airflow.apache.org) serves as a platform for **orchestrating and scheduling data pipelines or workflows**. The term "orchestration" in the context of data pipelines signifies the process of arranging, coordinating, and managing complex data workflows originating from various sources. The primary purpose of these orchestrated data pipelines is to furnish processed and consumable data sets. These data sets are extensively utilized by a myriad of applications, including but not limited to business intelligence tools, data science and machine learning models, all of which are foundational to the functioning of big data applications.<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/apache-airflow-security/airflow-configuration.md
+++ b/src/pentesting-ci-cd/apache-airflow-security/airflow-configuration.md
@@ -1,7 +1,5 @@
 # Airflow Configuration
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Configuration File
 
 **Apache Airflow** generates a **config file** in all the airflow machines called **`airflow.cfg`** in the home of the airflow user. This config file contains configuration information and **might contain interesting and sensitive information.** <sup>[[10]](#references)</sup>

--- a/src/pentesting-ci-cd/apache-airflow-security/airflow-rbac.md
+++ b/src/pentesting-ci-cd/apache-airflow-security/airflow-rbac.md
@@ -1,7 +1,5 @@
 # Airflow RBAC
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## RBAC
 
 Airflow ships with five default roles: **Admin**, **User**, **Op**, **Viewer**, and **Public**. Only **`Admin`** users can configure or alter role permissions, and the defaults should remain unchanged; create a custom role when a more granular permission set is needed.<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/argocd-security.md
+++ b/src/pentesting-ci-cd/argocd-security.md
@@ -1,7 +1,5 @@
 # Argo CD Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 [Argo CD](https://argo-cd.readthedocs.io/) is a GitOps continuous delivery platform for Kubernetes. It watches Git repositories, renders Kubernetes manifests with tools such as Helm, Kustomize, Jsonnet or config management plugins, and reconciles the live cluster state with the desired state stored in Git.<sup>[[2]](#references)</sup>

--- a/src/pentesting-ci-cd/atlantis-security.md
+++ b/src/pentesting-ci-cd/atlantis-security.md
@@ -1,7 +1,5 @@
 # Atlantis Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ### Basic Information
 
 Atlantis is a pull-request-driven service that runs Terraform commands from comments on a Git host. <sup>[[1]](#references)[[13]](#references)</sup>

--- a/src/pentesting-ci-cd/chef-automate-security/README.md
+++ b/src/pentesting-ci-cd/chef-automate-security/README.md
@@ -1,7 +1,5 @@
 # Chef Automate Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is Chef Automate
 
 Chef Automate is a platform for infrastructure automation, compliance, and application delivery.<sup>[[1]](#references)</sup> It exposes a web UI (often Angular) that talks to backend gRPC services via a gRPC-Gateway, providing REST-like endpoints under paths such as /api/v0/.<sup>[[3]](#references)</sup>

--- a/src/pentesting-ci-cd/chef-automate-security/chef-automate-enumeration-and-attacks.md
+++ b/src/pentesting-ci-cd/chef-automate-security/chef-automate-enumeration-and-attacks.md
@@ -1,7 +1,5 @@
 # Chef Automate Enumeration & Attacks
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Overview
 
 This page collects practical techniques to enumerate and attack Chef Automate instances, with emphasis on:

--- a/src/pentesting-ci-cd/circleci-security.md
+++ b/src/pentesting-ci-cd/circleci-security.md
@@ -1,7 +1,5 @@
 # CircleCI Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ### Basic Information
 
 [**CircleCI**](https://circleci.com/docs/2.0/about-circleci/) is a Continuos Integration platform where you can **define templates** indicating what you want it to do with some code and when to do it. This way you can **automate testing** or **deployments** directly **from your repo master branch** for example.<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/cloudflare-security/README.md
+++ b/src/pentesting-ci-cd/cloudflare-security/README.md
@@ -1,7 +1,5 @@
 # Cloudflare Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 In a Cloudflare account there are some **general settings and services** that can be configured. In this page we are going to **analyze the security related settings of each section:**
 
 <figure><img src="../../images/image (117).png" alt=""><figcaption></figcaption></figure>

--- a/src/pentesting-ci-cd/cloudflare-security/cloudflare-domains.md
+++ b/src/pentesting-ci-cd/cloudflare-security/cloudflare-domains.md
@@ -1,7 +1,5 @@
 # Cloudflare Domains
 
-{{#include ../../banners/hacktricks-training.md}}
-
 In each zone configured in Cloudflare there are **general settings and services** that can be configured. In this page we are going to **analyze the security-related settings of each section:**
 
 <figure><img src="../../images/image (101).png" alt=""><figcaption></figcaption></figure>

--- a/src/pentesting-ci-cd/cloudflare-security/cloudflare-workers-pass-through-proxy-ip-rotation.md
+++ b/src/pentesting-ci-cd/cloudflare-security/cloudflare-workers-pass-through-proxy-ip-rotation.md
@@ -1,7 +1,5 @@
 # Abusing Cloudflare Workers as pass-through proxies (IP rotation, FireProx-style)
 
-{{#include ../../banners/hacktricks-training.md}}
-
 Cloudflare Workers can be deployed as transparent HTTP pass-through proxies where the upstream target URL is supplied by the client. Requests egress from Cloudflare's network so the target observes Cloudflare IPs instead of the client's. This mirrors the well-known FireProx technique on AWS API Gateway, but uses Cloudflare Workers.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ### Key capabilities

--- a/src/pentesting-ci-cd/cloudflare-security/cloudflare-zero-trust-network.md
+++ b/src/pentesting-ci-cd/cloudflare-security/cloudflare-zero-trust-network.md
@@ -1,7 +1,5 @@
 # Cloudflare Zero Trust Network
 
-{{#include ../../banners/hacktricks-training.md}}
-
 In a **Cloudflare Zero Trust Network** account there are some **settings and services** that can be configured. In this page we are going to **analyze the security related settings of each section:**
 
 <figure><img src="../../images/image (206).png" alt=""><figcaption></figcaption></figure>

--- a/src/pentesting-ci-cd/concourse-security/README.md
+++ b/src/pentesting-ci-cd/concourse-security/README.md
@@ -1,7 +1,5 @@
 # Concourse Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 Concourse allows you to **build pipelines** to automatically run tests, actions and build images whenever you need it (time based, when something happens...) <sup>[[1]](#references)[[2]](#references)</sup>

--- a/src/pentesting-ci-cd/concourse-security/concourse-architecture.md
+++ b/src/pentesting-ci-cd/concourse-security/concourse-architecture.md
@@ -1,7 +1,5 @@
 # Concourse Architecture
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Concourse Architecture
 
 

--- a/src/pentesting-ci-cd/concourse-security/concourse-enumeration-and-attacks.md
+++ b/src/pentesting-ci-cd/concourse-security/concourse-enumeration-and-attacks.md
@@ -1,7 +1,5 @@
 # Concourse Enumeration & Attacks
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Concourse Enumeration & Attacks
 
 

--- a/src/pentesting-ci-cd/concourse-security/concourse-lab-creation.md
+++ b/src/pentesting-ci-cd/concourse-security/concourse-lab-creation.md
@@ -1,7 +1,5 @@
 # Concourse Lab Creation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Testing Environment
 
 ### Running Concourse
@@ -11,14 +9,11 @@
 This docker-compose file simplifies the installation to do some tests with Concourse.<sup>[[1]](#references)</sup>
 
 ```bash
-wget https://raw.githubusercontent.com/starkandwayne/concourse-tutorial/master/docker-compose.yml
-docker-compose up -d
+curl -O https://concourse-ci.org/docker-compose.yml
+docker compose up -d
 ```
 
 After startup, open the web UI at `127.0.0.1:8080` to download the `fly` command line for your OS.<sup>[[1]](#references)</sup>
-
-> [!NOTE]
-> The historical tutorial URL in the preserved command may no longer be available; if it fails, use the current Docker Compose file from the official [Concourse Quick Start](https://concourse-ci.org/docs/getting-started/quick-start/).<sup>[[1]](#references)</sup>
 
 #### With Kubernetes (Recommended)
 
@@ -177,5 +172,4 @@ Check a YAML pipeline example that triggers on new commits to master in [https:/
 - [15] [Across Step Modifier - Concourse](https://concourse-ci.org/docs/steps/modifier-and-hooks/across/)
 
 {{#include ../../banners/hacktricks-training.md}}
-
 

--- a/src/pentesting-ci-cd/docker-build-context-abuse.md
+++ b/src/pentesting-ci-cd/docker-build-context-abuse.md
@@ -1,7 +1,5 @@
 # Abusing Docker Build Context in Hosted Builders (Path Traversal, Exfil, and Cloud Pivot)
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## TL;DR
 
 If a CI/CD platform or hosted builder lets contributors specify the Docker build context path and Dockerfile path, you can often set the context to a parent directory (e.g., "..") and make host files part of the build context. Then, an attacker-controlled Dockerfile can COPY and exfiltrate secrets found in the builder user’s home (for example, ~/.docker/config.json). Stolen registry tokens may also work against the provider’s control-plane APIs, enabling org-wide RCE.<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>

--- a/src/pentesting-ci-cd/gitblit-security/README.md
+++ b/src/pentesting-ci-cd/gitblit-security/README.md
@@ -1,7 +1,5 @@
 # Gitblit Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is Gitblit
 
 Gitblit is a self‑hosted Git server written in Java. <sup>[[1]](#references)</sup> It can run as a standalone JAR or in servlet containers and ships an embedded SSH service (Apache MINA SSHD) for Git over SSH. <sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>

--- a/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
+++ b/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
@@ -1,7 +1,5 @@
 # Gitblit Embedded SSH Auth Bypass (CVE-2024-28080)
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Summary
 
 CVE-2024-28080 is an authentication bypass in Gitblit's embedded SSH transport caused by session state being treated as authenticated before a public-key signature is verified. In the vulnerable v1.9.3 implementation, a matching public key populated the SSH client state and the password authenticator accepted any subsequent password without validating it, so an attacker who knows a Gitblit username and one of that account's registered public keys can authenticate without the private key or a valid password.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[9]](#references)</sup>

--- a/src/pentesting-ci-cd/gitea-security/README.md
+++ b/src/pentesting-ci-cd/gitea-security/README.md
@@ -1,7 +1,5 @@
 # Gitea Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is Gitea
 
 **Gitea** is a **self-hosted community managed lightweight code hosting** solution written in Go. <sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/gitea-security/basic-gitea-information.md
+++ b/src/pentesting-ci-cd/gitea-security/basic-gitea-information.md
@@ -1,7 +1,5 @@
 # Basic Gitea Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Structure
 
 The basic Gitea environment structure is to group repos by **organization(s),** each of them may contain **several repositories** and **several teams.** However, note that just like in github users can have repos outside of the organization.<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/github-security/README.md
+++ b/src/pentesting-ci-cd/github-security/README.md
@@ -1,7 +1,5 @@
 # Github Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is Github
 
 (From [here](https://kinsta.com/knowledgebase/what-is-github/)) At a high level, **GitHub is a website and cloud-based service that helps developers store and manage their code, as well as track and control changes to their code**.<sup>[[8]](#references)</sup>

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
@@ -1,7 +1,5 @@
 # Abusing Github Actions
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Tools
 
 The following tools are useful to find Github Action workflows and even find vulnerable ones:

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-cache-poisoning.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-cache-poisoning.md
@@ -1,7 +1,5 @@
 # GH Actions - Cache Poisoning
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Overview
 
 The GitHub Actions cache is shared across workflow runs in a repository, subject to branch and tag scope, rather than isolated per workflow or job. Historically, any workflow run with cache-write access that knew a cache `key` (or `restore-keys`) could populate that entry even if the job only had `permissions: contents: read`, so an attacker who compromised a low-privilege job could poison a cache that a privileged release job later restored.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup> This is how the Ultralytics compromise pivoted from a `pull_request_target` workflow into the PyPI publishing pipeline.<sup>[[1]](#references)[[5]](#references)</sup>

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-context-script-injections.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-context-script-injections.md
@@ -1,7 +1,5 @@
 # Gh Actions - Context Script Injections
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Understanding the risk
 
 GitHub Actions renders expressions ${{ ... }} before the step executes. The rendered value is pasted into the step’s program (for run steps, a shell script). If you interpolate untrusted input directly inside run:, the attacker controls part of the shell program and can execute arbitrary commands.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-npm-supply-chain-abuse.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-npm-supply-chain-abuse.md
@@ -1,7 +1,5 @@
 # GH Actions - npm Supply Chain Abuse
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Overview
 
 After an attacker gets code execution in a GitHub Actions release workflow, maintainer workstation, or package build pipeline, npm publishing becomes a high-impact pivot. The goal is usually to steal publisher identity material, publish malicious versions, and turn downstream installs into more credential-generation nodes.<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/github-security/accessible-deleted-data-in-github.md
+++ b/src/pentesting-ci-cd/github-security/accessible-deleted-data-in-github.md
@@ -1,7 +1,5 @@
 # Accessible Deleted Data in GitHub
 
-{{#include ../../banners/hacktricks-training.md}}
-
 These ways to access data from GitHub that was supposedly deleted were [**reported in this blog post**](https://trufflesecurity.com/blog/anyone-can-access-deleted-and-private-repo-data-github).<sup>[[1]](#references)</sup>
 
 ## Accessing Deleted Fork Data

--- a/src/pentesting-ci-cd/github-security/basic-github-information.md
+++ b/src/pentesting-ci-cd/github-security/basic-github-information.md
@@ -1,7 +1,5 @@
 # Basic Github Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Structure
 
 The basic github environment structure of a big **company** is to own an **enterprise** which owns **several organizations** and each of them may contain **several repositories** and **several teams.**. Smaller companies may just **own one organization and no enterprises**. <sup>[[4]](#references)[[13]](#references)</sup>

--- a/src/pentesting-ci-cd/gogs-security/README.md
+++ b/src/pentesting-ci-cd/gogs-security/README.md
@@ -1,7 +1,5 @@
 # Gogs Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is Gogs
 
 **Gogs** is a **self-hosted lightweight Git service** written in Go. From an attacker point of view, treat it as a **multi-tenant Git hosting platform** where a low-privileged user may still control branch names, pull requests, webhooks, tokens, and repository settings. <sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/jenkins-security/README.md
+++ b/src/pentesting-ci-cd/jenkins-security/README.md
@@ -1,7 +1,5 @@
 # Jenkins Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 Jenkins is a tool that offers a straightforward method for establishing a **continuous integration** or **continuous delivery** (CI/CD) environment for almost **any** combination of **programming languages** and source code repositories using pipelines. Furthermore, it automates various routine development tasks. While Jenkins doesn't eliminate the **need to create scripts for individual steps**, it does provide a faster and more robust way to integrate the entire sequence of build, test, and deployment tools than one can easily construct manually.

--- a/src/pentesting-ci-cd/jenkins-security/basic-jenkins-information.md
+++ b/src/pentesting-ci-cd/jenkins-security/basic-jenkins-information.md
@@ -1,7 +1,5 @@
 # Basic Jenkins Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Access
 
 ### Username + Password

--- a/src/pentesting-ci-cd/jenkins-security/jenkins-arbitrary-file-read-to-rce-via-remember-me.md
+++ b/src/pentesting-ci-cd/jenkins-security/jenkins-arbitrary-file-read-to-rce-via-remember-me.md
@@ -1,7 +1,5 @@
 # Jenkins Arbitrary File Read to RCE via "Remember Me"
 
-{{#include ../../banners/hacktricks-training.md}}
-
 The original page linked the [SecureLayer7 Spring Cloud Skipper post](https://blog.securelayer7.net/spring-cloud-skipper-vulnerability/), but that article covers a different vulnerability; the Jenkins chain summarized here is documented in Conviso's analysis of CVE-2024-43044 and its companion PoC, which use an arbitrary file read to forge an administrator remember-me cookie and reach the Script Console.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 The following is a concise summary of the cookie-forging portion of that exploit chain.<sup>[[6]](#references)</sup>

--- a/src/pentesting-ci-cd/jenkins-security/jenkins-dumping-secrets-from-groovy.md
+++ b/src/pentesting-ci-cd/jenkins-security/jenkins-dumping-secrets-from-groovy.md
@@ -1,7 +1,5 @@
 # Jenkins Dumping Secrets from Groovy
 
-{{#include ../../banners/hacktricks-training.md}}
-
 > [!WARNING]
 > Note that these scripts will only list the secrets inside the `credentials.xml` file, but **build configuration files** might also have **more credentials**.<sup>[[2]](#references)[[3]](#references)</sup>
 

--- a/src/pentesting-ci-cd/jenkins-security/jenkins-rce-creating-modifying-pipeline.md
+++ b/src/pentesting-ci-cd/jenkins-security/jenkins-rce-creating-modifying-pipeline.md
@@ -1,7 +1,5 @@
 # Jenkins RCE Creating/Modifying Pipeline
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Creating a new Pipeline
 
 In "New Item" (accessible in `/view/all/newJob`) select **Pipeline:**<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/jenkins-security/jenkins-rce-creating-modifying-project.md
+++ b/src/pentesting-ci-cd/jenkins-security/jenkins-rce-creating-modifying-project.md
@@ -1,7 +1,5 @@
 # Jenkins RCE Creating/Modifying Project
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Creating a Project
 
 This method is very noisy because you have to create a hole new project (obviously this will only work if you user is allowed to create a new project).<sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/jenkins-security/jenkins-rce-with-groovy-script.md
+++ b/src/pentesting-ci-cd/jenkins-security/jenkins-rce-with-groovy-script.md
@@ -1,7 +1,5 @@
 # Jenkins RCE with Groovy Script
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Jenkins RCE with Groovy Script
 
 The Jenkins Script Console is a web-based Groovy shell controlled by the `Administer` permission and can create subprocesses on the controller or agents. <sup>[[1]](#references)</sup>
@@ -69,8 +67,6 @@ You can automate this process with [**this script**](https://github.com/gquere/p
 You can use MSF to get a reverse shell. Rapid7 documents a Jenkins Script Console module that executes OS commands and currently shows the module path `exploit/multi/http/jenkins/script_console`. <sup>[[5]](#references)</sup>
 
 ```
-msf> use exploit/multi/http/jenkins_script_console
-# Current Rapid7 module path:
 msf> use exploit/multi/http/jenkins/script_console
 ```
 
@@ -86,5 +82,4 @@ msf> use exploit/multi/http/jenkins/script_console
 - [8] [Invoke-Expression (Microsoft.PowerShell.Utility)](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-expression?view=powershell-7.6)
 
 {{#include ../../banners/hacktricks-training.md}}
-
 

--- a/src/pentesting-ci-cd/okta-security/README.md
+++ b/src/pentesting-ci-cd/okta-security/README.md
@@ -1,7 +1,5 @@
 # Okta Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 [Okta, Inc.](https://www.okta.com/) is an identity and access management provider whose cloud services are used to centralize authentication and access to applications, services, and devices.<sup>[[3]](#references)</sup>

--- a/src/pentesting-ci-cd/okta-security/okta-hardening.md
+++ b/src/pentesting-ci-cd/okta-security/okta-hardening.md
@@ -1,7 +1,5 @@
 # Okta Hardening
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Directory
 
 ### People

--- a/src/pentesting-ci-cd/pentesting-ci-cd-methodology.md
+++ b/src/pentesting-ci-cd/pentesting-ci-cd-methodology.md
@@ -1,7 +1,5 @@
 # Pentesting CI/CD Methodology
 
-{{#include ../banners/hacktricks-training.md}}
-
 <figure><img src="../images/CLOUD-logo-letters.svg" alt=""><figcaption></figcaption></figure>
 
 ## VCS

--- a/src/pentesting-ci-cd/serverless.com-security.md
+++ b/src/pentesting-ci-cd/serverless.com-security.md
@@ -1,7 +1,5 @@
 # Serverless.com Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 ### Organization

--- a/src/pentesting-ci-cd/supabase-security.md
+++ b/src/pentesting-ci-cd/supabase-security.md
@@ -1,7 +1,5 @@
 # Supabase Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 As per their [**landing page**](https://supabase.com/): Supabase is an open source Firebase alternative. Start your project with a Postgres database, Authentication, instant APIs, Edge Functions, Realtime subscriptions, Storage, and Vector embeddings. <sup>[[8]](#references)</sup>

--- a/src/pentesting-ci-cd/teamcity-security/README.md
+++ b/src/pentesting-ci-cd/teamcity-security/README.md
@@ -1,7 +1,5 @@
 # TeamCity Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 [TeamCity](https://www.jetbrains.com/teamcity/) is JetBrains' CI/CD server. It can run as **TeamCity Cloud** or as **TeamCity On-Premises**. In real environments the on-premises product is the most interesting target because it is commonly connected to private repositories, deployment credentials, internal networks, and cloud build agents.<sup>[[16]](#references)</sup>

--- a/src/pentesting-ci-cd/terraform-security.md
+++ b/src/pentesting-ci-cd/terraform-security.md
@@ -1,7 +1,5 @@
 # Terraform Security
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 [From the docs:](https://developer.hashicorp.com/terraform/intro)

--- a/src/pentesting-ci-cd/travisci-security/README.md
+++ b/src/pentesting-ci-cd/travisci-security/README.md
@@ -1,7 +1,5 @@
 # TravisCI Security
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## What is TravisCI
 
 **Travis CI** is a **hosted** or on **premises** **continuous integration** service used to build and test software projects hosted on several **different git platform**.

--- a/src/pentesting-ci-cd/travisci-security/basic-travisci-information.md
+++ b/src/pentesting-ci-cd/travisci-security/basic-travisci-information.md
@@ -1,7 +1,5 @@
 # Basic TravisCI Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Access
 
 TravisCI directly integrates with different git platforms such as Github, Bitbucket, Assembla, and Gitlab. It will ask the user to give TravisCI permissions to access the repos he wants to integrate with TravisCI. <sup>[[1]](#references)</sup>

--- a/src/pentesting-ci-cd/vercel-security.md
+++ b/src/pentesting-ci-cd/vercel-security.md
@@ -1,7 +1,5 @@
 # Vercel
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 In Vercel a **Team** is the complete **environment** that belongs a client and a **project** is an **application**.<sup>[[2]](#references)[[3]](#references)</sup>


### PR DESCRIPTION
Corrects the already-merged first reference-audit batch after a full manual re-audit.

- removes duplicated legacy/current examples found during review
- fixes the root README citation numbering and removes an invalid standalone banner citation
- leaves exactly one training banner, after References
- validates numbered references, inline citations, and forbidden-source absence across all 48 pages

Validation: structural/citation audit 48/48; paragraph, heading, and code-block duplicate-delta scans clean; git diff --check clean. mdBook could not run locally because mdbook-tabs is not installed.