### PR TITLE
Ensure references footer on audited pages

### DIFF
--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-artifact-poisoning.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/gh-actions-artifact-poisoning.md
@@ -1,5 +1,6 @@
 # Gh Actions - Artifact Poisoning
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-ci-cd/todo.md
+++ b/src/pentesting-ci-cd/todo.md
@@ -1,7 +1,5 @@
 # TODO
 
-{{#include ../banners/hacktricks-training.md}}
-
 Github PRs are welcome explaining how to (ab)use those platforms from an attacker perspective
 
 - Drone
@@ -13,7 +11,8 @@ Github PRs are welcome explaining how to (ab)use those platforms from an attacke
 - Radicle
 - Any other CI/CD platform...
 
-{{#include ../banners/hacktricks-training.md}}
+## References
 
+{{#include ../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/aws-security/aws-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/README.md
@@ -1,5 +1,6 @@
 # AWS - Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/README.md
@@ -1,5 +1,6 @@
 # AWS - Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/README.md
@@ -1,5 +1,6 @@
 # GCP - Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-api-keys-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-api-keys-persistence.md
@@ -16,5 +16,6 @@ Check how to do this in:
 ../gcp-privilege-escalation/gcp-apikeys-privesc.md
 {{#endref}}
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigquery-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-bigquery-persistence.md
@@ -16,4 +16,6 @@ Grant further access over datasets, tables, rows and columns to compromised user
 ../gcp-privilege-escalation/gcp-bigquery-privesc.md
 {{#endref}}
 
+## References
+
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/README.md
@@ -1,3 +1,5 @@
 # GCP - Post Exploitation
 
+## References
+
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-artifact-registry-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-artifact-registry-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Artifact Registry Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Artifact Registry
 
 For more information about Artifact Registry check:
@@ -18,7 +16,8 @@ The Post Exploitation and Privesc techniques of Artifact Registry were mixed in:
 ../gcp-privilege-escalation/gcp-artifact-registry-privesc.md
 {{#endref}}
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-workflows-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-workflows-post-exploitation.md
@@ -1,7 +1,5 @@
 # GCP - Workflows Post Exploitation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Workflow
 
 Basic information:
@@ -18,7 +16,8 @@ The post exploitation techniques are actually the same ones as the ones shared i
 ../gcp-privilege-escalation/gcp-workflows-privesc.md
 {{#endref}}
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/gcp-security/gcp-services/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/README.md
@@ -1,5 +1,6 @@
 # GCP - Services
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-artifact-registry-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-artifact-registry-unauthenticated-enum.md
@@ -16,6 +16,7 @@ Check the following page:
 ../gcp-persistence/gcp-artifact-registry-persistence.md
 {{#endref}}
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../banners/hacktricks-training.md}}
 


### PR DESCRIPTION
Follow-up audit of the first 350 SUMMARY pages. Adds the required single final References heading to 12 source-free/index pages and removes three duplicate top training banners.

Validation: all positions 1-350 now have exactly one References heading, exactly one training banner, and the banner is the final nonblank line; git diff --check passes.