### PR TITLE
Retranslate missed reference updates

### DIFF
--- a/src/pentesting-ci-cd/atlantis-security.md
+++ b/src/pentesting-ci-cd/atlantis-security.md
@@ -391,3 +391,4 @@ You can also pass these as environment variables `ATLANTIS_WEB_BASIC_AUTH=true` 
 - [29] [Managing protected branches | GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches)
 
 {{#include ../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
+++ b/src/pentesting-ci-cd/gitblit-security/gitblit-embedded-ssh-auth-bypass-cve-2024-28080.md
@@ -130,3 +130,4 @@ Related protocol/design notes and literature:
 - [15] [OpenSSH client public-key authentication source](https://github.com/openssh/openssh-portable/blob/master/sshconnect2.c)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/gitea-security/README.md
+++ b/src/pentesting-ci-cd/gitea-security/README.md
@@ -158,3 +158,4 @@ If you are inside the server you can also **use the `gitea` binary** to access/m
 - [21] [Gitea Command Line | Gitea Documentation](https://docs.gitea.com/1.26/administration/command-line)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/github-security/README.md
+++ b/src/pentesting-ci-cd/github-security/README.md
@@ -485,3 +485,4 @@ For more information, see [Chainguard’s imposter-commits research](https://www
 - [54] [GitHub public SSH keys (example: octocat)](https://github.com/octocat.keys)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
+++ b/src/pentesting-ci-cd/github-security/abusing-github-actions/README.md
@@ -954,3 +954,4 @@ An organization in GitHub is very proactive in reporting accounts to GitHub. All
 - [45] [Vulnerable GitHub Actions Workflows: CI/CD Pipeline Attacks](https://www.legitsecurity.com/blog/github-actions-that-open-the-door-to-cicd-pipeline-attacks)
 - [46] [actions/toolkit core package - GitHub](https://github.com/actions/toolkit/tree/main/packages/core#setting-a-secret)
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/github-security/basic-github-information.md
+++ b/src/pentesting-ci-cd/github-security/basic-github-information.md
@@ -300,3 +300,4 @@ This chain prevents a single collaborator from retagging or force-publishing rel
 - [39] [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/jenkins-security/README.md
+++ b/src/pentesting-ci-cd/jenkins-security/README.md
@@ -442,3 +442,4 @@ println(hudson.util.Secret.decrypt("{...}"))
 - [20] [Using credentials](https://www.jenkins.io/doc/book/using/using-credentials/)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/serverless.com-security.md
+++ b/src/pentesting-ci-cd/serverless.com-security.md
@@ -867,3 +867,4 @@ Granting excessive permissions to team members and external collaborators can le
 - [25] [GetFunctionConfiguration - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunctionConfiguration.html)
 
 {{#include ../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/supabase-security.md
+++ b/src/pentesting-ci-cd/supabase-security.md
@@ -296,3 +296,4 @@ It's possible to **store secrets** in supabase also which will be **accessible b
 - [26] [Supabase: Configure Phone Login & MFA](https://supabase.com/docs/guides/self-hosting/self-hosted-phone-mfa)
 
 {{#include ../banners/hacktricks-training.md}}
+

--- a/src/pentesting-ci-cd/terraform-security.md
+++ b/src/pentesting-ci-cd/terraform-security.md
@@ -473,3 +473,4 @@ docker run -t -v $(pwd):/path checkmarx/kics:latest scan -p /path -o "/path/"
 - [38] [KICS](https://github.com/Checkmarx/kics)
 
 {{#include ../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/README.md
+++ b/src/pentesting-cloud/aws-security/README.md
@@ -442,3 +442,4 @@ aws ...
 - [49] [StreamAlert repository](https://github.com/airbnb/streamalert)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-basic-information/README.md
+++ b/src/pentesting-cloud/aws-security/aws-basic-information/README.md
@@ -450,3 +450,4 @@ The command _must_ return credentials to STDOUT in the following format. When `E
 - [35] [Getting started with Simple AD](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/simple_ad_getting_started.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-basic-information/aws-federation-abuse.md
+++ b/src/pentesting-cloud/aws-security/aws-basic-information/aws-federation-abuse.md
@@ -141,3 +141,4 @@ An explicit `sub` condition prevents other service accounts in the cluster or na
 - [12] [Get started with Amazon EKS - eksctl](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-permissions-for-a-pentest.md
+++ b/src/pentesting-cloud/aws-security/aws-permissions-for-a-pentest.md
@@ -17,3 +17,4 @@ To run the AWS component of [Blue-CloudPEASS](https://github.com/peass-ng/Blue-C
 - [4] [Using service-linked roles for IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-using-service-linked-roles.html)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-api-gateway-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-api-gateway-persistence/README.md
@@ -75,3 +75,4 @@ Usage plans use API keys to identify clients and control access to selected API 
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-cloudformation-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-cloudformation-persistence/README.md
@@ -37,3 +37,4 @@ aws cloudformation update-stack \
 - [3] [update-stack - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/update-stack.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-cognito-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-cognito-persistence/README.md
@@ -48,3 +48,4 @@ Threat protection starts in audit-only mode; full-function enforcement must be a
 - [5] [Advanced security with threat protection - Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-dynamodb-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-dynamodb-persistence/README.md
@@ -85,3 +85,4 @@ The compromised instances or Lambda functions can periodically check the C2 tabl
 - [8] [Using Amazon DynamoDB in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-dynamodb.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-ec2-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-ec2-persistence/README.md
@@ -68,3 +68,4 @@ Create a peering connection between the victim VPC and the attacker VPC so he wi
 - [8] [Replace the root volume for an Amazon EC2 instance without stopping it - Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/replace-root.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-ec2-replace-root-volume-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-ec2-replace-root-volume-persistence/README.md
@@ -95,3 +95,4 @@ aws ec2 delete-volume --region $REGION --volume-id $ORIG_VOL
 - [8] [get-console-output — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/get-console-output.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-ecr-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-ecr-persistence/README.md
@@ -171,3 +171,4 @@ aws ecr get-repository-policy --region $REGION --repository-name ptc2/nginx --qu
 
 
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-ecs-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-ecs-persistence/README.md
@@ -156,3 +156,4 @@ Impact: A protected task is not terminated by ECS scale-in events or deployment 
 
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-efs-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-efs-persistence/README.md
@@ -26,3 +26,4 @@ An access point can use `/` as the default root directory and enforce a POSIX id
 {{#include ../../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-elastic-beanstalk-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-elastic-beanstalk-persistence/README.md
@@ -124,3 +124,4 @@ aws elasticbeanstalk update-environment --environment-name my-env --version-labe
 {{#include ../../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-iam-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-iam-persistence/README.md
@@ -59,3 +59,4 @@ An IAM OIDC identity provider establishes trust between an OIDC-compatible provi
 - [11] [Create a role for OpenID Connect federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-kms-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-kms-persistence/README.md
@@ -46,3 +46,4 @@ aws kms list-grants --key-id <key-id>
 
 
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/README.md
@@ -159,3 +159,4 @@ aws lambda put-runtime-management-config \
 - [19] [FilterLogEvents - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-abusing-lambda-extensions.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-abusing-lambda-extensions.md
@@ -44,3 +44,4 @@ The [**LambdaSpy**](https://github.com/clearvector/lambda-spy) repository contai
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-alias-version-policy-backdoor.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-alias-version-policy-backdoor.md
@@ -130,3 +130,4 @@ The cleanup command reuses the statement ID and qualifier to remove only the ver
 - [12] [remove-permission — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/remove-permission.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-async-self-loop-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-async-self-loop-persistence.md
@@ -114,3 +114,4 @@ aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name allow-invoke-s
 - [8] [PutFunctionEventInvokeConfig](https://docs.aws.amazon.com/lambda/latest/api/API_PutFunctionEventInvokeConfig.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-exec-wrapper-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-exec-wrapper-persistence.md
@@ -113,3 +113,4 @@ aws logs filter-log-events --log-group-name "/aws/lambda/$TARGET_FN" --limit 50 
 - [8] [filter-log-events — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/logs/filter-log-events.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-layers-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lambda-persistence/aws-lambda-layers-persistence.md
@@ -151,3 +151,4 @@ aws lambda remove-layer-version-permission --layer-name ExternalBackdoor --state
 - [11] [publish-layer-version — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/lambda/publish-layer-version.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-lightsail-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-lightsail-persistence/README.md
@@ -56,3 +56,4 @@ If the assessment includes control of a domain's authoritative DNS zone:
 {{#include ../../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-rds-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-rds-persistence/README.md
@@ -39,3 +39,4 @@ aws rds modify-db-snapshot-attribute --db-snapshot-identifier <snapshot-name> --
 - [7] [modify-db-snapshot-attribute - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-snapshot-attribute.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-s3-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-s3-persistence/README.md
@@ -29,3 +29,4 @@ New S3 buckets use the Bucket owner enforced Object Ownership setting by default
 - [5] [Controlling ownership of objects and disabling ACLs for your bucket - Amazon Simple Storage Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sagemaker-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sagemaker-persistence/README.md
@@ -304,3 +304,4 @@ The role and target model group still need the corresponding cross-account trust
 - [19] [update-space — AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sagemaker/update-space.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-secrets-manager-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-secrets-manager-persistence/README.md
@@ -265,3 +265,4 @@ aws secretsmanager get-secret-value --region "$R2" --secret-id "$NAME" --query S
 - [14] [Troubleshoot AWS Secrets Manager replication - AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/replicate-secrets_troubleshoot.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sns-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sns-persistence/README.md
@@ -127,3 +127,4 @@ Steps (AWS CLI):
 - [10] [Amazon SNS raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/README.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/README.md
@@ -52,3 +52,4 @@ aws-sqs-orgid-policy-backdoor.md
 - [3] [Tutorial: Using a cross-account Amazon SQS queue as an event source](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs-cross-account-example.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/aws-sqs-dlq-backdoor-persistence.md
+++ b/src/pentesting-cloud/aws-security/aws-persistence/aws-sqs-persistence/aws-sqs-dlq-backdoor-persistence.md
@@ -100,3 +100,4 @@ aws sqs set-queue-attributes \
 - [7] [receive-message - AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/sqs/receive-message.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-lambda-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-lambda-enum.md
@@ -206,3 +206,4 @@ In the following page you can check how to **abuse Lambda permissions to escalat
 - [21] [Lambda layers — Getting started concepts](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-layer)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-cloudwatch-enum.md
@@ -493,3 +493,4 @@ aws cloudwatch untag-resource --resource-arn <value> --tag-keys <value>
 - [31] [Actions, resources, and condition keys for Amazon CloudWatch - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-detective-enum.md
@@ -15,3 +15,4 @@ The service eases in-depth exploration of security incidents, allowing security 
 - [5] [Amazon Detective - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#detective)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-firewall-manager-enum.md
@@ -345,3 +345,4 @@ aws fms untag-resource --resource-arn <value> --tag-keys <value>
 - [31] [Actions, resources, and condition keys for AWS Firewall Manager - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsfirewallmanager.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-inspector-enum.md
@@ -402,3 +402,4 @@ aws inspector2 untag-resource --resource-arn <value> --tag-keys <value>
 - [21] [Actions, resources, and condition keys for Amazon Inspector2 - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoninspector2.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-security-hub-enum.md
@@ -75,3 +75,4 @@ TODO, PRs accepted
 - [9] [AWS Security Hub - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#security-hub)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-trusted-advisor-enum.md
@@ -76,3 +76,4 @@ AWS Trusted Advisor is therefore useful for enumerating account-level recommenda
 - [6] [AWS Trusted Advisor - CloudSecDocs (archived)](https://web.archive.org/web/20211123225615/https://cloudsecdocs.com/aws/services/logging/other/#trusted-advisor)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
+++ b/src/pentesting-cloud/aws-security/aws-services/aws-security-and-detection-services/aws-waf-enum.md
@@ -482,3 +482,4 @@ aws wafv2 untag-resource --resource-arn <value> --tag-keys <value>
 - [19] [Actions, resources, and condition keys for AWS WAF V2 - legacy URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-accounts-unauthenticated-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-accounts-unauthenticated-enum/README.md
@@ -47,3 +47,4 @@ Inspect error responses from probes for account-scoped ARNs. AWS documents that 
 - [8] [Troubleshoot access denied error messages](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_access-denied.html)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-iam-and-sts-unauthenticated-enum/README.md
+++ b/src/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-iam-and-sts-unauthenticated-enum/README.md
@@ -187,3 +187,4 @@ Because `StringLike` treats `*` as a wildcard, `repo:org_name*:*` also matches n
 - [14] [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-basic-information/README.md
+++ b/src/pentesting-cloud/azure-security/az-basic-information/README.md
@@ -424,3 +424,4 @@ You **cannot** explicitly **deny** **access** to specific resources **using cond
 - [43] [Manage the Stay signed in prompt](https://learn.microsoft.com/en-us/entra/fundamentals/how-to-manage-stay-signed-in-prompt)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-connect-sync.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-connect-sync.md
@@ -235,3 +235,4 @@ az-seamless-sso.md
 - [21] [TR19: I'm in your cloud, reading everyone's emails - hacking Azure AD via Active Directory](https://www.youtube.com/watch?v=JEIR5oGCwdg)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-hybrid-identity-misc-attacks.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-hybrid-identity-misc-attacks.md
@@ -28,3 +28,4 @@ To assess this historical technique, the relevant requirements are:
 - [7] [Microsoft Entra Connect: Troubleshoot errors during synchronization](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/tshoot-connect-sync-errors)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-seamless-sso.md
+++ b/src/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-seamless-sso.md
@@ -226,3 +226,4 @@ If the Active Directory administrators have access to Azure AD Connect, they can
 - [20] [Security identifiers](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-identifiers)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-ai-foundry-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-ai-foundry-privesc.md
@@ -692,3 +692,4 @@ If a pipeline resolves `faq-clean@1` to the same mutable blob URI, it may ingest
 - [27] [Quickstart: Create, download, and list blobs with Azure CLI](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-cli)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-entraid-privesc/README.md
@@ -678,3 +678,4 @@ az rest --method GET \
 - [30] [Microsoft Graph application resource basics](https://learn.microsoft.com/en-us/graph/tutorial-applications-basics)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-privilege-escalation/az-functions-app-privesc.md
+++ b/src/pentesting-cloud/azure-security/az-privilege-escalation/az-functions-app-privesc.md
@@ -531,3 +531,4 @@ az functionapp deployment source config \
 - [23] [Functions API · projectkudu/kudu Wiki](https://github.com/projectkudu/kudu/wiki/Functions-API)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-services/az-cloud-shell.md
+++ b/src/pentesting-cloud/azure-security/az-services/az-cloud-shell.md
@@ -137,3 +137,4 @@ The following policy definition can audit, deny, or disable the creation of auto
 
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/azure-security/az-services/az-queue.md
+++ b/src/pentesting-cloud/azure-security/az-services/az-queue.md
@@ -96,3 +96,4 @@ $queueMessage.Value
 - [7] [Introduction to Azure Queue Storage](https://learn.microsoft.com/en-us/azure/storage/queues/storage-queues-introduction)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-cloud-shell-persistence.md
@@ -106,3 +106,4 @@ For managed Google Workspace or Cloud Identity accounts, administrators can disa
 - [15] [Free Google Cloud features and trial offer](https://docs.cloud.google.com/free/docs/free-cloud-features)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-filestore-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-filestore-persistence.md
@@ -63,3 +63,4 @@ For mounting the share and validating access from a controlled client, see:
 - [3] [IAM roles and permissions](https://docs.cloud.google.com/filestore/docs/iam)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-logging-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-logging-persistence.md
@@ -34,3 +34,4 @@ gcloud logging sinks create <sink-name> <destination> --log-filter="FILTER_CONDI
 {{#include ../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-non-svc-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-non-svc-persistence.md
@@ -139,3 +139,4 @@ Netskope's [remediation guidance](https://www.netskope.com/blog/gcp-oauth-token-
 - [11] [Authenticate workloads to Google Cloud APIs using service accounts](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-secret-manager-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-secret-manager-persistence.md
@@ -27,3 +27,4 @@ An attacker who can update the secret's metadata could:
 - [4] [REST Resource: projects.secrets](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-storage-persistence.md
+++ b/src/pentesting-cloud/gcp-security/gcp-persistence/gcp-storage-persistence.md
@@ -57,3 +57,4 @@ Another exploit script for this method can be found [here](https://github.com/Rh
 - [5] [Cloud Storage HMAC key exploit script](https://github.com/RhinoSecurityLabs/GCP-IAM-Privilege-Escalation/blob/master/ExploitScripts/storage.hmacKeys.create.py)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
+++ b/src/pentesting-cloud/gcp-security/gcp-privilege-escalation/gcp-vertex-ai-privesc.md
@@ -708,3 +708,4 @@ Current Workbench notebook execution runs notebook code on Vertex AI custom trai
 - [21] [Prebuilt containers for inference and explanation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/pre-built-containers)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-ai-platform-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-ai-platform-enum.md
@@ -43,3 +43,4 @@ The model-level IAM check uses the Vertex AI `models.getIamPolicy` REST method a
 - [9] [Locations for machine learning services](https://docs.cloud.google.com/vertex-ai/docs/general/locations)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-api-keys-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-api-keys-enum.md
@@ -47,3 +47,4 @@ gcloud services api-keys list --show-deleted
 - [4] [gcloud services api-keys describe | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/services/api-keys/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-app-engine-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-app-engine-enum.md
@@ -139,3 +139,4 @@ The service, version, log, instance, firewall, domain-mapping, and certificate c
 - [18] [App Engine staging bucket deployment log](https://discuss.google.dev/t/deploy-strapi-in-gcloud-app/92530)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-artifact-registry-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-artifact-registry-enum.md
@@ -114,3 +114,4 @@ gcloud artifacts docker images list-vulnerabilities projects/<proj-name>/locatio
 - [16] [gcloud artifacts docker images list](https://cloud.google.com/sdk/gcloud/reference/artifacts/docker/images/list)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-batch-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-batch-enum.md
@@ -40,3 +40,4 @@ gcloud batch tasks describe projects/<project-id>/locations/<location>/jobs/<job
 - [4] [View jobs and tasks | Batch](https://docs.cloud.google.com/batch/docs/view-jobs-tasks)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-bigquery-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-bigquery-enum.md
@@ -263,3 +263,4 @@ The following payload shapes are context-dependent examples from the case studie
 - [26] [BigQuery SQL Injection Cheat Sheet](https://ozguralp.medium.com/bigquery-sql-injection-cheat-sheet-65ad70e11eac)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-bigtable-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-bigtable-enum.md
@@ -152,3 +152,4 @@ The commands above follow the current Google Cloud CLI resource syntax; cluster 
 - [28] [gcloud bigtable authorized-views describe](https://docs.cloud.google.com/sdk/gcloud/reference/bigtable/authorized-views/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-build-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-build-enum.md
@@ -201,3 +201,4 @@ done
 - [27] [cloud-console-sample-build](https://github.com/GoogleCloudBuild/cloud-console-sample-build)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-functions-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-functions-enum.md
@@ -128,3 +128,4 @@ In the following page, you can check how to **abuse cloud function permissions t
 - [18] [Event providers and destinations | Eventarc Standard](https://docs.cloud.google.com/eventarc/standard/docs/event-providers-targets)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-run-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-run-enum.md
@@ -132,3 +132,4 @@ In the following page, you can check how to **abuse cloud run permissions to esc
 - [22] [Configure secrets for services](https://docs.cloud.google.com/run/docs/configuring/services/secrets)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-scheduler-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-scheduler-enum.md
@@ -55,3 +55,4 @@ gcloud scheduler jobs describe --location us-central1 <scheduler-name>
 - [7] [Schedule a workflow using Cloud Scheduler | Workflows | Google Cloud Documentation](https://docs.cloud.google.com/workflows/docs/schedule-workflow)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-shell-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-shell-enum.md
@@ -33,3 +33,4 @@ Administrators can disable Cloud Shell for managed Google Workspace and Cloud Id
 - [5] [Authorize with Cloud Shell](https://docs.cloud.google.com/shell/docs/auth)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-sql-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-cloud-sql-enum.md
@@ -112,3 +112,4 @@ gcloud sql backups describe <backup-name> --instance <instance-name>
 - [20] [gcloud sql backups describe](https://docs.cloud.google.com/sdk/gcloud/reference/sql/backups/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-composer-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-composer-enum.md
@@ -54,3 +54,4 @@ In the following page you can check how to **abuse composer permissions to escal
 - [10] [Create Managed Service for Apache Airflow environments](https://docs.cloud.google.com/composer/docs/composer-3/create-environments)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/README.md
@@ -258,3 +258,4 @@ Check the Compute Instances privilege escalation section.
 - [24] [gcloud compute snapshots](https://cloud.google.com/sdk/gcloud/reference/compute/snapshots)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/gcp-compute-instance.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/gcp-compute-instance.md
@@ -121,3 +121,4 @@ https://book.hacktricks.wiki/en/pentesting-web/ssrf-server-side-request-forgery/
 - [19] [View and query VM metadata](https://docs.cloud.google.com/compute/docs/metadata/querying-metadata)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/gcp-vpc-and-networking.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-compute-instances-enum/gcp-vpc-and-networking.md
@@ -95,3 +95,4 @@ For the peering setup task, Google Cloud lists these permissions for a custom ro
 - [11] [Set up and manage VPC Network Peering | Virtual Private Cloud | Google Cloud Documentation](https://docs.cloud.google.com/vpc/docs/using-vpc-peering?hl=en)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-containers-gke-and-composer-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-containers-gke-and-composer-enum.md
@@ -160,3 +160,4 @@ Even if the API **doesn't allow to modify resources**, it could be possible to f
 - [21] [Cloudflare Pages, part 3: The return of the secrets](https://blog.assetnote.io/2022/05/06/cloudflare-pages-pt3/)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataflow-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataflow-enum.md
@@ -88,3 +88,4 @@ gcloud storage ls --recursive gs://<bucket>/
 - [10] [Job builder UI overview](https://docs.cloud.google.com/dataflow/docs/guides/job-builder)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-dataproc-enum.md
@@ -56,3 +56,4 @@ gcloud dataproc jobs describe <job-id> --region=<region>
 - [8] [gcloud dataproc jobs describe](https://docs.cloud.google.com/sdk/gcloud/reference/dataproc/jobs/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-dns-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-dns-enum.md
@@ -38,3 +38,4 @@ gcloud dns policies list
 {{#include ../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-filestore-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-filestore-enum.md
@@ -83,3 +83,4 @@ There aren't ways to escalate privileges in GCP directly abusing this service, b
 - [11] [gcloud compute networks peerings list-routes](https://docs.cloud.google.com/sdk/gcloud/reference/compute/networks/peerings/list-routes)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.md
@@ -96,3 +96,4 @@ An authorized review can use those values to check client-side Remote Config exp
 - [17] [Firebase Realtime Database | Firebase Documentation](https://firebase.google.com/products/realtime-database/)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-firestore-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-firestore-enum.md
@@ -24,3 +24,4 @@ gcloud firestore export gs://my-source-project-export/export-20190113_2109 --col
 - [6] [gcloud firestore export](https://docs.cloud.google.com/sdk/gcloud/reference/firestore/export)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-iam-and-org-policies-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-iam-and-org-policies-enum.md
@@ -271,3 +271,4 @@ In the following page you can check how to **abuse org policies permissions to e
 - [35] [gcloud resource-manager org-policies list](https://docs.cloud.google.com/sdk/gcloud/reference/resource-manager/org-policies/list)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-kms-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-kms-enum.md
@@ -111,3 +111,4 @@ The `encrypt` command reads the plaintext input and writes ciphertext to the out
 - [18] [gcloud kms decrypt | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/kms/decrypt)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-logging-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-logging-enum.md
@@ -155,3 +155,4 @@ Audit coverage is service-specific: some Google Cloud services document `testIam
 - [14] [Monitored resources and services](https://docs.cloud.google.com/logging/docs/api/v2/resource-list)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-memorystore-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-memorystore-enum.md
@@ -36,3 +36,4 @@ For Redis, the export command writes an RDB backup to a Cloud Storage bucket. Th
 {{#include ../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-monitoring-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-monitoring-enum.md
@@ -67,3 +67,4 @@ gcloud alpha monitoring channels describe <channel>
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-pub-sub.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-pub-sub.md
@@ -75,3 +75,4 @@ To replay previously acknowledged or older messages, use [**seek**](https://clou
 - [8] [Pub/Sub pricing](https://cloud.google.com/pubsub/pricing)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-secrets-manager-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-secrets-manager-enum.md
@@ -65,3 +65,4 @@ An attacker with permission to update the secret could attempt to **stop rotatio
 - [11] [gcloud secrets versions access](https://cloud.google.com/sdk/gcloud/reference/secrets/versions/access)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-security-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-security-enum.md
@@ -112,3 +112,4 @@ gcp-secrets-manager-enum.md
 - [16] [BeyondCorp Zero Trust Enterprise Security](https://cloud.google.com/beyondcorp)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-source-repositories-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-source-repositories-enum.md
@@ -86,3 +86,4 @@ git add, commit, push...
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-spanner-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-spanner-enum.md
@@ -46,3 +46,4 @@ gcloud spanner instance-configs describe <name>
 - [14] [gcloud spanner instance-configs describe](https://docs.cloud.google.com/sdk/gcloud/reference/spanner/instance-configs/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-stackdriver-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-stackdriver-enum.md
@@ -57,3 +57,4 @@ gcloud logging buckets list --project=PROJECT_ID
 - [13] [VPC Flow Logs](https://docs.cloud.google.com/vpc/docs/flow-logs)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-storage-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-storage-enum.md
@@ -184,3 +184,4 @@ In the following page you can check how to **abuse storage permissions to escala
 - [16] [List objects with the XML API](https://cloud.google.com/storage/docs/xml-api/get-bucket-list)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-vertex-ai-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-vertex-ai-enum.md
@@ -330,3 +330,4 @@ In the following page, you can check how to **abuse Vertex AI permissions to esc
 - [25] [`gcloud workbench instances describe`](https://docs.cloud.google.com/sdk/gcloud/reference/workbench/instances/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-services/gcp-workflows-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-services/gcp-workflows-enum.md
@@ -46,3 +46,4 @@ gcloud workflows executions describe projects/<proj-number>/locations/<location>
 - [7] [gcloud workflows executions describe](https://docs.cloud.google.com/sdk/gcloud/reference/workflows/executions/describe)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/README.md
@@ -192,3 +192,4 @@ Abusing this **Google Groups privilege-escalation path** may allow escalation to
 - [22] [Choose who can see and join your groups](https://support.google.com/a/users/answer/167427?hl=en-GB)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-understanding-domain-wide-delegation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-to-workspace-pivoting/gcp-understanding-domain-wide-delegation.md
@@ -31,3 +31,4 @@ This is how a GCP Service Account can access Google APIs on behalf of other iden
 - [4] [DeleFriend: Severe design flaw in Domain Wide Delegation could leave Google Workspace vulnerable for takeover](https://www.hunters.security/en/blog/delefriend-a-newly-discovered-design-flaw-in-domain-wide-delegation-could-leave-google-workspace-vulnerable-for-takeover)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/README.md
@@ -22,3 +22,4 @@ Note that other cloud resources could be searched for and that sometimes these r
 - [5] [Request endpoints | Cloud Storage](https://docs.cloud.google.com/storage/docs/request-endpoints)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-api-keys-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-api-keys-unauthenticated-enum.md
@@ -172,3 +172,4 @@ If the endpoint returns another user's phone number, email address, settings, or
 - [6] [gcloud services api-keys lookup | Google Cloud SDK](https://cloud.google.com/sdk/gcloud/reference/services/api-keys/lookup)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-app-engine-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-app-engine-unauthenticated-enum.md
@@ -28,3 +28,4 @@ You could use tools like the ones indicated in:
 {{#include ../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-artifact-registry-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-artifact-registry-unauthenticated-enum.md
@@ -20,3 +20,4 @@ Check the following page:
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-build-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-build-unauthenticated-enum.md
@@ -44,3 +44,4 @@ Moreover, it's easy to see if some cloudbuild execution needs to be performed wh
 - [3] [Default Cloud Build service account](https://docs.cloud.google.com/build/docs/cloud-build-service-account)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-functions-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-functions-unauthenticated-enum.md
@@ -83,3 +83,4 @@ Treat the script's output as a candidate list: `allUsers` represents anyone on t
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-run-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-run-unauthenticated-enum.md
@@ -63,3 +63,4 @@ done
 - [6] [GitLab Security: find_open_cloudrun.sh](https://gitlab.com/gitlab-com/gl-security/security-operations/redteam/redteam-public/pocs/gcp_misc/-/blob/master/find_open_cloudrun.sh)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-sql-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-cloud-sql-unauthenticated-enum.md
@@ -27,3 +27,4 @@ An authorized identity with the `cloudsql.users.list` permission can use the Clo
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-compute-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-compute-unauthenticated-enum.md
@@ -26,3 +26,4 @@ If a GCP instance has a vulnerable exposed service an attacker could abuse it to
 - [2] [Authenticate workloads to Google Cloud APIs using service accounts | Compute Engine](https://docs.cloud.google.com/compute/docs/access/authenticate-workloads)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-iam-principals-and-org-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-iam-principals-and-org-unauthenticated-enum.md
@@ -116,3 +116,4 @@ ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Principal test
 - [8] [Method: projects.serviceAccounts.get](https://docs.cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/get)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-source-repositories-unauthenticated-enum.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-source-repositories-unauthenticated-enum.md
@@ -29,3 +29,4 @@ Cloud Source Repositories can connect to GitHub or Bitbucket repositories and sy
 {{#include ../../../banners/hacktricks-training.md}}
 
 
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-storage-unauthenticated-enum/README.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-storage-unauthenticated-enum/README.md
@@ -75,3 +75,4 @@ done
 - [3] [find_open_buckets.sh](https://gitlab.com/gitlab-com/gl-security/security-operations/redteam/redteam-public/pocs/gcp_misc/-/blob/master/find_open_buckets.sh)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-storage-unauthenticated-enum/gcp-public-buckets-privilege-escalation.md
+++ b/src/pentesting-cloud/gcp-security/gcp-unauthenticated-enum-and-access/gcp-storage-unauthenticated-enum/gcp-public-buckets-privilege-escalation.md
@@ -37,3 +37,4 @@ If `storage.buckets.delete` is also available, deleting the bucket frees its glo
 - [7] [About Cloud Storage buckets](https://docs.cloud.google.com/storage/docs/buckets)
 
 {{#include ../../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
+++ b/src/pentesting-cloud/kubernetes-security/abusing-roles-clusterroles-in-kubernetes/README.md
@@ -905,3 +905,4 @@ https://github.com/aquasecurity/kube-bench
 - [46] [pid_namespaces(7)](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
+++ b/src/pentesting-cloud/kubernetes-security/exposing-services-in-kubernetes.md
@@ -291,3 +291,4 @@ Do not check only HTTPRoute. GRPCRoute, TLSRoute, TCPRoute, and UDPRoute can exp
 - [19] [External Application Load Balancer overview](https://cloud.google.com/compute/docs/load-balancing/http/)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-enumeration.md
@@ -984,3 +984,4 @@ ccurl --path-as-is -i -s -k -X $'DELETE' \
 - [42] [Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
+++ b/src/pentesting-cloud/kubernetes-security/kubernetes-hardening/README.md
@@ -388,3 +388,4 @@ Kubernetes currently releases approximately three times per year, and its versio
 - [28] [Falco](https://github.com/falcosecurity/falco)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
+++ b/src/pentesting-cloud/kubernetes-security/pentesting-kubernetes-services/README.md
@@ -272,3 +272,4 @@ An example of how this vulnerability can be exploited involves a remote attacker
 - [22] [Create a Private Azure Kubernetes Service (AKS) Cluster](https://learn.microsoft.com/en-us/azure/aks/private-clusters)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/README.md
+++ b/src/pentesting-cloud/workspace-security/README.md
@@ -88,3 +88,4 @@ After an account compromise, review recent security events, active sessions, rec
 - [11] [Secure a hacked or compromised Google Account](https://support.google.com/accounts/answer/6294825?hl=en)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-google-platforms-phishing/README.md
+++ b/src/pentesting-cloud/workspace-security/gws-google-platforms-phishing/README.md
@@ -252,3 +252,4 @@ Configure app access control according to the tenant's risk tolerance:<sup>[[21]
 - [23] [HTML Service: Restrictions](https://developers.google.com/apps-script/guides/html/restrictions)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-google-platforms-phishing/gws-app-scripts.md
+++ b/src/pentesting-cloud/workspace-security/gws-google-platforms-phishing/gws-app-scripts.md
@@ -260,3 +260,4 @@ If someone **shares** a document with you with **Editor** access, you can create
 - [21] [Troubleshooting](https://developers.google.com/apps-script/guides/support/troubleshooting)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-persistence.md
+++ b/src/pentesting-cloud/workspace-security/gws-persistence.md
@@ -151,3 +151,4 @@ gws-google-platforms-phishing/gws-app-scripts.md
 - [16] [Make your account more secure](https://support.google.com/accounts/answer/46526?hl=en)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-post-exploitation.md
+++ b/src/pentesting-cloud/workspace-security/gws-post-exploitation.md
@@ -85,3 +85,4 @@ You can also search recent message delivery records with [**Email Log Search**](
 - [18] [Troubleshoot message delivery with Email Log Search — Google Workspace Help](https://support.google.com/a/answer/7513679?hl=en-GB)
 
 {{#include ../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/README.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/README.md
@@ -67,3 +67,4 @@ gws-admin-directory-sync.md
 
 {{#include ../../../banners/hacktricks-training.md}}
 
+

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcds-google-cloud-directory-sync.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcds-google-cloud-directory-sync.md
@@ -354,3 +354,4 @@ curl -X POST \
 - [14] [Manage user accounts](https://developers.google.com/workspace/admin/directory/v1/guides/manage-users)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcpw-google-credential-provider-for-windows.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gcpw-google-credential-provider-for-windows.md
@@ -978,3 +978,4 @@ It was checked that even if the computer doesn't have internet access it's possi
 - [24] [The Chain Reaction: New Methods for Extending Local Breaches in Google Workspace](https://businessinsights.bitdefender.com/the-chain-reaction-new-methods-for-extending-local-breaches-in-google-workspace)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gps-google-password-sync.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gps-google-password-sync.md
@@ -208,3 +208,4 @@ Which is the same one you get if you don't indicate any scope.
 - [17] [Manage roles](https://developers.google.com/workspace/admin/directory/v1/guides/manage-roles)
 
 {{#include ../../../banners/hacktricks-training.md}}
+

--- a/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gws-admin-directory-sync.md
+++ b/src/pentesting-cloud/workspace-security/gws-workspace-sync-attacks-gcpw-gcds-gps-directory-sync-with-ad-and-entraid/gws-admin-directory-sync.md
@@ -70,3 +70,4 @@ Authorized administrators can still inspect Directory Sync reporting and audit i
 - [13] [Set up password recovery for users](https://knowledge.workspace.google.com/admin/users/set-up-password-recovery-for-users)
 
 {{#include ../../../banners/hacktricks-training.md}}
+


### PR DESCRIPTION
## Summary

- identify SUMMARY pages changed by the five failed Translator All reference-update runs
- compare their latest English numbered References and linked citation signatures against all 16 language branches
- add exactly one trailing newline to only the 134 pages still stale in at least one language

## Validation

- 135 candidate SUMMARY pages from the failed runs
- 134 stale pages selected; one already current in all languages
- exactly 134 changed files, each with one blank-line insertion and no nonblank content changes
- no temporary refresh markers
- one `## References` section per selected English page
- training banner remains the final nonblank line