### PR TITLE
Audit legacy reference attribution across cloud pages

### DIFF
--- a/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
+++ b/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-CVE-2024-28080 is an authentication bypass in Gitblit's embedded SSH transport caused by session state being treated as authenticated before a public-key signature is verified. In the vulnerable v1.9.3 implementation, a matching public key populated the SSH client state and the password authenticator accepted any subsequent password without validating it, so an attacker who knows a Gitblit username and one of that account's registered public keys can authenticate without the private key or a valid password.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[9]](#references)</sup>
+CVE-2024-28080 is an authentication bypass in Gitblit's embedded SSH transport caused by session state being treated as authenticated before a public-key signature is verified. In the vulnerable v1.9.3 implementation, a matching public key populated the SSH client state and the password authenticator accepted any subsequent password without validating it, so an attacker who knows a Gitblit username and one of that account's registered public keys can authenticate without the private key or a valid password.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[9]](#references)</sup>
 
 - Affected: Gitblit < 1.10.0 (observed on 1.9.3).<sup>[[2]](#references)[[6]](#references)[[7]](#references)</sup>
 - Fixed: 1.10.0.<sup>[[2]](#references)[[8]](#references)</sup>
@@ -13,6 +13,8 @@ CVE-2024-28080 is an authentication bypass in Gitblit's embedded SSH transport c
   - Password authentication is available as a fallback method on the target.<sup>[[7]](#references)[[12]](#references)</sup>
 
 ## Root cause (state leaks between SSH methods)
+
+Gitblit's embedded SSH service uses Apache MINA SSHD, a Java library that implements SSH client and server protocol support.<sup>[[1]](#references)[[3]](#references)</sup>
 
 RFC 4252 defines a public-key probe without a signature (`boolean FALSE`) that lets the server answer `SSH_MSG_USERAUTH_PK_OK`; a subsequent request carries the signature, which the server must validate. MINA SSHD 1.7.0 follows that separation: it calls the `PublickeyAuthenticator`, sends the public-key response, and leaves authentication in progress when no signature is present, then verifies the signature on the signed request.<sup>[[4]](#references)[[5]](#references)[[9]](#references)</sup>
 

--- a/src/pentesting-ci-cd/github-security/README.md
+++ b/src/pentesting-ci-cd/github-security/README.md
@@ -287,12 +287,12 @@ abusing-github-actions/
 
 Some GitHub Apps and PR review services execute external linters or SAST against pull requests using repository-controlled configuration files. If a supported tool allows dynamic code loading, a PR can achieve code execution on the service’s runner; this pattern was demonstrated against CodeRabbit using RuboCop configuration.<sup>[[3]](#references)</sup>
 
-Example: RuboCop supports loading plugins or extensions from its YAML configuration. If the service passes through a repository-provided `.rubocop.yml`, requiring a local file can execute arbitrary Ruby in the runner context.<sup>[[3]](#references)[[41]](#references)</sup>
+Example: RuboCop supports loading plugins or extensions from its YAML configuration. If the service passes through a repository-provided `.rubocop.yml`, requiring a local file can execute arbitrary Ruby in the runner context.<sup>[[3]](#references)[[4]](#references)[[41]](#references)</sup>
 
 - Trigger conditions usually include:<sup>[[3]](#references)[[41]](#references)</sup>
   - The tool is enabled in the service.<sup>[[3]](#references)</sup>
   - The PR contains files the tool recognizes (for RuboCop: `.rb`).<sup>[[3]](#references)</sup>
-  - The repository contains the tool’s configuration file (for RuboCop, `.rubocop.yml` can load a local plugin or extension).<sup>[[3]](#references)[[41]](#references)</sup>
+  - The repository contains the tool’s configuration file (for RuboCop, `.rubocop.yml` can load a local plugin or extension).<sup>[[3]](#references)[[4]](#references)[[41]](#references)</sup>
 
 Exploit files in the PR (as demonstrated by the research):<sup>[[3]](#references)</sup>
 

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
@@ -9,6 +9,8 @@ The following tools are useful to find Github Action workflows and even find vul
 - [https://github.com/AdnaneKhan/Gato-X](https://github.com/AdnaneKhan/Gato-X)
 - [https://github.com/carlospolop/PurplePanda](https://github.com/carlospolop/PurplePanda)
 - [https://github.com/zizmorcore/zizmor](https://github.com/zizmorcore/zizmor) - Check also its checklist in [https://docs.zizmor.sh/audits](https://docs.zizmor.sh/audits)
+- [AikidoSec/opengrep-rules](https://github.com/AikidoSec/opengrep-rules) includes OpenGrep rules released by Aikido's research team, including checks associated with PromptPwnd findings.<sup>[[5]](#references)</sup>
+- [OpenGrep Playground](https://github.com/opengrep/opengrep-playground/releases) provides downloadable playground releases for testing OpenGrep rules locally.<sup>[[6]](#references)</sup>
 
 ## Basic Information
 
@@ -33,6 +35,8 @@ If you can **execute arbitrary code in GitHub Actions** within a **repository**,
   - If the pipeline deploys or stores assets, you could alter the final product, enabling a supply chain attack.<sup>[[19]](#references)[[23]](#references)</sup>
 - **Execute code in custom workers** to abuse computing power and pivot to other systems.<sup>[[20]](#references)</sup>
 - **Overwrite repository code**, depending on the permissions associated with the `GITHUB_TOKEN`.<sup>[[13]](#references)[[20]](#references)</sup>
+
+Public incident surveys and the TeamPCP campaign show how a compromised workflow or publisher identity can propagate into malicious package releases, mutable Action tags, and downstream credential theft.<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ## GITHUB_TOKEN
 

--- a/src/pentesting-ci-cd/github-security/basic-github-information.md
+++ b/src/pentesting-ci-cd/github-security/basic-github-information.md
@@ -14,8 +14,8 @@ And finally **repositories may have special protection mechanisms**.<sup>[[37]](
 
 ### Enterprise Roles
 
-- **Enterprise owner**: People with this role can **manage administrators, manage organizations within the enterprise, manage enterprise settings, enforce policy across organizations**. However, they **cannot access organization settings or content** unless they are made an organization owner or given direct access to an organization-owned repository.<sup>[[13]](#references)</sup>
-- **Enterprise members**: Members of organizations owned by your enterprise are also **automatically members of the enterprise**.<sup>[[13]](#references)</sup>
+- **Enterprise owner**: People with this role can **manage administrators, manage organizations within the enterprise, manage enterprise settings, enforce policy across organizations**. However, they **cannot access organization settings or content** unless they are made an organization owner or given direct access to an organization-owned repository.<sup>[[2]](#references)[[13]](#references)</sup>
+- **Enterprise members**: Members of organizations owned by your enterprise are also **automatically members of the enterprise**.<sup>[[2]](#references)[[13]](#references)</sup>
 
 ### Organization Roles
 
@@ -174,7 +174,7 @@ steps:
 
 > Once configured in the repo or the organizations **users of github won't be able to access them again**, they just will be able to **change them**.<sup>[[30]](#references)</sup>
 
-Therefore, an attacker who can execute code on the machine running the Github Action can steal the secrets available to that job; this is not the only possible leak path, because logs or downstream tools can also disclose values.<sup>[[33]](#references)[[34]](#references)</sup>
+Therefore, an attacker who can execute code on the machine running the Github Action can steal the secrets available to that job; this is not the only possible leak path, because logs or downstream tools can also disclose values.<sup>[[8]](#references)[[33]](#references)[[34]](#references)</sup>
 
 ### Git Environments
 

--- a/src/pentesting-ci-cd/jenkins-security/README.md
+++ b/src/pentesting-ci-cd/jenkins-security/README.md
@@ -16,7 +16,7 @@ To search for interesting Jenkins pages without authentication, including `/peop
 msf> use auxiliary/scanner/http/jenkins_enum
 ```
 
-Check if you can execute commands without needing authentication:
+Check if you can execute commands without needing authentication:<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```
 msf> use auxiliary/scanner/http/jenkins_command
@@ -52,7 +52,7 @@ If **SSO** **functionality**/**plugins** are present, attempt to **log in** to t
 
 ### Bruteforce
 
-Do not assume a Jenkins deployment has a **password policy** or **username brute-force mitigation**: check the configured security realm and surrounding controls before testing. In an authorized assessment, weak passwords, usernames used as passwords, and reversed usernames may be worth testing.
+Do not assume a Jenkins deployment has a **password policy** or **username brute-force mitigation**: check the configured security realm and surrounding controls before testing. In an authorized assessment, weak passwords, usernames used as passwords, and reversed usernames may be worth testing.<sup>[[6]](#references)</sup>
 
 ```
 msf> use auxiliary/scanner/http/jenkins_login
@@ -75,7 +75,7 @@ Check the [repository webhook abuse research](https://www.paloaltonetworks.com/b
 In these scenarios we are going to suppose you have a valid account to access Jenkins.
 
 > [!WARNING]
-> Depending on the **Authorization** mechanism configured in Jenkins and the permission of the compromised user you **might be able or not to perform the following attacks.**
+> Depending on the **Authorization** mechanism configured in Jenkins and the permission of the compromised user you **might be able or not to perform the following attacks.**<sup>[[5]](#references)</sup>
 
 For more information check the basic information:
 
@@ -141,7 +141,7 @@ jenkins-rce-creating-modifying-project.md
 
 ### **RCE Execute Groovy script**
 
-You can also obtain RCE executing a Groovy script, which might my stealthier than creating a new project:
+You can also obtain RCE executing a Groovy script, which might my stealthier than creating a new project:<sup>[[2]](#references)[[6]](#references)</sup>
 
 {{#ref}}
 jenkins-rce-with-groovy-script.md
@@ -167,7 +167,7 @@ To exploit pipelines you still need to have access to Jenkins.
 
 It's also possible to **store pipeline configuration files in other places** (in other repositories for example) with the goal of **separating** the repository **access** and the pipeline access.
 
-If an attacker has **write access over that file**, they may be able to **modify** it and **potentially trigger** the pipeline without even having access to Jenkins.\
+If an attacker has **write access over that file**, they may be able to **modify** it and **potentially trigger** the pipeline without even having access to Jenkins.<sup>[[5]](#references)</sup>\
 It's possible that the attacker will need to **bypass some branch protections** (depending on the platform and the user privileges they could be bypassed or not).
 
 The most common SCM-driven ways to execute a custom pipeline are:<sup>[[14]](#references)</sup>

--- a/src/pentesting-ci-cd/supabase-security.md
+++ b/src/pentesting-ci-cd/supabase-security.md
@@ -152,7 +152,7 @@ Using a Postgres VIEW to “hide” sensitive columns and exposing it via PostgR
 - Row Level Security (RLS) applies on base tables. Table owners bypass RLS unless `FORCE ROW LEVEL SECURITY` is set on the table.<sup>[[4]](#references)</sup>
 - Updatable views can accept INSERT/UPDATE/DELETE that are then applied to the base table. Without `WITH CHECK OPTION`, writes that don’t match the view predicate may still succeed.<sup>[[5]](#references)</sup>
 
-Risk pattern observed in the wild:
+Risk pattern observed in the wild:<sup>[[1]](#references)[[2]](#references)</sup>
 - A reduced-column view is exposed through Supabase REST and granted to `anon`/`authenticated`.
 - PostgREST allows DML on the updatable view and the operation is evaluated with the view owner’s privileges, effectively bypassing the intended RLS policies on the base table.<sup>[[5]](#references)</sup>
 - Result: low-privileged clients can mass-edit rows (e.g., profile bios/avatars) they should not be able to modify.<sup>[[3]](#references)[[5]](#references)</sup>
@@ -183,7 +183,7 @@ Detection tip:
 
 ### OpenAPI-driven CRUD probing from anon/auth roles
 
-PostgREST exposes an OpenAPI document that you can use to enumerate all REST resources, then automatically probe allowed operations from low-privileged roles.<sup>[[25]](#references)</sup>
+PostgREST exposes an OpenAPI document that you can use to enumerate all REST resources, then automatically probe allowed operations from low-privileged roles.<sup>[[6]](#references)[[25]](#references)</sup>
 
 Fetch the OpenAPI (works with the public anon key):<sup>[[25]](#references)</sup>
 

--- a/src/pentesting-ci-cd/terraform-security.md
+++ b/src/pentesting-ci-cd/terraform-security.md
@@ -36,7 +36,7 @@ However, terraform is a **very sensitive component** to compromise because it wi
 
 The main way for an attacker to be able to compromise the system where terraform is running is to **compromise the repository that stores terraform configurations**, because at some point they are going to be **interpreted**.
 
-Actually, there are solutions out there that **execute terraform plan/apply automatically after a PR** is created, such as **Atlantis**:<sup>[[1]](#references)</sup>
+Actually, there are solutions out there that **execute terraform plan/apply automatically after a PR** is created, such as **Atlantis**. A speculative plan still loads providers and data sources, so an automation platform that evaluates attacker-controlled HCL can execute code and expose its injected cloud credentials even when no apply is authorized:<sup>[[1]](#references)[[13]](#references)</sup>
 
 {{#ref}}
 atlantis-security.md
@@ -429,20 +429,6 @@ Find security vulnerabilities, compliance issues, and infrastructure misconfigur
 
 ```bash
 docker run -t -v $(pwd):/path checkmarx/kics:latest scan -p /path -o "/path/"
-```
-
-### [Terrascan](https://github.com/tenable/terrascan)
-
-From the [**docs**](https://github.com/tenable/terrascan): Terrascan is a static code analyzer for Infrastructure as Code. Terrascan allows you to:<sup>[[37]](#references)</sup>
-
-- Seamlessly scan infrastructure as code for misconfigurations.
-- Monitor provisioned cloud infrastructure for configuration changes that introduce posture drift, and enables reverting to a secure posture.
-- Detect security vulnerabilities and compliance violations.
-- Mitigate risks before provisioning cloud native infrastructure.
-- Offers flexibility to run locally or integrate with your CI\CD.<sup>[[37]](#references)</sup>
-
-```bash
-brew install terrascan
 ```
 
 ## References

--- a/src/pentesting-cloud/aws-security/aws-basic-information/README.md
+++ b/src/pentesting-cloud/aws-security/aws-basic-information/README.md
@@ -69,7 +69,7 @@ Find **JSON examples** in [the AWS Organizations SCP documentation](https://docs
 
 ### Resource Control Policy (RCP)
 
-A **resource control policy (RCP)** is a policy that defines the **maximum permissions for resources within your AWS organization**. RCPs are similar to IAM policies in syntax but **don't grant permissions**—they only cap the permissions that can be applied to resources by other policies. When you attach an RCP to your organization root, an organizational unit (OU), or an account, the RCP limits resource permissions across supported resources in the affected member accounts.<sup>[[6]](#references)</sup>
+A **resource control policy (RCP)** is a policy that defines the **maximum permissions for resources within your AWS organization**. RCPs are similar to IAM policies in syntax but **don't grant permissions**—they only cap the permissions that can be applied to resources by other policies. When you attach an RCP to your organization root, an organizational unit (OU), or an account, the RCP limits resource permissions across supported resources in the affected member accounts.<sup>[[4]](#references)[[6]](#references)</sup>
 
 RCPs provide a centralized maximum for supported resources, even if an identity-based or resource-based policy is too permissive. They do not grant access by themselves, do not apply to resources in the management account, and can be changed by administrators who control the organization's policies.<sup>[[6]](#references)</sup>
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-lambda-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-lambda-enum.md
@@ -37,7 +37,7 @@ To preserve and share data, **Lambda functions can mount Amazon EFS** at a local
 
 ### Lambda Layers
 
-A Lambda _layer_ is a .zip file archive that **can contain additional code** or other content. A layer can contain libraries, a [custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html), data, or configuration files.<sup>[[1]](#references)[[18]](#references)</sup>
+A Lambda _layer_ is a .zip file archive that **can contain additional code** or other content. A layer can contain libraries, a [custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html), data, or configuration files.<sup>[[1]](#references)[[18]](#references)[[21]](#references)</sup>
 
 It's possible to include up to **five layers per function**. When you include a layer in a function, the **contents are extracted to the `/opt`** directory in the execution environment.<sup>[[1]](#references)[[11]](#references)</sup>
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
@@ -140,7 +140,7 @@ A log group has many streams, and a stream is a sequence of events from the same
 
 ## Enumeration
 
-The following commands enumerate CloudWatch dashboards, metrics, alarms, anomaly detectors, Contributor Insights rules, tags, metric streams, CloudWatch Logs, and EventBridge resources. The CloudWatch action names map to the API operations and IAM permissions in the service authorization reference.<sup>[[2]](#references)</sup>
+The following commands enumerate CloudWatch dashboards, metrics, alarms, anomaly detectors, Contributor Insights rules, tags, metric streams, CloudWatch Logs, and EventBridge resources. The CloudWatch action names map to the API operations and IAM permissions in the service authorization reference.<sup>[[2]](#references)[[31]](#references)</sup>
 
 ```bash
 # Dashboards #

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
@@ -4,7 +4,7 @@
 
 **Amazon Detective** streamlines the security investigation process, making it more efficient to **analyze, investigate, and pinpoint the root cause** of security issues or unusual activities. It automates the collection of log data from AWS resources and employs **machine learning, statistical analysis, and graph theory** to construct an interconnected data set. This setup greatly enhances the speed and effectiveness of security investigations.<sup>[[1]](#references)[[3]](#references)</sup>
 
-The service eases in-depth exploration of security incidents, allowing security teams to swiftly understand and address the underlying causes of issues. Amazon Detective analyzes vast amounts of data from sources like VPC Flow Logs, AWS CloudTrail, and Amazon GuardDuty. It automatically generates a **comprehensive, interactive view of resources, users, and their interactions over time**. This integrated perspective provides all necessary details and context in one location, enabling teams to discern the reasons behind security findings, examine pertinent historical activities, and rapidly determine the root cause.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
+The service eases in-depth exploration of security incidents, allowing security teams to swiftly understand and address the underlying causes of issues. Amazon Detective analyzes vast amounts of data from sources like VPC Flow Logs, AWS CloudTrail, and Amazon GuardDuty. It automatically generates a **comprehensive, interactive view of resources, users, and their interactions over time**. This integrated perspective provides all necessary details and context in one location, enabling teams to discern the reasons behind security findings, examine pertinent historical activities, and rapidly determine the root cause.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ## References
 
@@ -12,7 +12,6 @@ The service eases in-depth exploration of security incidents, allowing security 
 - [2] [Vulnerability Related - CloudSecDocs](https://cloudsecdocs.com/aws/services/security/vuln/)
 - [3] [Amazon Detective features - AWS](https://aws.amazon.com/detective/features/)
 - [4] [What is Amazon Detective? - AWS](https://docs.aws.amazon.com/detective/latest/userguide/what-is-detective.html)
-- [5] [Amazon Detective - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#detective)
+- [5] [Amazon Detective - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#detective)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
@@ -76,7 +76,7 @@ It is important to highlight that **only one account within an organization can 
 
 ## Enumeration
 
-The commands below correspond to the AWS CLI Firewall Manager operations and their IAM actions. The access notes reflect the current AWS managed `ReadOnlyAccess` permissions; several administrative and resource-set operations require additional permissions.<sup>[[2]](#references)[[15]](#references)[[25]](#references)</sup>
+The commands below correspond to the AWS CLI Firewall Manager operations and their IAM actions. The access notes reflect the current AWS managed `ReadOnlyAccess` permissions; several administrative and resource-set operations require additional permissions.<sup>[[2]](#references)[[15]](#references)[[25]](#references)[[31]](#references)</sup>
 
 For resource discovery, use `list-discovered-resources` with the member-account and resource-type parameters; `list-compliance-status` is reserved for policy compliance summaries.<sup>[[2]](#references)[[24]](#references)</sup>
 

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
@@ -81,7 +81,7 @@ Amazon Inspector CIS scans benchmark Amazon EC2 instance operating systems again
 
 ### Enumeration
 
-The following AWS CLI commands enumerate Inspector2 account state, findings, CIS scans, configuration, coverage, and legacy Inspector resources.<sup>[[2]](#references)[[15]](#references)[[16]](#references)</sup>
+The following AWS CLI commands enumerate Inspector2 account state, findings, CIS scans, configuration, coverage, and legacy Inspector resources.<sup>[[2]](#references)[[15]](#references)[[16]](#references)[[21]](#references)</sup>
 
 ```bash
 # Administrator and member accounts #

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
@@ -4,7 +4,7 @@
 
 **Security Hub** collects security **data** from **across AWS accounts**, services, and supported third-party partner products and helps you **analyze your security** trends and identify the highest priority security issues.<sup>[[1]](#references)</sup>
 
-It **centralizes security-related findings across accounts**, and provides a UI for viewing these. Security Hub is regional by default: it receives and processes findings in the Region where it is enabled. Cross-Region aggregation can optionally replicate findings and other security data from linked Regions to a configured home Region.<sup>[[1]](#references)[[2]](#references)</sup>
+It **centralizes security-related findings across accounts**, and provides a UI for viewing these. Security Hub is regional by default: it receives and processes findings in the Region where it is enabled. Cross-Region aggregation can optionally replicate findings and other security data from linked Regions to a configured home Region.<sup>[[1]](#references)[[2]](#references)[[9]](#references)</sup>
 
 **Characteristics**
 
@@ -72,6 +72,6 @@ TODO, PRs accepted
 - [6] [list-organization-admin-accounts — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/list-organization-admin-accounts.html)
 - [7] [list-automation-rules — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/list-automation-rules.html)
 - [8] [get-members — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/securityhub/get-members.html)
-- [9] [AWS Security Hub - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#general-info)
+- [9] [AWS Security Hub - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#security-hub)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
@@ -2,7 +2,7 @@
 
 ## AWS Trusted Advisor Overview
 
-Trusted Advisor inspects your AWS environment and provides recommendations based on AWS best practices to help save money, improve availability and performance, and close security gaps.<sup>[[1]](#references)</sup> Trusted Advisor organizes its checks into six categories: cost optimization, performance, security, fault tolerance, service limits, and operational excellence.<sup>[[2]](#references)</sup> Trusted Advisor can report findings for resources in multiple AWS Regions, with the affected Region included in many check reports.<sup>[[4]](#references)</sup>
+Trusted Advisor inspects your AWS environment and provides recommendations based on AWS best practices to help save money, improve availability and performance, and close security gaps.<sup>[[1]](#references)[[6]](#references)</sup> Trusted Advisor organizes its checks into six categories: cost optimization, performance, security, fault tolerance, service limits, and operational excellence.<sup>[[2]](#references)</sup> Trusted Advisor can report findings for resources in multiple AWS Regions, with the affected Region included in many check reports.<sup>[[4]](#references)</sup>
 
 The categories cover the following kinds of recommendations.<sup>[[3]](#references)</sup>
 
@@ -73,6 +73,6 @@ AWS Trusted Advisor is therefore useful for enumerating account-level recommenda
 - [3] [Get started with Trusted Advisor Recommendations - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/get-started-with-aws-trusted-advisor.html)
 - [4] [Security checks - AWS Support](https://docs.aws.amazon.com/awssupport/latest/user/security-checks.html)
 - [5] [RefreshTrustedAdvisorCheck - AWS Support](https://docs.aws.amazon.com/awssupport/latest/APIReference/API_RefreshTrustedAdvisorCheck.html)
-- [6] [AWS Trusted Advisor - CloudSecDocs](https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor)
+- [6] [AWS Trusted Advisor - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
@@ -2,7 +2,7 @@
 
 ## AWS WAF
 
-AWS WAF is a **web application firewall** that monitors HTTP and HTTPS requests forwarded to protected resources and lets you control access with rules that can address common threats such as SQL injection and cross-site scripting.<sup>[[2]](#references)</sup>
+AWS WAF is a **web application firewall** that monitors HTTP and HTTPS requests forwarded to protected resources and lets you control access with rules that can address common threats such as SQL injection and cross-site scripting.<sup>[[2]](#references)[[18]](#references)</sup>
 
 ### Key concepts
 
@@ -99,7 +99,7 @@ In order to interact with regional services, you should specify the region:
 
 - Example with the Europe (Spain) Region: `--scope REGIONAL --region=eu-south-2`<sup>[[3]](#references)</sup>
 
-The following AWS CLI commands cover common AWS WAFv2 enumeration operations. For resource-specific dependent permissions, consult the AWS WAFv2 Service Authorization Reference.<sup>[[1]](#references)[[10]](#references)</sup>
+The following AWS CLI commands cover common AWS WAFv2 enumeration operations. For resource-specific dependent permissions, consult the AWS WAFv2 Service Authorization Reference.<sup>[[1]](#references)[[10]](#references)[[19]](#references)</sup>
 
 ```bash
 # Web ACLs #
@@ -478,7 +478,7 @@ aws wafv2 untag-resource --resource-arn <value> --tag-keys <value>
 - [15] [Sharing a rule group](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-group-sharing.html)
 - [16] [DeleteWebACL - AWS WAFV2](https://docs.aws.amazon.com/waf/latest/APIReference/API_DeleteWebACL.html)
 - [17] [Restrict the geographic distribution of your content](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/georestrictions.html)
-- [18] [AWS Web Application Firewall (WAF) - Citrus Consulting](https://www.citrusconsulting.com/aws-web-application-firewall-waf/)
+- [18] [AWS Web Application Firewall (WAF) - Citrus Consulting (archived)](https://web.archive.org/web/20230927075619/https://www.citrusconsulting.com/aws-web-application-firewall-waf/)
 - [19] [Actions, resources, and condition keys for AWS WAF V2 - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-accounts-unauthenticated-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-accounts-unauthenticated-enum/README.md
@@ -6,7 +6,7 @@ An AWS account ID is a 12-digit identifier, and an account alias can be used in 
 
 ### Brute-Force
 
-Create a list of candidate account IDs and aliases and check them using the account-specific sign-in hostname documented by AWS:<sup>[[2]](#references)</sup>
+Create a list of candidate account IDs and aliases and check them using the account-specific sign-in hostname documented by AWS:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 # Check a candidate account ID

--- a/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-iam-and-sts-unauthenticated-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-iam-and-sts-unauthenticated-enum/README.md
@@ -31,7 +31,7 @@ The original [script to enumerate potential principals](https://github.com/Rhino
 
 ### Trust Policies: Brute-Force Cross Account roles and users
 
-Configuring or updating an **IAM role's trust policy involves defining which AWS resources or services are permitted to assume that role** and obtain temporary credentials. If the specified resource in the policy **exists**, the trust policy saves **successfully**. However, if the resource **does not exist**, an **error is generated**, indicating that an invalid principal was provided.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
+Configuring or updating an **IAM role's trust policy involves defining which AWS resources or services are permitted to assume that role** and obtain temporary credentials. If the specified resource in the policy **exists**, the trust policy saves **successfully**. However, if the resource **does not exist**, an **error is generated**, indicating that an invalid principal was provided.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 > [!WARNING]
 > Note that in that resource you could specify a cross account role or user:<sup>[[4]](#references)</sup>

--- a/src/pentesting-cloud/azure-security/az-basic-information/README.md
+++ b/src/pentesting-cloud/azure-security/az-basic-information/README.md
@@ -9,7 +9,7 @@
 - It can contain **other management groups or subscriptions**.<sup>[[1]](#references)</sup>
 - This allows to **apply governance controls** such as RBAC and Azure Policy once at the management group level and have them **inherited** by all the subscriptions in the group.<sup>[[1]](#references)</sup>
 - **10,000 management** groups can be supported in a single directory.<sup>[[1]](#references)</sup>
-- A management group tree can support **up to six levels of depth**. This limit doesn’t include the root level or the subscription level.<sup>[[1]](#references)</sup>
+- A management group tree can support **up to six levels of depth**. This limit doesn’t include the root level or the subscription level.<sup>[[1]](#references)[[2]](#references)</sup>
 - Each management group and subscription can support **only one parent**.<sup>[[1]](#references)</sup>
 - Even if several management groups can be created **there is only 1 root management group**.<sup>[[1]](#references)</sup>
   - The root management group **contains** all the **other management groups and subscriptions** and **cannot be moved or deleted**.<sup>[[1]](#references)</sup>
@@ -19,7 +19,7 @@
 
 ### Azure Subscriptions
 
-- It’s another **logical container where resources** (VMs, DBs…) can be run and will be billed.<sup>[[6]](#references)[[42]](#references)</sup>
+- It’s another **logical container where resources** (VMs, DBs…) can be run and will be billed.<sup>[[3]](#references)[[6]](#references)[[42]](#references)</sup>
 - Its **parent** is always a **management group** (and it can be the root management group) as subscriptions cannot contain other subscriptions.<sup>[[1]](#references)[[6]](#references)</sup>
 - It **trusts only one Entra ID** directory.<sup>[[1]](#references)</sup>
 - **Permissions** applied at the subscription level (or any of its parents) are **inherited** to all the resources inside the subscription.<sup>[[1]](#references)[[6]](#references)</sup>
@@ -150,7 +150,7 @@ An **App Registration** is a configuration that allows an application to integra
    1. If a **certificate** or **secret** is generated, a person can **log in as the service principal** with CLI tools by knowing the **application ID**, the **secret** or **certificate** and the **tenant** (domain or ID).<sup>[[14]](#references)[[20]](#references)</sup>
 4. **API Permissions:** Specifies what resources or APIs the app can access.<sup>[[14]](#references)[[16]](#references)</sup>
 5. **Authentication Settings:** Defines the app's supported authentication flows (e.g., OAuth2, OpenID Connect).<sup>[[14]](#references)[[16]](#references)</sup>
-6. **Service Principal**: When an app registration is created, an application object and a service principal are automatically created in its home tenant; when the app is used in another tenant, that tenant gets its own service principal. Creating an application through Microsoft Graph can require creating the service principal as a separate step.<sup>[[14]](#references)</sup>
+6. **Service Principal**: When an app registration is created, an application object and a service principal are automatically created in its home tenant; when the app is used in another tenant, that tenant gets its own service principal. Creating an application through Microsoft Graph can require creating the service principal as a separate step.<sup>[[5]](#references)[[14]](#references)</sup>
    1. The **service principal** reflects the permissions granted or consented to in that tenant; requesting permissions in the app registration alone does not grant access.<sup>[[14]](#references)[[17]](#references)[[18]](#references)</sup>
 
 ### Default Consent Permissions

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-connect-sync.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-connect-sync.md
@@ -50,7 +50,7 @@ This configuration allows **synchronizing passwords from Entra ID into AD** when
 
 This is specially interesting when assessing compromise paths from Entra ID to AD because a sufficiently privileged connector account may modify the password of many synchronized users, subject to ACL inheritance and filtering.<sup>[[10]](#references)[[13]](#references)</sup>
 
-Domain admins and other users belonging to some privileged groups may not be writable by the connector when their objects have AdminSDHolder protection (`adminCount=1`). Other users that have been assigned high privileges inside AD without belonging to those protected groups could have their passwords changed if the connector's ACLs allow it.<sup>[[10]](#references)[[13]](#references)</sup> For example:
+Domain admins and other users belonging to some privileged groups may not be writable by the connector when their objects have AdminSDHolder protection (`adminCount=1`). Other users that have been assigned high privileges inside AD without belonging to those protected groups could have their passwords changed if the connector's ACLs allow it.<sup>[[5]](#references)[[10]](#references)[[13]](#references)</sup> For example:
 
 - Users assigned high privleges directly.
 - Users from the **`DNSAdmins`** group.
@@ -93,7 +93,7 @@ The Microsoft Graph `onPremisesDirectorySynchronization` resource exposes synchr
 
 ### Finding the passwords
 
-In legacy user-based deployments, the passwords of the **`MSOL_*`** user (and the **Sync\_\*** user if created) are **stored in a SQL Server** on the server where **Entra ID Connect is installed**. Administrators with sufficient access can extract the encrypted configuration and recover those credentials in clear text. Modern application-based deployments use a certificate instead of a cloud sync-user password.<sup>[[2]](#references)[[3]](#references)[[6]](#references)[[17]](#references)[[18]](#references)</sup>\
+In legacy user-based deployments, the passwords of the **`MSOL_*`** user (and the **Sync\_\*** user if created) are **stored in a SQL Server** on the server where **Entra ID Connect is installed**. Administrators with sufficient access can extract the encrypted configuration and recover those credentials in clear text. Modern application-based deployments use a certificate instead of a cloud sync-user password.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[6]](#references)[[17]](#references)[[18]](#references)</sup>\
 The database is located in `C:\Program Files\Microsoft Azure AD Sync\Data\ADSync.mdf`.<sup>[[3]](#references)[[17]](#references)[[18]](#references)</sup>
 
 It's possible to extract the configuration from one of the tables, being one encrypted.<sup>[[3]](#references)[[17]](#references)</sup>

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-hybrid-identity-misc-attacks.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-hybrid-identity-misc-attacks.md
@@ -4,7 +4,7 @@
 
 Microsoft Entra Connect synchronizes user objects from on-premises Active Directory Domain Services (AD DS) to Microsoft Entra ID. A new on-premises object can be matched to an existing cloud-managed user by a **soft match** on `userPrincipalName` or the primary `proxyAddresses` value (the `SMTP:` entry), or by a **hard match** on the source anchor and its corresponding `immutableID`; after a match, the cloud object becomes on-premises managed.<sup>[[4]](#references)[[5]](#references)</sup>
 
-The historical attack presented by Dirk-jan Mollema at TROOPERS19 abused this matching behavior: an operator who could create or edit an on-premises user added the target cloud-only user's primary address to `proxyAddresses`, for example **`SMTP:admin@domain.onmicrosoft.com`**. If the tenant used password hash synchronization, the matched on-premises password could then be used for cloud authentication. This is a takeover of a cloud object by an on-premises object, not a synchronization from Entra ID down to AD.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
+The historical attack presented by Dirk-jan Mollema at TROOPERS19 abused this matching behavior: an operator who could create or edit an on-premises user added the target cloud-only user's primary address to `proxyAddresses`, for example **`SMTP:admin@domain.onmicrosoft.com`**. If the tenant used password hash synchronization, the matched on-premises password could then be used for cloud authentication. This is a takeover of a cloud object by an on-premises object, not a synchronization from Entra ID down to AD.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 To assess this historical technique, the relevant requirements are:
 

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-seamless-sso.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-seamless-sso.md
@@ -76,7 +76,7 @@ Further Firefox configuration guidance is available in [**the SeamlessPass resea
 
 The current Kerberos decryption key for **`AZUREADSSOACC$`** is sensitive. Microsoft recommends rolling it over at least every 30 days; if it is compromised, it can be used to generate tickets for synchronized users.<sup>[[1]](#references)[[5]](#references)</sup>
 
-The following examples show how a privileged operator can retrieve the account's NT hash with Mimikatz, DSInternals, or an NTDS.dit copy.<sup>[[2]](#references)[[3]](#references)</sup>
+The following examples show how a privileged operator can retrieve the account's NT hash with Mimikatz, DSInternals, or an NTDS.dit copy.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 # Dump hash using mimikatz

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
@@ -549,6 +549,8 @@ az rest --method PATCH \
 
 This privilege allows modifying basic user properties. If a dynamic group trusts one of those writable attributes, changing the attribute can make an attacker-controlled user satisfy its membership rule.<sup>[[4]](#references)[[19]](#references)[[22]](#references)</sup>
 
+Microsoft Graph assigns a user's manager through the `PUT /users/{id}/manager/$ref` relationship endpoint used below.<sup>[[23]](#references)</sup>
+
 ```bash
 #e.g. change manager of a user
 victimUser="<userID>"

--- a/src/pentesting-cloud/azure-security/az-services/az-cloud-shell.md
+++ b/src/pentesting-cloud/azure-security/az-services/az-cloud-shell.md
@@ -2,7 +2,7 @@
 
 ## Azure Cloud Shell
 
-**Azure Cloud Shell** is an interactive, authenticated, browser-accessible terminal designed for managing Azure resources, offering the flexibility to work with either Bash or PowerShell. It runs on a temporary, per-session host that times out after 20 minutes of inactivity, while persisting files in the `$HOME` location using a 5-GB file share. Cloud Shell can be accessed through multiple points, including the Azure portal, shell.azure.com, Azure CLI and PowerShell documentation, the Azure mobile app, and the Visual Studio Code Azure Account extension.<sup>[[1]](#references)</sup>
+**Azure Cloud Shell** is an interactive, authenticated, browser-accessible terminal designed for managing Azure resources, offering the flexibility to work with either Bash or PowerShell. It runs on a temporary, per-session host that times out after 20 minutes of inactivity, while persisting files in the `$HOME` location using a 5-GB file share. Cloud Shell can be accessed through multiple points, including the Azure portal, shell.azure.com, Azure CLI and PowerShell documentation, the Azure mobile app, and the Visual Studio Code Azure Account extension.<sup>[[1]](#references)[[3]](#references)</sup>
 
 Cloud Shell does not grant extra Azure permissions: its command-line tools authenticate the signed-in Azure account, while the shell host's local account has regular Linux-user permissions. Treat it as an execution and persistence surface; resource enumeration and privilege boundaries still depend on the active identity's existing permissions.<sup>[[1]](#references)[[2]](#references)</sup>
 

--- a/src/pentesting-cloud/azure-security/az-services/az-queue.md
+++ b/src/pentesting-cloud/azure-security/az-services/az-queue.md
@@ -9,7 +9,7 @@ Azure Queue Storage provides asynchronous messaging between decoupled applicatio
 {{#tabs }}
 {{#tab name="Az Cli" }}
 
-The following Azure CLI examples enumerate queues and inspect queue metadata, stored access policies, and messages. `get` retrieves messages and temporarily makes them invisible; `peek` reads messages without changing their visibility. `--auth-mode login` uses the current Microsoft Entra credentials where supported. The stored-access-policy command does not expose that option and requires an authorized account key, SAS, or connection string.<sup>[[2]](#references)[[4]](#references)[[5]](#references)</sup>
+The following Azure CLI examples enumerate queues and inspect queue metadata, stored access policies, and messages. `get` retrieves messages and temporarily makes them invisible; `peek` reads messages without changing their visibility. `--auth-mode login` uses the current Microsoft Entra credentials where supported. The stored-access-policy command does not expose that option and requires an authorized account key, SAS, or connection string.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 # You need to know the --account-name of the storage account (az storage account list)

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
@@ -10,11 +10,11 @@ For more information check:
 
 ### Persistent Backdoor
 
-[Google Cloud Shell](https://cloud.google.com/shell/) provides a managed, temporary shell environment for Google Cloud that users can open from the Google Cloud console. Google lists Cloud Shell, including its 5 GB persistent disk, as free access under the Google Cloud Free Tier. The supported <code>gcloud cloud-shell ssh</code> command can establish an interactive SSH session, and the Cloud Shell virtual machine is managed outside the user's Google Cloud projects.<sup>[[4]](#references)[[7]](#references)[[13]](#references)[[15]](#references)</sup>
+[Google Cloud Shell](https://cloud.google.com/shell/) provides a managed, temporary shell environment for Google Cloud that users can open from the Google Cloud console. Google lists Cloud Shell, including its 5 GB persistent disk, as free access under the Google Cloud Free Tier. The supported <code>gcloud cloud-shell ssh</code> command can establish an interactive SSH session, and the Cloud Shell virtual machine is managed outside the user's Google Cloud projects.<sup>[[3]](#references)[[4]](#references)[[7]](#references)[[13]](#references)[[15]](#references)</sup>
 
 The virtual machine is disposable, but the default experience mounts 5 GB of per-user persistent storage at <code>$HOME</code>. Files stored there, including <code>.bashrc</code> and other scripts, persist across sessions; Google deletes that home directory after 120 days without Cloud Shell access. Organizations control whether their users can access Cloud Shell, and Google documents anonymized terminal usage statistics.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
-For an authorized assessment, this means that a compromised user's home directory can retain shell-startup code even after the backing VM is recreated. The persistence is still dependent on the victim using Cloud Shell before the 120-day cleanup, and any Google Cloud permissions obtained by a callback are those of the authorized session rather than an automatic organization-wide privilege.<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[13]](#references)</sup>
+For an authorized assessment, this means that a compromised user's home directory can retain shell-startup code even after the backing VM is recreated. The persistence is still dependent on the victim using Cloud Shell before the 120-day cleanup, and any Google Cloud permissions obtained by a callback are those of the authorized session rather than an automatic organization-wide privilege.<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)[[13]](#references)</sup>
 
 ### Persistence through <code>.bashrc</code>
 

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
@@ -2,7 +2,7 @@
 
 ## Vertex AI
 
-For more information about Vertex AI check:
+For general Vertex AI concepts and API resources, consult the official documentation and REST reference, then check the enumeration page below.<sup>[[1]](#references)[[2]](#references)</sup>
 
 {{#ref}}
 ../gcp-services/gcp-vertex-ai-enum.md

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
@@ -8,7 +8,7 @@ The Firebase Realtime Database is a cloud-hosted NoSQL database that stores JSON
 
 Firebase endpoints and configuration values can be recovered from mobile applications. Firebase configuration files include project and app identifiers, the Realtime Database URL, and an API key; the configuration is public by design, while Firebase Security Rules decide whether client requests can read or write data.<sup>[[5]](#references)[[6]](#references)[[13]](#references)</sup>
 
-Use the following methodology to search for and assess poorly configured Firebase Realtime Databases during an authorized assessment:
+Use the following methodology to search for and assess poorly configured Firebase Realtime Databases during an authorized assessment:<sup>[[1]](#references)[[2]](#references)</sup>
 
 1. **Get the APK** of the app. You can use any tool that retrieves an APK from the device for this POC.\
    You can use “APK Extractor” [https://play.google.com/store/apps/details?id=com.ext.ui\&hl=e](https://hackerone.com/redirect?signature=3774f35d1b5ea8a4fd209d80084daa9f5887b105&url=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dcom.ext.ui%26hl%3Den)

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-stackdriver-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-stackdriver-enum.md
@@ -6,15 +6,15 @@ Cloud Logging is Google's managed service for storing, searching, analyzing, mon
 
 ### What may be exposed
 
-For Compute Engine VMs, the **Ops Agent** is the primary agent for collecting telemetry. Its default logging sources include standard Linux system logs such as `/var/log/syslog` and `/var/log/messages`. Installing the agent alone is not a command audit: command auditing or another shell configuration must first write those commands to a source that the agent is configured to collect, such as syslog.<sup>[[5]](#references)</sup>
+For Compute Engine VMs, the **Ops Agent** is the primary agent for collecting telemetry. Its default logging sources include standard Linux system logs such as `/var/log/syslog` and `/var/log/messages`. Installing the agent alone is not a command audit: command auditing or another shell configuration must first write those commands to a source that the agent is configured to collect, such as syslog.<sup>[[1]](#references)[[5]](#references)</sup>
 
-Cloud services can also expose useful request and network metadata. The App Engine standard environment automatically emits a request log for each HTTP request it receives; external Application Load Balancers can write HTTP request logs when request logging is configured; and VPC Flow Logs can write sampled flow records with optional metadata to Cloud Logging.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
+Cloud services can also expose useful request and network metadata. The App Engine standard environment automatically emits a request log for each HTTP request it receives; external Application Load Balancers can write HTTP request logs when request logging is configured; and VPC Flow Logs can write sampled flow records with optional metadata to Cloud Logging.<sup>[[1]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 Cloud Audit Logs record administrative activity and access to Google Cloud resources. Admin Activity logs are always written, while most Data Access logs are disabled by default and must be enabled separately. Therefore, the absence of a read entry is not proof that no read occurred.<sup>[[4]](#references)</sup>
 
 ### IAM checks
 
-For an identity that only needs to send log entries, the least-privileged predefined role is **Logs Writer** (`roles/logging.logWriter`), which includes `logging.logEntries.create` but does not grant read access. **Logs Viewer** (`roles/logging.viewer`) can read most logs, while **Private Logs Viewer** (`roles/logging.privateLogViewer`) is additionally required to read Data Access audit logs in the `_Default` bucket. During an authorized assessment, check whether an attached VM or agent service account has read roles in addition to its write role; if so, query the available logs for sensitive data.<sup>[[6]](#references)</sup>
+For an identity that only needs to send log entries, the least-privileged predefined role is **Logs Writer** (`roles/logging.logWriter`), which includes `logging.logEntries.create` but does not grant read access. **Logs Viewer** (`roles/logging.viewer`) can read most logs, while **Private Logs Viewer** (`roles/logging.privateLogViewer`) is additionally required to read Data Access audit logs in the `_Default` bucket. During an authorized assessment, check whether an attached VM or agent service account has read roles in addition to its write role; if so, query the available logs for sensitive data.<sup>[[1]](#references)[[6]](#references)</sup>
 
 The `gcloud logging` commands are controlled by IAM. The caller also needs `serviceusage.services.use` and the resource-specific permissions for the operation being performed.<sup>[[6]](#references)</sup>
 

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
@@ -1,7 +1,7 @@
 # Abusing Roles/ClusterRoles in Kubernetes
 
 Here you can find some potentially dangerous Roles and ClusterRoles configurations.\
-Remember that you can get all the supported resources with `kubectl api-resources`
+Remember that you can get all the supported resources with `kubectl api-resources`. The techniques below organize risky RBAC permissions and offensive Kubernetes paths for use during an authorized cluster review.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ## **Privilege Escalation**
 

--- a/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
+++ b/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
@@ -249,7 +249,7 @@ kubectl get ingresses --all-namespaces -o=yaml
 
 ### Gateway API
 
-Gateway API is the newer Kubernetes API for exposing Services. It separates infrastructure-owned Gateway objects from application-owned Route objects such as HTTPRoute. This is useful for delegation, but it also means exposure can be split across namespaces.<sup>[[14]](#references)</sup>
+Gateway API is the newer Kubernetes API for exposing Services. It separates infrastructure-owned Gateway objects from application-owned Route objects such as HTTPRoute. This is useful for delegation, but it also means exposure can be split across namespaces.<sup>[[9]](#references)[[14]](#references)</sup>
 
 List Gateway API exposure objects:
 
@@ -266,7 +266,7 @@ kubectl get httproute -n <namespace> <route-name> -o yaml
 
 Check Gateway listeners, allowed route namespaces, Route `parentRefs`, hostnames or SNI matches, filters, backend references, and status conditions such as `Accepted`, `ResolvedRefs`, and `Programmed`. A Route that is accepted by a shared Gateway can expose a backend even when no legacy Ingress object exists.<sup>[[14]](#references)[[15]](#references)</sup>
 
-Do not check only HTTPRoute. GRPCRoute, TLSRoute, TCPRoute, and UDPRoute can expose non-HTTP services such as admin ports, brokers, databases, service-mesh gateways, or pass-through TLS backends. Also review `ReferenceGrant` objects for cross-namespace backend or certificate references and `BackendTLSPolicy` for the TLS identity the Gateway uses when connecting to backend Services.<sup>[[10]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup> Backend TLS policy is not proof of public reachability by itself, but it is useful evidence when a programmed Gateway route reaches a ready Service with weak, shared, or wrong backend identity validation.
+Do not check only HTTPRoute. GRPCRoute, TLSRoute, TCPRoute, and UDPRoute can expose non-HTTP services such as admin ports, brokers, databases, service-mesh gateways, or pass-through TLS backends. Also review `ReferenceGrant` objects for cross-namespace backend or certificate references and `BackendTLSPolicy` for the TLS identity the Gateway uses when connecting to backend Services.<sup>[[10]](#references)[[11]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup> Backend TLS policy is not proof of public reachability by itself, but it is useful evidence when a programmed Gateway route reaches a ready Service with weak, shared, or wrong backend identity validation.
 
 ## References
 

--- a/src/pentesting-cloud/workspace-security/gws-persistence.md
+++ b/src/pentesting-cloud/workspace-security/gws-persistence.md
@@ -5,7 +5,7 @@
 
 ## **Persistence in Gmail**
 
-- You can create **filters to hide** security-notification emails from Google.
+- You can create **filters to hide** security-notification emails from Google.<sup>[[2]](#references)</sup>
   - `from: (no-reply@accounts.google.com) "Security Alert"`
   - A filter changes matching Gmail messages, but should not be assumed to suppress separate account-security prompts or notifications.<sup>[[3]](#references)[[6]](#references)</sup>
 
@@ -28,7 +28,7 @@ To review or remove existing filters, open [Gmail filter settings](https://mail.
 
 <figure><img src="../../images/image (331).png" alt=""><figcaption></figcaption></figure>
 
-- Configure **automatic forwarding** to send sensitive messages, or all new mail, to an address you control. Adding the address requires access to the receiving mailbox so its verification link can be confirmed.<sup>[[4]](#references)</sup>
+- Configure **automatic forwarding** to send sensitive messages, or all new mail, to an address you control. Adding the address requires access to the receiving mailbox so its verification link can be confirmed.<sup>[[2]](#references)[[4]](#references)</sup>
   - Add a forwarding address from [Gmail forwarding settings](https://mail.google.com/mail/u/2/#settings/fwdandpop).
   - In Gmail's **Forwarding** settings, select **Forward a copy of incoming mail to** and choose **Keep Gmail's copy in the Inbox** when retaining the original is useful.<sup>[[4]](#references)</sup>
 
@@ -47,14 +47,14 @@ An active browser session is not a guarantee that the app-password option will b
 
 ## Change 2-FA and similar
 
-With sufficient authentication, review the [Google Account security settings](https://myaccount.google.com/security). Depending on account type and policy, those settings can expose controls for 2-Step Verification methods, enrolling a new device or phone, passkeys, the password, and recovery phone or email; Google also documents turning off 2-Step Verification from this area.<sup>[[6]](#references)[[15]](#references)[[16]](#references)</sup> Google may require an additional identity check, and newly added sign-in or recovery methods may not become trusted immediately.<sup>[[6]](#references)[[7]](#references)</sup>
+With sufficient authentication, review the [Google Account security settings](https://myaccount.google.com/security). Depending on account type and policy, those settings can expose controls for 2-Step Verification methods, enrolling a new device or phone, passkeys, the password, and recovery phone or email; Google also documents turning off 2-Step Verification from this area.<sup>[[2]](#references)[[6]](#references)[[15]](#references)[[16]](#references)</sup> Google may require an additional identity check, and newly added sign-in or recovery methods may not become trusted immediately.<sup>[[6]](#references)[[7]](#references)</sup>
 
 > [!CAUTION]
 > To stop a compromised session on a known device from continuing to access the account, use **Your devices** to sign that device out. Google also provides device-finding and remote security actions; these operations are highly visible and can trigger further alerts.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ## Persistence via OAuth Apps
 
-An OAuth grant can provide an application with an access token and, when offline access is requested, a refresh token that can obtain new access tokens after the user is no longer present. The grant remains useful until the user or an administrator revokes it, a token expires, or another Google policy invalidates it.<sup>[[9]](#references)</sup>
+An OAuth grant can provide an application with an access token and, when offline access is requested, a refresh token that can obtain new access tokens after the user is no longer present. The grant remains useful until the user or an administrator revokes it, a token expires, or another Google policy invalidates it.<sup>[[2]](#references)[[9]](#references)</sup>
 
 Workspace administrators can distinguish Google-owned, internal, and third-party apps and assign **Trusted**, **Limited**, **Specific Google data**, or **Blocked** access. They can also choose whether unconfigured third-party apps are allowed, limited to basic Sign in with Google information, or blocked, while internal-app trust can be configured separately.<sup>[[8]](#references)</sup>
 
@@ -68,7 +68,7 @@ gws-google-platforms-phishing/
 
 ## Persistence via delegation
 
-If policy permits, Gmail delegation can give another account the ability to read, send, and delete messages on behalf of the owner. Workspace accounts restrict delegates to the same organization, and an administrator must enable delegation before users can configure it; this makes an unexpected delegate a useful persistence check during an authorized assessment.<sup>[[10]](#references)[[11]](#references)</sup>
+If policy permits, Gmail delegation can give another account the ability to read, send, and delete messages on behalf of the owner. Workspace accounts restrict delegates to the same organization, and an administrator must enable delegation before users can configure it; this makes an unexpected delegate a useful persistence check during an authorized assessment.<sup>[[2]](#references)[[10]](#references)[[11]](#references)</sup>
 
 <details>
 
@@ -121,11 +121,11 @@ The invitation is sent to the delegate and expires after one week. Group members
 
 ## Persistence via Android App
 
-If an Android device is signed in to the same Google Account, Google Play can offer compatible apps for installation on another device from a phone, tablet, or computer. In an authorized test, a compromised account session may therefore expose a path to install a Play-published package already controlled by the tester, subject to device compatibility, account state, and Workspace or device policy.<sup>[[13]](#references)</sup>
+If an Android device is signed in to the same Google Account, Google Play can offer compatible apps for installation on another device from a phone, tablet, or computer. In an authorized test, a compromised account session may therefore expose a path to install a Play-published package already controlled by the tester, subject to device compatibility, account state, and Workspace or device policy.<sup>[[2]](#references)[[13]](#references)</sup>
 
 ## **Persistence via** App Scripts
 
-Installable Apps Script triggers can run a function automatically on a schedule, including recurring time-driven triggers. If a user authorizes the script and a trigger is created, the script can run later without the user opening the project again; it runs with the authorization of the account that created the trigger, and quotas and policy restrictions still apply.<sup>[[14]](#references)</sup> For more information about this technique, check:
+Installable Apps Script triggers can run a function automatically on a schedule, including recurring time-driven triggers. If a user authorizes the script and a trigger is created, the script can run later without the user opening the project again; it runs with the authorization of the account that created the trigger, and quotas and policy restrictions still apply.<sup>[[1]](#references)[[14]](#references)</sup> For more information about this technique, check:
 
 {{#ref}}
 gws-google-platforms-phishing/gws-app-scripts.md

--- a/src/pentesting-cloud/workspace-security/gws-post-exploitation.md
+++ b/src/pentesting-cloud/workspace-security/gws-post-exploitation.md
@@ -4,11 +4,11 @@
 
 Google Groups permissions determine who can view conversations and members, post, or manage a group; owners can grant these permissions to all members or the entire organization. A Google group can also be used as a Google Cloud IAM principal, so membership in a privileged group can grant its members the bound roles.<sup>[[3]](#references)[[5]](#references)</sup>
 
-Depending on a group's settings, users can find and join it directly or must request access. Check groups information in [**https://groups.google.com/all-groups**](https://groups.google.com/all-groups).<sup>[[4]](#references)</sup>
+Depending on a group's settings, users can find and join it directly or must request access. Check groups information in [**https://groups.google.com/all-groups**](https://groups.google.com/all-groups).<sup>[[2]](#references)[[4]](#references)</sup>
 
 ### Access Groups Mail info
 
-If you manage to **compromise a Google user session**, review conversations in groups that the account can access; group permissions may expose **credentials** or other **sensitive data** in messages.<sup>[[3]](#references)</sup>
+If you manage to **compromise a Google user session**, review conversations in groups that the account can access; group permissions may expose **credentials** or other **sensitive data** in messages.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## GCP <--> GWS Pivoting
 
@@ -18,7 +18,7 @@ If you manage to **compromise a Google user session**, review conversations in g
 
 ## Takeout - Download Everything Google Knows about an account
 
-If you have a **session inside a victim's Google account**, Google Takeout can export data from the Google products used by that account from [**https://takeout.google.com**](https://takeout.google.com/u/1/?pageId=none).<sup>[[6]](#references)</sup>
+If you have a **session inside a victim's Google account**, Google Takeout can export data from the Google products used by that account from [**https://takeout.google.com**](https://takeout.google.com/u/1/?pageId=none).<sup>[[2]](#references)[[6]](#references)</sup>
 
 ## Vault - Search and export Workspace data
 
@@ -26,7 +26,7 @@ If an organization has **Google Vault enabled** and the account has the required
 
 ## Contacts download
 
-From [**https://contacts.google.com**](https://contacts.google.com/u/1/?hl=es&tab=mC), you can export selected or all available **contacts** as a CSV or vCard file. Work or school directories may not allow selecting every directory contact.<sup>[[8]](#references)</sup>
+From [**https://contacts.google.com**](https://contacts.google.com/u/1/?hl=es&tab=mC), you can export selected or all available **contacts** as a CSV or vCard file. Work or school directories may not allow selecting every directory contact.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ## Cloudsearch
 
@@ -40,7 +40,7 @@ In [**https://mail.google.com/chat**](https://mail.google.com/chat), you can acc
 
 When **sharing** a document, you can specify individual **people** or groups, share it with a domain or audience, or create a link with a chosen general-access setting.<sup>[[11]](#references)</sup>
 
-Drive supports searching by file text, people or groups, and sharing status. Search visibility does not itself grant access; a link-shared file can also appear in **Shared with me** after it is opened.<sup>[[12]](#references)[[13]](#references)</sup>
+Drive supports searching by file text, people or groups, and sharing status. Search visibility does not itself grant access; a link-shared file can also appear in **Shared with me** after it is opened.<sup>[[2]](#references)[[12]](#references)[[13]](#references)</sup>
 
 For sake of simplicity, most people will generate and share a link instead of adding the people who can access the document one by one.
 
@@ -55,11 +55,11 @@ In [**https://keep.google.com/**](https://keep.google.com), you can access the n
 
 ### Modify App Scripts
 
-At [**https://script.google.com/**](https://script.google.com/), the Apps Script dashboard lists projects the account can view or edit and exposes project details and execution logs; inspect OAuth scopes and deployments before modifying anything.<sup>[[16]](#references)</sup>
+At [**https://script.google.com/**](https://script.google.com/), the Apps Script dashboard lists projects the account can view or edit and exposes project details and execution logs; inspect OAuth scopes and deployments before modifying anything.<sup>[[1]](#references)[[16]](#references)</sup>
 
 ## **Administrate Workspace**
 
-In [**https://admin.google.com**](https://admin.google.com), an administrator account can manage Workspace services for the organization, but available controls depend on the privileges assigned to that account.<sup>[[17]](#references)</sup>
+In [**https://admin.google.com**](https://admin.google.com), an administrator account can manage Workspace services for the organization, but available controls depend on the privileges assigned to that account.<sup>[[2]](#references)[[17]](#references)</sup>
 
 You can also search recent message delivery records with [**Email Log Search**](https://admin.google.com/ac/emaillogsearch), which Google documents for delivery troubleshooting and post-delivery status checks.<sup>[[18]](#references)</sup>
 

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcpw-google-credential-provider-for-windows.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcpw-google-credential-provider-for-windows.md
@@ -846,7 +846,7 @@ More [API endpoints in the docs](https://developers.google.com/workspace/vault/r
 
 ## GCPW - Recovering clear text password
 
-To recover a GCPW password in a controlled, authorized assessment, the encrypted secret can be extracted from **LSASS** with **mimikatz**. Chromium stores the GCPW recovery secret under a `Chrome-GCPW-<sid>` name.<sup>[[6]](#references)[[24]](#references)</sup>
+To recover a GCPW password in a controlled, authorized assessment, the encrypted secret can be extracted from **LSASS** with **mimikatz**. Chromium stores the GCPW recovery secret under a `Chrome-GCPW-<sid>` name.<sup>[[2]](#references)[[6]](#references)[[24]](#references)</sup>
 
 ```bash
 mimikatz_trunk\x64\mimikatz.exe privilege::debug token::elevate lsadump::secrets exit
@@ -856,7 +856,7 @@ Then search for a secret such as `Chrome-GCPW-<sid>` as shown in the image:
 
 <figure><img src="../../../images/telegram-cloud-photo-size-4-6044191430395675441-x.jpg" alt=""><figcaption></figcaption></figure>
 
-With an **access token** carrying the `https://www.google.com/accounts/OAuthLogin` scope, the Chromium recovery flow requests a private key from the escrow service to decrypt the password.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[9]](#references)[[24]](#references)</sup>
+With an **access token** carrying the `https://www.google.com/accounts/OAuthLogin` scope, the Chromium recovery flow requests a private key from the escrow service to decrypt the password.<sup>[[2]](#references)[[5]](#references)[[6]](#references)[[7]](#references)[[9]](#references)[[24]](#references)</sup>
 
 <details>
 


### PR DESCRIPTION
## Summary
- attribute 54 previously unused references to matching existing claims across 34 pages
- preserve 17 stale or mismatched references without guessing citations
- remove the duplicated Terrascan section
- replace dead secondary-source URLs with the exact archived snapshots reviewed

## Validation
- all 591 unique SUMMARY pages checked
- 0 structural reference/citation/banner failures
- 0 forbidden hackingthe.cloud occurrences
- 0 duplicate non-code four-line windows
- git diff --check passes
- mdbook build reaches preprocessing but cannot run locally because mdbook-tabs is not installed