### PR TITLE
Fix Translator All asset copy failure

### DIFF
--- a/.github/workflows/translate_all.yml
+++ b/.github/workflows/translate_all.yml
@@ -87,7 +87,12 @@ jobs:
           cp scripts/mark_unchanged_s3_files.py /tmp/mark_unchanged_s3_files.py
           cp scripts/upload_immutable_images.sh /tmp/upload_immutable_images.sh
           mkdir -p /tmp/immutable-images
-          cp src/images/{hacktricks-summer-discount-2026-v1.webp,arte-badge-v1.webp,grte-badge-v1.webp,azrte-badge-v1.webp} /tmp/immutable-images/
+          cp \
+            src/images/hacktricks-summer-discount-2026-v1.webp \
+            src/images/arte-badge-v1.webp \
+            src/images/grte-badge-v1.webp \
+            src/images/azrte-badge-v1.webp \
+            /tmp/immutable-images/
           cp theme/discount.js /tmp/discount.js
 
       - name: Run get_and_save_refs.py


### PR DESCRIPTION
## Summary
- replace Bash-only brace expansion in the translation workflow with portable explicit asset paths
- prevent every language job from failing in the setup step under POSIX `sh`

## Validation
- workflow YAML parses successfully
- all four referenced image assets exist
- `git diff --check` passes